### PR TITLE
chore: release v0.9.2

### DIFF
--- a/.loa-version.json
+++ b/.loa-version.json
@@ -1,5 +1,5 @@
 {
-  "framework_version": "0.9.0",
+  "framework_version": "0.9.2",
   "schema_version": 2,
   "last_sync": null,
   "zones": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to Loa will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2025-12-31
+
+### Why This Release
+
+The `/update` command was overwriting project-specific `CHANGELOG.md` and `README.md` files with Loa framework template versions. These files define the project, not the framework, and should always be preserved during updates.
+
+### Fixed
+
+- **`/update` Command**: Now preserves project identity files during framework updates
+  - Added `CHANGELOG.md` and `README.md` to the Merge Strategy table as preserved files
+  - Added "Project Identity Files" section in Conflict Resolution guidance
+  - These files are now automatically resolved with `--ours` (keep project version)
+  - Updated Next Steps to link to upstream releases instead of local CHANGELOG
+
+### Upgrade Instructions
+
+No action required. The fix is in the `/update` command documentation itself, so future updates will properly preserve your project files.
+
+If you previously lost your `CHANGELOG.md` or `README.md` during an update:
+```bash
+git checkout <commit-before-update> -- CHANGELOG.md README.md
+git commit -m "fix: restore project CHANGELOG and README"
+```
+
+---
+
 ## [0.9.1] - 2025-12-30
 
 ### Why This Release
@@ -691,6 +717,7 @@ loa-grimoire/           # Loa process artifacts
 └── deployment/         # Production infrastructure docs
 ```
 
+[0.9.2]: https://github.com/0xHoneyJar/loa/releases/tag/v0.9.2
 [0.9.1]: https://github.com/0xHoneyJar/loa/releases/tag/v0.9.1
 [0.9.0]: https://github.com/0xHoneyJar/loa/releases/tag/v0.9.0
 [0.8.0]: https://github.com/0xHoneyJar/loa/releases/tag/v0.8.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Loa
 
-[![Version](https://img.shields.io/badge/version-0.9.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.9.2-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE.md)
 
 > *"The Loa are pragmatic entities... They're not worshipped for salvation—they're worked with for practical results."*


### PR DESCRIPTION
## Summary

Release 0.9.2 - fixes `/update` command to preserve project identity files.

## Changes

- Bump version from 0.9.1 to 0.9.2
- Add release notes to CHANGELOG.md

## What's Fixed

The `/update` command was overwriting project-specific `CHANGELOG.md` and `README.md` files with Loa framework template versions. This release documents the proper merge strategy:

- Added these files to the "Preserved" list in the Merge Strategy table
- Added explicit "Project Identity Files" section in Conflict Resolution
- Files are now resolved with `--ours` (keep project version)

Relates to fix in #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)