### PR TITLE
feat: Add CLI install command for Loa Constructs packs

### DIFF
--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -1,0 +1,1042 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Loa Constructs - Installation Script
+# =============================================================================
+# Install packs and skills from the Loa Constructs Registry.
+#
+# Usage:
+#   constructs-install.sh pack <slug>              # Install a pack
+#   constructs-install.sh skill <vendor/slug>      # Install a skill
+#   constructs-install.sh uninstall pack <slug>    # Remove a pack
+#   constructs-install.sh uninstall skill <slug>   # Remove a skill
+#   constructs-install.sh link-commands <slug>     # Re-link pack commands
+#
+# Exit Codes:
+#   0 = success
+#   1 = authentication error
+#   2 = network error
+#   3 = not found
+#   4 = extraction error
+#   5 = validation error
+#   6 = general error
+#
+# Environment Variables:
+#   LOA_CONSTRUCTS_API_KEY  - API key for authentication
+#   LOA_REGISTRY_URL        - Override API URL
+#   LOA_OFFLINE             - Set to 1 for offline mode (skip download)
+#
+# Sources: GitHub Issue #20, GitHub Issue #21
+# =============================================================================
+
+set -euo pipefail
+
+# Get script directory for sourcing dependencies
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared library
+if [[ -f "$SCRIPT_DIR/constructs-lib.sh" ]]; then
+    source "$SCRIPT_DIR/constructs-lib.sh"
+else
+    echo "ERROR: constructs-lib.sh not found" >&2
+    exit 6
+fi
+
+# =============================================================================
+# Exit Codes
+# =============================================================================
+
+EXIT_SUCCESS=0
+EXIT_AUTH_ERROR=1
+EXIT_NETWORK_ERROR=2
+EXIT_NOT_FOUND=3
+EXIT_EXTRACT_ERROR=4
+EXIT_VALIDATION_ERROR=5
+EXIT_ERROR=6
+
+# =============================================================================
+# Authentication
+# =============================================================================
+
+# Get API key from environment or credentials file
+# Returns: API key or empty string
+get_api_key() {
+    # Check environment variable first
+    if [[ -n "${LOA_CONSTRUCTS_API_KEY:-}" ]]; then
+        echo "$LOA_CONSTRUCTS_API_KEY"
+        return 0
+    fi
+
+    # Check credentials file
+    local creds_file="${HOME}/.loa/credentials.json"
+    if [[ -f "$creds_file" ]]; then
+        local key
+        key=$(jq -r '.api_key // empty' "$creds_file" 2>/dev/null)
+        if [[ -n "$key" ]]; then
+            echo "$key"
+            return 0
+        fi
+    fi
+
+    # Alternative credentials location
+    local alt_creds="${HOME}/.loa-constructs/credentials.json"
+    if [[ -f "$alt_creds" ]]; then
+        local key
+        key=$(jq -r '.api_key // .apiKey // empty' "$alt_creds" 2>/dev/null)
+        if [[ -n "$key" ]]; then
+            echo "$key"
+            return 0
+        fi
+    fi
+
+    echo ""
+}
+
+# =============================================================================
+# Directory Management
+# =============================================================================
+
+# Get constructs directory
+get_constructs_dir() {
+    echo "${LOA_CONSTRUCTS_DIR:-.claude/constructs}"
+}
+
+# Get packs directory
+get_packs_dir() {
+    echo "$(get_constructs_dir)/packs"
+}
+
+# Get skills directory
+get_skills_dir() {
+    echo "$(get_constructs_dir)/skills"
+}
+
+# Get commands directory
+get_commands_dir() {
+    echo ".claude/commands"
+}
+
+# =============================================================================
+# Command Symlinking (Fixes GitHub Issue #21)
+# =============================================================================
+
+# Symlink pack commands to .claude/commands/
+# Args:
+#   $1 - Pack slug
+# Returns: Number of commands linked
+symlink_pack_commands() {
+    local pack_slug="$1"
+    local pack_dir="$(get_packs_dir)/$pack_slug"
+    local commands_source="$pack_dir/commands"
+    local commands_target="$(get_commands_dir)"
+    local linked=0
+
+    # Check if pack has commands
+    if [[ ! -d "$commands_source" ]]; then
+        echo "0"
+        return 0
+    fi
+
+    # Ensure commands target directory exists
+    mkdir -p "$commands_target"
+
+    # Symlink each command
+    for cmd in "$commands_source"/*.md; do
+        [[ -f "$cmd" ]] || continue
+
+        local filename
+        filename=$(basename "$cmd")
+
+        # Calculate relative path from .claude/commands/ to pack commands
+        local relative_path="../constructs/packs/$pack_slug/commands/$filename"
+        local target_link="$commands_target/$filename"
+
+        # Check for existing file/symlink
+        if [[ -e "$target_link" ]] || [[ -L "$target_link" ]]; then
+            if [[ -L "$target_link" ]]; then
+                # It's a symlink - check if it points to a constructs pack
+                local existing_target
+                existing_target=$(readlink "$target_link" 2>/dev/null || echo "")
+                if [[ "$existing_target" == *"constructs/packs"* ]]; then
+                    # Remove old pack symlink
+                    rm -f "$target_link"
+                else
+                    print_warning "  Skipping $filename: symlink exists to custom location"
+                    continue
+                fi
+            else
+                # It's a regular file - don't overwrite
+                print_warning "  Skipping $filename: user file exists (not overwriting)"
+                continue
+            fi
+        fi
+
+        # Create symlink
+        ln -sf "$relative_path" "$target_link"
+        ((linked++))
+    done
+
+    echo "$linked"
+}
+
+# Remove pack command symlinks
+# Args:
+#   $1 - Pack slug
+# Returns: Number of commands unlinked
+unlink_pack_commands() {
+    local pack_slug="$1"
+    local pack_dir="$(get_packs_dir)/$pack_slug"
+    local commands_source="$pack_dir/commands"
+    local commands_target="$(get_commands_dir)"
+    local unlinked=0
+
+    # Check if pack has commands
+    if [[ ! -d "$commands_source" ]]; then
+        echo "0"
+        return 0
+    fi
+
+    # Remove symlinks for each command
+    for cmd in "$commands_source"/*.md; do
+        [[ -f "$cmd" ]] || continue
+
+        local filename
+        filename=$(basename "$cmd")
+        local target_link="$commands_target/$filename"
+
+        # Check if it's our symlink
+        if [[ -L "$target_link" ]]; then
+            local existing_target
+            existing_target=$(readlink "$target_link" 2>/dev/null || echo "")
+            if [[ "$existing_target" == *"constructs/packs/$pack_slug"* ]]; then
+                rm -f "$target_link"
+                ((unlinked++))
+            fi
+        fi
+    done
+
+    echo "$unlinked"
+}
+
+# =============================================================================
+# Skill Symlinking (for loader compatibility)
+# =============================================================================
+
+# Symlink pack skills to constructs/skills for loader discovery
+# Args:
+#   $1 - Pack slug
+# Returns: Number of skills linked
+symlink_pack_skills() {
+    local pack_slug="$1"
+    local pack_dir="$(get_packs_dir)/$pack_slug"
+    local skills_source="$pack_dir/skills"
+    local skills_target="$(get_skills_dir)/$pack_slug"
+    local linked=0
+
+    # Check if pack has skills
+    if [[ ! -d "$skills_source" ]]; then
+        echo "0"
+        return 0
+    fi
+
+    # Create target directory
+    mkdir -p "$skills_target"
+
+    # Symlink each skill directory
+    for skill in "$skills_source"/*/; do
+        [[ -d "$skill" ]] || continue
+
+        local skill_name
+        skill_name=$(basename "$skill")
+        local relative_path="../../packs/$pack_slug/skills/$skill_name"
+        local target_link="$skills_target/$skill_name"
+
+        # Remove existing symlink if present
+        if [[ -L "$target_link" ]]; then
+            rm -f "$target_link"
+        elif [[ -d "$target_link" ]]; then
+            print_warning "  Skipping skill $skill_name: directory exists"
+            continue
+        fi
+
+        # Create symlink
+        ln -sf "$relative_path" "$target_link"
+        ((linked++))
+    done
+
+    echo "$linked"
+}
+
+# Remove pack skill symlinks
+# Args:
+#   $1 - Pack slug
+unlink_pack_skills() {
+    local pack_slug="$1"
+    local skills_target="$(get_skills_dir)/$pack_slug"
+
+    # Remove the pack's skill symlinks directory
+    if [[ -d "$skills_target" ]]; then
+        rm -rf "$skills_target"
+    fi
+}
+
+# =============================================================================
+# Pack Installation
+# =============================================================================
+
+# Download and install a pack from the registry
+# Args:
+#   $1 - Pack slug
+do_install_pack() {
+    local pack_slug="$1"
+    local api_key
+    local registry_url
+    local packs_dir
+
+    print_status "$icon_valid" "Installing pack: $pack_slug"
+
+    # Check offline mode
+    if [[ "${LOA_OFFLINE:-}" == "1" ]]; then
+        print_error "ERROR: Cannot install packs in offline mode"
+        return $EXIT_NETWORK_ERROR
+    fi
+
+    # Get authentication
+    api_key=$(get_api_key)
+    if [[ -z "$api_key" ]]; then
+        print_error "ERROR: No API key found"
+        echo ""
+        echo "To authenticate, either:"
+        echo "  1. Set LOA_CONSTRUCTS_API_KEY environment variable"
+        echo "  2. Run /skill-login to save credentials"
+        echo "  3. Create ~/.loa/credentials.json with {\"api_key\": \"your-key\"}"
+        return $EXIT_AUTH_ERROR
+    fi
+
+    # Get registry URL
+    registry_url=$(get_registry_url)
+
+    # Create directories
+    packs_dir=$(get_packs_dir)
+    mkdir -p "$packs_dir"
+
+    # Ensure constructs directory is gitignored
+    ensure_constructs_gitignored
+
+    echo "  Downloading from $registry_url/packs/$pack_slug/download..."
+
+    # Download pack
+    local response
+    local http_code
+    local tmp_file
+    tmp_file=$(mktemp)
+
+    http_code=$(curl -s -w "%{http_code}" \
+        -H "Authorization: Bearer $api_key" \
+        -H "Accept: application/json" \
+        "$registry_url/packs/$pack_slug/download" \
+        -o "$tmp_file" 2>/dev/null) || {
+        rm -f "$tmp_file"
+        print_error "ERROR: Network error while downloading pack"
+        echo "  Check your network connection and try again"
+        return $EXIT_NETWORK_ERROR
+    }
+
+    # Check HTTP status
+    case "$http_code" in
+        200)
+            # Success
+            ;;
+        401|403)
+            rm -f "$tmp_file"
+            print_error "ERROR: Authentication failed (HTTP $http_code)"
+            echo "  Your API key may be invalid or expired"
+            echo "  Run /skill-login to re-authenticate"
+            return $EXIT_AUTH_ERROR
+            ;;
+        404)
+            rm -f "$tmp_file"
+            print_error "ERROR: Pack '$pack_slug' not found"
+            echo "  Check the pack name and try again"
+            return $EXIT_NOT_FOUND
+            ;;
+        *)
+            rm -f "$tmp_file"
+            print_error "ERROR: API returned HTTP $http_code"
+            return $EXIT_NETWORK_ERROR
+            ;;
+    esac
+
+    # Parse response and extract files
+    local pack_dir="$packs_dir/$pack_slug"
+
+    echo "  Extracting files..."
+
+    # Create pack directory
+    mkdir -p "$pack_dir"
+
+    # Extract using Python (jq doesn't handle base64 well)
+    if ! python3 << PYEOF
+import json
+import base64
+import os
+import sys
+
+try:
+    with open('$tmp_file', 'r') as f:
+        data = json.load(f)
+
+    pack_dir = '$pack_dir'
+
+    # Handle nested response structure
+    if 'data' in data:
+        data = data['data']
+
+    # Get pack info
+    pack_info = data.get('pack', data)
+
+    # Write manifest
+    manifest = pack_info.get('manifest', {})
+    if manifest:
+        with open(os.path.join(pack_dir, 'manifest.json'), 'w') as f:
+            json.dump(manifest, f, indent=2)
+
+    # Write license
+    license_data = data.get('license', {})
+    if license_data:
+        with open(os.path.join(pack_dir, '.license.json'), 'w') as f:
+            json.dump(license_data, f, indent=2)
+
+    # Extract files
+    files = pack_info.get('files', [])
+    extracted = 0
+    for file_info in files:
+        path = file_info.get('path', '')
+        content = file_info.get('content', '')
+
+        if not path or not content:
+            continue
+
+        # Create full path
+        full_path = os.path.join(pack_dir, path)
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+
+        # Decode and write
+        try:
+            decoded = base64.b64decode(content)
+            with open(full_path, 'wb') as f:
+                f.write(decoded)
+            extracted += 1
+        except Exception as e:
+            print(f"  Warning: Failed to extract {path}: {e}", file=sys.stderr)
+
+    print(f"  Extracted {extracted} files")
+
+except json.JSONDecodeError as e:
+    print(f"ERROR: Invalid JSON response: {e}", file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f"ERROR: Extraction failed: {e}", file=sys.stderr)
+    sys.exit(1)
+PYEOF
+    then
+        rm -f "$tmp_file"
+        rm -rf "$pack_dir"
+        print_error "ERROR: Failed to extract pack files"
+        return $EXIT_EXTRACT_ERROR
+    fi
+
+    rm -f "$tmp_file"
+
+    # Symlink commands
+    echo "  Linking commands..."
+    local commands_linked
+    commands_linked=$(symlink_pack_commands "$pack_slug")
+    echo "  Created $commands_linked command symlinks"
+
+    # Symlink skills for loader discovery
+    echo "  Linking skills..."
+    local skills_linked
+    skills_linked=$(symlink_pack_skills "$pack_slug")
+    echo "  Created $skills_linked skill symlinks"
+
+    # Validate pack license
+    echo "  Validating license..."
+    local validator="$SCRIPT_DIR/constructs-loader.sh"
+    if [[ -x "$validator" ]]; then
+        local validation_result=0
+        "$validator" validate-pack "$pack_dir" >/dev/null 2>&1 || validation_result=$?
+
+        case $validation_result in
+            0)
+                print_success "  License valid"
+                ;;
+            1)
+                print_warning "  License in grace period - please renew soon"
+                ;;
+            2)
+                print_error "  License expired - pack may not work correctly"
+                ;;
+            3)
+                print_warning "  No license file found - pack may be free tier"
+                ;;
+            *)
+                print_warning "  License validation returned code $validation_result"
+                ;;
+        esac
+    fi
+
+    # Update registry meta
+    update_pack_meta "$pack_slug" "$pack_dir"
+
+    echo ""
+    print_success "Pack '$pack_slug' installed successfully!"
+
+    # List available commands
+    local commands_dir="$pack_dir/commands"
+    if [[ -d "$commands_dir" ]]; then
+        echo ""
+        echo "Available commands:"
+        for cmd in "$commands_dir"/*.md; do
+            [[ -f "$cmd" ]] || continue
+            local cmd_name
+            cmd_name=$(basename "$cmd" .md)
+            echo "  /$cmd_name"
+        done
+    fi
+
+    return $EXIT_SUCCESS
+}
+
+# Update pack metadata in .constructs-meta.json
+# Args:
+#   $1 - Pack slug
+#   $2 - Pack directory
+update_pack_meta() {
+    local pack_slug="$1"
+    local pack_dir="$2"
+    local meta_path
+    meta_path=$(get_registry_meta_path)
+    local now
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    # Get pack version from manifest
+    local version="unknown"
+    local manifest_file="$pack_dir/manifest.json"
+    if [[ -f "$manifest_file" ]]; then
+        version=$(jq -r '.version // "unknown"' "$manifest_file" 2>/dev/null || echo "unknown")
+    fi
+
+    # Get license expiry
+    local license_expires=""
+    local license_file="$pack_dir/.license.json"
+    if [[ -f "$license_file" ]]; then
+        license_expires=$(jq -r '.expires_at // ""' "$license_file" 2>/dev/null || echo "")
+    fi
+
+    # Get skills list
+    local skills_json="[]"
+    if [[ -d "$pack_dir/skills" ]]; then
+        skills_json=$(find "$pack_dir/skills" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | jq -R -s 'split("\n") | map(select(length > 0))')
+    fi
+
+    # Ensure meta file exists
+    init_registry_meta
+
+    # Update meta
+    local tmp_file="${meta_path}.tmp"
+    jq --arg slug "$pack_slug" \
+       --arg version "$version" \
+       --arg installed_at "$now" \
+       --arg license_expires "$license_expires" \
+       --argjson skills "$skills_json" \
+       '.installed_packs[$slug] = {
+           "version": $version,
+           "installed_at": $installed_at,
+           "registry": "default",
+           "license_expires": $license_expires,
+           "skills": $skills
+       }' "$meta_path" > "$tmp_file" && mv "$tmp_file" "$meta_path"
+}
+
+# =============================================================================
+# Skill Installation
+# =============================================================================
+
+# Download and install a skill from the registry
+# Args:
+#   $1 - Skill slug (vendor/name)
+do_install_skill() {
+    local skill_slug="$1"
+    local api_key
+    local registry_url
+    local skills_dir
+
+    print_status "$icon_valid" "Installing skill: $skill_slug"
+
+    # Check offline mode
+    if [[ "${LOA_OFFLINE:-}" == "1" ]]; then
+        print_error "ERROR: Cannot install skills in offline mode"
+        return $EXIT_NETWORK_ERROR
+    fi
+
+    # Get authentication
+    api_key=$(get_api_key)
+    if [[ -z "$api_key" ]]; then
+        print_error "ERROR: No API key found"
+        echo ""
+        echo "To authenticate, either:"
+        echo "  1. Set LOA_CONSTRUCTS_API_KEY environment variable"
+        echo "  2. Run /skill-login to save credentials"
+        return $EXIT_AUTH_ERROR
+    fi
+
+    # Get registry URL
+    registry_url=$(get_registry_url)
+
+    # Create directories
+    skills_dir=$(get_skills_dir)
+    mkdir -p "$skills_dir"
+
+    # Ensure constructs directory is gitignored
+    ensure_constructs_gitignored
+
+    echo "  Downloading from $registry_url/skills/$skill_slug/download..."
+
+    # Download skill
+    local http_code
+    local tmp_file
+    tmp_file=$(mktemp)
+
+    http_code=$(curl -s -w "%{http_code}" \
+        -H "Authorization: Bearer $api_key" \
+        -H "Accept: application/json" \
+        "$registry_url/skills/$skill_slug/download" \
+        -o "$tmp_file" 2>/dev/null) || {
+        rm -f "$tmp_file"
+        print_error "ERROR: Network error while downloading skill"
+        return $EXIT_NETWORK_ERROR
+    }
+
+    # Check HTTP status
+    case "$http_code" in
+        200)
+            # Success
+            ;;
+        401|403)
+            rm -f "$tmp_file"
+            print_error "ERROR: Authentication failed (HTTP $http_code)"
+            return $EXIT_AUTH_ERROR
+            ;;
+        404)
+            rm -f "$tmp_file"
+            print_error "ERROR: Skill '$skill_slug' not found"
+            return $EXIT_NOT_FOUND
+            ;;
+        *)
+            rm -f "$tmp_file"
+            print_error "ERROR: API returned HTTP $http_code"
+            return $EXIT_NETWORK_ERROR
+            ;;
+    esac
+
+    # Determine directory structure
+    # skill_slug might be "vendor/name" or just "name"
+    local skill_dir
+    if [[ "$skill_slug" == *"/"* ]]; then
+        skill_dir="$skills_dir/$skill_slug"
+    else
+        skill_dir="$skills_dir/default/$skill_slug"
+    fi
+
+    echo "  Extracting files..."
+
+    # Create skill directory
+    mkdir -p "$skill_dir"
+
+    # Extract using Python
+    if ! python3 << PYEOF
+import json
+import base64
+import os
+import sys
+
+try:
+    with open('$tmp_file', 'r') as f:
+        data = json.load(f)
+
+    skill_dir = '$skill_dir'
+
+    # Handle nested response structure
+    if 'data' in data:
+        data = data['data']
+
+    # Get skill info
+    skill_info = data.get('skill', data)
+
+    # Write license
+    license_data = data.get('license', {})
+    if license_data:
+        with open(os.path.join(skill_dir, '.license.json'), 'w') as f:
+            json.dump(license_data, f, indent=2)
+
+    # Extract files
+    files = skill_info.get('files', [])
+    extracted = 0
+    for file_info in files:
+        path = file_info.get('path', '')
+        content = file_info.get('content', '')
+
+        if not path or not content:
+            continue
+
+        # Create full path
+        full_path = os.path.join(skill_dir, path)
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+
+        # Decode and write
+        try:
+            decoded = base64.b64decode(content)
+            with open(full_path, 'wb') as f:
+                f.write(decoded)
+            extracted += 1
+        except Exception as e:
+            print(f"  Warning: Failed to extract {path}: {e}", file=sys.stderr)
+
+    print(f"  Extracted {extracted} files")
+
+except json.JSONDecodeError as e:
+    print(f"ERROR: Invalid JSON response: {e}", file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f"ERROR: Extraction failed: {e}", file=sys.stderr)
+    sys.exit(1)
+PYEOF
+    then
+        rm -f "$tmp_file"
+        rm -rf "$skill_dir"
+        print_error "ERROR: Failed to extract skill files"
+        return $EXIT_EXTRACT_ERROR
+    fi
+
+    rm -f "$tmp_file"
+
+    # Validate skill license
+    echo "  Validating license..."
+    local validator="$SCRIPT_DIR/constructs-loader.sh"
+    if [[ -x "$validator" ]]; then
+        local validation_result=0
+        "$validator" validate "$skill_dir" >/dev/null 2>&1 || validation_result=$?
+
+        case $validation_result in
+            0)
+                print_success "  License valid"
+                ;;
+            1)
+                print_warning "  License in grace period"
+                ;;
+            2)
+                print_error "  License expired"
+                ;;
+            *)
+                print_warning "  License validation returned code $validation_result"
+                ;;
+        esac
+    fi
+
+    # Update registry meta
+    update_skill_meta "$skill_slug" "$skill_dir"
+
+    echo ""
+    print_success "Skill '$skill_slug' installed successfully!"
+
+    return $EXIT_SUCCESS
+}
+
+# Update skill metadata in .constructs-meta.json
+# Args:
+#   $1 - Skill slug
+#   $2 - Skill directory
+update_skill_meta() {
+    local skill_slug="$1"
+    local skill_dir="$2"
+    local meta_path
+    meta_path=$(get_registry_meta_path)
+    local now
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    # Get skill version from index.yaml
+    local version="unknown"
+    local index_file="$skill_dir/index.yaml"
+    if [[ -f "$index_file" ]] && command -v yq &>/dev/null; then
+        local yq_version_output
+        yq_version_output=$(yq --version 2>&1 || echo "")
+        if echo "$yq_version_output" | grep -q "mikefarah\|version.*4"; then
+            version=$(yq eval '.version // "unknown"' "$index_file" 2>/dev/null || echo "unknown")
+        else
+            version=$(yq '.version // "unknown"' "$index_file" 2>/dev/null || echo "unknown")
+        fi
+    fi
+
+    # Get license expiry
+    local license_expires=""
+    local license_file="$skill_dir/.license.json"
+    if [[ -f "$license_file" ]]; then
+        license_expires=$(jq -r '.expires_at // ""' "$license_file" 2>/dev/null || echo "")
+    fi
+
+    # Ensure meta file exists
+    init_registry_meta
+
+    # Update meta
+    local tmp_file="${meta_path}.tmp"
+    jq --arg slug "$skill_slug" \
+       --arg version "$version" \
+       --arg installed_at "$now" \
+       --arg license_expires "$license_expires" \
+       '.installed_skills[$slug] = {
+           "version": $version,
+           "installed_at": $installed_at,
+           "registry": "default",
+           "license_expires": $license_expires,
+           "from_pack": null
+       }' "$meta_path" > "$tmp_file" && mv "$tmp_file" "$meta_path"
+}
+
+# =============================================================================
+# Uninstall Commands
+# =============================================================================
+
+# Uninstall a pack
+# Args:
+#   $1 - Pack slug
+do_uninstall_pack() {
+    local pack_slug="$1"
+    local pack_dir="$(get_packs_dir)/$pack_slug"
+
+    print_status "$icon_warning" "Uninstalling pack: $pack_slug"
+
+    # Check if pack exists
+    if [[ ! -d "$pack_dir" ]]; then
+        print_error "ERROR: Pack '$pack_slug' is not installed"
+        return $EXIT_NOT_FOUND
+    fi
+
+    # Remove command symlinks first
+    echo "  Removing command symlinks..."
+    local commands_unlinked
+    commands_unlinked=$(unlink_pack_commands "$pack_slug")
+    echo "  Removed $commands_unlinked command symlinks"
+
+    # Remove skill symlinks
+    echo "  Removing skill symlinks..."
+    unlink_pack_skills "$pack_slug"
+
+    # Remove pack directory
+    echo "  Removing pack files..."
+    rm -rf "$pack_dir"
+
+    # Update registry meta
+    local meta_path
+    meta_path=$(get_registry_meta_path)
+    if [[ -f "$meta_path" ]]; then
+        local tmp_file="${meta_path}.tmp"
+        jq --arg slug "$pack_slug" 'del(.installed_packs[$slug])' "$meta_path" > "$tmp_file" && mv "$tmp_file" "$meta_path"
+    fi
+
+    echo ""
+    print_success "Pack '$pack_slug' uninstalled successfully!"
+
+    return $EXIT_SUCCESS
+}
+
+# Uninstall a skill
+# Args:
+#   $1 - Skill slug
+do_uninstall_skill() {
+    local skill_slug="$1"
+    local skills_dir
+    skills_dir=$(get_skills_dir)
+
+    print_status "$icon_warning" "Uninstalling skill: $skill_slug"
+
+    # Find skill directory
+    local skill_dir
+    if [[ -d "$skills_dir/$skill_slug" ]]; then
+        skill_dir="$skills_dir/$skill_slug"
+    elif [[ -d "$skills_dir/default/$skill_slug" ]]; then
+        skill_dir="$skills_dir/default/$skill_slug"
+    else
+        print_error "ERROR: Skill '$skill_slug' is not installed"
+        return $EXIT_NOT_FOUND
+    fi
+
+    # Check if it's a symlink (pack skill)
+    if [[ -L "$skill_dir" ]]; then
+        print_error "ERROR: Skill '$skill_slug' is part of a pack"
+        echo "  Uninstall the pack instead, or remove the symlink manually"
+        return $EXIT_ERROR
+    fi
+
+    # Remove skill directory
+    echo "  Removing skill files..."
+    rm -rf "$skill_dir"
+
+    # Update registry meta
+    local meta_path
+    meta_path=$(get_registry_meta_path)
+    if [[ -f "$meta_path" ]]; then
+        local tmp_file="${meta_path}.tmp"
+        jq --arg slug "$skill_slug" 'del(.installed_skills[$slug])' "$meta_path" > "$tmp_file" && mv "$tmp_file" "$meta_path"
+    fi
+
+    echo ""
+    print_success "Skill '$skill_slug' uninstalled successfully!"
+
+    return $EXIT_SUCCESS
+}
+
+# =============================================================================
+# Re-link Commands (for manual fixing)
+# =============================================================================
+
+# Re-link pack commands (useful after updates or manual changes)
+# Args:
+#   $1 - Pack slug (or "all" for all packs)
+do_link_commands() {
+    local pack_slug="$1"
+    local packs_dir
+    packs_dir=$(get_packs_dir)
+
+    if [[ "$pack_slug" == "all" ]]; then
+        # Link all packs
+        local total_linked=0
+        for pack_path in "$packs_dir"/*/; do
+            [[ -d "$pack_path" ]] || continue
+            local slug
+            slug=$(basename "$pack_path")
+
+            echo "Linking commands for pack: $slug"
+            local linked
+            linked=$(symlink_pack_commands "$slug")
+            echo "  Created $linked command symlinks"
+            total_linked=$((total_linked + linked))
+        done
+        echo ""
+        print_success "Total: $total_linked command symlinks created"
+    else
+        # Link specific pack
+        local pack_dir="$packs_dir/$pack_slug"
+        if [[ ! -d "$pack_dir" ]]; then
+            print_error "ERROR: Pack '$pack_slug' is not installed"
+            return $EXIT_NOT_FOUND
+        fi
+
+        echo "Linking commands for pack: $pack_slug"
+        local linked
+        linked=$(symlink_pack_commands "$pack_slug")
+        print_success "Created $linked command symlinks"
+    fi
+
+    return $EXIT_SUCCESS
+}
+
+# =============================================================================
+# Command Line Interface
+# =============================================================================
+
+show_usage() {
+    cat << 'EOF'
+Usage: constructs-install.sh <command> [arguments]
+
+Commands:
+    pack <slug>              Install a pack from the registry
+    skill <vendor/slug>      Install a skill from the registry
+    uninstall pack <slug>    Uninstall a pack
+    uninstall skill <slug>   Uninstall a skill
+    link-commands <slug>     Re-link pack commands (use "all" for all packs)
+
+Exit Codes:
+    0 = success
+    1 = authentication error
+    2 = network error
+    3 = not found
+    4 = extraction error
+    5 = validation error
+    6 = general error
+
+Environment Variables:
+    LOA_CONSTRUCTS_API_KEY  API key for authentication
+    LOA_REGISTRY_URL        Override registry API URL
+    LOA_OFFLINE             Set to 1 for offline mode
+
+Examples:
+    constructs-install.sh pack gtm-collective
+    constructs-install.sh skill thj/terraform-assistant
+    constructs-install.sh uninstall pack gtm-collective
+    constructs-install.sh link-commands all
+
+Authentication:
+    Set LOA_CONSTRUCTS_API_KEY environment variable, or create:
+    ~/.loa/credentials.json with {"api_key": "your-key"}
+
+After Installation:
+    Pack commands will be available as slash commands (e.g., /gtm-setup)
+    Skills will be available in the skill loader (constructs-loader.sh list)
+EOF
+}
+
+main() {
+    local command="${1:-}"
+
+    if [[ -z "$command" ]]; then
+        show_usage
+        exit $EXIT_ERROR
+    fi
+
+    case "$command" in
+        pack)
+            [[ -n "${2:-}" ]] || { print_error "ERROR: Missing pack slug"; show_usage; exit $EXIT_ERROR; }
+            do_install_pack "$2"
+            ;;
+        skill)
+            [[ -n "${2:-}" ]] || { print_error "ERROR: Missing skill slug"; show_usage; exit $EXIT_ERROR; }
+            do_install_skill "$2"
+            ;;
+        uninstall)
+            local type="${2:-}"
+            local slug="${3:-}"
+            [[ -n "$type" ]] || { print_error "ERROR: Missing uninstall type (pack/skill)"; exit $EXIT_ERROR; }
+            [[ -n "$slug" ]] || { print_error "ERROR: Missing slug to uninstall"; exit $EXIT_ERROR; }
+            case "$type" in
+                pack)
+                    do_uninstall_pack "$slug"
+                    ;;
+                skill)
+                    do_uninstall_skill "$slug"
+                    ;;
+                *)
+                    print_error "ERROR: Unknown uninstall type: $type (use 'pack' or 'skill')"
+                    exit $EXIT_ERROR
+                    ;;
+            esac
+            ;;
+        link-commands)
+            [[ -n "${2:-}" ]] || { print_error "ERROR: Missing pack slug (or 'all')"; exit $EXIT_ERROR; }
+            do_link_commands "$2"
+            ;;
+        -h|--help|help)
+            show_usage
+            exit $EXIT_SUCCESS
+            ;;
+        *)
+            print_error "ERROR: Unknown command: $command"
+            show_usage
+            exit $EXIT_ERROR
+            ;;
+    esac
+}
+
+# Only run main if not being sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,8 +354,10 @@ See `loa-grimoire/context/CLI-INSTALLATION.md` for full setup guide.
 │   └── SKILL.md               # Instructions
 ├── packs/{name}/              # Skill packs
 │   ├── .license.json          # Pack license
-│   └── skills/                # Bundled skills
-└── .registry-meta.json        # Installation state
+│   ├── manifest.json          # Pack metadata
+│   ├── skills/                # Bundled skills
+│   └── commands/              # Pack commands (auto-symlinked to .claude/commands/)
+└── .constructs-meta.json      # Installation state
 ```
 
 ### Loading Priority
@@ -379,10 +381,18 @@ Local skills always win. Conflicts resolved silently by priority.
 ### CLI Commands
 
 ```bash
+# Loader commands
 constructs-loader.sh list              # Show skills with status
 constructs-loader.sh loadable          # Get loadable skill paths
 constructs-loader.sh validate <dir>    # Validate single skill
 constructs-loader.sh check-updates     # Check for updates
+
+# Installation commands
+constructs-install.sh pack <slug>              # Install pack from registry
+constructs-install.sh skill <vendor/slug>      # Install individual skill
+constructs-install.sh uninstall pack <slug>    # Remove a pack
+constructs-install.sh uninstall skill <slug>   # Remove a skill
+constructs-install.sh link-commands <slug|all> # Re-link pack commands
 ```
 
 ### Configuration
@@ -400,6 +410,7 @@ registry:
 - `LOA_OFFLINE_GRACE_HOURS` - Grace period
 - `LOA_REGISTRY_ENABLED` - Master toggle
 - `LOA_OFFLINE=1` - Force offline mode
+- `LOA_CONSTRUCTS_API_KEY` - API key for pack/skill installation
 
 **Protocol**: See `.claude/protocols/constructs-integration.md`
 

--- a/tests/unit/test_constructs_install.bats
+++ b/tests/unit/test_constructs_install.bats
@@ -1,0 +1,491 @@
+#!/usr/bin/env bats
+# Unit tests for .claude/scripts/constructs-install.sh
+# Tests pack and skill installation, symlinking, and uninstallation
+#
+# GitHub Issues:
+#   #20 - Add CLI install command for Loa Constructs packs
+#   #21 - Pack commands not automatically available after installation
+
+# Test setup
+setup() {
+    BATS_TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIR/../.." && pwd)"
+    FIXTURES_DIR="$PROJECT_ROOT/tests/fixtures"
+    INSTALL_SCRIPT="$PROJECT_ROOT/.claude/scripts/constructs-install.sh"
+    LOADER_SCRIPT="$PROJECT_ROOT/.claude/scripts/constructs-loader.sh"
+
+    # Create temp directory for test artifacts
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    export TEST_TMPDIR="$BATS_TMPDIR/constructs-install-test-$$"
+    mkdir -p "$TEST_TMPDIR"
+
+    # Override directories for testing
+    export LOA_CONSTRUCTS_DIR="$TEST_TMPDIR/.claude/constructs"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/packs"
+    mkdir -p "$TEST_TMPDIR/.claude/commands"
+
+    # Override cache directory
+    export LOA_CACHE_DIR="$TEST_TMPDIR/.loa/cache"
+    mkdir -p "$LOA_CACHE_DIR/public-keys"
+
+    # Copy mock public key
+    if [[ -f "$FIXTURES_DIR/mock_public_key.pem" ]]; then
+        cp "$FIXTURES_DIR/mock_public_key.pem" "$LOA_CACHE_DIR/public-keys/test-key-01.pem"
+        cat > "$LOA_CACHE_DIR/public-keys/test-key-01.meta.json" << EOF
+{
+    "key_id": "test-key-01",
+    "algorithm": "RS256",
+    "fetched_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+    "expires_at": "2030-01-01T00:00:00Z"
+}
+EOF
+    fi
+
+    # Set offline mode to prevent actual API calls during tests
+    export LOA_OFFLINE=0
+
+    # Change to temp directory for tests
+    cd "$TEST_TMPDIR"
+
+    # Create .gitignore and .git directory to simulate git repo
+    mkdir -p .git
+    touch .gitignore
+
+    # Source the library for helper functions
+    if [[ -f "$PROJECT_ROOT/.claude/scripts/constructs-lib.sh" ]]; then
+        source "$PROJECT_ROOT/.claude/scripts/constructs-lib.sh"
+    fi
+}
+
+teardown() {
+    # Return to original directory
+    cd /
+
+    # Clean up temp directory
+    if [[ -d "$TEST_TMPDIR" ]]; then
+        rm -rf "$TEST_TMPDIR"
+    fi
+}
+
+# Helper to skip if script not implemented
+skip_if_not_implemented() {
+    if [[ ! -f "$INSTALL_SCRIPT" ]]; then
+        skip "constructs-install.sh not yet implemented"
+    fi
+    if [[ ! -x "$INSTALL_SCRIPT" ]]; then
+        skip "constructs-install.sh not executable"
+    fi
+}
+
+# Helper to create a mock installed pack
+create_mock_pack() {
+    local pack_slug="$1"
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/$pack_slug"
+
+    mkdir -p "$pack_dir/skills/test-skill"
+    mkdir -p "$pack_dir/commands"
+
+    # Create manifest
+    cat > "$pack_dir/manifest.json" << EOF
+{
+    "name": "$pack_slug",
+    "version": "1.0.0",
+    "description": "Test pack",
+    "skills": [
+        {"slug": "test-skill", "name": "Test Skill"}
+    ]
+}
+EOF
+
+    # Create license
+    cat > "$pack_dir/.license.json" << EOF
+{
+    "token": "test-jwt-token",
+    "expires_at": "2030-01-01T00:00:00Z",
+    "user_id": "test-user",
+    "plan": "pro"
+}
+EOF
+
+    # Create a test command
+    cat > "$pack_dir/commands/test-command.md" << EOF
+# Test Command
+This is a test command for the pack.
+EOF
+
+    # Create a test skill
+    cat > "$pack_dir/skills/test-skill/index.yaml" << EOF
+name: test-skill
+version: "1.0.0"
+description: Test skill
+EOF
+
+    cat > "$pack_dir/skills/test-skill/SKILL.md" << EOF
+# Test Skill
+This is a test skill.
+EOF
+
+    echo "$pack_dir"
+}
+
+# =============================================================================
+# Script Structure Tests
+# =============================================================================
+
+@test "constructs-install.sh exists and is executable" {
+    skip_if_not_implemented
+    [ -f "$INSTALL_SCRIPT" ]
+    [ -x "$INSTALL_SCRIPT" ]
+}
+
+@test "constructs-install.sh shows usage with --help" {
+    skip_if_not_implemented
+    run "$INSTALL_SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"pack"* ]]
+    [[ "$output" == *"skill"* ]]
+    [[ "$output" == *"uninstall"* ]]
+}
+
+@test "constructs-install.sh shows error without arguments" {
+    skip_if_not_implemented
+    run "$INSTALL_SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "constructs-install.sh pack requires slug argument" {
+    skip_if_not_implemented
+    run "$INSTALL_SCRIPT" pack
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing pack slug"* ]] || [[ "$output" == *"ERROR"* ]]
+}
+
+@test "constructs-install.sh skill requires slug argument" {
+    skip_if_not_implemented
+    run "$INSTALL_SCRIPT" skill
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing skill slug"* ]] || [[ "$output" == *"ERROR"* ]]
+}
+
+# =============================================================================
+# Authentication Tests
+# =============================================================================
+
+@test "pack install fails without API key" {
+    skip_if_not_implemented
+    # Ensure no API key is set
+    unset LOA_CONSTRUCTS_API_KEY
+
+    run "$INSTALL_SCRIPT" pack test-pack
+    [ "$status" -eq 1 ]  # AUTH_ERROR
+    [[ "$output" == *"No API key"* ]] || [[ "$output" == *"authenticate"* ]]
+}
+
+@test "skill install fails without API key" {
+    skip_if_not_implemented
+    unset LOA_CONSTRUCTS_API_KEY
+
+    run "$INSTALL_SCRIPT" skill test/skill
+    [ "$status" -eq 1 ]  # AUTH_ERROR
+    [[ "$output" == *"No API key"* ]] || [[ "$output" == *"authenticate"* ]]
+}
+
+# =============================================================================
+# Command Symlinking Tests (Issue #21)
+# =============================================================================
+
+@test "symlink_pack_commands creates symlinks in .claude/commands/" {
+    skip_if_not_implemented
+
+    # Create a mock pack with commands
+    local pack_dir
+    pack_dir=$(create_mock_pack "test-pack")
+
+    # Source the script to get access to functions
+    source "$INSTALL_SCRIPT"
+
+    # Run symlink function
+    cd "$TEST_TMPDIR"
+    local linked
+    linked=$(symlink_pack_commands "test-pack")
+
+    # Check symlink was created
+    [ -L "$TEST_TMPDIR/.claude/commands/test-command.md" ]
+
+    # Check it points to the right place
+    local target
+    target=$(readlink "$TEST_TMPDIR/.claude/commands/test-command.md")
+    [[ "$target" == *"constructs/packs/test-pack/commands/test-command.md"* ]]
+}
+
+@test "symlink_pack_commands returns count of linked commands" {
+    skip_if_not_implemented
+
+    # Create mock pack with multiple commands
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/multi-cmd-pack"
+    mkdir -p "$pack_dir/commands"
+    echo "# Cmd 1" > "$pack_dir/commands/cmd1.md"
+    echo "# Cmd 2" > "$pack_dir/commands/cmd2.md"
+    echo "# Cmd 3" > "$pack_dir/commands/cmd3.md"
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    local linked
+    linked=$(symlink_pack_commands "multi-cmd-pack")
+
+    [ "$linked" -eq 3 ]
+}
+
+@test "symlink_pack_commands skips existing user files" {
+    skip_if_not_implemented
+
+    # Create a user file that shouldn't be overwritten
+    echo "# User's custom command" > "$TEST_TMPDIR/.claude/commands/user-cmd.md"
+
+    # Create mock pack with same command name
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/conflict-pack"
+    mkdir -p "$pack_dir/commands"
+    echo "# Pack command" > "$pack_dir/commands/user-cmd.md"
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    run symlink_pack_commands "conflict-pack"
+
+    # Should NOT be a symlink (user file preserved)
+    [ ! -L "$TEST_TMPDIR/.claude/commands/user-cmd.md" ]
+
+    # Content should still be user's
+    run cat "$TEST_TMPDIR/.claude/commands/user-cmd.md"
+    [[ "$output" == *"User's custom command"* ]]
+}
+
+@test "unlink_pack_commands removes symlinks" {
+    skip_if_not_implemented
+
+    # Create and link a pack
+    create_mock_pack "unlink-test-pack"
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    # Ensure commands directory exists
+    mkdir -p "$TEST_TMPDIR/.claude/commands"
+
+    # Create symlinks manually for this test
+    ln -sf "../constructs/packs/unlink-test-pack/commands/test-command.md" "$TEST_TMPDIR/.claude/commands/test-command.md"
+    [ -L "$TEST_TMPDIR/.claude/commands/test-command.md" ]
+
+    # Remove symlinks
+    local unlinked
+    unlinked=$(unlink_pack_commands "unlink-test-pack")
+
+    [ ! -L "$TEST_TMPDIR/.claude/commands/test-command.md" ]
+    [ "$unlinked" -eq 1 ]
+}
+
+# =============================================================================
+# Skill Symlinking Tests
+# =============================================================================
+
+@test "symlink_pack_skills creates symlinks in constructs/skills/" {
+    skip_if_not_implemented
+
+    create_mock_pack "skill-link-pack"
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    local linked
+    linked=$(symlink_pack_skills "skill-link-pack")
+
+    # Check symlink was created
+    [ -L "$LOA_CONSTRUCTS_DIR/skills/skill-link-pack/test-skill" ]
+    [ "$linked" -eq 1 ]
+}
+
+@test "unlink_pack_skills removes skill symlinks" {
+    skip_if_not_implemented
+
+    create_mock_pack "skill-unlink-pack"
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    # Create skill symlinks directory manually for this test
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills/skill-unlink-pack"
+    ln -sf "../../packs/skill-unlink-pack/skills/test-skill" "$LOA_CONSTRUCTS_DIR/skills/skill-unlink-pack/test-skill"
+    [ -d "$LOA_CONSTRUCTS_DIR/skills/skill-unlink-pack" ]
+
+    # Remove symlinks
+    unlink_pack_skills "skill-unlink-pack"
+    [ ! -d "$LOA_CONSTRUCTS_DIR/skills/skill-unlink-pack" ]
+}
+
+# =============================================================================
+# Uninstall Tests
+# =============================================================================
+
+@test "uninstall pack removes pack directory" {
+    skip_if_not_implemented
+
+    # Create a mock pack
+    create_mock_pack "remove-pack"
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    # Create symlinks manually
+    mkdir -p "$TEST_TMPDIR/.claude/commands"
+    ln -sf "../constructs/packs/remove-pack/commands/test-command.md" "$TEST_TMPDIR/.claude/commands/test-command.md"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills/remove-pack"
+    ln -sf "../../packs/remove-pack/skills/test-skill" "$LOA_CONSTRUCTS_DIR/skills/remove-pack/test-skill"
+
+    # Verify pack exists
+    [ -d "$LOA_CONSTRUCTS_DIR/packs/remove-pack" ]
+    [ -L "$TEST_TMPDIR/.claude/commands/test-command.md" ]
+
+    # Uninstall
+    run do_uninstall_pack "remove-pack"
+    [ "$status" -eq 0 ]
+
+    # Verify removal
+    [ ! -d "$LOA_CONSTRUCTS_DIR/packs/remove-pack" ]
+    [ ! -L "$TEST_TMPDIR/.claude/commands/test-command.md" ]
+}
+
+@test "uninstall pack fails for non-existent pack" {
+    skip_if_not_implemented
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    run do_uninstall_pack "nonexistent-pack"
+    [ "$status" -eq 3 ]  # NOT_FOUND
+}
+
+# =============================================================================
+# link-commands Tests
+# =============================================================================
+
+@test "link-commands all links commands for all packs" {
+    skip_if_not_implemented
+
+    # Create multiple packs
+    local pack1_dir="$LOA_CONSTRUCTS_DIR/packs/pack1"
+    local pack2_dir="$LOA_CONSTRUCTS_DIR/packs/pack2"
+    mkdir -p "$pack1_dir/commands" "$pack2_dir/commands"
+    echo "# Pack1 Cmd" > "$pack1_dir/commands/pack1-cmd.md"
+    echo "# Pack2 Cmd" > "$pack2_dir/commands/pack2-cmd.md"
+
+    cd "$TEST_TMPDIR"
+    run "$INSTALL_SCRIPT" link-commands all
+
+    [ "$status" -eq 0 ]
+    [ -L "$TEST_TMPDIR/.claude/commands/pack1-cmd.md" ]
+    [ -L "$TEST_TMPDIR/.claude/commands/pack2-cmd.md" ]
+}
+
+@test "link-commands specific pack only links that pack" {
+    skip_if_not_implemented
+
+    # Create multiple packs
+    local pack1_dir="$LOA_CONSTRUCTS_DIR/packs/specific-pack"
+    local pack2_dir="$LOA_CONSTRUCTS_DIR/packs/other-pack"
+    mkdir -p "$pack1_dir/commands" "$pack2_dir/commands"
+    echo "# Specific Cmd" > "$pack1_dir/commands/specific-cmd.md"
+    echo "# Other Cmd" > "$pack2_dir/commands/other-cmd.md"
+
+    cd "$TEST_TMPDIR"
+    run "$INSTALL_SCRIPT" link-commands specific-pack
+
+    [ "$status" -eq 0 ]
+    [ -L "$TEST_TMPDIR/.claude/commands/specific-cmd.md" ]
+    [ ! -L "$TEST_TMPDIR/.claude/commands/other-cmd.md" ]
+}
+
+# =============================================================================
+# Registry Meta Tests
+# =============================================================================
+
+@test "pack installation updates .constructs-meta.json" {
+    skip_if_not_implemented
+
+    # Create mock pack
+    create_mock_pack "meta-test-pack"
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    # Initialize meta file
+    init_registry_meta
+
+    # Update meta as if pack was installed
+    update_pack_meta "meta-test-pack" "$LOA_CONSTRUCTS_DIR/packs/meta-test-pack"
+
+    # Check meta was updated
+    local meta_path="$LOA_CONSTRUCTS_DIR/.constructs-meta.json"
+    [ -f "$meta_path" ]
+
+    # Check pack is in meta
+    run jq -r '.installed_packs["meta-test-pack"].version' "$meta_path"
+    [ "$output" == "1.0.0" ]
+}
+
+# =============================================================================
+# Offline Mode Tests
+# =============================================================================
+
+@test "pack install fails in offline mode" {
+    skip_if_not_implemented
+
+    export LOA_OFFLINE=1
+    export LOA_CONSTRUCTS_API_KEY="test-key"
+
+    cd "$TEST_TMPDIR"
+    run "$INSTALL_SCRIPT" pack some-pack
+
+    [ "$status" -eq 2 ]  # NETWORK_ERROR
+    [[ "$output" == *"offline"* ]]
+}
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+@test "handles pack without commands directory" {
+    skip_if_not_implemented
+
+    # Create pack without commands
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/no-commands-pack"
+    mkdir -p "$pack_dir"
+    echo '{"name": "no-commands-pack", "version": "1.0.0"}' > "$pack_dir/manifest.json"
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    # Should not error
+    local linked
+    linked=$(symlink_pack_commands "no-commands-pack")
+    [ "$linked" -eq 0 ]
+}
+
+@test "handles pack without skills directory" {
+    skip_if_not_implemented
+
+    # Create pack without skills
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/no-skills-pack"
+    mkdir -p "$pack_dir"
+    echo '{"name": "no-skills-pack", "version": "1.0.0"}' > "$pack_dir/manifest.json"
+
+    source "$INSTALL_SCRIPT"
+    cd "$TEST_TMPDIR"
+
+    # Should not error
+    local linked
+    linked=$(symlink_pack_skills "no-skills-pack")
+    [ "$linked" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Add `constructs-install.sh` script for installing packs and skills from the Loa Constructs Registry
- Auto-symlink pack commands to `.claude/commands/` on install (fixes #21)
- Add uninstall and link-commands maintenance utilities
- 21 unit tests covering installation, symlinking, and uninstall flows

## GitHub Issues Fixed

- Fixes #20 - Add CLI install command for Loa Constructs packs
- Fixes #21 - Pack commands not automatically available after installation

## New Commands

```bash
# Installation
constructs-install.sh pack <slug>              # Install pack from registry
constructs-install.sh skill <vendor/slug>      # Install individual skill

# Uninstallation  
constructs-install.sh uninstall pack <slug>    # Remove a pack
constructs-install.sh uninstall skill <slug>   # Remove a skill

# Maintenance
constructs-install.sh link-commands <slug|all> # Re-link pack commands
```

## Key Features

- **Authentication**: Uses `LOA_CONSTRUCTS_API_KEY` environment variable or `~/.loa/credentials.json`
- **Auto-symlinking**: Pack commands are automatically symlinked to `.claude/commands/` so they're immediately available as slash commands
- **Skill discovery**: Pack skills are symlinked to `.claude/constructs/skills/` for loader compatibility
- **Safety**: Won't overwrite existing user files (non-symlinks)
- **Validation**: Runs license validation after installation
- **Meta tracking**: Updates `.constructs-meta.json` with installation state

## Test Results

```
21 tests, 21 passed
```

## Files Changed

| File | Purpose |
|------|---------|
| `.claude/scripts/constructs-install.sh` | New installation script |
| `tests/unit/test_constructs_install.bats` | Unit tests |
| `CLAUDE.md` | Documentation updates |

## Test Plan

- [x] All 21 unit tests pass
- [x] Verified `link-commands all` successfully symlinks GTM Collective commands
- [x] Verified symlinks point to correct relative paths
- [x] Verified unlink removes symlinks correctly
- [ ] Test actual pack download from production API (requires API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)