### PR TITLE
fix: Update SessionStart hook to new Claude Code format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,15 @@
 {
   "hooks": {
     "SessionStart": [
-      ".claude/scripts/check-updates.sh --notify"
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/scripts/check-updates.sh --notify"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Updates `.claude/settings.json` to use the new hooks format required by Claude Code v2.1.12+
- The new format requires both `matcher` (string) and `hooks` (array) fields for all hook types including SessionStart

## Test plan
- [x] Verified Claude Code starts without settings errors
- [x] Verified `/doctor` shows no invalid settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)