### PR TITLE
fix: correct invalid permission patterns in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -404,7 +404,6 @@
       "Bash(rm -rf /bin:*)",
       "Bash(rm -rf /sbin:*)",
       "Bash(rm -rf /boot:*)",
-      "Bash(:(){ :|:& };::*)",
       "Bash(fork bomb:*)",
       "Bash(curl*|*bash:*)",
       "Bash(curl*|*sh:*)",
@@ -421,8 +420,8 @@
       "Bash(parted:*)",
       "Bash(chmod -R 777 /:*)",
       "Bash(chmod -R 777 /*:*)",
-      "Bash(chown -R:*:/)",
-      "Bash(chown -R:*:/*)",
+      "Bash(chown -R * /)",
+      "Bash(chown -R * /*)",
       "Bash(passwd:*)",
       "Bash(useradd:*)",
       "Bash(userdel:*)",
@@ -441,10 +440,8 @@
       "Bash(iptables -F:*)",
       "Bash(iptables -X:*)",
       "Bash(ufw disable:*)",
-      "Bash(eval \"$(curl:*)",
-      "Bash(eval \"$(wget:*)",
-      "Bash(eval $(curl:*)",
-      "Bash(eval $(wget:*)"
+      "Bash(eval *curl*)",
+      "Bash(eval *wget*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- Remove fork bomb pattern `:(){ :|:& };:` that caused "empty parentheses" validation error
- Fix `chown -R` patterns where `:*` was in the middle instead of at the end
- Fix `eval` patterns that had mismatched parentheses due to `$(` syntax

## Test plan
- [x] Verify JSON is valid with `jq`
- [x] Restart Claude Code session to confirm no validation warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)