### PR TITLE
docs: add /constructs command documentation

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -422,6 +422,18 @@ git checkout --ours grimoires/loa/
 
 Loa Constructs is a registry for commercial skill packs that extend Loa with specialized capabilities (GTM strategy, security auditing, etc.).
 
+### Browse and Install with `/constructs` Command
+
+The easiest way to discover and install packs:
+
+```bash
+/constructs              # Browse available packs with multi-select UI
+/constructs install observer   # Install a specific pack
+/constructs list         # Show installed packs
+/constructs update       # Check for updates
+/constructs uninstall observer # Remove a pack
+```
+
 ### Authentication
 
 ```bash
@@ -431,11 +443,16 @@ export LOA_CONSTRUCTS_API_KEY="sk_your_api_key_here"
 # Option 2: Credentials file
 mkdir -p ~/.loa
 echo '{"api_key": "sk_your_api_key_here"}' > ~/.loa/credentials.json
+
+# Option 3: Interactive setup
+/constructs auth setup
 ```
 
 Contact the THJ team for API key access.
 
-### Installing Packs
+### Installing via Script (Alternative)
+
+For scripting or CI/CD, use the bash script directly:
 
 ```bash
 # Install a pack (downloads and symlinks commands)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ See **[INSTALLATION.md](INSTALLATION.md)** for detailed setup options and prereq
 
 **Ad-hoc**: `/audit`, `/translate`, `/validate`, `/compound`, `/feedback`, `/update-loa`, `/loa` (guided workflow)
 
+**Extensions**: `/constructs` (browse and install skill packs from registry)
+
 See **[PROCESS.md](PROCESS.md)** for complete workflow documentation.
 
 ## The Agents


### PR DESCRIPTION
## Summary

Documents the `/constructs` command in README and INSTALLATION.md.

**Changes:**
- Add `/constructs` to README quick commands section
- Document `/constructs` command workflow in INSTALLATION.md
- Add `/constructs auth setup` option
- Reorganize to prioritize `/constructs` command over bash script

Closes #102

🤖 Generated with [Claude Code](https://claude.ai/code)