### PR TITLE
feat(install): release-based installation & spinner verbs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+  "spinnerVerbs": {
+    "mode": "append",
+    "verbs": [
+      "Channeling",
+      "Invoking",
+      "Conjuring",
+      "Manifesting",
+      "Summoning",
+      "Weaving",
+      "Binding"
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(npm:*)",


### PR DESCRIPTION
## Summary
- **Release-based installation**: Install script now fetches latest release tag instead of main branch
- **Spinner verbs**: Added Loa-themed spinner verbs (Channeling, Invoking, Conjuring, etc.)
- **Post-install guidance**: Updated success message with clear next steps

## Changes

### Release-Based Installation (FR-1)
The mount script now:
1. Fetches tags from upstream with `git fetch --tags`
2. Detects latest semver tag (v*.*.*) using `git tag -l --sort=-v:refname`
3. Sets `LOA_CHECKOUT_REF` to the latest tag (or falls back to main)
4. Uses `LOA_CHECKOUT_REF` for all checkout operations

**Root cause addressed**: Lines 166 and 175 previously used `$LOA_REMOTE_NAME/$LOA_BRANCH` (main), now use `$LOA_CHECKOUT_REF` (latest tag).

### Spinner Verbs (FR-2)
Added to `.claude/settings.json`:
```json
"spinnerVerbs": {
  "mode": "append",
  "verbs": ["Channeling", "Invoking", "Conjuring", "Manifesting", "Summoning", "Weaving", "Binding"]
}
```

### Post-Install Guidance (FR-3)
Updated completion banner:
```
╭───────────────────────────────────────────────────────────────╮
│  ✓ Loa 1.10.0 installed successfully!                        │
╰───────────────────────────────────────────────────────────────╯

Next steps:
  1. Run /loa to see guided workflow
  2. Run /plan-and-analyze to start a new project
  3. See PROCESS.md for detailed documentation
```

## Test plan
- [ ] Fresh install using `curl -fsSL .../mount-loa.sh | bash` gets latest release tag
- [ ] Install shows version number in success message
- [ ] Falls back to main branch when no tags exist
- [ ] Spinner verbs appear during Claude Code operations

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)