### PR TITLE
fix: sync README version badge to 1.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Loa
 
-[![Version](https://img.shields.io/badge/version-1.14.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.14.1-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE.md)
 [![Release](https://img.shields.io/badge/release-Oracle%20Compound%20Learnings-purple.svg)](CHANGELOG.md#1120---2026-02-01--oracle-compound-learnings)
 


### PR DESCRIPTION
## Summary

Syncs README version badge with CHANGELOG (1.14.0 → 1.14.1).

## Problem

The 'Validate Framework Files' CI check was failing on all PRs due to version mismatch:
- CHANGELOG: 1.14.1
- README badge: 1.14.0

## Fix

Updated README.md badge to 1.14.1.

## Affected PRs

This should unblock:
- #120 (Intelligent Prompt Enhancement)
- #111 (Installation UX Improvements)

---
🤖 Generated by Legba during heartbeat maintenance