### PR TITLE
fix(run-mode): Preserve autonomous state after context compaction

### DIFF
--- a/.claude/protocols/context-compaction.md
+++ b/.claude/protocols/context-compaction.md
@@ -20,6 +20,24 @@ These items must survive any compaction event:
 | Trajectory entries | External files, already lossless |
 | Active bead references | Task continuity |
 | Sprint context | Current work state |
+| **Run mode state** (v1.27.0) | `.run/sprint-plan-state.json` - autonomous execution continuity |
+
+### Run Mode State Recovery (v1.27.0)
+
+**CRITICAL**: After compaction, ALWAYS check for active run mode:
+
+```bash
+if [[ -f .run/sprint-plan-state.json ]]; then
+  state=$(jq -r '.state' .run/sprint-plan-state.json)
+  if [[ "$state" == "RUNNING" ]]; then
+    # Resume autonomous execution - DO NOT prompt for confirmation
+    current=$(jq -r '.sprints.current' .run/sprint-plan-state.json)
+    # Continue sprint loop from $current
+  fi
+fi
+```
+
+If `state=RUNNING`, the agent MUST resume autonomous sprint execution without user confirmation. This enables overnight/unattended runs to survive context compaction.
 
 ### COMPACTABLE
 


### PR DESCRIPTION
## Summary

Fixes #164 - `/run sprint-plan` loses autonomous state after context compaction

### Problem

When running `/run sprint-plan` for overnight execution with multiple sprints, context compaction would cause the agent to:
- Lose awareness that it's in autonomous `/run` mode
- Revert to interactive behavior (asking for confirmation before next sprint)
- Require re-invoking the command multiple times instead of once

### Root Cause

After context compaction, the agent had no instructions to:
1. Check for active run mode state (`.run/sprint-plan-state.json`)
2. Resume autonomous execution without user confirmation

### Solution

Add **Run Mode State Recovery** to the session/compaction recovery sequence:

1. **CLAUDE.loa.md** (v1.27.0): New section documenting run mode state recovery
2. **context-compaction.md**: Add `.run/sprint-plan-state.json` to preservation list
3. **session-continuity.md**: Add Step 0 to check run mode state FIRST before any interactive recovery

### Recovery Sequence

```
0. Check .run/sprint-plan-state.json  ← NEW (takes precedence)
   - If state=RUNNING → Resume autonomous execution
   - DO NOT prompt for confirmation
1. br ready
2. br show <active_id>
3. Tiered Ledger Recovery
...
```

## Test plan

- [ ] Start `/run sprint-plan` with 4 sprints
- [ ] Enable GPT review (increases context usage)
- [ ] Let execution run until context compaction triggers
- [ ] Verify agent continues to next sprint without prompting
- [ ] Verify `.run/sprint-plan-state.json` is checked on recovery

## Files changed

| File | Change |
|------|--------|
| `.claude/loa/CLAUDE.loa.md` | +48 lines (Run Mode State Recovery section) |
| `.claude/protocols/context-compaction.md` | +18 lines (preservation list + recovery) |
| `.claude/protocols/session-continuity.md` | +24 lines (Step 0 run mode check) |

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>