### PR TITLE
fix(flatline): Apply macOS case-sensitivity fix to orchestrator

### DIFF
--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -45,7 +45,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Use realpath for macOS case-sensitivity (fixes #166, regression from #150)
+PROJECT_ROOT="$(realpath "$(cd "$SCRIPT_DIR/../.." && pwd)" 2>/dev/null || (cd "$SCRIPT_DIR/../.." && pwd))"
 CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
 TRAJECTORY_DIR="$PROJECT_ROOT/grimoires/loa/a2a/trajectory"
 


### PR DESCRIPTION
## Summary

Fixes #166 - Regression from #150

The `realpath` fix for macOS case-insensitive filesystem was applied to other scripts in PR #151 but missed `flatline-orchestrator.sh`.

### Error

```
ERROR: Document must be within project directory: grimoires/loa/prd-local-dev-dx.md
ERROR: Resolved to: /Users/zksoju/Documents/GitHub/loa-constructs/grimoires/loa/prd-local-dev-dx.md (outside /users/zksoju/documents/github/loa-constructs)
```

### Root Cause

Path comparison failed because macOS returns `/Users` but the comparison used lowercase `/users`.

### Fix

```bash
# Before
PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"

# After  
PROJECT_ROOT="$(realpath "$(cd "$SCRIPT_DIR/../.." && pwd)" 2>/dev/null || (cd "$SCRIPT_DIR/../.." && pwd))"
```

## Test plan

- [x] Syntax check passes
- [ ] Test on macOS with loa-constructs repo

## Files changed

| File | Change |
|------|--------|
| `.claude/scripts/flatline-orchestrator.sh` | +2/-1 (realpath fix) |

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>