### PR TITLE
fix(constructs): use manifest.skills for skill count fallback

### DIFF
--- a/.claude/scripts/constructs-browse.sh
+++ b/.claude/scripts/constructs-browse.sh
@@ -211,7 +211,8 @@ format_packs_human() {
     
     # Parse and display each pack
     # API returns { data: [...], pagination: {...} } envelope
-    echo "$packs_json" | jq -r '.data[]? | "\(.icon // "📦") \(.name) (\(.skills_count // .skills | length // 0) skills) - \(.tier_required // .tier // "free")\n   \(.description)\n"' 2>/dev/null || {
+    # skills_count field added in API, with fallback to manifest.skills array length
+    echo "$packs_json" | jq -r '.data[]? | "\(.icon // "📦") \(.name) (\(.skills_count // (.manifest.skills | length?) // 0) skills) - \(.tier_required // .tier // "free")\n   \(.description)\n"' 2>/dev/null || {
         echo "No packs available or error parsing response"
         return 1
     }
@@ -223,12 +224,13 @@ format_packs_json() {
     
     # Normalize to array format expected by UI
     # API returns { data: [...], pagination: {...} } envelope
+    # skills_count field added in API, with fallback to manifest.skills array length
     echo "$packs_json" | jq '[
         .data[]? | {
             slug: .slug,
             name: .name,
             description: .description,
-            skills_count: (.skills_count // (.skills | length?) // 0),
+            skills_count: (.skills_count // (.manifest.skills | length?) // 0),
             tier: (.tier_required // .tier // "free"),
             icon: (.icon // "📦"),
             version: (.latest_version.version // .version // "1.0.0")


### PR DESCRIPTION
## Summary

- Update jq queries in `constructs-browse.sh` to read skill count from `manifest.skills` array
- The API now returns `skills_count` field (added in loa-constructs), with fallback to `manifest.skills | length`

## Context

The browse script was looking for `.skills` at the top level, but the API returns skills inside `.manifest.skills`. This caused all packs to show "0 skills".

Related fixes in loa-constructs:
- `ff9dacb` - API fix: skills_count field, manifest skill names, deduplication  
- `a9a78f3` - API fix: use semver comparison to determine latest version

## Test plan

- [x] Verified `constructs-browse.sh list` shows correct skill counts
- [x] API tests pass (350 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)