### PR TITLE
fix(scripts): macOS date %N incompatibility breaks Flatline Protocol

### DIFF
--- a/.claude/scripts/flatline-manifest.sh
+++ b/.claude/scripts/flatline-manifest.sh
@@ -29,6 +29,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
 RUNS_DIR="$PROJECT_ROOT/.flatline/runs"
+
+# Source cross-platform time utilities
+# shellcheck source=time-lib.sh
+source "$SCRIPT_DIR/time-lib.sh"
 INDEX_FILE="$RUNS_DIR/index.json"
 TRAJECTORY_DIR="$PROJECT_ROOT/grimoires/loa/a2a/trajectory"
 
@@ -109,8 +113,8 @@ generate_run_id() {
     elif command -v python3 &> /dev/null; then
         uuid=$(python3 -c 'import uuid; print(uuid.uuid4())')
     else
-        # Last resort: use timestamp + random
-        uuid=$(date +%s%N)$(( RANDOM * RANDOM ))
+        # Last resort: use timestamp + random (cross-platform via time-lib.sh)
+        uuid=$(get_timestamp_ns)$(( RANDOM * RANDOM ))
     fi
 
     echo "flatline-run-${uuid}"

--- a/.claude/scripts/guardrails-orchestrator.sh
+++ b/.claude/scripts/guardrails-orchestrator.sh
@@ -24,6 +24,10 @@ readonly SCRIPT_NAME="$(basename "$0")"
 readonly PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 readonly CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
 
+# Source cross-platform time utilities
+# shellcheck source=time-lib.sh
+source "$SCRIPT_DIR/time-lib.sh"
+
 # Scripts
 readonly PII_FILTER="$SCRIPT_DIR/pii-filter.sh"
 readonly INJECTION_DETECT="$SCRIPT_DIR/injection-detect.sh"
@@ -303,7 +307,7 @@ main() {
     local do_log="true"
     local start_time
 
-    start_time=$(date +%s%3N 2>/dev/null || echo "0")
+    start_time=$(get_timestamp_ms)
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -399,7 +403,7 @@ EOF
         reason=$(echo "$danger_result" | jq -r '.reason')
 
         local end_time
-        end_time=$(date +%s%3N 2>/dev/null || echo "0")
+        end_time=$(get_timestamp_ms)
         local latency_ms=$((end_time - start_time))
         [[ $latency_ms -lt 0 ]] && latency_ms=0
 
@@ -463,7 +467,7 @@ EOF
     fi
 
     local end_time
-    end_time=$(date +%s%3N 2>/dev/null || echo "0")
+    end_time=$(get_timestamp_ms)
     local latency_ms=$((end_time - start_time))
     [[ $latency_ms -lt 0 ]] && latency_ms=0
 

--- a/.claude/scripts/injection-detect.sh
+++ b/.claude/scripts/injection-detect.sh
@@ -27,6 +27,10 @@ set -euo pipefail
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"
 
+# Source cross-platform time utilities
+# shellcheck source=time-lib.sh
+source "$SCRIPT_DIR/time-lib.sh"
+
 # Default threshold
 DEFAULT_THRESHOLD="0.7"
 
@@ -266,7 +270,7 @@ process_input() {
     local end_time
     local latency_ms
 
-    start_time=$(date +%s%3N 2>/dev/null || echo "0")
+    start_time=$(get_timestamp_ms)
 
     # Apply Unicode normalization (H-1 fix)
     # This handles homoglyphs, zero-width chars, and whitespace normalization
@@ -344,7 +348,7 @@ process_input() {
         status="DETECTED"
     fi
 
-    end_time=$(date +%s%3N 2>/dev/null || echo "0")
+    end_time=$(get_timestamp_ms)
     latency_ms=$((end_time - start_time))
     [[ $latency_ms -lt 0 ]] && latency_ms=0
 

--- a/.claude/scripts/pii-filter.sh
+++ b/.claude/scripts/pii-filter.sh
@@ -23,6 +23,10 @@ set -euo pipefail
 # =============================================================================
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source cross-platform time utilities
+# shellcheck source=time-lib.sh
+source "$SCRIPT_DIR/time-lib.sh"
 readonly SCRIPT_NAME="$(basename "$0")"
 
 # Default settings
@@ -136,7 +140,7 @@ process_input() {
     local end_time
     local latency_ms
 
-    start_time=$(date +%s%3N 2>/dev/null || echo "0")
+    start_time=$(get_timestamp_ms)
 
     local redacted="$input"
     local total_redactions=0
@@ -254,7 +258,7 @@ process_input() {
         fi
     fi
 
-    end_time=$(date +%s%3N 2>/dev/null || echo "0")
+    end_time=$(get_timestamp_ms)
     latency_ms=$((end_time - start_time))
     [[ $latency_ms -lt 0 ]] && latency_ms=0
 

--- a/.claude/scripts/rlm-benchmark.sh
+++ b/.claude/scripts/rlm-benchmark.sh
@@ -7,6 +7,10 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Source cross-platform time utilities
+# shellcheck source=time-lib.sh
+source "$SCRIPT_DIR/time-lib.sh"
+
 # Allow environment variable overrides for testing
 CONFIG_FILE="${CONFIG_FILE:-${SCRIPT_DIR}/../../.loa.config.yaml}"
 GRIMOIRE_DIR="${GRIMOIRE_DIR:-${SCRIPT_DIR}/../../grimoires/loa}"
@@ -168,13 +172,10 @@ estimate_tokens() {
 
 #######################################
 # Get current time in milliseconds
+# Uses cross-platform time-lib.sh
 #######################################
 get_time_ms() {
-    if date +%s%3N &>/dev/null 2>&1; then
-        date +%s%3N
-    else
-        echo "$(($(date +%s) * 1000))"
-    fi
+    get_timestamp_ms
 }
 
 #######################################

--- a/.claude/scripts/tests/test-memory-e2e.bats
+++ b/.claude/scripts/tests/test-memory-e2e.bats
@@ -14,6 +14,10 @@ setup() {
     export DB_FILE="$TEST_LOA_DIR/memory.db"
     mkdir -p "$TEST_LOA_DIR"
 
+    # Source cross-platform time utilities
+    # shellcheck source=../time-lib.sh
+    source "$PROJECT_ROOT/.claude/scripts/time-lib.sh"
+
     # Path to scripts
     export MEMORY_ADMIN="$PROJECT_ROOT/.claude/scripts/memory-admin.sh"
     export MEMORY_INJECT="$PROJECT_ROOT/.claude/hooks/memory-inject.sh"
@@ -102,10 +106,10 @@ skip_if_no_sentence_transformers() {
 
 measure_latency() {
     local start end
-    start=$(date +%s%N)
+    start=$(get_timestamp_ms)
     "$@" >/dev/null 2>&1
-    end=$(date +%s%N)
-    echo $(( (end - start) / 1000000 ))  # milliseconds
+    end=$(get_timestamp_ms)
+    echo $(( end - start ))  # milliseconds
 }
 
 # =============================================================================

--- a/.claude/scripts/time-lib.sh
+++ b/.claude/scripts/time-lib.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# =============================================================================
+# time-lib.sh - Cross-platform time utilities
+# =============================================================================
+# Version: 1.0.0
+# Part of: Loa Framework
+#
+# Provides cross-platform timestamp functions that work on both Linux and macOS.
+#
+# Problem:
+#   - Linux `date` supports %N for nanoseconds: date +%s%3N → 1738742714123
+#   - macOS `date` does NOT support %N: date +%s%3N → 1738742714N (literal N)
+#   - The fallback pattern `$(date +%s%3N 2>/dev/null || date +%s)000` fails
+#     because `date +%s%3N` doesn't error on macOS, it just outputs garbage
+#
+# Solution:
+#   Detect platform once, use appropriate method.
+#
+# Usage:
+#   source .claude/scripts/time-lib.sh
+#
+#   start=$(get_timestamp_ms)
+#   # ... do work ...
+#   end=$(get_timestamp_ms)
+#   duration=$((end - start))
+#   echo "Took ${duration}ms"
+#
+# Functions:
+#   get_timestamp_ms      Returns current time in milliseconds since epoch
+#   get_timestamp_ns      Returns current time in nanoseconds (Linux only, ms*1000000 on macOS)
+#   get_elapsed_ms        Returns elapsed time since a start timestamp
+#   format_duration_ms    Formats milliseconds as human-readable string
+#
+# Environment:
+#   LOA_TIME_DEBUG=1      Enable debug output for timing operations
+# =============================================================================
+
+# Prevent double-sourcing
+if [[ "${_TIME_LIB_LOADED:-}" == "true" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+_TIME_LIB_LOADED=true
+
+_TIME_LIB_VERSION="1.0.0"
+
+# =============================================================================
+# Platform Detection (run once at source time)
+# =============================================================================
+
+_TIME_HAS_NANOSECONDS=false
+
+# Test if date supports %N by checking output format
+# On Linux: date +%s%3N → 1738742714123 (all digits)
+# On macOS: date +%s%3N → 1738742714N (contains literal N)
+_test_output=$(date +%s%3N 2>/dev/null)
+if [[ "$_test_output" =~ ^[0-9]+$ ]]; then
+  _TIME_HAS_NANOSECONDS=true
+fi
+unset _test_output
+
+# Debug output
+if [[ "${LOA_TIME_DEBUG:-}" == "1" ]]; then
+  if [[ "$_TIME_HAS_NANOSECONDS" == "true" ]]; then
+    echo "[time-lib] Platform supports nanoseconds (date +%N)" >&2
+  else
+    echo "[time-lib] Platform does NOT support nanoseconds (using second precision)" >&2
+  fi
+fi
+
+# =============================================================================
+# Core Functions
+# =============================================================================
+
+# Get current timestamp in milliseconds since Unix epoch
+# Returns: integer milliseconds
+get_timestamp_ms() {
+  if [[ "$_TIME_HAS_NANOSECONDS" == "true" ]]; then
+    # Linux: native millisecond support
+    date +%s%3N
+  else
+    # macOS: multiply seconds by 1000
+    # Note: This loses sub-second precision, but is safe for timing operations
+    echo "$(($(date +%s) * 1000))"
+  fi
+}
+
+# Get current timestamp in nanoseconds since Unix epoch
+# Returns: integer nanoseconds
+# Note: On macOS, this returns milliseconds * 1000000 (microsecond precision lost)
+get_timestamp_ns() {
+  if [[ "$_TIME_HAS_NANOSECONDS" == "true" ]]; then
+    # Linux: native nanosecond support
+    date +%s%N
+  else
+    # macOS: convert seconds to nanoseconds
+    echo "$(($(date +%s) * 1000000000))"
+  fi
+}
+
+# Get elapsed time in milliseconds since a start timestamp
+# Arguments:
+#   $1 - Start timestamp in milliseconds (from get_timestamp_ms)
+# Returns: integer milliseconds elapsed
+get_elapsed_ms() {
+  local start_ms="$1"
+  local end_ms
+  end_ms=$(get_timestamp_ms)
+  echo $((end_ms - start_ms))
+}
+
+# Format milliseconds as human-readable duration
+# Arguments:
+#   $1 - Duration in milliseconds
+# Returns: String like "1.234s" or "45ms" or "2m 30s"
+format_duration_ms() {
+  local ms="$1"
+
+  if [[ $ms -lt 1000 ]]; then
+    echo "${ms}ms"
+  elif [[ $ms -lt 60000 ]]; then
+    # Less than a minute: show as seconds with 3 decimal places
+    local seconds=$((ms / 1000))
+    local remainder=$((ms % 1000))
+    printf "%d.%03ds\n" "$seconds" "$remainder"
+  else
+    # More than a minute: show as Xm Ys
+    local total_seconds=$((ms / 1000))
+    local minutes=$((total_seconds / 60))
+    local seconds=$((total_seconds % 60))
+    echo "${minutes}m ${seconds}s"
+  fi
+}
+
+# =============================================================================
+# Convenience Functions
+# =============================================================================
+
+# Generate a unique ID using timestamp + random
+# Useful for run IDs, transaction IDs, etc.
+# Returns: String like "1738742714123-a1b2c3"
+generate_timestamp_id() {
+  local prefix="${1:-}"
+  local ts
+  ts=$(get_timestamp_ms)
+  local rand
+  rand=$(printf '%06x' $((RANDOM * RANDOM % 16777216)))
+
+  if [[ -n "$prefix" ]]; then
+    echo "${prefix}-${ts}-${rand}"
+  else
+    echo "${ts}-${rand}"
+  fi
+}
+
+# =============================================================================
+# Version
+# =============================================================================
+
+get_time_lib_version() {
+  echo "$_TIME_LIB_VERSION"
+}


### PR DESCRIPTION
## Summary

Closes #194

- Created `time-lib.sh` cross-platform time utility library
- Fixed 7 scripts that used `date +%s%3N` (fails on macOS)
- Also fixed `.env` loading in model-adapter.sh to search PROJECT_ROOT

## Problem

macOS `date` doesn't support `%N` nanoseconds format. The command `date +%s%3N` outputs `1738742714N` (literal N) instead of milliseconds, causing arithmetic errors that break:

- Flatline Protocol Phase 1 (all 4 model adapter calls fail)
- PII filter latency measurement
- Injection detection latency measurement  
- Guardrails orchestrator timing

## Solution

| Approach | Description |
|----------|-------------|
| Platform detection | Tests output format at source time, not per-call |
| Graceful fallback | Second-precision on macOS (`$(date +%s) * 1000`) |
| Single source of truth | All scripts use `time-lib.sh` |

## Files Changed

| File | Change |
|------|--------|
| `time-lib.sh` | **NEW** - Cross-platform time utilities |
| `model-adapter.sh` | Use time-lib, fix .env path resolution |
| `pii-filter.sh` | Use time-lib |
| `injection-detect.sh` | Use time-lib |
| `guardrails-orchestrator.sh` | Use time-lib |
| `flatline-manifest.sh` | Use time-lib |
| `rlm-benchmark.sh` | Use time-lib |
| `tests/test-memory-e2e.bats` | Use time-lib |

## Test plan

- [x] Verified `time-lib.sh` works on Linux
- [x] Verified `pii-filter.sh` returns valid latency_ms
- [x] Verified `model-adapter.sh --help` runs without error
- [ ] Test on macOS (requires macOS environment)

---

🤖 Generated with [Claude Code](https://claude.ai/code)