### PR TITLE
feat(models): add Opus 4.6 and GPT-5.3-Codex support

### DIFF
--- a/.claude/commands/gpt-review.md
+++ b/.claude/commands/gpt-review.md
@@ -324,7 +324,7 @@ gpt_review:
   max_iterations: 3          # Auto-approve after this many
   models:
     documents: "gpt-5.2"     # For PRD, SDD, Sprint
-    code: "gpt-5.2-codex"    # For code reviews
+    code: "gpt-5.2-codex"    # For code reviews (gpt-5.3-codex when API available)
   phases:
     prd: true                # Enable/disable per type
     sdd: true

--- a/.claude/protocols/gpt-review-integration.md
+++ b/.claude/protocols/gpt-review-integration.md
@@ -1,4 +1,4 @@
-# GPT 5.2 Cross-Model Review Integration Protocol
+# GPT Cross-Model Review Integration Protocol
 
 ## Overview
 
@@ -68,7 +68,7 @@ gpt_review:
   max_iterations: 3          # Auto-approve after this
   models:
     documents: "gpt-5.2"     # PRD, SDD, Sprint reviews
-    code: "gpt-5.2-codex"    # Code reviews
+    code: "gpt-5.2-codex"    # Code reviews (gpt-5.3-codex when API available)
   phases:
     prd: true
     sdd: true
@@ -211,9 +211,9 @@ The context file (created by toggle script when enabled) provides detailed instr
 - Model: `gpt-5.2`
 - Format: `messages` array with system + user roles
 
-### GPT 5.2 Codex (Code)
+### GPT Codex (Code)
 - Endpoint: `https://api.openai.com/v1/responses`
-- Model: `gpt-5.2-codex`
+- Model: `gpt-5.2-codex` (default; `gpt-5.3-codex` registered, awaiting API availability)
 - Format: `input` field (not messages)
 - Supports: `reasoning: {effort: "medium"}`
 

--- a/.claude/schemas/README.md
+++ b/.claude/schemas/README.md
@@ -78,7 +78,7 @@ For API integration, schemas can be passed directly to the Claude API:
 
 ```python
 response = client.messages.create(
-    model="claude-opus-4-6-20260201",
+    model="claude-opus-4-6",
     messages=[...],
     response_format={
         "type": "json_schema",

--- a/.claude/scripts/gpt-review-api.sh
+++ b/.claude/scripts/gpt-review-api.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# GPT 5.2 API interaction for cross-model review
+# GPT 5.2/5.3 API interaction for cross-model review
 #
 # Usage: gpt-review-api.sh <review_type> <content_file> [options]
 #

--- a/.claude/skills/autonomous-agent/resources/operator-detection.md
+++ b/.claude/skills/autonomous-agent/resources/operator-detection.md
@@ -90,7 +90,7 @@ Check for automated heartbeat patterns in `.claude/HEARTBEAT.md`:
 ```markdown
 <!-- HEARTBEAT.md -->
 Last activity: 2026-01-31T14:00:00Z
-Agent: claude-opus-4-6-20260201
+Agent: claude-opus-4-6
 Session: autonomous-run-abc123
 ```
 

--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -790,7 +790,7 @@ recursive_jit:
     update_bead: true
 
 # =============================================================================
-# GPT 5.2 Cross-Model Review (v0.20.0)
+# GPT Cross-Model Review (v0.20.0)
 # =============================================================================
 # GPT review for catching issues Claude might miss
 gpt_review:
@@ -806,6 +806,7 @@ gpt_review:
     # Model for document reviews (PRD, SDD, Sprint)
     documents: "gpt-5.2"
     # Model for code reviews (uses Responses API)
+    # gpt-5.3-codex registered in model-adapter but not yet available via API
     code: "gpt-5.2-codex"
   # Per-phase toggles (only used when enabled: true)
   phases:


### PR DESCRIPTION
## Summary

- Update Claude Opus 4.5 → 4.6 across all framework references (API ID: `claude-opus-4-6`)
- Register `gpt-5.3-codex` in model-adapter (awaiting API availability; default remains `gpt-5.2-codex`)
- Corrected Opus pricing to match official $5/$25 per MTok
- Retain backward compatibility aliases for `claude-opus-4.5` and `gpt-5.2-codex`
- Add `validate_model_registry()` startup check to prevent cross-PR map inconsistencies

## Files Changed (9)

| Area | Files | Change |
|------|-------|--------|
| Core | `model-adapter.sh` | New model entries, updated defaults, registry validation |
| Core | `gpt-review-api.sh` | Updated header comment |
| Config | `.loa.config.yaml` | Code model comment, Opus version refs |
| Docs | `CLAUDE.loa.md`, `flatline-protocol.md`, `gpt-review-integration.md`, `gpt-review.md` | Version references |
| Schemas | `README.md` | API example model ID |
| Skills | `operator-detection.md` | Heartbeat example |

## Test plan

- [x] `model-adapter.sh --model opus --dry-run` resolves to `claude-opus-4-6`
- [x] `model-adapter.sh --model gpt-5.3-codex --dry-run` resolves to `gpt-5.3-codex`
- [x] `model-adapter.sh --model claude-opus-4.6 --dry-run` resolves to `claude-opus-4-6`
- [x] `model-adapter.sh --model claude-opus-4.5 --dry-run` resolves to `claude-opus-4-6` (backward compat)
- [x] `validate_model_registry()` passes on healthy config
- [x] GPT review: APPROVED (iteration 2) on model-adapter.sh
- [x] GPT review: APPROVED on validate_model_registry() after `((errors+=1))` fix

## Note on GPT-5.3-Codex

`gpt-5.3-codex` is registered in the model adapter but returns `model_not_found` from the OpenAI API (Codex-app-only as of Feb 5, 2026). Default code review model remains `gpt-5.2-codex`. When API access opens, flip the default in `.loa.config.yaml` and `gpt-review-api.sh`.

## Conflict note

Branch `fix/heredoc-template-literal-expansion` contains `a24ac6f` with partial Opus 4.6 changes using dated ID `claude-opus-4-6-20260201`. This PR uses the dateless alias `claude-opus-4-6` (auto-upgrades). When both merge, resolve in favor of this PR's approach (dateless default + dated as pinnable option + backward compat alias + corrected pricing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)