### PR TITLE
feat(constructs): Construct Manifest Standard — event contracts, tool deps, schema validation

### DIFF
--- a/.claude/schemas/event-envelope.schema.json
+++ b/.claude/schemas/event-envelope.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://loa.dev/schemas/event-envelope.schema.json",
+  "title": "Loa Event Envelope",
+  "description": "Standard event envelope for inter-construct communication. Inspired by CloudEvents (https://cloudevents.io) but adapted for Loa's agent-driven architecture. All events flowing between constructs MUST use this envelope.",
+  "type": "object",
+  "required": ["specversion", "id", "type", "source", "time"],
+  "properties": {
+    "specversion": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Event envelope schema version. Follows CloudEvents specversion pattern for forward compatibility."
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique event identifier. MUST be unique within the scope of the source. UUIDv4 recommended. Maps to CloudEvents 'id' attribute."
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
+      "description": "Event type using reverse-domain notation (e.g., 'forge.observer.utc_created'). Analogous to Kafka topic names or EventBridge detail-type. Pattern: {system}.{construct}.{event_name}"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifies the construct that produced the event. Format: '{pack_slug}/{skill_name}' (e.g., 'forge/observing-users'). Equivalent to CloudEvents 'source' URI."
+    },
+    "time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the event was produced. ISO 8601 UTC format."
+    },
+    "datacontenttype": {
+      "type": "string",
+      "default": "application/json",
+      "description": "Content type of the data field. Defaults to application/json."
+    },
+    "subject": {
+      "type": "string",
+      "description": "Optional subject of the event in context of the source. E.g., the artifact path or entity ID the event relates to."
+    },
+    "correlation_id": {
+      "type": "string",
+      "description": "Root trace identifier that propagates through an entire event chain. Equivalent to OpenTelemetry trace_id or W3C traceparent. Enables: 'Show me everything that happened because a user submitted feedback.'"
+    },
+    "causation_id": {
+      "type": "string",
+      "description": "ID of the event that directly caused this one. Forms a causal DAG when combined with correlation_id. Pattern from Greg Young's event sourcing: every effect has a cause."
+    },
+    "data": {
+      "type": "object",
+      "description": "Event payload. Structure defined by per-event schemas referenced in construct manifests. Consumers MUST validate against the event's declared schema."
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "eventRef": {
+      "type": "object",
+      "description": "Reference to a declared event type. Used in manifest emits/consumes arrays.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
+          "description": "Event type name. Use dotted notation for namespaced events (e.g., 'observer.utc_created')."
+        },
+        "schema": {
+          "type": "string",
+          "description": "Path to JSON Schema defining the event's data payload. Relative to pack root. Analogous to Confluent Schema Registry schema references."
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+          "description": "Semantic version of the event schema. Major version bumps indicate breaking changes (field removal, type changes). Minor for additive changes."
+        },
+        "compatibility": {
+          "type": "string",
+          "enum": ["backward", "forward", "full", "none"],
+          "default": "backward",
+          "description": "Schema evolution compatibility mode. Borrowed from Confluent Schema Registry: backward = new schema reads old data, forward = old schema reads new data, full = both directions."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this event represents and when it fires."
+        }
+      }
+    },
+    "consumeRef": {
+      "type": "object",
+      "description": "Reference to a consumed event with delivery semantics.",
+      "required": ["event"],
+      "properties": {
+        "event": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
+          "description": "Event type name to consume."
+        },
+        "delivery": {
+          "type": "string",
+          "enum": ["broadcast", "queue"],
+          "default": "broadcast",
+          "description": "Delivery semantic. 'broadcast' = all consumers get every event (pub/sub). 'queue' = one consumer per event (competing consumers). Maps to Kafka consumer groups vs. broadcast topics."
+        },
+        "consumer_group": {
+          "type": "string",
+          "description": "Consumer group identifier for 'queue' delivery. Defaults to construct name. Kafka-inspired pattern for load balancing across instances."
+        },
+        "idempotency": {
+          "type": "object",
+          "description": "Idempotency contract for at-least-once delivery. Without this, duplicate events cause duplicate processing.",
+          "properties": {
+            "key": {
+              "type": "string",
+              "description": "JSONPath expression identifying the deduplication key in the event data (e.g., '$.utc_id'). Events with the same key within the window are deduplicated."
+            },
+            "window_hours": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 168,
+              "default": 24,
+              "description": "Duration in hours to track seen event IDs for deduplication."
+            }
+          }
+        },
+        "contract": {
+          "type": "string",
+          "description": "Path to consumer-driven contract file. The Pact pattern: consumers declare what fields they need, CI verifies producers satisfy those contracts. Prevents breaking changes."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "specversion": "1.0",
+      "id": "evt-550e8400-e29b-41d4-a716-446655440000",
+      "type": "forge.observer.utc_created",
+      "source": "forge/observing-users",
+      "time": "2026-02-06T10:30:00Z",
+      "correlation_id": "trace-123e4567-e89b-12d3-a456-426614174000",
+      "causation_id": null,
+      "data": {
+        "utc_id": "utc-789",
+        "user_id": "user-456",
+        "raw_truth": "Users are confused by the onboarding flow",
+        "captured_at": "2026-02-06T10:30:00Z"
+      }
+    }
+  ]
+}

--- a/.claude/schemas/pack-manifest.schema.json
+++ b/.claude/schemas/pack-manifest.schema.json
@@ -1,0 +1,283 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://loa.dev/schemas/pack-manifest.schema.json",
+  "title": "Loa Pack Manifest",
+  "description": "Schema for construct pack manifest.json files. Defines pack metadata, skills, commands, events, tool dependencies, and health probes. Extends the existing pack format with event-driven construct coordination (RFC #162).",
+  "type": "object",
+  "required": ["name", "slug", "version", "description", "skills"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "Human-readable pack name (e.g., 'GTM Collective')"
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]+$",
+      "description": "URL-safe pack identifier (kebab-case). Used as directory name and in event source references."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Semantic version. Major bumps for breaking event schema changes, minor for new events/skills, patch for fixes."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 500,
+      "description": "Pack description (10-500 characters)"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]+$"
+      },
+      "description": "Searchable tags for registry discovery"
+    },
+    "author": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string", "format": "email" },
+        "url": { "type": "string", "format": "uri" }
+      },
+      "description": "Pack author information"
+    },
+    "license": {
+      "type": "string",
+      "description": "SPDX license identifier (e.g., 'MIT', 'proprietary')"
+    },
+    "pricing": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["free", "subscription", "one-time"],
+          "description": "Pricing model"
+        },
+        "tier": {
+          "type": "string",
+          "enum": ["free", "starter", "pro", "enterprise"],
+          "description": "Pricing tier"
+        }
+      },
+      "description": "Pack pricing information"
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/skillRef"
+      },
+      "minItems": 1,
+      "description": "Skills provided by this pack. Each skill SHOULD have an index.yaml for natural language triggers."
+    },
+    "commands": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/commandRef"
+      },
+      "description": "Slash commands provided by this pack"
+    },
+    "events": {
+      "type": "object",
+      "description": "Event declarations for inter-construct communication. The emits/consumes topology enables workflow chaining, dependency visualization, and dead-letter detection.",
+      "properties": {
+        "emits": {
+          "type": "array",
+          "items": {
+            "$ref": "event-envelope.schema.json#/$defs/eventRef"
+          },
+          "description": "Events this pack produces. Each event SHOULD have a schema defining its data payload. Think of this as the pack's public API surface for downstream consumers."
+        },
+        "consumes": {
+          "type": "array",
+          "items": {
+            "$ref": "event-envelope.schema.json#/$defs/consumeRef"
+          },
+          "description": "Events this pack subscribes to. Consumer-driven contracts (Pact pattern) can be specified to prevent upstream breaking changes."
+        }
+      },
+      "additionalProperties": false
+    },
+    "tools": {
+      "type": "object",
+      "description": "External tool dependencies. Declarative only — Loa does NOT auto-install. The loader checks tool availability and warns users. Inspired by loa-constructs field report (Issue #162, @zkSoju).",
+      "additionalProperties": {
+        "$ref": "#/$defs/toolDependency"
+      }
+    },
+    "meta_probe": {
+      "$ref": "#/$defs/metaProbe",
+      "description": "Health check probe for internal coherence. Maps to the existing beads-health.sh pattern but standardized across construct systems."
+    },
+    "dependencies": {
+      "type": "object",
+      "properties": {
+        "loa_version": {
+          "type": "string",
+          "description": "Required Loa version constraint (semver range, e.g., '>=1.20.0')"
+        },
+        "packs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/packDependency"
+          },
+          "description": "Required packs that must be installed"
+        },
+        "skills": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Required skills (by slug)"
+        }
+      },
+      "description": "Pack dependencies. Version constraints follow semver range syntax."
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "skillRef": {
+      "type": "object",
+      "required": ["slug", "path"],
+      "properties": {
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]+$",
+          "description": "Skill identifier (kebab-case)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path to skill directory from pack root"
+        }
+      },
+      "additionalProperties": false
+    },
+    "commandRef": {
+      "type": "object",
+      "required": ["name", "path"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]+$",
+          "description": "Command name (kebab-case, without leading slash)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path to command markdown file"
+        }
+      },
+      "additionalProperties": false
+    },
+    "toolDependency": {
+      "type": "object",
+      "required": ["purpose"],
+      "properties": {
+        "install": {
+          "type": "string",
+          "description": "Installation command. Displayed to user, never auto-executed. Security boundary: Loa shows this as guidance, user decides whether to run it."
+        },
+        "required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the pack functions without this tool. If true, affected skills are blocked when tool is missing."
+        },
+        "purpose": {
+          "type": "string",
+          "description": "Human-readable explanation of why this tool is needed"
+        },
+        "check": {
+          "type": "string",
+          "description": "Command to verify tool is installed (e.g., 'agent-browser --version'). Exit code 0 = installed."
+        },
+        "version": {
+          "type": "string",
+          "description": "Required version constraint (semver range)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "metaProbe": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Probe identifier"
+        },
+        "command": {
+          "type": "string",
+          "description": "Slash command to trigger the probe (e.g., '/pulse')"
+        },
+        "skill": {
+          "type": "string",
+          "description": "Skill slug that implements the health check"
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["internal", "external"],
+          "default": "internal",
+          "description": "Whether the probe is pack-internal or externally accessible"
+        }
+      },
+      "additionalProperties": false
+    },
+    "packDependency": {
+      "type": "object",
+      "required": ["slug"],
+      "properties": {
+        "slug": {
+          "type": "string",
+          "description": "Required pack slug"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version constraint (semver range)"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "examples": [
+    {
+      "name": "GTM Collective",
+      "slug": "gtm-collective",
+      "version": "1.1.0",
+      "description": "Go-To-Market skills and commands for product launches, positioning, and developer relations.",
+      "tags": ["gtm", "marketing", "product"],
+      "license": "proprietary",
+      "skills": [
+        { "slug": "analyzing-market", "path": "skills/analyzing-market/" },
+        { "slug": "positioning-product", "path": "skills/positioning-product/" }
+      ],
+      "commands": [
+        { "name": "analyze-market", "path": "commands/analyze-market.md" }
+      ],
+      "events": {
+        "emits": [
+          {
+            "name": "gtm.market_analysis_complete",
+            "version": "1.0.0",
+            "description": "Fired when market analysis produces actionable insights",
+            "compatibility": "backward"
+          }
+        ],
+        "consumes": [
+          {
+            "event": "forge.observer.utc_created",
+            "delivery": "broadcast",
+            "idempotency": {
+              "key": "$.utc_id",
+              "window_hours": 24
+            }
+          }
+        ]
+      },
+      "dependencies": {
+        "loa_version": ">=1.29.0",
+        "packs": [],
+        "skills": []
+      }
+    }
+  ]
+}

--- a/.claude/schemas/skill-index.schema.json
+++ b/.claude/schemas/skill-index.schema.json
@@ -266,6 +266,27 @@
           }
         }
       }
+    },
+    "events": {
+      "type": "object",
+      "description": "Event declarations for this skill. Enables inter-construct communication, workflow chaining, and dependency visualization. See event-envelope.schema.json for the event wire format.",
+      "properties": {
+        "emits": {
+          "type": "array",
+          "items": {
+            "$ref": "event-envelope.schema.json#/$defs/eventRef"
+          },
+          "description": "Events this skill produces. Each emitted event becomes part of the pack's public event surface. Analogous to a service's published API endpoints."
+        },
+        "consumes": {
+          "type": "array",
+          "items": {
+            "$ref": "event-envelope.schema.json#/$defs/consumeRef"
+          },
+          "description": "Events this skill subscribes to. The consumer-driven contract pattern (Pact) can be used to prevent upstream producers from breaking this skill's expectations."
+        }
+      },
+      "additionalProperties": false
     }
   },
   "examples": [

--- a/.claude/scripts/constructs-loader.sh
+++ b/.claude/scripts/constructs-loader.sh
@@ -925,14 +925,11 @@ do_validate_pack() {
     # Ensure constructs directory is gitignored
     ensure_constructs_gitignored
 
-    # First validate the manifest is valid JSON
+    # Validate manifest against schema (warnings only — does not block license validation)
     local manifest_file="$pack_dir/manifest.json"
     if [[ -f "$manifest_file" ]]; then
-        if command -v jq &>/dev/null; then
-            if ! jq empty "$manifest_file" 2>/dev/null; then
-                echo "ERROR: Invalid JSON in manifest: $manifest_file" >&2
-                return $EXIT_ERROR
-            fi
+        if ! validate_pack_manifest "$pack_dir" "--quiet" 2>/dev/null; then
+            echo "WARN: Pack manifest has validation issues. Run 'validate-manifest $pack_dir' for details." >&2
         fi
     fi
 
@@ -1242,6 +1239,204 @@ do_check_updates() {
 }
 
 # =============================================================================
+# Manifest Schema Validation
+# =============================================================================
+
+# Schema directory for manifest validation
+MANIFEST_SCHEMA_DIR="${SCRIPT_DIR}/../schemas"
+
+# Validate a pack manifest.json against the pack-manifest schema
+# Args:
+#   $1 - Pack directory path (or path to manifest.json directly)
+#   $2 - Optional: --json for JSON output, --quiet for silent validation
+# Returns: 0 if valid, 1 if invalid, 5 if error
+validate_pack_manifest() {
+    local input="$1"
+    local mode="${2:-}"
+    local manifest_file
+
+    # Accept either a directory or a file path
+    if [[ -d "$input" ]]; then
+        manifest_file="$input/manifest.json"
+    elif [[ -f "$input" ]]; then
+        manifest_file="$input"
+    else
+        [[ "$mode" != "--quiet" ]] && echo "ERROR: Not a valid path: $input" >&2
+        return $EXIT_ERROR
+    fi
+
+    if [[ ! -f "$manifest_file" ]]; then
+        [[ "$mode" != "--quiet" ]] && echo "ERROR: manifest.json not found: $manifest_file" >&2
+        return $EXIT_ERROR
+    fi
+
+    # Require jq for schema validation
+    if ! command -v jq &>/dev/null; then
+        [[ "$mode" != "--quiet" ]] && echo "WARN: jq not available, skipping schema validation" >&2
+        return 0
+    fi
+
+    local errors=()
+
+    # 1. Validate JSON syntax
+    if ! jq empty "$manifest_file" 2>/dev/null; then
+        errors+=("Invalid JSON syntax")
+        if [[ "$mode" == "--json" ]]; then
+            jq -n --arg file "$manifest_file" --arg err "Invalid JSON syntax" \
+                '{valid: false, file: $file, errors: [$err]}'
+        elif [[ "$mode" != "--quiet" ]]; then
+            echo "FAIL: Invalid JSON syntax in $manifest_file" >&2
+        fi
+        return 1
+    fi
+
+    # 2. Check required fields: name, slug, version, description, skills
+    local required_fields=("name" "slug" "version" "description" "skills")
+    for field in "${required_fields[@]}"; do
+        if ! jq -e "has(\"$field\")" "$manifest_file" > /dev/null 2>&1; then
+            errors+=("Missing required field: $field")
+        fi
+    done
+
+    # 3. Validate field types
+    # slug must be kebab-case
+    local slug
+    slug=$(jq -r '.slug // ""' "$manifest_file" 2>/dev/null)
+    if [[ -n "$slug" ]] && ! [[ "$slug" =~ ^[a-z][a-z0-9-]+$ ]]; then
+        errors+=("Invalid slug format (must be kebab-case): $slug")
+    fi
+
+    # version must be semver
+    local version
+    version=$(jq -r '.version // ""' "$manifest_file" 2>/dev/null)
+    if [[ -n "$version" ]] && ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        errors+=("Invalid version format (must be semver): $version")
+    fi
+
+    # skills must be a non-empty array
+    local skills_count
+    skills_count=$(jq '.skills | if type == "array" then length else -1 end' "$manifest_file" 2>/dev/null)
+    if [[ "${skills_count:-0}" -lt 1 ]]; then
+        errors+=("skills must be a non-empty array")
+    fi
+
+    # 4. Validate each skill has required fields (slug, path)
+    local invalid_skills
+    invalid_skills=$(jq -r '.skills // [] | to_entries[] | select(.value.slug == null or .value.path == null) | .key' "$manifest_file" 2>/dev/null)
+    if [[ -n "$invalid_skills" ]]; then
+        errors+=("Skills at indices [$invalid_skills] missing required fields (slug, path)")
+    fi
+
+    # 5. Validate events structure if present
+    local has_events
+    has_events=$(jq 'has("events")' "$manifest_file" 2>/dev/null)
+    if [[ "$has_events" == "true" ]]; then
+        # Validate emits entries have 'name' field
+        local invalid_emits
+        invalid_emits=$(jq -r '.events.emits // [] | to_entries[] | select(.value.name == null) | .key' "$manifest_file" 2>/dev/null)
+        if [[ -n "$invalid_emits" ]]; then
+            errors+=("events.emits entries at indices [$invalid_emits] missing 'name' field")
+        fi
+
+        # Validate consumes entries have 'event' field
+        local invalid_consumes
+        invalid_consumes=$(jq -r '.events.consumes // [] | to_entries[] | select(.value.event == null) | .key' "$manifest_file" 2>/dev/null)
+        if [[ -n "$invalid_consumes" ]]; then
+            errors+=("events.consumes entries at indices [$invalid_consumes] missing 'event' field")
+        fi
+    fi
+
+    # 6. Validate tools entries if present
+    local has_tools
+    has_tools=$(jq 'has("tools")' "$manifest_file" 2>/dev/null)
+    if [[ "$has_tools" == "true" ]]; then
+        local tools_missing_purpose
+        tools_missing_purpose=$(jq -r '.tools // {} | to_entries[] | select(.value.purpose == null) | .key' "$manifest_file" 2>/dev/null)
+        if [[ -n "$tools_missing_purpose" ]]; then
+            errors+=("tools entries [$tools_missing_purpose] missing required 'purpose' field")
+        fi
+    fi
+
+    # 7. Try full schema validation with schema-validator.sh if available
+    local schema_file="$MANIFEST_SCHEMA_DIR/pack-manifest.schema.json"
+    if [[ -f "$schema_file" ]] && command -v ajv &>/dev/null; then
+        if ! ajv validate -s "$schema_file" -d "$manifest_file" 2>/dev/null; then
+            errors+=("Full schema validation failed (ajv)")
+        fi
+    fi
+
+    # Report results
+    if [[ ${#errors[@]} -eq 0 ]]; then
+        if [[ "$mode" == "--json" ]]; then
+            jq -n --arg file "$manifest_file" '{valid: true, file: $file, errors: []}'
+        elif [[ "$mode" != "--quiet" ]]; then
+            echo "PASS: $manifest_file"
+        fi
+        return 0
+    else
+        if [[ "$mode" == "--json" ]]; then
+            local errors_json
+            errors_json=$(printf '%s\n' "${errors[@]}" | jq -R . | jq -s .)
+            jq -n --arg file "$manifest_file" --argjson errors "$errors_json" \
+                '{valid: false, file: $file, errors: $errors}'
+        elif [[ "$mode" != "--quiet" ]]; then
+            echo "FAIL: $manifest_file" >&2
+            for err in "${errors[@]}"; do
+                echo "  - $err" >&2
+            done
+        fi
+        return 1
+    fi
+}
+
+# Validate all pack manifests in the registry
+# Args:
+#   $1 - Optional: --json for JSON output
+# Returns: 0 if all valid, 1 if any invalid
+do_validate_all_manifests() {
+    local mode="${1:-}"
+    local packs_dir
+    packs_dir=$(get_packs_dir)
+
+    if [[ ! -d "$packs_dir" ]]; then
+        [[ "$mode" != "--json" ]] && echo "No packs directory found" >&2
+        return 0
+    fi
+
+    local total=0
+    local passed=0
+    local failed=0
+    local results=()
+
+    for pack_dir in "$packs_dir"/*/; do
+        [[ -d "$pack_dir" ]] || continue
+        local manifest_file="$pack_dir/manifest.json"
+        [[ -f "$manifest_file" ]] || continue
+
+        total=$((total + 1))
+        if validate_pack_manifest "$pack_dir" "--quiet" 2>/dev/null; then
+            passed=$((passed + 1))
+            results+=("{\"pack\":\"$(basename "$pack_dir")\",\"valid\":true}")
+        else
+            failed=$((failed + 1))
+            results+=("{\"pack\":\"$(basename "$pack_dir")\",\"valid\":false}")
+        fi
+    done
+
+    if [[ "$mode" == "--json" ]]; then
+        local results_json
+        results_json=$(printf '%s\n' "${results[@]}" | jq -s '.')
+        jq -n --argjson total "$total" --argjson passed "$passed" \
+            --argjson failed "$failed" --argjson results "$results_json" \
+            '{total: $total, passed: $passed, failed: $failed, results: $results}'
+    else
+        echo "Manifest validation: $passed/$total passed ($failed failed)"
+    fi
+
+    [[ "$failed" -eq 0 ]]
+}
+
+# =============================================================================
 # Command Line Interface
 # =============================================================================
 
@@ -1259,6 +1454,8 @@ Commands:
     list-pack-skills <dir>  List skills in a pack
     get-pack-version <dir>  Get pack version from manifest
     check-updates           Check for available updates
+    validate-manifest <dir> Validate a pack's manifest.json against schema
+    validate-all-manifests  Validate all pack manifests in registry
     ensure-gitignore        Add .claude/constructs/ to .gitignore if missing
 
 Exit Codes (validate/preload):
@@ -1283,6 +1480,8 @@ Examples:
     constructs-loader.sh loadable | xargs -I {} echo "Loading: {}"
     constructs-loader.sh validate .claude/constructs/skills/vendor/skill
     constructs-loader.sh validate-pack .claude/constructs/packs/my-pack
+    constructs-loader.sh validate-manifest .claude/constructs/packs/my-pack
+    constructs-loader.sh validate-all-manifests --json
     constructs-loader.sh preload .claude/constructs/skills/vendor/skill
     constructs-loader.sh ensure-gitignore
 EOF
@@ -1328,6 +1527,13 @@ main() {
             ;;
         check-updates)
             do_check_updates
+            ;;
+        validate-manifest)
+            [[ -n "${2:-}" ]] || { echo "ERROR: Missing pack directory argument" >&2; exit $EXIT_ERROR; }
+            validate_pack_manifest "$2" "${3:-}"
+            ;;
+        validate-all-manifests)
+            do_validate_all_manifests "${2:-}"
             ;;
         ensure-gitignore)
             ensure_constructs_gitignored


### PR DESCRIPTION
## Summary

Implements the Construct Manifest Standard RFC (#162), introducing typed event contracts, external tool dependency declarations, and schema-driven validation for pack manifests.

**4 files changed, 666 insertions**

- **`event-envelope.schema.json`** — CloudEvents-inspired event wire format
- **`pack-manifest.schema.json`** — Full schema for `manifest.json` (events, tools, meta_probe)
- **`skill-index.schema.json`** — Extended with `events.emits`/`events.consumes` arrays
- **`constructs-loader.sh`** — New `validate-manifest` and `validate-all-manifests` commands

## Design Decisions & Industry Patterns

### Why CloudEvents-Inspired (Not Full AsyncAPI)

The RFC discussion surfaced two competing approaches: adopt AsyncAPI wholesale, or build a Loa-native format inspired by industry standards. We chose the latter — the same approach Kubernetes took when designing resource manifests. K8s didn't adopt JSON-API; it borrowed *semantics* (declarative state, reconciliation loops) while keeping its own YAML format.

**What we borrowed from CloudEvents:**
- `specversion` for forward compatibility (you'll thank yourself at v2)
- `type` with reverse-domain notation (`forge.observer.utc_created`) — the same pattern Kafka topic naming conventions use
- `source` identifying the producing construct — enables tracing without centralized registry
- `correlation_id` + `causation_id` — the Greg Young event sourcing pattern for causal chains

**What we didn't adopt:**
- Full AsyncAPI channels/bindings — too verbose for Loa's philosophy of minimal manifests
- CloudEvents `dataschema` URI — we use local file refs instead, which are simpler and don't require a registry service

### Consumer-Driven Contracts (The Pact Pattern)

The `consumeRef` type includes an optional `contract` field pointing to a consumer contract file. This is borrowed from [Pact](https://pact.io/) — the industry standard for preventing breaking changes in event-driven systems.

**Why this matters:** Without contracts, Producer A can "safely" remove an "unused" field that Consumer B actually depends on. The field was unused *from A's perspective*, but critical from B's. Consumer-driven contracts make these dependencies explicit and CI-verifiable.

```yaml
# In crucible's manifest
consumes:
  - event: utc_created
    contract: "contracts/crucible-expects-utc_created.json"
```

### Schema Evolution via Compatibility Modes

Every `eventRef` includes a `compatibility` field with four modes borrowed from Confluent Schema Registry:

| Mode | Rule | When to Use |
|------|------|-------------|
| `backward` | New schema reads old data | **Default.** Add optional fields only |
| `forward` | Old schema reads new data | Remove optional fields only |
| `full` | Both directions | Strictest — additive OR subtractive |
| `none` | Breaking allowed | New event type recommended instead |

This is battle-tested at LinkedIn (10M+ events/sec) and prevents the "deploy Producer v2, break all consumers" cascade.

### Tool Dependencies: Declarative, Not Executable

The `tools` section in pack manifests is **purely declarative** — Loa never auto-installs anything. This addresses @zkSoju's field report about skills failing silently when external tools (like `agent-browser`) are missing.

**Security boundary:** The `install` field is displayed as guidance to the user. The `check` field lets the loader verify presence. But the decision to install is always the user's.

```json
"tools": {
  "agent-browser": {
    "install": "npm install -g agent-browser",
    "required": false,
    "purpose": "Screenshot capture for design iteration",
    "check": "agent-browser --version"
  }
}
```

### Idempotency Contracts (At-Least-Once Delivery)

Every `consumeRef` can declare an idempotency contract:

```json
{
  "event": "utc_created",
  "idempotency": {
    "key": "$.utc_id",
    "window_hours": 24
  }
}
```

**Why this matters:** At-least-once delivery means consumers *will* see duplicate events. Without declared dedup keys, duplicate processing corrupts state. This is table stakes at every FAANG company — Kafka consumers, SQS handlers, and Pub/Sub subscribers all implement idempotency.

### Delivery Semantics: Queue vs Broadcast

The `delivery` field on `consumeRef` supports two modes — borrowed directly from Kafka's consumer group model:

- **`broadcast`** (default): Every consumer gets every event. Classic pub/sub.
- **`queue`**: Competing consumers — one instance processes each event. Enables load balancing.

Without this distinction, two constructs both consuming `utc_created` leads to "why did both process this?" bugs.

## What's NOT in This PR (Intentionally Deferred)

Per the discussion's priority matrix:

| Deferred | Reason |
|----------|--------|
| Event bus runtime | Schema-first. Wiring comes later. |
| Full AsyncAPI adoption | Semantics > specification. Revisit at v2. |
| ACL / permissions model | Lower priority for single-tenant. |
| Event sourcing / compaction | Future scope per RFC discussion. |
| Ordering guarantees | Requires runtime; schema can't enforce this. |

## Validation

```bash
# Validate a specific pack manifest
.claude/scripts/constructs-loader.sh validate-manifest .claude/constructs/packs/my-pack

# Validate all manifests in registry
.claude/scripts/constructs-loader.sh validate-all-manifests --json

# JSON output for CI integration
.claude/scripts/constructs-loader.sh validate-manifest path/to/pack --json
```

## Test plan

- [x] New schemas are valid JSON (`jq empty` passes on all 3)
- [x] `validate-manifest` catches invalid manifests (missing fields, bad slug format, wrong semver)
- [x] `validate-manifest --json` produces structured error output
- [x] `validate-all-manifests --json` aggregates results across all packs
- [x] `validate-pack` now warns on manifest schema issues (non-blocking)
- [x] Existing gtm-collective manifest still validates after pack-manifest schema is applied
- [ ] Construct pack authors can add `events` and `tools` sections to their manifests
- [ ] CI integration: `validate-all-manifests` exits non-zero on failures

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)