### PR TITLE
feat(lib): add portable persistence framework

### DIFF
--- a/.claude/lib/persistence/__tests__/beads.test.ts
+++ b/.claude/lib/persistence/__tests__/beads.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BeadsRecoveryHandler, type IShellExecutor } from "../beads/beads-recovery.js";
+import {
+  BeadsWALAdapter,
+  type IBeadsWAL,
+  type IBeadsWALEntry,
+  type BeadWALEntry,
+} from "../beads/beads-wal-adapter.js";
+
+// ── Mock WAL ───────────────────────────────────────────────
+
+function createMockWAL(): IBeadsWAL & {
+  entries: { operation: string; path: string; data?: Buffer }[];
+  seq: number;
+} {
+  const entries: { operation: string; path: string; data?: Buffer }[] = [];
+  let seq = 0;
+
+  return {
+    entries,
+    seq,
+    async append(operation: string, path: string, data?: Buffer) {
+      seq++;
+      entries.push({ operation, path, data });
+      return seq;
+    },
+    async replay(visitor: (entry: IBeadsWALEntry) => void | Promise<void>) {
+      for (const e of entries) {
+        await visitor({
+          operation: e.operation,
+          path: e.path,
+          data: e.data?.toString("base64"),
+        });
+      }
+    },
+    getStatus() {
+      return { seq };
+    },
+  };
+}
+
+// ── Mock Shell ─────────────────────────────────────────────
+
+function createMockShell(): IShellExecutor & { commands: string[] } {
+  const commands: string[] = [];
+  return {
+    commands,
+    async exec(cmd: string) {
+      commands.push(cmd);
+      return { stdout: "", stderr: "" };
+    },
+  };
+}
+
+describe("BeadsWALAdapter", () => {
+  let wal: ReturnType<typeof createMockWAL>;
+  let adapter: BeadsWALAdapter;
+
+  beforeEach(() => {
+    wal = createMockWAL();
+    adapter = new BeadsWALAdapter(wal, { pathPrefix: ".beads/wal" });
+  });
+
+  it("records a transition and returns sequence number", async () => {
+    const seq = await adapter.recordTransition({
+      operation: "create",
+      beadId: "bead-123",
+      payload: { title: "Test bead", type: "task" },
+    });
+
+    expect(seq).toBe(1);
+    expect(wal.entries).toHaveLength(1);
+    expect(wal.entries[0].path).toContain(".beads/wal/bead-123/");
+    expect(wal.entries[0].operation).toBe("write");
+  });
+
+  it("replays entries with checksum verification", async () => {
+    await adapter.recordTransition({
+      operation: "create",
+      beadId: "bead-1",
+      payload: { title: "First" },
+    });
+    await adapter.recordTransition({
+      operation: "update",
+      beadId: "bead-1",
+      payload: { status: "done" },
+    });
+
+    const entries = await adapter.replay();
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].operation).toBe("create");
+    expect(entries[1].operation).toBe("update");
+  });
+
+  it("rejects invalid beadId with path traversal chars", async () => {
+    await expect(
+      adapter.recordTransition({
+        operation: "create",
+        beadId: "../etc/passwd",
+        payload: { title: "malicious" },
+      }),
+    ).rejects.toThrow("Invalid beadId");
+  });
+
+  it("rejects invalid operation type", async () => {
+    await expect(
+      adapter.recordTransition({
+        operation: "rm -rf" as any,
+        beadId: "bead-1",
+        payload: {},
+      }),
+    ).rejects.toThrow("Invalid operation");
+  });
+});
+
+describe("BeadsRecoveryHandler", () => {
+  let wal: ReturnType<typeof createMockWAL>;
+  let adapter: BeadsWALAdapter;
+  let shell: ReturnType<typeof createMockShell>;
+
+  beforeEach(() => {
+    wal = createMockWAL();
+    adapter = new BeadsWALAdapter(wal);
+    shell = createMockShell();
+  });
+
+  it("recovers by replaying WAL entries through br CLI", async () => {
+    // Record transitions
+    await adapter.recordTransition({
+      operation: "create",
+      beadId: "bead-1",
+      payload: { title: "Test task", type: "task", priority: 2 },
+    });
+    await adapter.recordTransition({
+      operation: "label",
+      beadId: "bead-1",
+      payload: { action: "add", labels: ["ready"] },
+    });
+
+    const handler = new BeadsRecoveryHandler(adapter, { skipSync: true }, shell);
+    const result = await handler.recover();
+
+    expect(result.success).toBe(true);
+    expect(result.entriesReplayed).toBe(2);
+    expect(result.beadsAffected).toContain("bead-1");
+    expect(shell.commands).toHaveLength(2);
+    expect(shell.commands[0]).toContain("create");
+    expect(shell.commands[1]).toContain("label add");
+  });
+
+  it("shell-escapes all user values", async () => {
+    await adapter.recordTransition({
+      operation: "create",
+      beadId: "bead-1",
+      payload: { title: "O'Reilly book's test; rm -rf /", type: "task", priority: 2 },
+    });
+
+    const handler = new BeadsRecoveryHandler(adapter, { skipSync: true }, shell);
+    await handler.recover();
+
+    // The title should be shell-escaped with single-quote wrapping
+    const cmd = shell.commands[0];
+    // Verify single quotes are escaped with '\'' idiom
+    expect(cmd).toContain("'\\''");
+    // Verify the command uses br create with properly quoted argument
+    expect(cmd).toMatch(/^br create '/);
+  });
+
+  it("enforces operation and update key whitelists", async () => {
+    await adapter.recordTransition({
+      operation: "update",
+      beadId: "bead-1",
+      payload: { title: "New title", malicious_key: "dropped" },
+    });
+
+    const handler = new BeadsRecoveryHandler(adapter, { skipSync: true }, shell);
+    await handler.recover();
+
+    // Only whitelisted keys should appear in command
+    const cmd = shell.commands[0];
+    expect(cmd).toContain("--title");
+    expect(cmd).not.toContain("malicious_key");
+  });
+
+  it("returns empty result when no WAL entries", async () => {
+    const handler = new BeadsRecoveryHandler(adapter, { skipSync: true }, shell);
+    const result = await handler.recover();
+
+    expect(result.success).toBe(true);
+    expect(result.entriesReplayed).toBe(0);
+    expect(result.beadsAffected).toEqual([]);
+    expect(shell.commands).toHaveLength(0);
+  });
+});

--- a/.claude/lib/persistence/__tests__/checkpoint.test.ts
+++ b/.claude/lib/persistence/__tests__/checkpoint.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { verifyManifest } from "../checkpoint/checkpoint-manifest.js";
+import { CheckpointProtocol } from "../checkpoint/checkpoint-protocol.js";
+import { MountCheckpointStorage } from "../checkpoint/storage-mount.js";
+
+describe("CheckpointProtocol", () => {
+  let mountDir: string;
+  let storage: MountCheckpointStorage;
+  let protocol: CheckpointProtocol;
+
+  beforeEach(() => {
+    mountDir = mkdtempSync(join(tmpdir(), "checkpoint-test-"));
+    storage = new MountCheckpointStorage(mountDir, "data");
+    protocol = new CheckpointProtocol({ storage, staleIntentTimeoutMs: 100 });
+  });
+
+  afterEach(() => {
+    rmSync(mountDir, { recursive: true, force: true });
+  });
+
+  // ── 1. Happy Path ──────────────────────────────────────
+
+  it("completes two-phase checkpoint: begin → finalize → manifest", async () => {
+    const files = [
+      { relativePath: "state/a.json", content: Buffer.from('{"a":1}') },
+      { relativePath: "state/b.json", content: Buffer.from('{"b":2}') },
+    ];
+
+    const intentId = await protocol.beginCheckpoint(files);
+    expect(intentId).toMatch(/^intent-/);
+
+    const manifest = await protocol.finalizeCheckpoint(intentId, files);
+    expect(manifest.version).toBe(1);
+    expect(manifest.files).toHaveLength(2);
+    expect(manifest.totalSize).toBe(14);
+    expect(verifyManifest(manifest)).toBe(true);
+
+    // Second checkpoint increments version
+    const manifest2 = await protocol.finalizeCheckpoint(
+      await protocol.beginCheckpoint(files),
+      files,
+    );
+    expect(manifest2.version).toBe(2);
+  });
+
+  // ── 2. Stale Intent Cleanup ────────────────────────────
+
+  it("cleans stale intents older than timeout", async () => {
+    const files = [{ relativePath: "x.txt", content: Buffer.from("data") }];
+
+    // Create an intent but don't finalize
+    await protocol.beginCheckpoint(files);
+
+    // Intents should exist
+    const intentsBefore = await storage.listFiles("_intents");
+    expect(intentsBefore.length).toBe(1);
+
+    // Wait for timeout
+    await new Promise((r) => setTimeout(r, 150));
+
+    const cleaned = await protocol.cleanStaleIntents();
+    expect(cleaned).toBe(1);
+
+    const intentsAfter = await storage.listFiles("_intents");
+    expect(intentsAfter.length).toBe(0);
+  });
+
+  // ── 3. Verify Failure ──────────────────────────────────
+
+  it("throws on verification failure when file content changes", async () => {
+    const files = [{ relativePath: "critical.json", content: Buffer.from("original") }];
+
+    const intentId = await protocol.beginCheckpoint(files);
+
+    // Tamper with the uploaded file
+    await storage.writeFile("critical.json", Buffer.from("tampered"));
+
+    await expect(protocol.finalizeCheckpoint(intentId, files)).rejects.toThrow(
+      /Verification failed/,
+    );
+  });
+
+  // ── 4. Concurrent Intent ───────────────────────────────
+
+  it("handles multiple concurrent intents independently", async () => {
+    const files1 = [{ relativePath: "a.txt", content: Buffer.from("a") }];
+    const files2 = [{ relativePath: "b.txt", content: Buffer.from("b") }];
+
+    const [intent1, intent2] = await Promise.all([
+      protocol.beginCheckpoint(files1),
+      protocol.beginCheckpoint(files2),
+    ]);
+
+    expect(intent1).not.toBe(intent2);
+
+    // Finalize both
+    const m1 = await protocol.finalizeCheckpoint(intent1, files1);
+    const m2 = await protocol.finalizeCheckpoint(intent2, files2);
+
+    // Second finalize should have higher version
+    expect(m2.version).toBe(m1.version + 1);
+  });
+
+  // ── 5. Manifest Versioning ─────────────────────────────
+
+  it("manifest version increments monotonically", async () => {
+    const files = [{ relativePath: "v.txt", content: Buffer.from("v1") }];
+
+    for (let i = 1; i <= 5; i++) {
+      const intent = await protocol.beginCheckpoint(files);
+      const manifest = await protocol.finalizeCheckpoint(intent, files);
+      expect(manifest.version).toBe(i);
+    }
+
+    const latest = await protocol.getManifest();
+    expect(latest?.version).toBe(5);
+  });
+});

--- a/.claude/lib/persistence/__tests__/circuit-breaker.test.ts
+++ b/.claude/lib/persistence/__tests__/circuit-breaker.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from "vitest";
+import { CircuitBreaker, type CircuitBreakerState } from "../circuit-breaker.js";
+import { PersistenceError } from "../types.js";
+
+describe("CircuitBreaker", () => {
+  function createCB(
+    config?: Partial<{ maxFailures: number; resetTimeMs: number; halfOpenRetries: number }>,
+    options?: {
+      onStateChange?: (from: CircuitBreakerState, to: CircuitBreakerState) => void;
+      now?: () => number;
+    },
+  ) {
+    return new CircuitBreaker(config, options);
+  }
+
+  // ── State Transitions ──────────────────────────────────
+
+  it("starts in CLOSED state", () => {
+    const cb = createCB();
+    expect(cb.getState()).toBe("CLOSED");
+  });
+
+  it("transitions CLOSED → OPEN after maxFailures consecutive failures", () => {
+    const transitions: Array<[CircuitBreakerState, CircuitBreakerState]> = [];
+    const cb = createCB(
+      { maxFailures: 3 },
+      {
+        onStateChange: (from, to) => transitions.push([from, to]),
+      },
+    );
+
+    cb.recordFailure();
+    expect(cb.getState()).toBe("CLOSED");
+
+    cb.recordFailure();
+    expect(cb.getState()).toBe("CLOSED");
+
+    cb.recordFailure();
+    expect(cb.getState()).toBe("OPEN");
+    expect(transitions).toEqual([["CLOSED", "OPEN"]]);
+  });
+
+  it("resets failure count on success before reaching threshold", () => {
+    const cb = createCB({ maxFailures: 3 });
+
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordSuccess();
+    expect(cb.getFailureCount()).toBe(0);
+
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe("CLOSED");
+  });
+
+  // ── Execute Wrapper ────────────────────────────────────
+
+  it("execute() passes through on CLOSED", async () => {
+    const cb = createCB();
+    const result = await cb.execute(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("execute() throws CB_OPEN when circuit is open", async () => {
+    const cb = createCB({ maxFailures: 1 });
+    cb.recordFailure();
+    expect(cb.getState()).toBe("OPEN");
+
+    await expect(cb.execute(async () => "nope")).rejects.toThrow(PersistenceError);
+    try {
+      await cb.execute(async () => "nope");
+    } catch (e) {
+      expect((e as PersistenceError).code).toBe("CB_OPEN");
+    }
+  });
+
+  it("execute() records failure on function throw", async () => {
+    const cb = createCB({ maxFailures: 2 });
+
+    await expect(
+      cb.execute(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(cb.getFailureCount()).toBe(1);
+  });
+
+  it("execute() records success on function resolve", async () => {
+    const cb = createCB();
+    cb.recordFailure();
+    expect(cb.getFailureCount()).toBe(1);
+
+    await cb.execute(async () => "ok");
+    expect(cb.getFailureCount()).toBe(0);
+  });
+
+  // ── Timeout Recovery (OPEN → HALF_OPEN) ────────────────
+
+  it("transitions OPEN → HALF_OPEN after resetTimeMs elapses", () => {
+    let clock = 0;
+    const transitions: Array<[CircuitBreakerState, CircuitBreakerState]> = [];
+
+    const cb = createCB(
+      { maxFailures: 1, resetTimeMs: 1000 },
+      {
+        now: () => clock,
+        onStateChange: (from, to) => transitions.push([from, to]),
+      },
+    );
+
+    cb.recordFailure();
+    expect(cb.getState()).toBe("OPEN");
+
+    clock = 500;
+    expect(cb.getState()).toBe("OPEN");
+
+    clock = 1000;
+    expect(cb.getState()).toBe("HALF_OPEN");
+    expect(transitions).toEqual([
+      ["CLOSED", "OPEN"],
+      ["OPEN", "HALF_OPEN"],
+    ]);
+  });
+
+  // ── Half-Open Probe ────────────────────────────────────
+
+  it("transitions HALF_OPEN → CLOSED after halfOpenRetries successes", () => {
+    let clock = 0;
+    const cb = createCB(
+      { maxFailures: 1, resetTimeMs: 100, halfOpenRetries: 2 },
+      {
+        now: () => clock,
+      },
+    );
+
+    cb.recordFailure();
+    expect(cb.getState()).toBe("OPEN");
+
+    clock = 100;
+    expect(cb.getState()).toBe("HALF_OPEN");
+
+    cb.recordSuccess();
+    expect(cb.getState()).toBe("HALF_OPEN");
+
+    cb.recordSuccess();
+    expect(cb.getState()).toBe("CLOSED");
+    expect(cb.getFailureCount()).toBe(0);
+  });
+
+  it("transitions HALF_OPEN → OPEN on failure during probe", () => {
+    let clock = 0;
+    const transitions: Array<[CircuitBreakerState, CircuitBreakerState]> = [];
+
+    const cb = createCB(
+      { maxFailures: 1, resetTimeMs: 100 },
+      {
+        now: () => clock,
+        onStateChange: (from, to) => transitions.push([from, to]),
+      },
+    );
+
+    cb.recordFailure();
+    clock = 100;
+    cb.getState(); // trigger HALF_OPEN
+
+    cb.recordFailure();
+    expect(cb.getState()).toBe("OPEN");
+
+    const lastTransition = transitions[transitions.length - 1];
+    expect(lastTransition).toEqual(["HALF_OPEN", "OPEN"]);
+  });
+
+  // ── Reset ──────────────────────────────────────────────
+
+  it("reset() forces CLOSED regardless of current state", () => {
+    const cb = createCB({ maxFailures: 1 });
+    cb.recordFailure();
+    expect(cb.getState()).toBe("OPEN");
+
+    cb.reset();
+    expect(cb.getState()).toBe("CLOSED");
+    expect(cb.getFailureCount()).toBe(0);
+  });
+});

--- a/.claude/lib/persistence/__tests__/identity.test.ts
+++ b/.claude/lib/persistence/__tests__/identity.test.ts
@@ -1,0 +1,193 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FileWatcher } from "../identity/file-watcher.js";
+import { IdentityLoader, createIdentityLoader } from "../identity/identity-loader.js";
+
+// ── Temp Directory ─────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "identity-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Sample BEAUVOIR.md ─────────────────────────────────────
+
+const SAMPLE_BEAUVOIR = `# BEAUVOIR
+
+**Version**: 1.0.0
+**Last Updated**: 2026-02-06
+
+## Core Principles
+
+### 1. Understand Before Acting
+
+**Take time to read existing code before modifying it.**
+
+**In practice**: Read at least 3 relevant files before writing code.
+
+### 2. Safety First
+
+**Validate inputs and handle errors gracefully.**
+
+**In practice**: Always use parameterized queries.
+
+## Boundaries
+
+### What I Won't Do
+
+- **Skip tests**: Writing code without tests is not acceptable
+- **Force push**: Never force-push to shared branches
+
+### What I Always Do
+
+- **Run tests**: Before committing, ensure all tests pass
+- **Sign commits**: DCO sign-off on every commit
+
+## Interaction Style
+
+### Concise
+
+Keep responses brief and focused.
+
+### Opinionated
+
+Recommend best practices proactively.
+
+## Recovery Protocol
+
+When a session starts:
+
+\`\`\`
+1. Read BEAUVOIR.md
+2. Check NOTES.md
+3. Resume context
+\`\`\`
+`;
+
+describe("IdentityLoader", () => {
+  it("loads and parses a BEAUVOIR.md document", async () => {
+    const beauvoirPath = path.join(tmpDir, "BEAUVOIR.md");
+    const notesPath = path.join(tmpDir, "NOTES.md");
+    fs.writeFileSync(beauvoirPath, SAMPLE_BEAUVOIR);
+
+    const loader = new IdentityLoader({ beauvoirPath, notesPath });
+    const identity = await loader.load();
+
+    expect(identity.version).toBe("1.0.0");
+    expect(identity.lastUpdated).toBe("2026-02-06");
+    expect(identity.checksum).toHaveLength(16);
+
+    // Principles
+    expect(identity.corePrinciples).toHaveLength(2);
+    expect(identity.corePrinciples[0].name).toBe("Understand Before Acting");
+    expect(identity.corePrinciples[0].id).toBe(1);
+
+    // Boundaries
+    expect(identity.boundaries).toHaveLength(2);
+    const willNot = identity.boundaries.find((b) => b.type === "will_not");
+    expect(willNot!.items.length).toBeGreaterThanOrEqual(2);
+
+    // Interaction style
+    expect(identity.interactionStyle).toContain("Concise");
+    expect(identity.interactionStyle).toContain("Opinionated");
+
+    // Recovery protocol
+    expect(identity.recoveryProtocol).toContain("Read BEAUVOIR.md");
+  });
+
+  it("detects changes on disk via hasChanged()", async () => {
+    const beauvoirPath = path.join(tmpDir, "BEAUVOIR.md");
+    const notesPath = path.join(tmpDir, "NOTES.md");
+    fs.writeFileSync(beauvoirPath, SAMPLE_BEAUVOIR);
+
+    const loader = new IdentityLoader({ beauvoirPath, notesPath });
+    await loader.load();
+
+    expect(await loader.hasChanged()).toBe(false);
+
+    // Modify the file
+    fs.writeFileSync(beauvoirPath, SAMPLE_BEAUVOIR + "\n## New Section\n");
+    expect(await loader.hasChanged()).toBe(true);
+  });
+
+  it("keeps previous state on corrupt file during watch callback", async () => {
+    const beauvoirPath = path.join(tmpDir, "BEAUVOIR.md");
+    const notesPath = path.join(tmpDir, "NOTES.md");
+    fs.writeFileSync(beauvoirPath, SAMPLE_BEAUVOIR);
+
+    const loader = new IdentityLoader({ beauvoirPath, notesPath });
+    const first = await loader.load();
+
+    expect(first.version).toBe("1.0.0");
+
+    // Write corrupt content then try to load — should throw but getIdentity keeps previous
+    fs.unlinkSync(beauvoirPath);
+    try {
+      await loader.load();
+    } catch {
+      // Expected — file deleted
+    }
+
+    // Previous state preserved
+    const identity = loader.getIdentity();
+    expect(identity).not.toBeNull();
+    expect(identity!.version).toBe("1.0.0");
+  });
+
+  it("validates document structure", async () => {
+    const beauvoirPath = path.join(tmpDir, "BEAUVOIR.md");
+    const notesPath = path.join(tmpDir, "NOTES.md");
+
+    // Minimal document (missing sections)
+    fs.writeFileSync(beauvoirPath, "# BEAUVOIR\n\n**Version**: 0.1.0\n");
+
+    const loader = new IdentityLoader({ beauvoirPath, notesPath });
+    await loader.load();
+
+    const { valid, issues } = loader.validate();
+    expect(valid).toBe(false);
+    expect(issues.length).toBeGreaterThan(0);
+  });
+});
+
+describe("FileWatcher", () => {
+  it("debounces rapid changes into single callback", async () => {
+    const filePath = path.join(tmpDir, "watched.txt");
+    fs.writeFileSync(filePath, "initial");
+
+    const calls: string[] = [];
+    const watcher = new FileWatcher({
+      filePath,
+      debounceMs: 100,
+      forcePolling: true,
+      pollIntervalMs: 50,
+    });
+
+    watcher.start((f) => {
+      calls.push(f);
+    });
+
+    // Rapid-fire changes
+    fs.writeFileSync(filePath, "change-1");
+    await new Promise((r) => setTimeout(r, 20));
+    fs.writeFileSync(filePath, "change-2");
+    await new Promise((r) => setTimeout(r, 20));
+    fs.writeFileSync(filePath, "change-3");
+
+    // Wait for debounce + poll interval
+    await new Promise((r) => setTimeout(r, 300));
+
+    watcher.stop();
+
+    // Should coalesce into <= 2 callbacks (debounce)
+    expect(calls.length).toBeLessThanOrEqual(2);
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/.claude/lib/persistence/__tests__/integration.test.ts
+++ b/.claude/lib/persistence/__tests__/integration.test.ts
@@ -1,0 +1,175 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { describe, it, expect, vi } from "vitest";
+import type { IRecoverySource } from "../recovery/recovery-source.js";
+import { CircuitBreaker } from "../circuit-breaker.js";
+import { RecoveryEngine, type RecoveryState } from "../recovery/recovery-engine.js";
+import { TemplateRecoverySource } from "../recovery/sources/template-source.js";
+import { WALManager } from "../wal/wal-manager.js";
+
+describe("Integration: Checkpoint failure → Recovery cascade", () => {
+  it("falls through to template fallback when mount source fails", async () => {
+    // Simulate: mount source unavailable, git source fails, template succeeds
+    const failingMount: IRecoverySource = {
+      name: "mount",
+      isAvailable: vi.fn().mockResolvedValue(false),
+      restore: vi.fn(),
+    };
+
+    const failingGit: IRecoverySource = {
+      name: "git",
+      isAvailable: vi.fn().mockResolvedValue(true),
+      restore: vi.fn().mockResolvedValue(null), // Returns null = failure
+    };
+
+    const templates = new Map([
+      ["BEAUVOIR.md", Buffer.from("# BEAUVOIR\n\nDefault identity.")],
+      ["NOTES.md", Buffer.from("# NOTES\n")],
+    ]);
+    const templateSource = new TemplateRecoverySource(templates);
+
+    const events: string[] = [];
+    const engine = new RecoveryEngine({
+      sources: [failingMount, failingGit, templateSource],
+      onEvent: (e) => events.push(e),
+    });
+
+    const result = await engine.run();
+
+    // Template fallback should succeed
+    expect(result.state).toBe("RUNNING");
+    expect(result.source).toBe("template");
+    expect(result.files?.get("BEAUVOIR.md")?.toString()).toContain("BEAUVOIR");
+
+    // Mount was unavailable, so its restore() should not have been called
+    expect(failingMount.restore).not.toHaveBeenCalled();
+    // Git was tried and failed
+    expect(failingGit.restore).toHaveBeenCalled();
+
+    // Events should show the cascade
+    expect(events).toContain("source_unavailable");
+    expect(events).toContain("restored");
+  });
+
+  it("enters DEGRADED when ALL sources fail, then recovers on next try", async () => {
+    let gitAvailable = false;
+
+    const failingMount: IRecoverySource = {
+      name: "mount",
+      isAvailable: vi.fn().mockResolvedValue(false),
+      restore: vi.fn(),
+    };
+
+    const gitSource: IRecoverySource = {
+      name: "git",
+      isAvailable: vi.fn().mockImplementation(async () => gitAvailable),
+      restore: vi.fn().mockResolvedValue(new Map([["BEAUVOIR.md", Buffer.from("# BEAUVOIR")]])),
+    };
+
+    const engine = new RecoveryEngine({
+      sources: [failingMount, gitSource],
+    });
+
+    // First attempt: all fail
+    const first = await engine.run();
+    expect(first.state).toBe("DEGRADED");
+
+    // Git becomes available
+    gitAvailable = true;
+
+    // Second attempt: git succeeds
+    const second = await engine.run();
+    expect(second.state).toBe("RUNNING");
+    expect(second.source).toBe("git");
+  });
+});
+
+describe("Integration: WAL with high-volume replay", () => {
+  let tmpDir: string;
+
+  it("handles 1000 entries with replay pagination", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wal-integration-"));
+    const walDir = path.join(tmpDir, "wal");
+
+    const wal = new WALManager({
+      walDir,
+      maxSegmentSize: 10 * 1024 * 1024,
+      maxSegmentAge: 60 * 60 * 1000,
+      maxSegments: 10,
+    });
+
+    await wal.initialize();
+
+    // Append 1000 entries sequentially
+    for (let i = 0; i < 1000; i++) {
+      await wal.append(
+        "write",
+        `data/file-${i}.json`,
+        Buffer.from(JSON.stringify({ index: i, value: `data-${i}` })),
+      );
+    }
+
+    // Replay all
+    const entries: number[] = [];
+    await wal.replay(async (entry) => {
+      if (entry.data) {
+        const parsed = JSON.parse(Buffer.from(entry.data, "base64").toString());
+        entries.push(parsed.index);
+      }
+    });
+
+    expect(entries).toHaveLength(1000);
+    // Verify ordering (first should be 0, last 999)
+    expect(entries[0]).toBe(0);
+    expect(entries[entries.length - 1]).toBe(999);
+
+    // Verify sinceSeq pagination
+    const laterEntries = await wal.getEntriesSince(990);
+    expect(laterEntries.length).toBe(10);
+
+    // Cleanup
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe("Integration: CircuitBreaker + RecoveryEngine coordination", () => {
+  it("circuit breaker state feeds into recovery decisions", async () => {
+    let clock = 0;
+    const cb = new CircuitBreaker(
+      { maxFailures: 2, resetTimeMs: 1000, halfOpenRetries: 1 },
+      { onStateChange: () => {}, now: () => clock },
+    );
+
+    // Open circuit breaker
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe("OPEN");
+
+    // Recovery engine with circuit-breaker-aware source
+    const cbAwareSource: IRecoverySource = {
+      name: "cb-aware",
+      isAvailable: vi.fn().mockImplementation(async () => cb.getState() !== "OPEN"),
+      restore: vi.fn().mockResolvedValue(new Map([["data.json", Buffer.from("{}")]])),
+    };
+
+    const templates = new Map([["fallback.txt", Buffer.from("fallback")]]);
+    const templateSource = new TemplateRecoverySource(templates);
+
+    const engine = new RecoveryEngine({
+      sources: [cbAwareSource, templateSource],
+    });
+
+    // While circuit is OPEN, cb-aware source is unavailable → template fallback
+    const result1 = await engine.run();
+    expect(result1.source).toBe("template");
+
+    // Wait for reset → HALF_OPEN
+    clock += 1001;
+    expect(cb.getState()).toBe("HALF_OPEN");
+
+    // Now cb-aware source is available
+    const result2 = await engine.run();
+    expect(result2.source).toBe("cb-aware");
+  });
+});

--- a/.claude/lib/persistence/__tests__/learning.test.ts
+++ b/.claude/lib/persistence/__tests__/learning.test.ts
@@ -1,0 +1,164 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { LearningStore, type Learning } from "../learning/learning-store.js";
+import {
+  scoreAllGates,
+  passesQualityGates,
+  DefaultQualityGateScorer,
+  GATE_THRESHOLDS,
+  MINIMUM_TOTAL_SCORE,
+} from "../learning/quality-gates.js";
+
+// ── Temp Directory ─────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "learning-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Helper ─────────────────────────────────────────────────
+
+function makeHighQualityLearning(): Omit<Learning, "id" | "created" | "gates" | "status"> {
+  return {
+    source: "sprint",
+    trigger:
+      "When deploying after a major update and the build fails with timeout errors during CI/CD pipeline execution",
+    pattern:
+      "A common pattern is that CI builds fail after updating dependencies because the new packages download takes longer. This approach involves setting a general timeout override in the pipeline config to handle similar transient network delays.",
+    solution:
+      "We tested and verified this works: Add `timeout: 30m` to the build step in CI config. This was confirmed to fix the issue. Passed all checks and validated in multiple environments.",
+    target: "devcontainer",
+  };
+}
+
+describe("LearningStore CRUD", () => {
+  it("adds and retrieves a learning", async () => {
+    const store = new LearningStore({ basePath: tmpDir });
+
+    const input = makeHighQualityLearning();
+    const learning = await store.addLearning(input);
+
+    expect(learning.id).toBeTruthy();
+    expect(learning.created).toBeTruthy();
+    expect(learning.status).toBe("active"); // Non-loa target auto-activates
+
+    // Retrieve
+    const found = await store.getLearning(learning.id);
+    expect(found).not.toBeNull();
+    expect(found!.trigger).toBe(input.trigger);
+  });
+
+  it("sends loa-target learnings to pending-self", async () => {
+    const store = new LearningStore({ basePath: tmpDir });
+
+    const learning = await store.addLearning({
+      ...makeHighQualityLearning(),
+      target: "loa",
+    });
+
+    // Should be in pending (not active store)
+    expect(learning.status).toBe("pending");
+
+    const pending = await store.getPendingLearnings();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(learning.id);
+
+    // Active store should be empty
+    const active = await store.getLearnings("active");
+    expect(active).toHaveLength(0);
+  });
+
+  it("records effectiveness tracking", async () => {
+    const store = new LearningStore({ basePath: tmpDir });
+
+    const learning = await store.addLearning(makeHighQualityLearning());
+    await store.recordApplication(learning.id, true);
+    await store.recordApplication(learning.id, true);
+    await store.recordApplication(learning.id, false);
+
+    const updated = await store.getLearning(learning.id);
+    expect(updated!.effectiveness).toEqual(
+      expect.objectContaining({
+        applications: 3,
+        successes: 2,
+        failures: 1,
+      }),
+    );
+  });
+
+  it("finds matching learnings by keyword", async () => {
+    const store = new LearningStore({ basePath: tmpDir });
+
+    await store.addLearning(makeHighQualityLearning());
+    await store.addLearning({
+      ...makeHighQualityLearning(),
+      trigger: "When database migrations fail during deployment with schema errors",
+      pattern:
+        "Database migration failures often occur when schema changes conflict. A general approach is to add verification steps.",
+    });
+
+    const matches = await store.findMatchingLearnings("deploying build fails timeout");
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("Quality Gates Scoring", () => {
+  it("scores a high-quality learning above thresholds", () => {
+    const learning = {
+      ...makeHighQualityLearning(),
+      gates: undefined as any,
+    };
+    const gates = scoreAllGates(learning);
+
+    expect(gates.discovery_depth).toBeGreaterThanOrEqual(GATE_THRESHOLDS.discovery_depth);
+    expect(gates.trigger_clarity).toBeGreaterThanOrEqual(GATE_THRESHOLDS.trigger_clarity);
+    expect(gates.verification).toBeGreaterThanOrEqual(GATE_THRESHOLDS.verification);
+
+    const total =
+      gates.discovery_depth + gates.reusability + gates.trigger_clarity + gates.verification;
+    expect(total).toBeGreaterThanOrEqual(MINIMUM_TOTAL_SCORE);
+    expect(passesQualityGates({ ...learning, gates })).toBe(true);
+  });
+
+  it("rejects a low-quality learning", () => {
+    const learning = {
+      source: "retrospective" as const,
+      trigger: "",
+      pattern: "x",
+      solution: "y",
+      target: "openclaw" as const,
+    };
+
+    const gates = scoreAllGates(learning);
+    expect(gates.trigger_clarity).toBe(0); // Empty trigger
+    expect(passesQualityGates({ ...learning, gates })).toBe(false);
+  });
+
+  it("DefaultQualityGateScorer implements IQualityGateScorer", () => {
+    const scorer = new DefaultQualityGateScorer();
+    const learning = makeHighQualityLearning();
+
+    const gates = scorer.scoreAll(learning);
+    expect(gates.discovery_depth).toBeGreaterThan(0);
+    expect(scorer.passes({ ...learning, gates })).toBe(true);
+  });
+
+  it("WAL-less degradation works", async () => {
+    // Store without WAL should still function
+    const store = new LearningStore({ basePath: tmpDir });
+
+    const learning = await store.addLearning(makeHighQualityLearning());
+    expect(learning.id).toBeTruthy();
+
+    // Verify file was written directly
+    const storeFile = path.join(tmpDir, "learnings.json");
+    expect(fs.existsSync(storeFile)).toBe(true);
+  });
+});

--- a/.claude/lib/persistence/__tests__/recovery.test.ts
+++ b/.claude/lib/persistence/__tests__/recovery.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from "vitest";
+import type { IRecoverySource } from "../recovery/recovery-source.js";
+import {
+  ManifestSigner,
+  generateKeyPair,
+  createManifestSigner,
+} from "../recovery/manifest-signer.js";
+import { RecoveryEngine, type RecoveryState } from "../recovery/recovery-engine.js";
+import { TemplateRecoverySource } from "../recovery/sources/template-source.js";
+
+function makeSource(
+  name: string,
+  available: boolean,
+  files: Map<string, Buffer> | null,
+): IRecoverySource {
+  return {
+    name,
+    isAvailable: vi.fn().mockResolvedValue(available),
+    restore: vi.fn().mockResolvedValue(files),
+  };
+}
+
+describe("RecoveryEngine", () => {
+  // ── 1. Full Cascade ────────────────────────────────────
+
+  it("cascades through sources until one succeeds", async () => {
+    const s1 = makeSource("mount", true, null); // fails
+    const s2 = makeSource("git", true, new Map([["a.txt", Buffer.from("ok")]]));
+    const s3 = makeSource("template", true, new Map([["t.txt", Buffer.from("fallback")]]));
+
+    const engine = new RecoveryEngine({ sources: [s1, s2, s3] });
+    const result = await engine.run();
+
+    expect(result.state).toBe("RUNNING");
+    expect(result.source).toBe("git");
+    expect(result.files?.size).toBe(1);
+
+    // Template source should not have been called
+    expect(s3.restore).not.toHaveBeenCalled();
+  });
+
+  // ── 2. Source Failure Fallthrough ──────────────────────
+
+  it("falls through unavailable sources to template", async () => {
+    const s1 = makeSource("mount", false, null); // unavailable
+    const s2 = makeSource("git", false, null); // unavailable
+    const templates = new Map([["default.json", Buffer.from("{}")]]);
+    const s3 = new TemplateRecoverySource(templates);
+
+    const engine = new RecoveryEngine({ sources: [s1, s2, s3] });
+    const result = await engine.run();
+
+    expect(result.state).toBe("RUNNING");
+    expect(result.source).toBe("template");
+    expect(result.files?.get("default.json")?.toString()).toBe("{}");
+  });
+
+  // ── 3. Loop Detection ─────────────────────────────────
+
+  it("detects recovery loop after N failures in window", async () => {
+    let clock = 0;
+    const failSource = makeSource("fail", true, null);
+
+    const transitions: [RecoveryState, RecoveryState][] = [];
+    const engine = new RecoveryEngine(
+      {
+        sources: [failSource],
+        loopMaxFailures: 3,
+        loopWindowMs: 1000,
+        onStateChange: (from, to) => transitions.push([from, to]),
+      },
+      { now: () => clock },
+    );
+
+    // Three failures within window
+    await engine.run(); // fail 1
+    clock += 100;
+    await engine.run(); // fail 2
+    clock += 100;
+    await engine.run(); // fail 3
+
+    // Next attempt should detect loop
+    clock += 100;
+    const result = await engine.run();
+    expect(result.state).toBe("LOOP_DETECTED");
+    expect(result.files).toBeNull();
+  });
+
+  // ── 4. Degraded Mode ──────────────────────────────────
+
+  it("enters DEGRADED when all sources fail", async () => {
+    const s1 = makeSource("mount", true, null);
+    const s2 = makeSource("git", true, null);
+
+    const events: string[] = [];
+    const engine = new RecoveryEngine({
+      sources: [s1, s2],
+      onEvent: (e) => events.push(e),
+    });
+
+    const result = await engine.run();
+    expect(result.state).toBe("DEGRADED");
+    expect(events).toContain("all_sources_failed");
+  });
+
+  // ── 5. Signature Verification ─────────────────────────
+
+  it("ManifestSigner signs and verifies with Ed25519", () => {
+    const { publicKey, privateKey } = generateKeyPair();
+    const signer = createManifestSigner(publicKey, privateKey);
+
+    const payload = {
+      version: 1,
+      createdAt: "2026-02-06T00:00:00Z",
+      files: [{ path: "a.txt", checksum: "abc123", size: 100 }],
+    };
+
+    const signature = signer.sign(payload);
+    expect(signature).toBeTruthy();
+
+    const manifest = { ...payload, signature };
+    expect(signer.verify(manifest)).toBe(true);
+
+    // Tampered manifest should fail
+    const tampered = { ...manifest, version: 999 };
+    expect(signer.verify(tampered)).toBe(false);
+  });
+
+  // ── 6. Key Pair Generation ─────────────────────────────
+
+  it("generates valid Ed25519 key pairs", () => {
+    const pair = generateKeyPair();
+
+    expect(pair.publicKey).toContain("BEGIN PUBLIC KEY");
+    expect(pair.privateKey).toContain("BEGIN PRIVATE KEY");
+
+    // Verify the keys work together
+    const signer = createManifestSigner(pair.publicKey, pair.privateKey);
+    const payload = {
+      version: 1,
+      createdAt: new Date().toISOString(),
+      files: [],
+    };
+
+    const signature = signer.sign(payload);
+    expect(signer.verify({ ...payload, signature })).toBe(true);
+
+    // Verify-only signer (no private key)
+    const verifier = createManifestSigner(pair.publicKey);
+    expect(verifier.verify({ ...payload, signature })).toBe(true);
+    expect(() => verifier.sign(payload)).toThrow("Private key required");
+  });
+});

--- a/.claude/lib/persistence/__tests__/wal.test.ts
+++ b/.claude/lib/persistence/__tests__/wal.test.ts
@@ -1,0 +1,230 @@
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { WALEntry } from "../wal/wal-entry.js";
+import { compactEntries } from "../wal/wal-compaction.js";
+import {
+  generateEntryId,
+  isLegacyUUID,
+  extractTimestamp,
+  verifyEntry,
+  computeEntryChecksum,
+} from "../wal/wal-entry.js";
+import { WALManager } from "../wal/wal-manager.js";
+import { evaluateDiskPressure } from "../wal/wal-pressure.js";
+
+describe("WAL", () => {
+  let walDir: string;
+
+  beforeEach(() => {
+    walDir = mkdtempSync(join(tmpdir(), "wal-test-"));
+  });
+
+  afterEach(async () => {
+    rmSync(walDir, { recursive: true, force: true });
+  });
+
+  // ── 1. Append ────────────────────────────────────────────
+
+  it("appends entries with incrementing sequence numbers", async () => {
+    const wal = new WALManager({ walDir });
+    await wal.initialize();
+
+    const seq1 = await wal.append("write", "/test/a.txt", Buffer.from("hello"));
+    const seq2 = await wal.append("write", "/test/b.txt", Buffer.from("world"));
+    const seq3 = await wal.append("delete", "/test/a.txt");
+
+    expect(seq1).toBe(1);
+    expect(seq2).toBe(2);
+    expect(seq3).toBe(3);
+    expect(wal.getStatus().seq).toBe(3);
+
+    await wal.shutdown();
+  });
+
+  // ── 2. Replay ────────────────────────────────────────────
+
+  it("replays all entries in sequence order", async () => {
+    const wal = new WALManager({ walDir });
+    await wal.initialize();
+
+    await wal.append("write", "/a.txt", Buffer.from("data-a"));
+    await wal.append("write", "/b.txt", Buffer.from("data-b"));
+    await wal.append("delete", "/a.txt");
+    await wal.shutdown();
+
+    // Re-open and replay
+    const wal2 = new WALManager({ walDir });
+    await wal2.initialize();
+
+    const replayed: WALEntry[] = [];
+    const result = await wal2.replay(async (entry) => {
+      replayed.push(entry);
+    });
+
+    expect(result.replayed).toBe(3);
+    expect(result.errors).toBe(0);
+    expect(replayed[0].path).toBe("/a.txt");
+    expect(replayed[0].operation).toBe("write");
+    expect(replayed[1].path).toBe("/b.txt");
+    expect(replayed[2].operation).toBe("delete");
+
+    await wal2.shutdown();
+  });
+
+  // ── 3. Compaction ────────────────────────────────────────
+
+  it("compaction keeps only latest write per path", () => {
+    const entries: WALEntry[] = [
+      makeEntry(1, "write", "/x.txt", "v1"),
+      makeEntry(2, "write", "/y.txt", "v1"),
+      makeEntry(3, "write", "/x.txt", "v2"),
+      makeEntry(4, "write", "/x.txt", "v3"),
+      makeEntry(5, "delete", "/y.txt"),
+    ];
+
+    const compacted = compactEntries(entries);
+
+    // /x.txt latest write (seq 4) + /y.txt delete (seq 5)
+    expect(compacted).toHaveLength(2);
+    expect(compacted[0].seq).toBe(4);
+    expect(compacted[0].path).toBe("/x.txt");
+    expect(compacted[1].seq).toBe(5);
+    expect(compacted[1].operation).toBe("delete");
+  });
+
+  // ── 4. Disk Pressure ────────────────────────────────────
+
+  it("evaluates disk pressure levels correctly", () => {
+    const config = {
+      warningBytes: 100,
+      criticalBytes: 200,
+    };
+
+    expect(evaluateDiskPressure(50, config)).toBe("normal");
+    expect(evaluateDiskPressure(100, config)).toBe("warning");
+    expect(evaluateDiskPressure(150, config)).toBe("warning");
+    expect(evaluateDiskPressure(200, config)).toBe("critical");
+    expect(evaluateDiskPressure(300, config)).toBe("critical");
+  });
+
+  // ── 5. Limit/Pagination ─────────────────────────────────
+
+  it("replay supports sinceSeq and limit for pagination", async () => {
+    const wal = new WALManager({ walDir });
+    await wal.initialize();
+
+    for (let i = 0; i < 10; i++) {
+      await wal.append("write", `/file-${i}.txt`, Buffer.from(`data-${i}`));
+    }
+    await wal.shutdown();
+
+    const wal2 = new WALManager({ walDir });
+    await wal2.initialize();
+
+    // Page 1: entries 1-3
+    const page1: WALEntry[] = [];
+    await wal2.replay(async (e) => page1.push(e), { sinceSeq: 0, limit: 3 });
+    expect(page1).toHaveLength(3);
+    expect(page1[0].seq).toBe(1);
+
+    // Page 2: entries 4-6
+    const page2: WALEntry[] = [];
+    await wal2.replay(async (e) => page2.push(e), { sinceSeq: 3, limit: 3 });
+    expect(page2).toHaveLength(3);
+    expect(page2[0].seq).toBe(4);
+
+    // getEntriesSince with limit
+    const entries = await wal2.getEntriesSince(7, 2);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].seq).toBe(8);
+
+    await wal2.shutdown();
+  });
+
+  // ── 6. Backwards Compat ─────────────────────────────────
+
+  it("handles legacy UUID entry IDs", () => {
+    expect(isLegacyUUID("550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+    expect(isLegacyUUID("1707000000000-0-a1b2")).toBe(false);
+
+    const id = generateEntryId();
+    expect(isLegacyUUID(id)).toBe(false);
+    expect(extractTimestamp(id)).toBeGreaterThan(0);
+    expect(extractTimestamp("550e8400-e29b-41d4-a716-446655440000")).toBe(0);
+  });
+
+  // ── 7. Flock / Lock ────────────────────────────────────
+
+  it("creates PID lockfile on initialize", async () => {
+    const wal = new WALManager({ walDir });
+    await wal.initialize();
+
+    const pidPath = join(walDir, "wal.pid");
+    expect(existsSync(pidPath)).toBe(true);
+    const pid = readFileSync(pidPath, "utf-8").trim();
+    expect(parseInt(pid, 10)).toBe(process.pid);
+
+    await wal.shutdown();
+    expect(existsSync(pidPath)).toBe(false);
+  });
+
+  // ── 8. PID Fallback ────────────────────────────────────
+
+  it("takes over lock from dead process PID file", async () => {
+    // Simulate stale PID file from a dead process
+    writeFileSync(join(walDir, "wal.pid"), "999999999", "utf-8");
+
+    const wal = new WALManager({ walDir });
+    await wal.initialize();
+
+    // Should have taken over
+    const pid = readFileSync(join(walDir, "wal.pid"), "utf-8").trim();
+    expect(parseInt(pid, 10)).toBe(process.pid);
+
+    await wal.shutdown();
+  });
+
+  // ── 9. Concurrent Append Safety ─────────────────────────
+
+  it("handles concurrent appends without data loss", async () => {
+    const wal = new WALManager({ walDir });
+    await wal.initialize();
+
+    // Fire 20 appends concurrently
+    const promises = Array.from({ length: 20 }, (_, i) =>
+      wal.append("write", `/concurrent-${i}.txt`, Buffer.from(`data-${i}`)),
+    );
+
+    const seqs = await Promise.all(promises);
+
+    // All seqs should be unique
+    const uniqueSeqs = new Set(seqs);
+    expect(uniqueSeqs.size).toBe(20);
+
+    // Verify all entries can be replayed
+    const entries = await wal.getEntriesSince(0);
+    expect(entries).toHaveLength(20);
+
+    await wal.shutdown();
+  });
+});
+
+// ── Helper ─────────────────────────────────────────────────
+
+function makeEntry(seq: number, operation: string, path: string, dataStr?: string): WALEntry {
+  const entry: Omit<WALEntry, "entryChecksum"> = {
+    id: generateEntryId(),
+    seq,
+    timestamp: new Date().toISOString(),
+    operation: operation as WALEntry["operation"],
+    path,
+  };
+
+  if (dataStr) {
+    entry.data = Buffer.from(dataStr).toString("base64");
+  }
+
+  return { ...entry, entryChecksum: computeEntryChecksum(entry) };
+}

--- a/.claude/lib/persistence/beads/beads-recovery.ts
+++ b/.claude/lib/persistence/beads/beads-recovery.ts
@@ -1,0 +1,302 @@
+/**
+ * Beads Recovery Handler — replays WAL entries through br CLI.
+ *
+ * Restores beads state from WAL after a crash by executing
+ * br commands to replay recorded transitions.
+ *
+ * SECURITY: All user-controllable values are validated and escaped
+ * before being used in shell commands to prevent command injection.
+ *
+ * @module .claude/lib/persistence/beads/beads-recovery
+ */
+
+import type { BeadsWALAdapter, BeadWALEntry } from "./beads-wal-adapter.js";
+import { PersistenceError } from "../types.js";
+
+// ── Security Constants ─────────────────────────────────────
+
+const ALLOWED_LABEL_ACTIONS = new Set(["add", "remove"]);
+const ALLOWED_DEP_ACTIONS = new Set(["add", "remove"]);
+const ALLOWED_UPDATE_KEYS = new Set([
+  "title",
+  "description",
+  "priority",
+  "type",
+  "status",
+  "assignee",
+  "due",
+  "estimate",
+]);
+const ALLOWED_TYPES = new Set(["task", "bug", "feature", "epic", "story", "chore"]);
+const BEAD_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const LABEL_PATTERN = /^[a-zA-Z0-9_:-]+$/;
+const MAX_STRING_LENGTH = 1024;
+
+// ── Shell Escape ───────────────────────────────────────────
+
+/**
+ * Shell-escape a string by wrapping in single quotes.
+ * Escapes embedded single quotes with '\'' idiom.
+ */
+function shellEscape(value: string): string {
+  // Strip null bytes which can truncate strings in some shells
+  const sanitized = value.replace(/\0/g, "");
+  const truncated =
+    sanitized.length > MAX_STRING_LENGTH ? sanitized.slice(0, MAX_STRING_LENGTH) : sanitized;
+  return `'${truncated.replace(/'/g, "'\\''")}'`;
+}
+
+function validateBeadId(beadId: string): void {
+  if (!beadId || !BEAD_ID_PATTERN.test(beadId) || beadId.length > 128) {
+    throw new PersistenceError("BEADS_SHELL_ESCAPE", `Invalid beadId: ${beadId?.slice(0, 32)}`);
+  }
+}
+
+// ── Types ──────────────────────────────────────────────────
+
+/** Result of a recovery operation */
+export interface RecoveryResult {
+  success: boolean;
+  entriesReplayed: number;
+  beadsAffected: string[];
+  durationMs: number;
+  error?: string;
+}
+
+/** Configuration for BeadsRecoveryHandler */
+export interface BeadsRecoveryConfig {
+  beadsDir?: string;
+  brCommand?: string;
+  verbose?: boolean;
+  skipSync?: boolean;
+}
+
+/**
+ * Injectable shell executor. Defaults to child_process.exec.
+ * Allows testing without actual shell execution.
+ */
+export interface IShellExecutor {
+  exec(
+    command: string,
+    options?: { cwd?: string; timeout?: number },
+  ): Promise<{ stdout: string; stderr: string }>;
+}
+
+/**
+ * Recovery handler for beads state.
+ *
+ * Checks if recovery is needed by comparing WAL timestamps with SQLite mtime,
+ * then replays WAL entries through br commands.
+ */
+export class BeadsRecoveryHandler {
+  private readonly adapter: BeadsWALAdapter;
+  private readonly beadsDir: string;
+  private readonly brCommand: string;
+  private readonly verbose: boolean;
+  private readonly skipSync: boolean;
+  private readonly shell: IShellExecutor;
+
+  constructor(adapter: BeadsWALAdapter, config?: BeadsRecoveryConfig, shell?: IShellExecutor) {
+    this.adapter = adapter;
+    this.beadsDir = config?.beadsDir ?? ".beads";
+    this.brCommand = config?.brCommand ?? "br";
+    this.verbose = config?.verbose ?? false;
+    this.skipSync = config?.skipSync ?? false;
+
+    // Default shell executor uses child_process
+    this.shell = shell ?? {
+      exec: async (cmd, opts) => {
+        const { exec } = await import("child_process");
+        const { promisify } = await import("util");
+        return promisify(exec)(cmd, opts);
+      },
+    };
+
+    // Validate brCommand is safe (no path traversal, no shell metacharacters)
+    if (!/^[a-zA-Z0-9._/-]+$/.test(this.brCommand) || /\.\./.test(this.brCommand)) {
+      throw new PersistenceError(
+        "BEADS_WHITELIST_VIOLATION",
+        "Invalid brCommand: must not contain path traversal or shell metacharacters",
+      );
+    }
+  }
+
+  /**
+   * Perform crash recovery by replaying WAL to SQLite.
+   */
+  async recover(): Promise<RecoveryResult> {
+    const start = Date.now();
+    const affectedBeads = new Set<string>();
+
+    try {
+      const entries = await this.adapter.replay();
+
+      if (entries.length === 0) {
+        return {
+          success: true,
+          entriesReplayed: 0,
+          beadsAffected: [],
+          durationMs: Date.now() - start,
+        };
+      }
+
+      // Group entries by bead for efficient replay
+      const byBead = new Map<string, BeadWALEntry[]>();
+      for (const entry of entries) {
+        const list = byBead.get(entry.beadId) ?? [];
+        list.push(entry);
+        byBead.set(entry.beadId, list);
+      }
+
+      for (const [beadId, beadEntries] of byBead) {
+        try {
+          validateBeadId(beadId);
+          for (const entry of beadEntries) {
+            await this.replayEntry(entry);
+          }
+          affectedBeads.add(beadId);
+        } catch {
+          // Continue with other beads
+        }
+      }
+
+      // Final sync
+      if (!this.skipSync) {
+        try {
+          await this.execBr("sync --flush-only");
+        } catch {
+          // Non-fatal
+        }
+      }
+
+      return {
+        success: true,
+        entriesReplayed: entries.length,
+        beadsAffected: Array.from(affectedBeads),
+        durationMs: Date.now() - start,
+      };
+    } catch {
+      return {
+        success: false,
+        entriesReplayed: 0,
+        beadsAffected: Array.from(affectedBeads),
+        durationMs: Date.now() - start,
+        error: "Recovery failed",
+      };
+    }
+  }
+
+  /**
+   * Replay a single WAL entry through br CLI.
+   */
+  private async replayEntry(entry: BeadWALEntry): Promise<void> {
+    const { operation, beadId, payload } = entry;
+    validateBeadId(beadId);
+
+    switch (operation) {
+      case "create":
+        await this.replayCreate(payload);
+        break;
+      case "update":
+        await this.replayUpdate(beadId, payload);
+        break;
+      case "close":
+        await this.replayClose(beadId, payload);
+        break;
+      case "reopen":
+        await this.execBr(`reopen ${shellEscape(beadId)}`);
+        break;
+      case "label":
+        await this.replayLabel(beadId, payload);
+        break;
+      case "comment":
+        await this.replayComment(beadId, payload);
+        break;
+      case "dep":
+        await this.replayDep(beadId, payload);
+        break;
+    }
+  }
+
+  private async replayCreate(payload: Record<string, unknown>): Promise<void> {
+    const title = shellEscape(String(payload.title ?? "Untitled"));
+    const rawType = String(payload.type ?? "task");
+    const type = ALLOWED_TYPES.has(rawType) ? rawType : "task";
+    const rawPriority = Number(payload.priority);
+    const priority =
+      Number.isInteger(rawPriority) && rawPriority >= 0 && rawPriority <= 10 ? rawPriority : 2;
+
+    let cmd = `create ${title} --type ${type} --priority ${priority}`;
+    if (payload.description) {
+      cmd += ` --description ${shellEscape(String(payload.description))}`;
+    }
+    await this.execBr(cmd);
+  }
+
+  private async replayUpdate(beadId: string, payload: Record<string, unknown>): Promise<void> {
+    const updates: string[] = [];
+    for (const [key, value] of Object.entries(payload)) {
+      if (value !== undefined && value !== null && ALLOWED_UPDATE_KEYS.has(key)) {
+        updates.push(`--${key} ${shellEscape(String(value))}`);
+      }
+    }
+    if (updates.length > 0) {
+      await this.execBr(`update ${shellEscape(beadId)} ${updates.join(" ")}`);
+    }
+  }
+
+  private async replayClose(beadId: string, payload: Record<string, unknown>): Promise<void> {
+    const reason = payload.reason ? ` --reason ${shellEscape(String(payload.reason))}` : "";
+    await this.execBr(`close ${shellEscape(beadId)}${reason}`);
+  }
+
+  private async replayLabel(beadId: string, payload: Record<string, unknown>): Promise<void> {
+    const rawAction = String(payload.action ?? "add");
+    const action = ALLOWED_LABEL_ACTIONS.has(rawAction) ? rawAction : "add";
+
+    let escapedLabels: string;
+    if (Array.isArray(payload.labels)) {
+      const safeLabels = payload.labels
+        .map((l) => String(l))
+        .filter((l) => LABEL_PATTERN.test(l))
+        .map((l) => shellEscape(l));
+      escapedLabels = safeLabels.join(" ");
+    } else {
+      const labelStr = String(payload.labels ?? payload.label ?? "");
+      escapedLabels = LABEL_PATTERN.test(labelStr) ? shellEscape(labelStr) : "";
+    }
+
+    if (escapedLabels) {
+      await this.execBr(`label ${action} ${shellEscape(beadId)} ${escapedLabels}`);
+    }
+  }
+
+  private async replayComment(beadId: string, payload: Record<string, unknown>): Promise<void> {
+    const text = String(payload.text ?? "");
+    if (text) {
+      await this.execBr(`comments add ${shellEscape(beadId)} ${shellEscape(text)}`);
+    }
+  }
+
+  private async replayDep(beadId: string, payload: Record<string, unknown>): Promise<void> {
+    const rawAction = String(payload.action ?? "add");
+    const action = ALLOWED_DEP_ACTIONS.has(rawAction) ? rawAction : "add";
+    const target = payload.target ?? payload.dependency;
+
+    if (target) {
+      const targetStr = String(target);
+      if (BEAD_ID_PATTERN.test(targetStr)) {
+        await this.execBr(`dep ${action} ${shellEscape(beadId)} ${shellEscape(targetStr)}`);
+      }
+    }
+  }
+
+  private async execBr(args: string): Promise<string> {
+    const cmd = `${this.brCommand} ${args}`;
+    const { stdout } = await this.shell.exec(cmd, {
+      cwd: this.beadsDir,
+      timeout: 30000,
+    });
+    return stdout;
+  }
+}

--- a/.claude/lib/persistence/beads/beads-wal-adapter.ts
+++ b/.claude/lib/persistence/beads/beads-wal-adapter.ts
@@ -1,0 +1,235 @@
+/**
+ * Beads WAL Adapter — framework-grade bridge between beads_rust and WAL.
+ *
+ * Records beads state transitions to the Write-Ahead Log for crash recovery.
+ * Portable: depends only on the framework WAL interface, not container paths.
+ *
+ * SECURITY: All beadIds are validated before use in paths to prevent
+ * path traversal attacks. Checksums use 128-bit (32 hex char) truncation
+ * for adequate collision resistance.
+ *
+ * @module .claude/lib/persistence/beads/beads-wal-adapter
+ */
+
+import { createHash, randomUUID } from "crypto";
+
+/**
+ * Minimal WAL interface — only what BeadsWALAdapter needs.
+ * Keeps the beads bridge decoupled from the full WALManager.
+ */
+export interface IBeadsWAL {
+  append(operation: string, path: string, data?: Buffer): Promise<number>;
+  replay(visitor: (entry: IBeadsWALEntry) => void | Promise<void>): Promise<void>;
+  getEntriesSince?(seq: number): Promise<IBeadsWALEntry[]>;
+  getStatus(): { seq: number };
+}
+
+/** WAL entry shape consumed during replay. */
+export interface IBeadsWALEntry {
+  operation: string;
+  path: string;
+  data?: string; // base64
+}
+
+/**
+ * SECURITY: Bead ID validation pattern (no path traversal chars).
+ */
+const BEAD_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_BEAD_ID_LENGTH = 128;
+
+/**
+ * SECURITY: Allowed operation types for WAL (whitelist)
+ */
+const ALLOWED_OPERATIONS = new Set([
+  "create",
+  "update",
+  "close",
+  "reopen",
+  "label",
+  "comment",
+  "dep",
+]);
+
+/** Operation types that can be recorded in WAL */
+export type BeadOperation = "create" | "update" | "close" | "reopen" | "label" | "comment" | "dep";
+
+/** WAL entry for a beads state transition */
+export interface BeadWALEntry {
+  id: string;
+  timestamp: string;
+  operation: BeadOperation;
+  beadId: string;
+  payload: Record<string, unknown>;
+  checksum: string;
+}
+
+/** Configuration for BeadsWALAdapter */
+export interface BeadsWALConfig {
+  pathPrefix?: string;
+  verbose?: boolean;
+}
+
+function validateBeadId(beadId: unknown): asserts beadId is string {
+  if (typeof beadId !== "string" || !beadId) {
+    throw new Error("Invalid beadId: must be a non-empty string");
+  }
+  if (beadId.length > MAX_BEAD_ID_LENGTH) {
+    throw new Error(`Invalid beadId: exceeds max length ${MAX_BEAD_ID_LENGTH}`);
+  }
+  if (!BEAD_ID_PATTERN.test(beadId)) {
+    throw new Error("Invalid beadId: contains forbidden characters");
+  }
+}
+
+function validateOperation(operation: unknown): asserts operation is BeadOperation {
+  if (typeof operation !== "string" || !ALLOWED_OPERATIONS.has(operation)) {
+    throw new Error(`Invalid operation: ${String(operation)}`);
+  }
+}
+
+function validateWALEntry(data: unknown): asserts data is BeadWALEntry {
+  if (!data || typeof data !== "object") {
+    throw new Error("Invalid WAL entry: must be an object");
+  }
+  const entry = data as Record<string, unknown>;
+  if (typeof entry.id !== "string" || !entry.id) {
+    throw new Error("Invalid WAL entry: missing id");
+  }
+  if (typeof entry.timestamp !== "string" || !entry.timestamp) {
+    throw new Error("Invalid WAL entry: missing timestamp");
+  }
+  if (typeof entry.checksum !== "string" || !entry.checksum) {
+    throw new Error("Invalid WAL entry: missing checksum");
+  }
+  validateBeadId(entry.beadId);
+  validateOperation(entry.operation);
+  if (!entry.payload || typeof entry.payload !== "object" || Array.isArray(entry.payload)) {
+    throw new Error("Invalid WAL entry: payload must be an object");
+  }
+}
+
+/**
+ * Adapter between beads_rust operations and framework WAL.
+ *
+ * Provides crash-resilient persistence for beads state transitions
+ * by recording operations to WAL before they're committed to SQLite.
+ */
+export class BeadsWALAdapter {
+  private readonly wal: IBeadsWAL;
+  private readonly pathPrefix: string;
+  private readonly verbose: boolean;
+
+  constructor(wal: IBeadsWAL, config?: BeadsWALConfig) {
+    this.wal = wal;
+    this.pathPrefix = config?.pathPrefix ?? ".beads/wal";
+    this.verbose = config?.verbose ?? false;
+  }
+
+  /**
+   * Record a beads transition to WAL.
+   *
+   * @returns WAL sequence number
+   * @throws if beadId or operation fails validation
+   */
+  async recordTransition(
+    entry: Omit<BeadWALEntry, "id" | "timestamp" | "checksum">,
+  ): Promise<number> {
+    validateBeadId(entry.beadId);
+    validateOperation(entry.operation);
+
+    const fullEntry: BeadWALEntry = {
+      ...entry,
+      id: randomUUID(),
+      timestamp: new Date().toISOString(),
+      checksum: this.computeChecksum(entry.payload),
+    };
+
+    const seq = await this.wal.append(
+      "write",
+      `${this.pathPrefix}/${entry.beadId}/${fullEntry.id}.json`,
+      Buffer.from(JSON.stringify(fullEntry)),
+    );
+
+    if (this.verbose) {
+      console.log(`[beads-wal] recorded ${entry.operation} (seq=${seq})`);
+    }
+
+    return seq;
+  }
+
+  /**
+   * Replay all beads transitions from WAL.
+   * Returns entries sorted by timestamp. Invalid entries are skipped.
+   */
+  async replay(): Promise<BeadWALEntry[]> {
+    const entries: BeadWALEntry[] = [];
+
+    await this.wal.replay((walEntry: IBeadsWALEntry) => {
+      if (walEntry.operation === "write" && walEntry.path.startsWith(this.pathPrefix)) {
+        try {
+          if (!walEntry.data) return;
+          const jsonStr = Buffer.from(walEntry.data, "base64").toString("utf-8");
+          const parsed: unknown = JSON.parse(jsonStr);
+          validateWALEntry(parsed);
+          const entry = parsed as BeadWALEntry;
+          if (this.verifyChecksum(entry)) {
+            entries.push(entry);
+          }
+        } catch {
+          // Skip invalid entries
+        }
+      }
+    });
+
+    entries.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    return entries;
+  }
+
+  /**
+   * Get transitions since a specific sequence number.
+   */
+  async getTransitionsSince(seq: number): Promise<BeadWALEntry[]> {
+    if (!this.wal.getEntriesSince) {
+      return []; // WAL doesn't support incremental queries
+    }
+    const walEntries = await this.wal.getEntriesSince(seq);
+    const beadEntries: BeadWALEntry[] = [];
+
+    for (const walEntry of walEntries) {
+      if (
+        walEntry.operation === "write" &&
+        walEntry.path.startsWith(this.pathPrefix) &&
+        walEntry.data
+      ) {
+        try {
+          const jsonStr = Buffer.from(walEntry.data, "base64").toString("utf-8");
+          const parsed: unknown = JSON.parse(jsonStr);
+          validateWALEntry(parsed);
+          const entry = parsed as BeadWALEntry;
+          if (this.verifyChecksum(entry)) {
+            beadEntries.push(entry);
+          }
+        } catch {
+          // Skip invalid entries
+        }
+      }
+    }
+
+    return beadEntries;
+  }
+
+  /** Get the current WAL sequence number. */
+  getCurrentSeq(): number {
+    return this.wal.getStatus().seq;
+  }
+
+  /** Compute SHA-256 checksum of payload (truncated to 32 hex chars = 128 bits). */
+  private computeChecksum(payload: Record<string, unknown>): string {
+    return createHash("sha256").update(JSON.stringify(payload)).digest("hex").slice(0, 32);
+  }
+
+  /** Verify entry checksum matches payload. */
+  private verifyChecksum(entry: BeadWALEntry): boolean {
+    return entry.checksum === this.computeChecksum(entry.payload);
+  }
+}

--- a/.claude/lib/persistence/checkpoint/checkpoint-manifest.ts
+++ b/.claude/lib/persistence/checkpoint/checkpoint-manifest.ts
@@ -1,0 +1,61 @@
+/**
+ * Checkpoint Manifest — tracks checkpoint state and version.
+ */
+
+import { createHash } from "crypto";
+
+export interface CheckpointManifest {
+  version: number;
+  createdAt: string;
+  files: CheckpointFileEntry[];
+  totalSize: number;
+  checksum: string; // SHA-256 of all file checksums concatenated
+}
+
+export interface CheckpointFileEntry {
+  relativePath: string;
+  size: number;
+  checksum: string; // SHA-256 of file content
+}
+
+export interface WriteIntent {
+  id: string;
+  startedAt: string;
+  files: string[];
+  pid: number;
+}
+
+/**
+ * Create a manifest from a list of file entries.
+ */
+export function createManifest(
+  files: CheckpointFileEntry[],
+  previousVersion?: number,
+): CheckpointManifest {
+  const totalSize = files.reduce((sum, f) => sum + f.size, 0);
+  const checksumInput = files
+    .map((f) => f.checksum)
+    .sort()
+    .join("");
+  const checksum = createHash("sha256").update(checksumInput).digest("hex");
+
+  return {
+    version: (previousVersion ?? 0) + 1,
+    createdAt: new Date().toISOString(),
+    files,
+    totalSize,
+    checksum,
+  };
+}
+
+/**
+ * Verify manifest integrity.
+ */
+export function verifyManifest(manifest: CheckpointManifest): boolean {
+  const checksumInput = manifest.files
+    .map((f) => f.checksum)
+    .sort()
+    .join("");
+  const expected = createHash("sha256").update(checksumInput).digest("hex");
+  return expected === manifest.checksum;
+}

--- a/.claude/lib/persistence/checkpoint/checkpoint-protocol.ts
+++ b/.claude/lib/persistence/checkpoint/checkpoint-protocol.ts
@@ -1,0 +1,172 @@
+/**
+ * Two-Phase Checkpoint Protocol
+ *
+ * Flow: write-intent → upload segments → verify → finalize manifest
+ *
+ * If any step fails, the intent remains and is cleaned up by
+ * cleanStaleIntents() on the next run.
+ */
+
+import { createHash } from "crypto";
+import type { ICheckpointStorage } from "./storage-mount.js";
+import { PersistenceError } from "../types.js";
+import {
+  createManifest,
+  verifyManifest,
+  type CheckpointManifest,
+  type CheckpointFileEntry,
+  type WriteIntent,
+} from "./checkpoint-manifest.js";
+
+export interface CheckpointProtocolConfig {
+  /** Storage backend */
+  storage: ICheckpointStorage;
+  /** Stale intent timeout in ms. Default: 10 minutes */
+  staleIntentTimeoutMs?: number;
+}
+
+const MANIFEST_PATH = "checkpoint.json";
+const INTENTS_DIR = "_intents";
+const DEFAULT_STALE_TIMEOUT = 10 * 60 * 1000;
+
+export class CheckpointProtocol {
+  private readonly storage: ICheckpointStorage;
+  private readonly staleTimeoutMs: number;
+
+  constructor(config: CheckpointProtocolConfig) {
+    this.storage = config.storage;
+    this.staleTimeoutMs = config.staleIntentTimeoutMs ?? DEFAULT_STALE_TIMEOUT;
+  }
+
+  /**
+   * Phase 1: Begin checkpoint — create write intent and upload files.
+   * Returns an intent ID that must be passed to finalize().
+   */
+  async beginCheckpoint(files: Array<{ relativePath: string; content: Buffer }>): Promise<string> {
+    const hex4 = Math.floor(Math.random() * 0xffff)
+      .toString(16)
+      .padStart(4, "0");
+    const intentId = `intent-${Date.now()}-${process.pid}-${hex4}`;
+
+    // Write intent marker
+    const intent: WriteIntent = {
+      id: intentId,
+      startedAt: new Date().toISOString(),
+      files: files.map((f) => f.relativePath),
+      pid: process.pid,
+    };
+
+    const ok = await this.storage.writeFile(
+      `${INTENTS_DIR}/${intentId}.json`,
+      Buffer.from(JSON.stringify(intent)),
+    );
+    if (!ok) {
+      throw new PersistenceError("CHECKPOINT_FAILED", "Failed to create write intent.");
+    }
+
+    // Upload each file
+    for (const file of files) {
+      const uploaded = await this.storage.writeFile(file.relativePath, file.content);
+      if (!uploaded) {
+        throw new PersistenceError(
+          "CHECKPOINT_FAILED",
+          `Failed to upload file: ${file.relativePath}`,
+        );
+      }
+    }
+
+    return intentId;
+  }
+
+  /**
+   * Phase 2: Finalize checkpoint — verify uploads and write manifest atomically.
+   */
+  async finalizeCheckpoint(
+    intentId: string,
+    files: Array<{ relativePath: string; content: Buffer }>,
+  ): Promise<CheckpointManifest> {
+    // Verify each uploaded file
+    const fileEntries: CheckpointFileEntry[] = [];
+
+    for (const file of files) {
+      const expectedChecksum = createHash("sha256").update(file.content).digest("hex");
+      const verified = await this.storage.verifyChecksum(file.relativePath, expectedChecksum);
+
+      if (!verified) {
+        throw new PersistenceError(
+          "CHECKPOINT_VERIFY_FAILED",
+          `Verification failed for: ${file.relativePath}`,
+        );
+      }
+
+      fileEntries.push({
+        relativePath: file.relativePath,
+        size: file.content.length,
+        checksum: expectedChecksum,
+      });
+    }
+
+    // Get previous version
+    const prevManifest = await this.getManifest();
+    const manifest = createManifest(fileEntries, prevManifest?.version);
+
+    // Write manifest atomically
+    const ok = await this.storage.writeFile(
+      MANIFEST_PATH,
+      Buffer.from(JSON.stringify(manifest, null, 2)),
+    );
+    if (!ok) {
+      throw new PersistenceError("CHECKPOINT_FAILED", "Failed to write manifest.");
+    }
+
+    // Clean up the intent
+    await this.storage.deleteFile(`${INTENTS_DIR}/${intentId}.json`);
+
+    return manifest;
+  }
+
+  /**
+   * Get the current manifest.
+   */
+  async getManifest(): Promise<CheckpointManifest | null> {
+    const data = await this.storage.readFile(MANIFEST_PATH);
+    if (!data) return null;
+
+    try {
+      const manifest = JSON.parse(data.toString()) as CheckpointManifest;
+      if (!verifyManifest(manifest)) return null;
+      return manifest;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Clean up stale intents older than the configured timeout.
+   */
+  async cleanStaleIntents(): Promise<number> {
+    const intentFiles = await this.storage.listFiles(INTENTS_DIR);
+    let cleaned = 0;
+
+    for (const file of intentFiles) {
+      const data = await this.storage.readFile(`${INTENTS_DIR}/${file}`);
+      if (!data) continue;
+
+      try {
+        const intent = JSON.parse(data.toString()) as WriteIntent;
+        const age = Date.now() - new Date(intent.startedAt).getTime();
+
+        if (age > this.staleTimeoutMs) {
+          await this.storage.deleteFile(`${INTENTS_DIR}/${file}`);
+          cleaned++;
+        }
+      } catch {
+        // Corrupt intent — remove it
+        await this.storage.deleteFile(`${INTENTS_DIR}/${file}`);
+        cleaned++;
+      }
+    }
+
+    return cleaned;
+  }
+}

--- a/.claude/lib/persistence/checkpoint/storage-mount.ts
+++ b/.claude/lib/persistence/checkpoint/storage-mount.ts
@@ -1,0 +1,125 @@
+/**
+ * Mount-based checkpoint storage.
+ *
+ * ICheckpointStorage interface allows plugging in different backends.
+ * MountCheckpointStorage is the default (filesystem mount, e.g. R2 via rclone).
+ */
+
+import { createHash } from "crypto";
+import { existsSync } from "fs";
+import { readFile, writeFile, mkdir, rename, unlink, readdir, stat } from "fs/promises";
+import { join, dirname, resolve, normalize } from "path";
+
+export interface ICheckpointStorage {
+  isAvailable(): Promise<boolean>;
+  readFile(relativePath: string): Promise<Buffer | null>;
+  writeFile(relativePath: string, content: Buffer): Promise<boolean>;
+  deleteFile(relativePath: string): Promise<boolean>;
+  listFiles(prefix?: string): Promise<string[]>;
+  verifyChecksum(relativePath: string, expected: string): Promise<boolean>;
+  stat(relativePath: string): Promise<{ size: number; mtime: Date } | null>;
+}
+
+export class MountCheckpointStorage implements ICheckpointStorage {
+  private readonly resolvedRoot: string;
+
+  constructor(
+    private readonly mountPath: string,
+    private readonly prefix: string = "grimoires",
+  ) {
+    this.resolvedRoot = resolve(mountPath, prefix);
+  }
+
+  async isAvailable(): Promise<boolean> {
+    if (!existsSync(this.mountPath)) return false;
+    try {
+      const entries = await readdir(this.mountPath);
+      return entries.length > 0 || existsSync(join(this.mountPath, this.prefix));
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Resolve a relative path within the mount, with path traversal protection.
+   * Rejects any path that would escape the mount root (e.g., ../../etc/passwd).
+   */
+  private resolvePath(relativePath: string): string {
+    const resolved = resolve(this.resolvedRoot, normalize(relativePath));
+    if (!resolved.startsWith(this.resolvedRoot)) {
+      throw new Error(`Path traversal rejected: ${relativePath}`);
+    }
+    return resolved;
+  }
+
+  async readFile(relativePath: string): Promise<Buffer | null> {
+    const path = this.resolvePath(relativePath);
+    if (!existsSync(path)) return null;
+    try {
+      return await readFile(path);
+    } catch {
+      return null;
+    }
+  }
+
+  async writeFile(relativePath: string, content: Buffer): Promise<boolean> {
+    const path = this.resolvePath(relativePath);
+    try {
+      await mkdir(dirname(path), { recursive: true });
+      const tmpPath = `${path}.tmp.${process.pid}`;
+      await writeFile(tmpPath, content);
+      await rename(tmpPath, path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async deleteFile(relativePath: string): Promise<boolean> {
+    const path = this.resolvePath(relativePath);
+    try {
+      await unlink(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async listFiles(subPrefix?: string): Promise<string[]> {
+    const dir = subPrefix
+      ? join(this.mountPath, this.prefix, subPrefix)
+      : join(this.mountPath, this.prefix);
+
+    if (!existsSync(dir)) return [];
+
+    const files: string[] = [];
+    const walk = async (d: string, base: string): Promise<void> => {
+      const entries = await readdir(d, { withFileTypes: true });
+      for (const e of entries) {
+        const full = join(d, e.name);
+        const rel = base ? `${base}/${e.name}` : e.name;
+        if (e.isDirectory()) await walk(full, rel);
+        else files.push(rel);
+      }
+    };
+    await walk(dir, "");
+    return files;
+  }
+
+  async verifyChecksum(relativePath: string, expected: string): Promise<boolean> {
+    const content = await this.readFile(relativePath);
+    if (!content) return false;
+    const actual = createHash("sha256").update(content).digest("hex");
+    return actual === expected;
+  }
+
+  async stat(relativePath: string): Promise<{ size: number; mtime: Date } | null> {
+    const path = this.resolvePath(relativePath);
+    try {
+      const s = await stat(path);
+      return { size: s.size, mtime: s.mtime };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/.claude/lib/persistence/circuit-breaker.ts
+++ b/.claude/lib/persistence/circuit-breaker.ts
@@ -1,0 +1,166 @@
+/**
+ * Standalone Circuit Breaker with lazy timeout checking.
+ *
+ * States: CLOSED → OPEN (after N failures) → HALF_OPEN (after timeout) → CLOSED
+ *
+ * No timers — state transitions happen lazily on execute()/getState() calls.
+ * This avoids timer leaks and makes the component fully testable with fake clocks.
+ *
+ * Extracted from deploy/loa-identity/scheduler/scheduler.ts
+ */
+
+import { PersistenceError } from "./types.js";
+
+// ── Types ────────────────────────────────────────────────────
+
+export type CircuitBreakerState = "CLOSED" | "OPEN" | "HALF_OPEN";
+
+export interface CircuitBreakerConfig {
+  /** Number of consecutive failures before opening the circuit. Default: 3 */
+  maxFailures: number;
+  /** Time in ms before attempting half-open probe. Default: 5 minutes */
+  resetTimeMs: number;
+  /** Number of successful probes in HALF_OPEN before closing. Default: 1 */
+  halfOpenRetries: number;
+}
+
+export type CircuitBreakerStateChangeCallback = (
+  from: CircuitBreakerState,
+  to: CircuitBreakerState,
+) => void;
+
+// ── Defaults ─────────────────────────────────────────────────
+
+const DEFAULT_CONFIG: CircuitBreakerConfig = {
+  maxFailures: 3,
+  resetTimeMs: 5 * 60 * 1000,
+  halfOpenRetries: 1,
+};
+
+// ── Implementation ───────────────────────────────────────────
+
+export class CircuitBreaker {
+  private state: CircuitBreakerState = "CLOSED";
+  private consecutiveFailures = 0;
+  private halfOpenSuccesses = 0;
+  private lastFailureTime = -1;
+  private readonly config: CircuitBreakerConfig;
+  private onStateChange?: CircuitBreakerStateChangeCallback;
+  private nowFn: () => number;
+
+  constructor(
+    config?: Partial<CircuitBreakerConfig>,
+    options?: {
+      onStateChange?: CircuitBreakerStateChangeCallback;
+      /** Injectable clock for testing. Defaults to Date.now */
+      now?: () => number;
+    },
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.onStateChange = options?.onStateChange;
+    this.nowFn = options?.now ?? Date.now;
+  }
+
+  /**
+   * Execute a function through the circuit breaker.
+   * Throws PersistenceError with code CB_OPEN if the circuit is open.
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    const currentState = this.getState();
+
+    if (currentState === "OPEN") {
+      throw new PersistenceError(
+        "CB_OPEN",
+        `Circuit breaker is OPEN (${this.consecutiveFailures} failures, ` +
+          `resets in ${this.msUntilReset()}ms)`,
+      );
+    }
+
+    try {
+      const result = await fn();
+      this.recordSuccess();
+      return result;
+    } catch (error) {
+      this.recordFailure();
+      throw error;
+    }
+  }
+
+  /**
+   * Record a successful operation.
+   */
+  recordSuccess(): void {
+    if (this.state === "HALF_OPEN") {
+      this.halfOpenSuccesses++;
+      if (this.halfOpenSuccesses >= this.config.halfOpenRetries) {
+        this.transition("CLOSED");
+        this.consecutiveFailures = 0;
+        this.halfOpenSuccesses = 0;
+      }
+    } else {
+      this.consecutiveFailures = 0;
+    }
+  }
+
+  /**
+   * Record a failed operation.
+   */
+  recordFailure(): void {
+    this.consecutiveFailures++;
+    this.lastFailureTime = this.nowFn();
+
+    if (this.state === "HALF_OPEN") {
+      // Half-open probe failed — go back to OPEN
+      this.halfOpenSuccesses = 0;
+      this.transition("OPEN");
+    } else if (this.consecutiveFailures >= this.config.maxFailures) {
+      this.transition("OPEN");
+    }
+  }
+
+  /**
+   * Get the current state, lazily transitioning OPEN → HALF_OPEN if timeout elapsed.
+   */
+  getState(): CircuitBreakerState {
+    if (this.state === "OPEN" && this.lastFailureTime >= 0) {
+      const elapsed = this.nowFn() - this.lastFailureTime;
+      if (elapsed >= this.config.resetTimeMs) {
+        this.transition("HALF_OPEN");
+        this.halfOpenSuccesses = 0;
+      }
+    }
+    return this.state;
+  }
+
+  /**
+   * Force-reset the circuit breaker to CLOSED state.
+   */
+  reset(): void {
+    this.consecutiveFailures = 0;
+    this.halfOpenSuccesses = 0;
+    this.lastFailureTime = -1;
+    this.transition("CLOSED");
+  }
+
+  /**
+   * Get the number of consecutive failures.
+   */
+  getFailureCount(): number {
+    return this.consecutiveFailures;
+  }
+
+  // ── Private ──────────────────────────────────────────────
+
+  private transition(to: CircuitBreakerState): void {
+    if (this.state === to) return;
+    const from = this.state;
+    this.state = to;
+    this.onStateChange?.(from, to);
+  }
+
+  private msUntilReset(): number {
+    if (this.state !== "OPEN" || this.lastFailureTime < 0) return 0;
+    const elapsed = this.nowFn() - this.lastFailureTime;
+    return Math.max(0, this.config.resetTimeMs - elapsed);
+  }
+}

--- a/.claude/lib/persistence/identity/file-watcher.ts
+++ b/.claude/lib/persistence/identity/file-watcher.ts
@@ -1,0 +1,130 @@
+/**
+ * File Watcher — fs.watch primary with fs.watchFile polling fallback.
+ *
+ * Provides cross-platform file change detection with configurable
+ * debounce to coalesce rapid writes into a single callback.
+ *
+ * @module .claude/lib/persistence/identity/file-watcher
+ */
+
+import type { FSWatcher } from "fs";
+import { watch, watchFile, unwatchFile, existsSync } from "fs";
+
+export interface FileWatcherConfig {
+  /** Path to watch */
+  filePath: string;
+  /** Debounce interval in ms (default: 1000) */
+  debounceMs?: number;
+  /** Use polling fallback only (default: false) */
+  forcePolling?: boolean;
+  /** Polling interval in ms for watchFile fallback (default: 2000) */
+  pollIntervalMs?: number;
+}
+
+export type FileChangeCallback = (filePath: string) => void | Promise<void>;
+
+/**
+ * FileWatcher with fs.watch primary and fs.watchFile polling fallback.
+ *
+ * fs.watch is inode-based and fast but unreliable on network mounts.
+ * fs.watchFile uses stat() polling — slower but universally reliable.
+ */
+export class FileWatcher {
+  private readonly filePath: string;
+  private readonly debounceMs: number;
+  private readonly forcePolling: boolean;
+  private readonly pollIntervalMs: number;
+
+  private watcher: FSWatcher | null = null;
+  private polling = false;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private callback: FileChangeCallback | null = null;
+  private stopped = false;
+
+  constructor(config: FileWatcherConfig) {
+    this.filePath = config.filePath;
+    this.debounceMs = config.debounceMs ?? 1000;
+    this.forcePolling = config.forcePolling ?? false;
+    this.pollIntervalMs = config.pollIntervalMs ?? 2000;
+  }
+
+  /**
+   * Start watching for changes.
+   */
+  start(callback: FileChangeCallback): void {
+    this.callback = callback;
+    this.stopped = false;
+
+    if (this.forcePolling) {
+      this.startPolling();
+      return;
+    }
+
+    try {
+      this.watcher = watch(this.filePath, { persistent: false }, () => {
+        this.onChangeDetected();
+      });
+
+      // Fallback if watcher errors
+      this.watcher.on("error", () => {
+        this.watcher?.close();
+        this.watcher = null;
+        this.startPolling();
+      });
+    } catch {
+      // fs.watch failed (e.g. ENOSYS on network mount)
+      this.startPolling();
+    }
+  }
+
+  /**
+   * Stop watching.
+   */
+  stop(): void {
+    this.stopped = true;
+
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+
+    if (this.polling) {
+      unwatchFile(this.filePath);
+      this.polling = false;
+    }
+
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  /** Whether the watcher is using polling fallback. */
+  isPolling(): boolean {
+    return this.polling;
+  }
+
+  private startPolling(): void {
+    if (this.stopped) return;
+    this.polling = true;
+    watchFile(this.filePath, { interval: this.pollIntervalMs }, () => {
+      this.onChangeDetected();
+    });
+  }
+
+  private onChangeDetected(): void {
+    if (this.stopped || !this.callback) return;
+
+    // Debounce: reset timer on each event
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      if (!this.stopped && this.callback) {
+        this.callback(this.filePath);
+      }
+    }, this.debounceMs);
+  }
+}

--- a/.claude/lib/persistence/identity/identity-loader.ts
+++ b/.claude/lib/persistence/identity/identity-loader.ts
@@ -1,0 +1,285 @@
+/**
+ * Identity Loader — parse and watch BEAUVOIR.md identity documents.
+ *
+ * Extracted from deploy/loa-identity/identity-loader.ts.
+ * Portable: constructor-injected paths, no process.env.
+ * Adds hot-reload via FileWatcher integration.
+ *
+ * @module .claude/lib/persistence/identity/identity-loader
+ */
+
+import { createHash } from "crypto";
+import { existsSync } from "fs";
+import { readFile, appendFile } from "fs/promises";
+import { PersistenceError } from "../types.js";
+import { FileWatcher, type FileChangeCallback } from "./file-watcher.js";
+
+// ── Types ──────────────────────────────────────────────────
+
+export interface Principle {
+  id: number;
+  name: string;
+  description: string;
+  inPractice?: string;
+}
+
+export interface Boundary {
+  type: "will_not" | "always";
+  items: string[];
+}
+
+export interface IdentityDocument {
+  version: string;
+  lastUpdated: string;
+  corePrinciples: Principle[];
+  boundaries: Boundary[];
+  interactionStyle: string[];
+  recoveryProtocol: string;
+  checksum: string;
+}
+
+export interface IdentityLoaderConfig {
+  beauvoirPath: string;
+  notesPath: string;
+  /** Debounce for hot-reload watcher (default: 1000ms) */
+  watchDebounceMs?: number;
+}
+
+// ── Implementation ─────────────────────────────────────────
+
+export class IdentityLoader {
+  private config: IdentityLoaderConfig;
+  private identity: IdentityDocument | null = null;
+  private lastLoadedChecksum: string | null = null;
+  private watcher: FileWatcher | null = null;
+
+  constructor(config: IdentityLoaderConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Load identity from BEAUVOIR.md.
+   */
+  async load(): Promise<IdentityDocument> {
+    if (!existsSync(this.config.beauvoirPath)) {
+      throw new PersistenceError(
+        "IDENTITY_PARSE_FAILED",
+        `BEAUVOIR.md not found at ${this.config.beauvoirPath}`,
+      );
+    }
+
+    const content = await readFile(this.config.beauvoirPath, "utf-8");
+    const checksum = this.computeChecksum(content);
+
+    if (this.lastLoadedChecksum && this.lastLoadedChecksum !== checksum) {
+      await this.logIdentityChange(checksum);
+    }
+
+    const identity = this.parseDocument(content, checksum);
+    this.identity = identity;
+    this.lastLoadedChecksum = checksum;
+
+    return identity;
+  }
+
+  /**
+   * Start watching BEAUVOIR.md for changes. Reloads automatically on change.
+   */
+  startWatching(callback?: FileChangeCallback): void {
+    if (this.watcher) {
+      this.watcher.stop();
+    }
+
+    this.watcher = new FileWatcher({
+      filePath: this.config.beauvoirPath,
+      debounceMs: this.config.watchDebounceMs ?? 1000,
+    });
+
+    this.watcher.start(async (filePath) => {
+      try {
+        await this.load();
+        if (callback) {
+          await callback(filePath);
+        }
+      } catch {
+        // Keep previous state on corrupt file
+      }
+    });
+  }
+
+  /**
+   * Stop watching.
+   */
+  stopWatching(): void {
+    if (this.watcher) {
+      this.watcher.stop();
+      this.watcher = null;
+    }
+  }
+
+  /**
+   * Check if identity document has changed on disk.
+   */
+  async hasChanged(): Promise<boolean> {
+    if (!existsSync(this.config.beauvoirPath)) {
+      return true;
+    }
+    const content = await readFile(this.config.beauvoirPath, "utf-8");
+    return this.computeChecksum(content) !== this.lastLoadedChecksum;
+  }
+
+  getIdentity(): IdentityDocument | null {
+    return this.identity;
+  }
+
+  getPrinciple(id: number): Principle | undefined {
+    return this.identity?.corePrinciples.find((p) => p.id === id);
+  }
+
+  getBoundaries(type: "will_not" | "always"): string[] {
+    const boundary = this.identity?.boundaries.find((b) => b.type === type);
+    return boundary?.items ?? [];
+  }
+
+  validate(): { valid: boolean; issues: string[] } {
+    const issues: string[] = [];
+    if (!this.identity) {
+      return { valid: false, issues: ["Identity not loaded"] };
+    }
+    if (this.identity.corePrinciples.length === 0) issues.push("No core principles found");
+    if (this.identity.boundaries.length === 0) issues.push("No boundaries defined");
+    if (this.identity.interactionStyle.length === 0) issues.push("No interaction style defined");
+    if (!this.identity.recoveryProtocol) issues.push("No recovery protocol defined");
+    return { valid: issues.length === 0, issues };
+  }
+
+  // ── Private ──────────────────────────────────────────────
+
+  private parseDocument(content: string, checksum: string): IdentityDocument {
+    const versionMatch = content.match(/\*\*Version\*\*:\s*(\S+)/);
+    const version = versionMatch?.[1] ?? "0.0.0";
+
+    const updatedMatch = content.match(/\*\*Last Updated\*\*:\s*(\S+)/);
+    const lastUpdated = updatedMatch?.[1] ?? new Date().toISOString().split("T")[0];
+
+    return {
+      version,
+      lastUpdated,
+      corePrinciples: this.parsePrinciples(content),
+      boundaries: this.parseBoundaries(content),
+      interactionStyle: this.parseInteractionStyle(content),
+      recoveryProtocol: this.parseRecoveryProtocol(content),
+      checksum,
+    };
+  }
+
+  private parsePrinciples(content: string): Principle[] {
+    const principles: Principle[] = [];
+    const re = /###\s*(\d+)\.\s*([^\n]+)\n\n([^#]+?)(?=###|\n---|\n##|$)/g;
+    let match;
+
+    while ((match = re.exec(content)) !== null) {
+      const id = parseInt(match[1], 10);
+      const name = match[2].trim();
+      const body = match[3].trim();
+
+      const inPracticeMatch = body.match(/\*\*In practice\*\*:\s*([^*]+)/);
+      let description = body;
+      if (inPracticeMatch) {
+        description = body.substring(0, body.indexOf("**In practice**")).trim();
+      }
+      const explanationMatch = description.match(/\*\*([^*]+)\*\*/);
+      if (explanationMatch) {
+        description = explanationMatch[1];
+      }
+
+      principles.push({
+        id,
+        name,
+        description,
+        inPractice: inPracticeMatch?.[1]?.trim(),
+      });
+    }
+
+    return principles;
+  }
+
+  private parseBoundaries(content: string): Boundary[] {
+    const boundaries: Boundary[] = [];
+
+    const willNotMatch = content.match(/###\s*What I Won't Do\n\n([\s\S]*?)(?=###|---|##|$)/);
+    if (willNotMatch) {
+      const items = this.parseListItems(willNotMatch[1]);
+      if (items.length > 0) boundaries.push({ type: "will_not", items });
+    }
+
+    const alwaysMatch = content.match(/###\s*What I Always Do\n\n([\s\S]*?)(?=###|---|##|$)/);
+    if (alwaysMatch) {
+      const items = this.parseListItems(alwaysMatch[1]);
+      if (items.length > 0) boundaries.push({ type: "always", items });
+    }
+
+    return boundaries;
+  }
+
+  private parseInteractionStyle(content: string): string[] {
+    const styles: string[] = [];
+    const styleMatch = content.match(/##\s*Interaction Style\n\n([\s\S]*?)(?=\n## [^#]|\n---|$)/);
+    if (styleMatch) {
+      const re = /###\s*([^\n]+)/g;
+      let match;
+      while ((match = re.exec(styleMatch[1])) !== null) {
+        styles.push(match[1].trim());
+      }
+    }
+    return styles;
+  }
+
+  private parseRecoveryProtocol(content: string): string {
+    const protocolMatch = content.match(
+      /##\s*Recovery Protocol\n\n([\s\S]*?)(?=\n## [^#]|\n---|$)/,
+    );
+    if (protocolMatch) {
+      const codeMatch = protocolMatch[1].match(/```([\s\S]*?)```/);
+      if (codeMatch) return codeMatch[1].trim();
+    }
+    return "";
+  }
+
+  private parseListItems(text: string): string[] {
+    const items: string[] = [];
+    const re = /^\s*(?:\d+\.|[-*])\s*\*\*([^*]+)\*\*\s*[-–]?\s*(.*)$/gm;
+    let match;
+    while ((match = re.exec(text)) !== null) {
+      const title = match[1].trim();
+      const desc = match[2].trim();
+      items.push(desc ? `${title}: ${desc}` : title);
+    }
+    return items;
+  }
+
+  private async logIdentityChange(newChecksum: string): Promise<void> {
+    const timestamp = new Date().toISOString();
+    const logEntry = `\n## [Identity Change] ${timestamp}\n\n- Previous checksum: ${this.lastLoadedChecksum}\n- New checksum: ${newChecksum}\n- Document reloaded\n`;
+
+    try {
+      if (existsSync(this.config.notesPath)) {
+        await appendFile(this.config.notesPath, logEntry, "utf-8");
+      }
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  private computeChecksum(content: string): string {
+    return createHash("sha256").update(content).digest("hex").substring(0, 16);
+  }
+}
+
+/** Create an IdentityLoader with default paths. */
+export function createIdentityLoader(basePath: string): IdentityLoader {
+  return new IdentityLoader({
+    beauvoirPath: `${basePath}/grimoires/loa/BEAUVOIR.md`,
+    notesPath: `${basePath}/grimoires/loa/NOTES.md`,
+  });
+}

--- a/.claude/lib/persistence/index.ts
+++ b/.claude/lib/persistence/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Loa Persistence Framework
+ *
+ * Portable persistence patterns extracted from deploy/loa-identity/.
+ * Framework-grade library with no container dependencies.
+ */
+
+// ── Types ────────────────────────────────────────────────────
+export {
+  PersistenceError,
+  type PersistenceErrorCode,
+  type RetryConfig,
+  type DiskPressureLevel,
+  type StateChangeCallback,
+  type EventCallback,
+} from "./types.js";
+
+// ── Circuit Breaker ──────────────────────────────────────────
+export {
+  CircuitBreaker,
+  type CircuitBreakerState,
+  type CircuitBreakerConfig,
+  type CircuitBreakerStateChangeCallback,
+} from "./circuit-breaker.js";
+
+// ── WAL ──────────────────────────────────────────────────────
+export { WALManager, createWALManager, type WALManagerConfig } from "./wal/wal-manager.js";
+export {
+  type WALEntry,
+  type WALOperation,
+  type WALSegment,
+  type WALCheckpoint,
+  generateEntryId,
+  isLegacyUUID,
+  verifyEntry,
+} from "./wal/wal-entry.js";
+export { compactEntries } from "./wal/wal-compaction.js";
+export { evaluateDiskPressure, type DiskPressureStatus } from "./wal/wal-pressure.js";
+
+// ── Checkpoint ───────────────────────────────────────────────
+export {
+  CheckpointProtocol,
+  type CheckpointProtocolConfig,
+} from "./checkpoint/checkpoint-protocol.js";
+export {
+  type CheckpointManifest,
+  type CheckpointFileEntry,
+  type WriteIntent,
+  createManifest,
+  verifyManifest,
+} from "./checkpoint/checkpoint-manifest.js";
+export { type ICheckpointStorage, MountCheckpointStorage } from "./checkpoint/storage-mount.js";
+
+// ── Recovery ─────────────────────────────────────────────────
+export {
+  RecoveryEngine,
+  type RecoveryState,
+  type RecoveryEngineConfig,
+} from "./recovery/recovery-engine.js";
+export { type IRecoverySource } from "./recovery/recovery-source.js";
+export { MountRecoverySource } from "./recovery/sources/mount-source.js";
+export { GitRecoverySource, type GitRestoreClient } from "./recovery/sources/git-source.js";
+export { TemplateRecoverySource } from "./recovery/sources/template-source.js";
+export {
+  ManifestSigner,
+  generateKeyPair,
+  createManifestSigner,
+  type SignedManifest,
+} from "./recovery/manifest-signer.js";
+
+// ── Beads Bridge ─────────────────────────────────────────────
+export {
+  BeadsWALAdapter,
+  type IBeadsWAL,
+  type IBeadsWALEntry,
+  type BeadWALEntry,
+  type BeadOperation,
+  type BeadsWALConfig,
+} from "./beads/beads-wal-adapter.js";
+export {
+  BeadsRecoveryHandler,
+  type RecoveryResult as BeadsRecoveryResult,
+  type BeadsRecoveryConfig,
+  type IShellExecutor,
+} from "./beads/beads-recovery.js";
+
+// ── Learning ─────────────────────────────────────────────────
+export {
+  LearningStore,
+  type Learning,
+  type LearningsStore,
+  type LearningSource,
+  type LearningTarget,
+  type LearningStatus,
+  type QualityGates,
+  type ILearningWAL,
+  type LearningStoreConfig,
+  type IQualityGateScorer,
+} from "./learning/learning-store.js";
+export {
+  scoreAllGates,
+  passesQualityGates,
+  scoreDiscoveryDepth,
+  scoreReusability,
+  scoreTriggerClarity,
+  scoreVerification,
+  DefaultQualityGateScorer,
+  GATE_THRESHOLDS,
+  MINIMUM_TOTAL_SCORE,
+} from "./learning/quality-gates.js";
+
+// ── Identity ─────────────────────────────────────────────────
+export {
+  IdentityLoader,
+  createIdentityLoader,
+  type IdentityDocument,
+  type Principle,
+  type Boundary,
+  type IdentityLoaderConfig,
+} from "./identity/identity-loader.js";
+export {
+  FileWatcher,
+  type FileWatcherConfig,
+  type FileChangeCallback,
+} from "./identity/file-watcher.js";

--- a/.claude/lib/persistence/learning/learning-store.ts
+++ b/.claude/lib/persistence/learning/learning-store.ts
@@ -1,0 +1,374 @@
+/**
+ * Learning Store — portable CRUD for compound learnings.
+ *
+ * Extracted from deploy/loa-identity/learning-store.ts.
+ * Uses constructor-injected paths (no process.env dependency).
+ * WAL integration is optional for graceful degradation.
+ *
+ * Storage locations (relative to configured base path):
+ *   - Active learnings:  {basePath}/learnings.json
+ *   - Pending self-improvements: {basePath}/pending-self/
+ *
+ * @module .claude/lib/persistence/learning/learning-store
+ */
+
+import { randomUUID } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+
+// ── Types ──────────────────────────────────────────────────
+
+export type LearningSource = "sprint" | "error-cycle" | "retrospective";
+export type LearningTarget = "loa" | "devcontainer" | "moltworker" | "openclaw";
+export type LearningStatus = "pending" | "approved" | "active" | "archived";
+
+export interface QualityGates {
+  discovery_depth: number;
+  reusability: number;
+  trigger_clarity: number;
+  verification: number;
+}
+
+export interface Learning {
+  id: string;
+  created: string;
+  source: LearningSource;
+  trigger: string;
+  pattern: string;
+  solution: string;
+  gates: QualityGates;
+  target: LearningTarget;
+  status: LearningStatus;
+  approved_by?: string;
+  approved_at?: string;
+  effectiveness?: {
+    applications: number;
+    successes: number;
+    failures: number;
+    last_applied?: string;
+  };
+}
+
+export interface LearningsStore {
+  version: string;
+  learnings: Learning[];
+}
+
+/** Optional WAL for write-protection. */
+export interface ILearningWAL {
+  write(path: string, content: string): Promise<void>;
+}
+
+/** Configuration for LearningStore. */
+export interface LearningStoreConfig {
+  basePath: string;
+  wal?: ILearningWAL;
+}
+
+// ── Quality Gate Scoring ───────────────────────────────────
+
+export interface IQualityGateScorer {
+  scoreAll(learning: Partial<Learning>): QualityGates;
+  passes(learning: Partial<Learning>): boolean;
+}
+
+// UUID pattern for validating learning IDs (prevents path traversal)
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ── Store Implementation ───────────────────────────────────
+
+export class LearningStore {
+  private readonly basePath: string;
+  private readonly wal?: ILearningWAL;
+  private readonly scorer?: IQualityGateScorer;
+  /** Promise chain for serializing write operations (prevents lost updates) */
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(config: LearningStoreConfig, scorer?: IQualityGateScorer) {
+    this.basePath = config.basePath;
+    this.wal = config.wal;
+    this.scorer = scorer;
+  }
+
+  private validateId(id: string): void {
+    if (!UUID_PATTERN.test(id)) {
+      throw new Error(`Invalid learning ID: ${id}`);
+    }
+  }
+
+  private get learningsPath(): string {
+    return path.join(this.basePath, "learnings.json");
+  }
+
+  private get pendingSelfDir(): string {
+    return path.join(this.basePath, "pending-self");
+  }
+
+  // ── Store Operations ─────────────────────────────────────
+
+  async loadStore(): Promise<LearningsStore> {
+    try {
+      const data = await fs.promises.readFile(this.learningsPath, "utf8");
+      return JSON.parse(data);
+    } catch {
+      return { version: "1.0.0", learnings: [] };
+    }
+  }
+
+  async saveStore(store: LearningsStore): Promise<void> {
+    const content = JSON.stringify(store, null, 2);
+
+    if (this.wal) {
+      await this.wal.write(this.learningsPath, content);
+    } else {
+      await fs.promises.mkdir(path.dirname(this.learningsPath), { recursive: true });
+      await fs.promises.writeFile(this.learningsPath, content);
+    }
+  }
+
+  // ── CRUD ─────────────────────────────────────────────────
+
+  async addLearning(
+    learning: Omit<Learning, "id" | "created" | "gates" | "status">,
+  ): Promise<Learning> {
+    const id = randomUUID();
+    const created = new Date().toISOString();
+    const gates = this.scorer?.scoreAll(learning) ?? {
+      discovery_depth: 5,
+      reusability: 5,
+      trigger_clarity: 5,
+      verification: 5,
+    };
+
+    const newLearning: Learning = {
+      ...learning,
+      id,
+      created,
+      gates,
+      status: "pending",
+    };
+
+    // Check quality gates
+    if (this.scorer && !this.scorer.passes(newLearning)) {
+      return newLearning; // Discarded
+    }
+
+    // Serialize writes to prevent lost updates
+    await this.serializedWrite(async () => {
+      // Self-improvement requires human approval
+      if (learning.target === "loa") {
+        await this.savePendingSelf(newLearning);
+      } else {
+        newLearning.status = "active";
+        const store = await this.loadStore();
+        store.learnings.push(newLearning);
+        await this.saveStore(store);
+      }
+    });
+
+    return newLearning;
+  }
+
+  async getLearning(id: string): Promise<Learning | null> {
+    this.validateId(id);
+    const store = await this.loadStore();
+    const learning = store.learnings.find((l) => l.id === id);
+    if (learning) return learning;
+
+    // Check pending-self
+    const pendingPath = path.join(this.pendingSelfDir, `${id}.json`);
+    try {
+      const data = await fs.promises.readFile(pendingPath, "utf8");
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }
+
+  async getLearnings(status?: LearningStatus): Promise<Learning[]> {
+    const store = await this.loadStore();
+    return status ? store.learnings.filter((l) => l.status === status) : store.learnings;
+  }
+
+  async getLearningsByTarget(target: LearningTarget): Promise<Learning[]> {
+    const store = await this.loadStore();
+    return store.learnings.filter((l) => l.target === target);
+  }
+
+  async getPendingLearnings(): Promise<Learning[]> {
+    const pending: Learning[] = [];
+
+    try {
+      await fs.promises.mkdir(this.pendingSelfDir, { recursive: true });
+      const files = await fs.promises.readdir(this.pendingSelfDir);
+
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue;
+        try {
+          const data = await fs.promises.readFile(path.join(this.pendingSelfDir, file), "utf8");
+          pending.push(JSON.parse(data));
+        } catch {
+          // Skip invalid files
+        }
+      }
+    } catch {
+      // Directory doesn't exist yet
+    }
+
+    return pending;
+  }
+
+  async updateLearningStatus(
+    id: string,
+    status: LearningStatus,
+    approvedBy?: string,
+  ): Promise<Learning | null> {
+    this.validateId(id);
+
+    return this.serializedWrite(async () => {
+      // Try pending-self first (for approvals)
+      const pendingPath = path.join(this.pendingSelfDir, `${id}.json`);
+
+      try {
+        const data = await fs.promises.readFile(pendingPath, "utf8");
+        const learning: Learning = JSON.parse(data);
+
+        learning.status = status;
+        if (status === "approved" || status === "active") {
+          learning.approved_by = approvedBy;
+          learning.approved_at = new Date().toISOString();
+          learning.status = "active";
+
+          const store = await this.loadStore();
+          store.learnings.push(learning);
+          await this.saveStore(store);
+          await fs.promises.unlink(pendingPath);
+
+          return learning;
+        } else if (status === "archived") {
+          await fs.promises.unlink(pendingPath);
+          return learning;
+        }
+      } catch {
+        // Not in pending-self
+      }
+
+      // Update in active store
+      const store = await this.loadStore();
+      const index = store.learnings.findIndex((l) => l.id === id);
+      if (index === -1) return null;
+
+      store.learnings[index].status = status;
+      if (approvedBy) {
+        store.learnings[index].approved_by = approvedBy;
+        store.learnings[index].approved_at = new Date().toISOString();
+      }
+
+      await this.saveStore(store);
+      return store.learnings[index];
+    });
+  }
+
+  async recordApplication(id: string, success: boolean): Promise<Learning | null> {
+    this.validateId(id);
+
+    return this.serializedWrite(async () => {
+      const store = await this.loadStore();
+      const index = store.learnings.findIndex((l) => l.id === id);
+      if (index === -1) return null;
+
+      const learning = store.learnings[index];
+
+      if (!learning.effectiveness) {
+        learning.effectiveness = {
+          applications: 0,
+          successes: 0,
+          failures: 0,
+        };
+      }
+
+      learning.effectiveness.applications++;
+      if (success) {
+        learning.effectiveness.successes++;
+      } else {
+        learning.effectiveness.failures++;
+      }
+      learning.effectiveness.last_applied = new Date().toISOString();
+
+      await this.saveStore(store);
+      return learning;
+    });
+  }
+
+  // ── Query Helpers ────────────────────────────────────────
+
+  async findMatchingLearnings(context: string): Promise<Learning[]> {
+    const store = await this.loadStore();
+    const active = store.learnings.filter((l) => l.status === "active");
+
+    const contextLower = context.toLowerCase();
+    return active.filter((l) => {
+      const words = [
+        ...l.trigger.toLowerCase().split(/\s+/),
+        ...l.pattern.toLowerCase().split(/\s+/),
+      ];
+      const matchCount = words.filter(
+        (word) => word.length > 3 && contextLower.includes(word),
+      ).length;
+      return matchCount >= 2;
+    });
+  }
+
+  async getStats(): Promise<{
+    total: number;
+    byStatus: Record<LearningStatus, number>;
+    byTarget: Record<LearningTarget, number>;
+    pendingSelf: number;
+  }> {
+    const store = await this.loadStore();
+    const pending = await this.getPendingLearnings();
+
+    const byStatus: Record<string, number> = {
+      pending: 0,
+      approved: 0,
+      active: 0,
+      archived: 0,
+    };
+    const byTarget: Record<string, number> = {
+      loa: 0,
+      devcontainer: 0,
+      moltworker: 0,
+      openclaw: 0,
+    };
+
+    for (const l of store.learnings) {
+      byStatus[l.status]++;
+      byTarget[l.target]++;
+    }
+
+    return {
+      total: store.learnings.length,
+      byStatus: byStatus as Record<LearningStatus, number>,
+      byTarget: byTarget as Record<LearningTarget, number>,
+      pendingSelf: pending.length,
+    };
+  }
+
+  // ── Private ──────────────────────────────────────────────
+
+  /** Serialize write operations to prevent concurrent read-modify-write races. */
+  private serializedWrite<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.writeChain.then(fn);
+    this.writeChain = next.then(
+      () => {},
+      () => {},
+    ); // Keep chain alive on error
+    return next;
+  }
+
+  private async savePendingSelf(learning: Learning): Promise<void> {
+    await fs.promises.mkdir(this.pendingSelfDir, { recursive: true });
+    const filePath = path.join(this.pendingSelfDir, `${learning.id}.json`);
+    await fs.promises.writeFile(filePath, JSON.stringify(learning, null, 2));
+  }
+}

--- a/.claude/lib/persistence/learning/quality-gates.ts
+++ b/.claude/lib/persistence/learning/quality-gates.ts
@@ -1,0 +1,192 @@
+/**
+ * Quality Gates — 4-gate quality filter for compound learnings.
+ *
+ * Extracted from deploy/loa-identity/quality-gates.ts.
+ * Portable: no container dependencies.
+ *
+ * Gates:
+ *   G1: Discovery Depth — Is the solution non-trivial?
+ *   G2: Reusability      — Is the pattern generalizable?
+ *   G3: Trigger Clarity   — Can we identify when this applies?
+ *   G4: Verification      — Was the solution verified to work?
+ *
+ * @module .claude/lib/persistence/learning/quality-gates
+ */
+
+import type { Learning, QualityGates, IQualityGateScorer } from "./learning-store.js";
+
+// ── Thresholds ─────────────────────────────────────────────
+
+export const GATE_THRESHOLDS = {
+  discovery_depth: 5,
+  reusability: 5,
+  trigger_clarity: 5,
+  verification: 3,
+} as const;
+
+export const MINIMUM_TOTAL_SCORE = 18;
+
+// ── Gate Scorers ───────────────────────────────────────────
+
+export function scoreDiscoveryDepth(learning: Partial<Learning>): number {
+  let score = 0;
+  const patternLength = (learning.pattern || "").length;
+  if (patternLength > 500) score += 3;
+  else if (patternLength > 200) score += 2;
+  else if (patternLength > 50) score += 1;
+
+  const solutionLength = (learning.solution || "").length;
+  if (solutionLength > 500) score += 3;
+  else if (solutionLength > 200) score += 2;
+  else if (solutionLength > 50) score += 1;
+
+  if (/```[\s\S]*```|`[^`]+`/.test(learning.solution || "")) score += 2;
+  if (/when|if|after|before|during/i.test(learning.trigger || "")) score += 2;
+
+  return Math.min(10, score);
+}
+
+export function scoreReusability(learning: Partial<Learning>): number {
+  let score = 0;
+  const text = `${learning.trigger || ""} ${learning.pattern || ""}`.toLowerCase();
+
+  const genericTerms = [
+    "similar",
+    "pattern",
+    "approach",
+    "strategy",
+    "general",
+    "common",
+    "typical",
+    "often",
+    "usually",
+    "any",
+    "all",
+  ];
+  score += Math.min(3, genericTerms.filter((t) => text.includes(t)).length);
+
+  const specificIndicators = [
+    "only this file",
+    "just for",
+    "exactly this",
+    "specific to",
+    "unique case",
+    "one-time",
+    "temporary fix",
+  ];
+  score -= Math.min(3, specificIndicators.filter((t) => text.includes(t)).length * 2);
+
+  if (/or|and|also|as well|multiple/i.test(learning.trigger || "")) score += 2;
+
+  if (learning.target === "loa" || learning.target === "devcontainer") score += 2;
+  else score += 1;
+
+  if (learning.pattern && learning.pattern.length > 0) score += 2;
+
+  return Math.max(0, Math.min(10, score));
+}
+
+export function scoreTriggerClarity(learning: Partial<Learning>): number {
+  let score = 0;
+  const trigger = learning.trigger || "";
+  if (trigger.length === 0) return 0;
+
+  const conditionalPatterns = [
+    /when\s+\w+/i,
+    /if\s+\w+/i,
+    /after\s+\w+/i,
+    /before\s+\w+/i,
+    /during\s+\w+/i,
+    /whenever\s+\w+/i,
+  ];
+  score += Math.min(4, conditionalPatterns.filter((p) => p.test(trigger)).length * 2);
+
+  const actionPatterns = [
+    /error|fail|crash|exception/i,
+    /deploy|build|test|install/i,
+    /create|update|delete|modify/i,
+    /start|stop|restart|initialize/i,
+    /request|response|api|endpoint/i,
+  ];
+  score += Math.min(3, actionPatterns.filter((p) => p.test(trigger)).length);
+
+  if (trigger.length >= 20 && trigger.length <= 200) score += 2;
+  else if (trigger.length >= 10) score += 1;
+
+  if (/in\s+\w+|with\s+\w+|using\s+\w+|for\s+\w+/i.test(trigger)) score += 1;
+
+  return Math.min(10, score);
+}
+
+export function scoreVerification(learning: Partial<Learning>): number {
+  let score = 0;
+
+  if (learning.source === "sprint") score += 3;
+  else if (learning.source === "error-cycle") score += 2;
+  else if (learning.source === "retrospective") score += 1;
+
+  const solution = learning.solution || "";
+  const terms = [
+    "tested",
+    "verified",
+    "confirmed",
+    "works",
+    "successful",
+    "passed",
+    "validated",
+    "checked",
+  ];
+  score += Math.min(3, terms.filter((t) => solution.toLowerCase().includes(t)).length);
+
+  if (learning.effectiveness) {
+    const { successes, applications } = learning.effectiveness;
+    if (applications > 0) {
+      const rate = successes / applications;
+      if (rate >= 0.8) score += 3;
+      else if (rate >= 0.6) score += 2;
+      else if (rate >= 0.4) score += 1;
+    }
+  }
+
+  if (solution.length > 0) score += 1;
+
+  return Math.min(10, score);
+}
+
+// ── Combined Scoring ───────────────────────────────────────
+
+export function scoreAllGates(learning: Partial<Learning>): QualityGates {
+  return {
+    discovery_depth: scoreDiscoveryDepth(learning),
+    reusability: scoreReusability(learning),
+    trigger_clarity: scoreTriggerClarity(learning),
+    verification: scoreVerification(learning),
+  };
+}
+
+export function passesQualityGates(learning: Partial<Learning>): boolean {
+  const gates = learning.gates || scoreAllGates(learning);
+
+  if (gates.discovery_depth < GATE_THRESHOLDS.discovery_depth) return false;
+  if (gates.reusability < GATE_THRESHOLDS.reusability) return false;
+  if (gates.trigger_clarity < GATE_THRESHOLDS.trigger_clarity) return false;
+  if (gates.verification < GATE_THRESHOLDS.verification) return false;
+
+  const total =
+    gates.discovery_depth + gates.reusability + gates.trigger_clarity + gates.verification;
+
+  return total >= MINIMUM_TOTAL_SCORE;
+}
+
+// ── Scorer Implementation ──────────────────────────────────
+
+/** Default quality gate scorer implementing IQualityGateScorer. */
+export class DefaultQualityGateScorer implements IQualityGateScorer {
+  scoreAll(learning: Partial<Learning>): QualityGates {
+    return scoreAllGates(learning);
+  }
+
+  passes(learning: Partial<Learning>): boolean {
+    return passesQualityGates(learning);
+  }
+}

--- a/.claude/lib/persistence/recovery/manifest-signer.ts
+++ b/.claude/lib/persistence/recovery/manifest-signer.ts
@@ -1,0 +1,82 @@
+/**
+ * Manifest Signer — Ed25519 signing and verification using Node.js built-in crypto.
+ *
+ * No external dependencies required (Ed25519 supported since Node.js 15).
+ */
+
+import {
+  createHash,
+  createPublicKey,
+  createPrivateKey,
+  sign,
+  verify,
+  generateKeyPairSync,
+  type KeyObject,
+} from "crypto";
+
+export interface SignedManifest {
+  version: number;
+  createdAt: string;
+  files: Array<{ path: string; checksum: string; size: number }>;
+  signature: string;
+}
+
+export class ManifestSigner {
+  constructor(
+    private readonly privateKey: KeyObject | null,
+    private readonly publicKey: KeyObject,
+  ) {}
+
+  /**
+   * Sign a manifest payload.
+   */
+  sign(payload: Omit<SignedManifest, "signature">): string {
+    if (!this.privateKey) {
+      throw new Error("Private key required for signing.");
+    }
+
+    const data = Buffer.from(JSON.stringify(payload, Object.keys(payload).sort()));
+    const sig = sign(null, data, this.privateKey);
+    return sig.toString("base64");
+  }
+
+  /**
+   * Verify a signed manifest.
+   */
+  verify(manifest: SignedManifest): boolean {
+    const { signature, ...payload } = manifest;
+    const data = Buffer.from(JSON.stringify(payload, Object.keys(payload).sort()));
+
+    try {
+      return verify(null, data, this.publicKey, Buffer.from(signature, "base64"));
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Generate an Ed25519 key pair for dev/test environments.
+ * Returns PEM-encoded key strings.
+ */
+export function generateKeyPair(): { publicKey: string; privateKey: string } {
+  const pair = generateKeyPairSync("ed25519", {
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+
+  return {
+    publicKey: pair.publicKey as string,
+    privateKey: pair.privateKey as string,
+  };
+}
+
+/**
+ * Create a ManifestSigner from PEM-encoded key strings.
+ */
+export function createManifestSigner(publicKeyPem: string, privateKeyPem?: string): ManifestSigner {
+  const publicKey = createPublicKey(publicKeyPem);
+  const privateKey = privateKeyPem ? createPrivateKey(privateKeyPem) : null;
+
+  return new ManifestSigner(privateKey, publicKey);
+}

--- a/.claude/lib/persistence/recovery/recovery-engine.ts
+++ b/.claude/lib/persistence/recovery/recovery-engine.ts
@@ -1,0 +1,139 @@
+/**
+ * Recovery Engine — multi-source cascade with loop detection.
+ *
+ * State machine: START → source1 → source2 → ... → DEGRADED
+ * Loop detection prevents infinite recovery cycles.
+ *
+ * Extracted from deploy/loa-identity/recovery/recovery-engine.ts
+ */
+
+import type { IRecoverySource } from "./recovery-source.js";
+import { PersistenceError } from "../types.js";
+
+export type RecoveryState = "IDLE" | "RECOVERING" | "RUNNING" | "DEGRADED" | "LOOP_DETECTED";
+
+export interface RecoveryEngineConfig {
+  /** Ordered list of recovery sources (first = highest priority) */
+  sources: IRecoverySource[];
+  /** Max failures within window before loop detection triggers. Default: 3 */
+  loopMaxFailures?: number;
+  /** Loop detection window in ms. Default: 10 minutes */
+  loopWindowMs?: number;
+  /** Callback on state changes */
+  onStateChange?: (from: RecoveryState, to: RecoveryState) => void;
+  /** Callback on recovery events */
+  onEvent?: (event: string, data?: Record<string, unknown>) => void;
+}
+
+interface FailureRecord {
+  timestamp: number;
+  source: string;
+  reason: string;
+}
+
+export class RecoveryEngine {
+  private state: RecoveryState = "IDLE";
+  private readonly sources: IRecoverySource[];
+  private readonly loopMaxFailures: number;
+  private readonly loopWindowMs: number;
+  private readonly onStateChange?: (from: RecoveryState, to: RecoveryState) => void;
+  private readonly onEvent?: (event: string, data?: Record<string, unknown>) => void;
+  private failures: FailureRecord[] = [];
+  private nowFn: () => number;
+
+  constructor(config: RecoveryEngineConfig, options?: { now?: () => number }) {
+    this.sources = config.sources;
+    this.loopMaxFailures = config.loopMaxFailures ?? 3;
+    this.loopWindowMs = config.loopWindowMs ?? 10 * 60 * 1000;
+    this.onStateChange = config.onStateChange;
+    this.onEvent = config.onEvent;
+    this.nowFn = options?.now ?? Date.now;
+  }
+
+  /**
+   * Run recovery cascade. Returns the restored files or null on failure.
+   */
+  async run(): Promise<{
+    state: RecoveryState;
+    source: string | null;
+    files: Map<string, Buffer> | null;
+  }> {
+    // Check loop detection
+    if (this.isLoopDetected()) {
+      this.transition("LOOP_DETECTED");
+      this.onEvent?.("loop_detected", { failures: this.failures.length });
+      return { state: "LOOP_DETECTED", source: null, files: null };
+    }
+
+    this.transition("RECOVERING");
+
+    for (const source of this.sources) {
+      this.onEvent?.("trying_source", { name: source.name });
+
+      const available = await source.isAvailable();
+      if (!available) {
+        this.onEvent?.("source_unavailable", { name: source.name });
+        continue;
+      }
+
+      try {
+        const files = await source.restore();
+        if (files && files.size > 0) {
+          this.transition("RUNNING");
+          this.onEvent?.("restored", { name: source.name, fileCount: files.size });
+          return { state: "RUNNING", source: source.name, files };
+        }
+
+        this.recordFailure(source.name, "restore returned empty");
+      } catch (e) {
+        const reason = e instanceof Error ? e.message : String(e);
+        this.recordFailure(source.name, reason);
+        this.onEvent?.("source_failed", { name: source.name, reason });
+      }
+    }
+
+    // All sources failed
+    this.transition("DEGRADED");
+    this.onEvent?.("all_sources_failed", {
+      sourceCount: this.sources.length,
+      totalFailures: this.failures.length,
+    });
+
+    return { state: "DEGRADED", source: null, files: null };
+  }
+
+  getState(): RecoveryState {
+    return this.state;
+  }
+
+  /**
+   * Check if loop detection has triggered.
+   */
+  private isLoopDetected(): boolean {
+    const now = this.nowFn();
+    const windowStart = now - this.loopWindowMs;
+    const recentFailures = this.failures.filter((f) => f.timestamp >= windowStart);
+    return recentFailures.length >= this.loopMaxFailures;
+  }
+
+  private recordFailure(source: string, reason: string): void {
+    this.failures.push({
+      timestamp: this.nowFn(),
+      source,
+      reason,
+    });
+
+    // Prune stale failure records to prevent unbounded memory growth
+    const windowStart = this.nowFn() - this.loopWindowMs;
+    if (this.failures.length > this.loopMaxFailures * 3) {
+      this.failures = this.failures.filter((f) => f.timestamp >= windowStart);
+    }
+  }
+
+  private transition(to: RecoveryState): void {
+    if (this.state === to) return;
+    const from = this.state;
+    this.state = to;
+    this.onStateChange?.(from, to);
+  }
+}

--- a/.claude/lib/persistence/recovery/recovery-source.ts
+++ b/.claude/lib/persistence/recovery/recovery-source.ts
@@ -1,0 +1,12 @@
+/**
+ * Recovery Source interface — pluggable sources for the recovery cascade.
+ */
+
+export interface IRecoverySource {
+  /** Human-readable name for logging */
+  readonly name: string;
+  /** Check if this source is available for restore */
+  isAvailable(): Promise<boolean>;
+  /** Attempt to restore from this source. Returns file map or null on failure. */
+  restore(): Promise<Map<string, Buffer> | null>;
+}

--- a/.claude/lib/persistence/recovery/sources/git-source.ts
+++ b/.claude/lib/persistence/recovery/sources/git-source.ts
@@ -1,0 +1,38 @@
+/**
+ * Git-based recovery source.
+ */
+
+import type { IRecoverySource } from "../recovery-source.js";
+
+export interface GitRestoreClient {
+  cloneOrPull(): Promise<boolean>;
+  listFiles(): Promise<string[]>;
+  getFile(path: string): Promise<Buffer | null>;
+  isAvailable(): Promise<boolean>;
+}
+
+export class GitRecoverySource implements IRecoverySource {
+  readonly name = "git";
+
+  constructor(private readonly client: GitRestoreClient) {}
+
+  async isAvailable(): Promise<boolean> {
+    return this.client.isAvailable();
+  }
+
+  async restore(): Promise<Map<string, Buffer> | null> {
+    const pulled = await this.client.cloneOrPull();
+    if (!pulled) return null;
+
+    const fileList = await this.client.listFiles();
+    const files = new Map<string, Buffer>();
+
+    for (const path of fileList) {
+      const content = await this.client.getFile(path);
+      if (!content) return null;
+      files.set(path, content);
+    }
+
+    return files;
+  }
+}

--- a/.claude/lib/persistence/recovery/sources/mount-source.ts
+++ b/.claude/lib/persistence/recovery/sources/mount-source.ts
@@ -1,0 +1,41 @@
+/**
+ * Mount-based recovery source (R2 via rclone/goofys).
+ */
+
+import type { CheckpointManifest } from "../../checkpoint/checkpoint-manifest.js";
+import type { ICheckpointStorage } from "../../checkpoint/storage-mount.js";
+import type { IRecoverySource } from "../recovery-source.js";
+
+export class MountRecoverySource implements IRecoverySource {
+  readonly name = "mount";
+
+  constructor(
+    private readonly storage: ICheckpointStorage,
+    private readonly manifestPath: string = "checkpoint.json",
+  ) {}
+
+  async isAvailable(): Promise<boolean> {
+    return this.storage.isAvailable();
+  }
+
+  async restore(): Promise<Map<string, Buffer> | null> {
+    const manifestData = await this.storage.readFile(this.manifestPath);
+    if (!manifestData) return null;
+
+    let manifest: CheckpointManifest;
+    try {
+      manifest = JSON.parse(manifestData.toString());
+    } catch {
+      return null;
+    }
+
+    const files = new Map<string, Buffer>();
+    for (const entry of manifest.files) {
+      const content = await this.storage.readFile(entry.relativePath);
+      if (!content) return null; // Any missing file = source failure
+      files.set(entry.relativePath, content);
+    }
+
+    return files;
+  }
+}

--- a/.claude/lib/persistence/recovery/sources/template-source.ts
+++ b/.claude/lib/persistence/recovery/sources/template-source.ts
@@ -1,0 +1,21 @@
+/**
+ * Template-based recovery source (last-resort fallback).
+ *
+ * Restores from a set of pre-defined template files.
+ */
+
+import type { IRecoverySource } from "../recovery-source.js";
+
+export class TemplateRecoverySource implements IRecoverySource {
+  readonly name = "template";
+
+  constructor(private readonly templates: Map<string, Buffer>) {}
+
+  async isAvailable(): Promise<boolean> {
+    return this.templates.size > 0;
+  }
+
+  async restore(): Promise<Map<string, Buffer> | null> {
+    return new Map(this.templates);
+  }
+}

--- a/.claude/lib/persistence/run-persistence-tests.sh
+++ b/.claude/lib/persistence/run-persistence-tests.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# run-persistence-tests.sh — Run vitest for .claude/lib/persistence/
+#
+# This script handles the temp package.json + vitest setup required
+# because the upstream loa repo has no package.json.
+#
+# Usage:
+#   ./run-persistence-tests.sh              # Run all persistence tests
+#   ./run-persistence-tests.sh --watch      # Run in watch mode
+#   ./run-persistence-tests.sh <pattern>    # Run tests matching pattern
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Track whether we created temp files (for cleanup)
+CREATED_PACKAGE_JSON=false
+CREATED_TSCONFIG=false
+
+cleanup() {
+  cd "$REPO_ROOT"
+  if [[ "$CREATED_PACKAGE_JSON" == "true" ]] && [[ -f package.json ]]; then
+    rm -f package.json
+  fi
+  if [[ "$CREATED_TSCONFIG" == "true" ]] && [[ -f tsconfig.json ]]; then
+    rm -f tsconfig.json
+  fi
+}
+
+trap cleanup EXIT
+
+cd "$REPO_ROOT"
+
+# ── Setup package.json if missing ──
+if [[ ! -f package.json ]]; then
+  echo -e "${YELLOW}Creating temporary package.json for vitest...${NC}"
+  cat > package.json << 'PKGJSON'
+{
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}
+PKGJSON
+  CREATED_PACKAGE_JSON=true
+fi
+
+# ── Setup tsconfig.json if missing ──
+if [[ ! -f tsconfig.json ]]; then
+  echo -e "${YELLOW}Creating temporary tsconfig.json...${NC}"
+  cat > tsconfig.json << 'TSCFG'
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": [".claude/lib/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+TSCFG
+  CREATED_TSCONFIG=true
+fi
+
+# ── Install deps if needed ──
+if [[ ! -d node_modules ]] || [[ ! -f node_modules/.package-lock.json ]]; then
+  echo -e "${YELLOW}Installing dependencies...${NC}"
+  npm install --no-audit --no-fund 2>&1 | tail -1
+fi
+
+# ── Parse args ──
+VITEST_ARGS=()
+WATCH=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --watch)
+      WATCH=true
+      ;;
+    *)
+      VITEST_ARGS+=("$arg")
+      ;;
+  esac
+done
+
+# ── Run tests ──
+echo -e "${GREEN}Running persistence tests...${NC}"
+
+VITEST_CONFIG="$SCRIPT_DIR/vitest.config.ts"
+
+if [[ "$WATCH" == "true" ]]; then
+  npx vitest watch --config "$VITEST_CONFIG" "${VITEST_ARGS[@]}"
+else
+  npx vitest run --config "$VITEST_CONFIG" "${VITEST_ARGS[@]}"
+fi

--- a/.claude/lib/persistence/types.ts
+++ b/.claude/lib/persistence/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared types for the Loa persistence framework.
+ *
+ * All persistence components use these common error types and configuration interfaces.
+ */
+
+// ── Error Codes ──────────────────────────────────────────────
+
+export type PersistenceErrorCode =
+  | "WAL_CORRUPT"
+  | "WAL_LOCK_FAILED"
+  | "WAL_APPEND_FAILED"
+  | "WAL_REPLAY_FAILED"
+  | "WAL_COMPACTION_FAILED"
+  | "CHECKPOINT_FAILED"
+  | "CHECKPOINT_VERIFY_FAILED"
+  | "CHECKPOINT_STALE_INTENT"
+  | "RECOVERY_LOOP"
+  | "RECOVERY_ALL_SOURCES_FAILED"
+  | "RECOVERY_SIGNATURE_INVALID"
+  | "RECOVERY_DEGRADED"
+  | "CB_OPEN"
+  | "CB_HALF_OPEN_REJECTED"
+  | "IDENTITY_PARSE_FAILED"
+  | "IDENTITY_WATCH_FAILED"
+  | "LEARNING_STORE_CORRUPT"
+  | "LEARNING_GATE_FAILED"
+  | "BEADS_REPLAY_FAILED"
+  | "BEADS_SHELL_ESCAPE"
+  | "BEADS_WHITELIST_VIOLATION"
+  | "DISK_PRESSURE_CRITICAL"
+  | "LOCK_CONTENTION";
+
+// ── Error Class ──────────────────────────────────────────────
+
+export class PersistenceError extends Error {
+  readonly code: PersistenceErrorCode;
+  readonly cause?: Error;
+
+  constructor(code: PersistenceErrorCode, message: string, cause?: Error) {
+    super(message);
+    this.name = "PersistenceError";
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+// ── Common Config Interfaces ─────────────────────────────────
+
+export interface RetryConfig {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export interface DiskPressureLevel {
+  normal: number; // bytes threshold for normal operation
+  warning: number; // bytes threshold for warning (trigger compaction)
+  critical: number; // bytes threshold for critical (reject writes)
+}
+
+// ── Callback Types ───────────────────────────────────────────
+
+export type StateChangeCallback<S extends string> = (
+  from: S,
+  to: S,
+  context?: Record<string, unknown>,
+) => void;
+
+export type EventCallback = (event: string, data?: Record<string, unknown>) => void;

--- a/.claude/lib/persistence/vitest.config.ts
+++ b/.claude/lib/persistence/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+    include: [".claude/lib/persistence/__tests__/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});

--- a/.claude/lib/persistence/wal/wal-compaction.ts
+++ b/.claude/lib/persistence/wal/wal-compaction.ts
@@ -1,0 +1,38 @@
+/**
+ * WAL Compaction — delta-based reduction.
+ *
+ * Keeps only the latest write per path, reducing segment size
+ * while preserving the final state. O(n) single pass.
+ */
+
+import type { WALEntry } from "./wal-entry.js";
+
+/**
+ * Compact a list of WAL entries by keeping only the latest operation per path.
+ * For each path, only the most recent operation (write, mkdir, or delete) is kept.
+ * A write after a delete correctly supersedes the delete for that path.
+ *
+ * @returns Compacted entries in original order (stable sort by seq)
+ */
+export function compactEntries(entries: WALEntry[]): WALEntry[] {
+  // Track the latest entry per path — always keyed by the actual path.
+  // Each new operation for a path overwrites the previous one,
+  // so delete→write correctly keeps the write.
+  const latestByPath = new Map<string, WALEntry>();
+
+  for (const entry of entries) {
+    latestByPath.set(entry.path, entry);
+  }
+
+  // Return entries sorted by seq (preserves causality)
+  return Array.from(latestByPath.values()).sort((a, b) => a.seq - b.seq);
+}
+
+/**
+ * Calculate compaction ratio.
+ * @returns Ratio between 0 (no reduction) and 1 (all entries removed)
+ */
+export function compactionRatio(original: number, compacted: number): number {
+  if (original === 0) return 0;
+  return 1 - compacted / original;
+}

--- a/.claude/lib/persistence/wal/wal-entry.ts
+++ b/.claude/lib/persistence/wal/wal-entry.ts
@@ -1,0 +1,95 @@
+/**
+ * WAL Entry types and ID generation.
+ *
+ * Entry IDs are time-sortable: `${timestamp}-${seq}-${hex4}`
+ * Backwards-compatible with legacy UUID entries.
+ */
+
+import { createHash } from "crypto";
+
+// ── Entry Types ──────────────────────────────────────────────
+
+export type WALOperation = "write" | "delete" | "mkdir";
+
+export interface WALEntry {
+  id: string;
+  seq: number;
+  timestamp: string;
+  operation: WALOperation;
+  path: string;
+  checksum?: string;
+  data?: string;
+  entryChecksum: string;
+}
+
+export interface WALSegment {
+  id: string;
+  path: string;
+  size: number;
+  entries: number;
+  createdAt: string;
+  closedAt?: string;
+}
+
+export interface WALCheckpoint {
+  lastSeq: number;
+  activeSegment: string;
+  segments: WALSegment[];
+  lastCheckpointAt: string;
+  rotationPhase: "none" | "checkpoint_written" | "rotating";
+}
+
+// ── ID Generation ────────────────────────────────────────────
+
+let seqCounter = 0;
+
+/**
+ * Generate a time-sortable entry ID: `{timestamp}-{seq}-{hex4}`
+ * Monotonic within a process (seq increments), sortable across processes (timestamp prefix).
+ */
+export function generateEntryId(): string {
+  const ts = Date.now();
+  const seq = seqCounter++;
+  const hex4 = Math.floor(Math.random() * 0xffff)
+    .toString(16)
+    .padStart(4, "0");
+  return `${ts}-${seq}-${hex4}`;
+}
+
+/**
+ * Check if an entry ID is a legacy UUID format.
+ * UUID v4: 8-4-4-4-12 hex pattern
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isLegacyUUID(id: string): boolean {
+  return UUID_RE.test(id);
+}
+
+/**
+ * Extract timestamp from a time-sortable ID. Returns 0 for UUIDs.
+ */
+export function extractTimestamp(id: string): number {
+  if (isLegacyUUID(id)) return 0;
+  const ts = parseInt(id.split("-")[0], 10);
+  return isNaN(ts) ? 0 : ts;
+}
+
+// ── Checksum Utilities ───────────────────────────────────────
+
+export function computeDataChecksum(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+export function computeEntryChecksum(entry: Omit<WALEntry, "entryChecksum">): string {
+  const sorted = JSON.stringify(entry, Object.keys(entry).sort());
+  return createHash("sha256").update(sorted).digest("hex").substring(0, 16);
+}
+
+/**
+ * Verify an entry's integrity checksum.
+ */
+export function verifyEntry(entry: WALEntry): boolean {
+  const { entryChecksum, ...rest } = entry;
+  return computeEntryChecksum(rest) === entryChecksum;
+}

--- a/.claude/lib/persistence/wal/wal-manager.ts
+++ b/.claude/lib/persistence/wal/wal-manager.ts
@@ -1,0 +1,630 @@
+/**
+ * Framework WAL Manager — Segmented Write-Ahead Log
+ *
+ * Extracted from deploy/loa-identity/wal/wal-manager.ts with enhancements:
+ * - Time-sortable entry IDs (no UUID dependency)
+ * - Delta-based compaction (keep latest write per path)
+ * - Disk pressure monitoring (warning/critical thresholds)
+ * - replay() with sinceSeq + limit pagination
+ * - flock locking with PID-file fallback
+ * - Backwards-compatible UUID entry parsing
+ */
+
+import { existsSync } from "fs";
+import {
+  appendFile,
+  readFile,
+  writeFile,
+  mkdir,
+  rename,
+  unlink,
+  stat,
+  readdir,
+  open,
+  type FileHandle,
+} from "fs/promises";
+import { join } from "path";
+import type { WALEntry, WALOperation, WALCheckpoint, WALSegment } from "./wal-entry.js";
+import { PersistenceError } from "../types.js";
+import { compactEntries, compactionRatio } from "./wal-compaction.js";
+import {
+  generateEntryId,
+  computeDataChecksum,
+  computeEntryChecksum,
+  verifyEntry,
+} from "./wal-entry.js";
+import {
+  evaluateDiskPressure,
+  type DiskPressureConfig,
+  type DiskPressureStatus,
+} from "./wal-pressure.js";
+
+// ── flock binding (optional) ─────────────────────────────────
+
+let flock: ((fd: number, operation: number) => Promise<void>) | null = null;
+try {
+  const fsExt = await import("fs-ext").catch(() => null);
+  if (fsExt?.flock) {
+    flock = (fd: number, operation: number): Promise<void> =>
+      new Promise((resolve, reject) => {
+        fsExt.flock(fd, operation, (err: Error | null) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+  }
+} catch {
+  // fs-ext not available
+}
+
+const LOCK_EX = 2;
+const LOCK_NB = 4;
+const LOCK_UN = 8;
+
+// ── Config ───────────────────────────────────────────────────
+
+export interface WALManagerConfig {
+  walDir: string;
+  /** Max segment size in bytes. Default: 10MB */
+  maxSegmentSize?: number;
+  /** Max segment age in ms. Default: 1 hour */
+  maxSegmentAge?: number;
+  /** Max retained segments. Default: 10 */
+  maxSegments?: number;
+  /** Disk pressure thresholds */
+  diskPressure?: Partial<DiskPressureConfig>;
+}
+
+// ── WAL Manager ──────────────────────────────────────────────
+
+export class WALManager {
+  private readonly walDir: string;
+  private readonly maxSegmentSize: number;
+  private readonly maxSegmentAge: number;
+  private readonly maxSegments: number;
+  private readonly pressureConfig: Partial<DiskPressureConfig>;
+
+  private checkpoint: WALCheckpoint | null = null;
+  private currentSegmentPath: string | null = null;
+  private currentSegmentSize = 0;
+  private seq = 0;
+  private lockHandle: FileHandle | null = null;
+  private initialized = false;
+  private initPromise: Promise<void> | null = null;
+  private writeChain: Promise<number> = Promise.resolve(0);
+
+  constructor(config: WALManagerConfig) {
+    this.walDir = config.walDir;
+    this.maxSegmentSize = config.maxSegmentSize ?? 10 * 1024 * 1024;
+    this.maxSegmentAge = config.maxSegmentAge ?? 60 * 60 * 1000;
+    this.maxSegments = config.maxSegments ?? 10;
+    this.pressureConfig = config.diskPressure ?? {};
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = this._doInitialize();
+    return this.initPromise;
+  }
+
+  private async _doInitialize(): Promise<void> {
+    if (!existsSync(this.walDir)) {
+      await mkdir(this.walDir, { recursive: true });
+    }
+
+    await this.acquireLock();
+    await this.loadCheckpoint();
+
+    if (this.checkpoint!.rotationPhase !== "none") {
+      await this.recoverFromInterruptedRotation();
+    }
+
+    if (!this.checkpoint!.activeSegment) {
+      await this.createNewSegment();
+    } else {
+      this.currentSegmentPath = join(this.walDir, this.checkpoint!.activeSegment);
+      if (existsSync(this.currentSegmentPath)) {
+        const stats = await stat(this.currentSegmentPath);
+        this.currentSegmentSize = stats.size;
+      }
+    }
+
+    this.seq = this.checkpoint!.lastSeq;
+    this.initialized = true;
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.initialized) return;
+    await this.saveCheckpoint();
+    await this.releaseLock();
+    this.initialized = false;
+  }
+
+  // ── Write Operations ─────────────────────────────────────
+
+  /**
+   * Append an entry. Writes are serialized via a promise chain to prevent
+   * interleaved file writes (single-writer pattern matches flock design).
+   */
+  append(operation: WALOperation, path: string, data?: Buffer): Promise<number> {
+    // Chain writes to prevent concurrent file corruption
+    const next = this.writeChain.then(() => this._doAppend(operation, path, data));
+    this.writeChain = next.catch(() => 0); // Keep chain alive on error
+    return next;
+  }
+
+  private async _doAppend(operation: WALOperation, path: string, data?: Buffer): Promise<number> {
+    if (!this.initialized) await this.initialize();
+
+    // Check disk pressure
+    const pressure = this.getDiskPressure();
+    if (pressure === "critical") {
+      throw new PersistenceError(
+        "DISK_PRESSURE_CRITICAL",
+        `WAL disk pressure critical (${this.getTotalSize()} bytes). Compact or free space.`,
+      );
+    }
+    if (pressure === "warning") {
+      await this.compact();
+    }
+
+    await this.maybeRotate();
+
+    const entry: Omit<WALEntry, "entryChecksum"> = {
+      id: generateEntryId(),
+      seq: ++this.seq,
+      timestamp: new Date().toISOString(),
+      operation,
+      path,
+    };
+
+    if (data) {
+      entry.checksum = computeDataChecksum(data);
+      entry.data = data.toString("base64");
+    }
+
+    const entryChecksum = computeEntryChecksum(entry);
+    const fullEntry: WALEntry = { ...entry, entryChecksum };
+
+    const line = JSON.stringify(fullEntry) + "\n";
+    await appendFile(this.currentSegmentPath!, line, "utf-8");
+    await this.fsyncFile(this.currentSegmentPath!);
+
+    this.currentSegmentSize += Buffer.byteLength(line);
+    this.checkpoint!.lastSeq = this.seq;
+
+    const activeSegment = this.checkpoint!.segments.find(
+      (s) => s.id === this.checkpoint!.activeSegment,
+    );
+    if (activeSegment) {
+      activeSegment.size = this.currentSegmentSize;
+      activeSegment.entries++;
+    }
+
+    return this.seq;
+  }
+
+  // ── Read Operations ──────────────────────────────────────
+
+  /**
+   * Replay WAL entries, optionally starting from a sequence number
+   * and limited to a maximum count.
+   */
+  async replay(
+    callback: (entry: WALEntry) => Promise<void>,
+    options?: { sinceSeq?: number; limit?: number },
+  ): Promise<{ replayed: number; errors: number }> {
+    if (!this.initialized) await this.initialize();
+
+    const sinceSeq = options?.sinceSeq ?? 0;
+    const limit = options?.limit ?? Infinity;
+    let replayed = 0;
+    let errors = 0;
+
+    const sortedSegments = [...this.checkpoint!.segments].sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+
+    for (const segment of sortedSegments) {
+      const segPath = join(this.walDir, segment.id);
+      if (!existsSync(segPath)) continue;
+
+      const content = await readFile(segPath, "utf-8");
+      const lines = content.split("\n").filter(Boolean);
+
+      for (const line of lines) {
+        if (replayed >= limit) return { replayed, errors };
+
+        try {
+          const entry = JSON.parse(line) as WALEntry;
+
+          if (entry.seq <= sinceSeq) continue;
+
+          if (!verifyEntry(entry)) {
+            errors++;
+            continue; // Skip corrupt entry, keep replaying valid ones
+          }
+
+          await callback(entry);
+          replayed++;
+        } catch {
+          errors++;
+        }
+      }
+    }
+
+    return { replayed, errors };
+  }
+
+  /**
+   * Get entries since a given sequence number, with optional limit.
+   */
+  async getEntriesSince(sinceSeq: number, limit?: number): Promise<WALEntry[]> {
+    if (!this.initialized) await this.initialize();
+
+    const entries: WALEntry[] = [];
+    const max = limit ?? Infinity;
+
+    // Sort segments by creation time (matches replay() ordering)
+    const sortedSegments = [...this.checkpoint!.segments].sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+
+    for (const segment of sortedSegments) {
+      const segPath = join(this.walDir, segment.id);
+      if (!existsSync(segPath)) continue;
+
+      const content = await readFile(segPath, "utf-8");
+      const lines = content.split("\n").filter(Boolean);
+
+      for (const line of lines) {
+        if (entries.length >= max) return entries.sort((a, b) => a.seq - b.seq);
+
+        try {
+          const entry = JSON.parse(line) as WALEntry;
+          if (entry.seq > sinceSeq) {
+            entries.push(entry);
+          }
+        } catch {
+          // Skip invalid entries
+        }
+      }
+    }
+
+    return entries.sort((a, b) => a.seq - b.seq);
+  }
+
+  // ── Compaction ───────────────────────────────────────────
+
+  /**
+   * Compact all closed segments by keeping only the latest write per path.
+   * The active segment is never compacted (it's still receiving writes).
+   */
+  async compact(): Promise<{ originalEntries: number; compactedEntries: number; ratio: number }> {
+    if (!this.initialized) await this.initialize();
+
+    const closedSegments = this.checkpoint!.segments.filter(
+      (s) => s.closedAt && s.id !== this.checkpoint!.activeSegment,
+    );
+
+    if (closedSegments.length === 0) return { originalEntries: 0, compactedEntries: 0, ratio: 0 };
+
+    // Read all entries from closed segments
+    const allEntries: WALEntry[] = [];
+    for (const segment of closedSegments) {
+      const segPath = join(this.walDir, segment.id);
+      if (!existsSync(segPath)) continue;
+
+      const content = await readFile(segPath, "utf-8");
+      const lines = content.split("\n").filter(Boolean);
+
+      for (const line of lines) {
+        try {
+          allEntries.push(JSON.parse(line));
+        } catch {
+          /* skip */
+        }
+      }
+    }
+
+    const compacted = compactEntries(allEntries);
+    const ratio = compactionRatio(allEntries.length, compacted.length);
+
+    if (ratio === 0)
+      return { originalEntries: allEntries.length, compactedEntries: compacted.length, ratio };
+
+    // Write compacted entries to a new segment
+    const compactedSegId = `segment-compacted-${Date.now()}.wal`;
+    const compactedPath = join(this.walDir, compactedSegId);
+    const lines = compacted.map((e) => JSON.stringify(e)).join("\n") + "\n";
+    await writeFile(compactedPath, lines, "utf-8");
+    await this.fsyncFile(compactedPath);
+
+    // Remove old closed segments
+    for (const segment of closedSegments) {
+      const segPath = join(this.walDir, segment.id);
+      try {
+        await unlink(segPath);
+      } catch {
+        /* ok */
+      }
+      const idx = this.checkpoint!.segments.findIndex((s) => s.id === segment.id);
+      if (idx !== -1) this.checkpoint!.segments.splice(idx, 1);
+    }
+
+    // Add compacted segment
+    this.checkpoint!.segments.unshift({
+      id: compactedSegId,
+      path: compactedPath,
+      size: Buffer.byteLength(lines),
+      entries: compacted.length,
+      createdAt: new Date().toISOString(),
+      closedAt: new Date().toISOString(),
+    });
+
+    await this.saveCheckpoint();
+
+    return { originalEntries: allEntries.length, compactedEntries: compacted.length, ratio };
+  }
+
+  // ── Disk Pressure ────────────────────────────────────────
+
+  getDiskPressure(): DiskPressureStatus {
+    return evaluateDiskPressure(this.getTotalSize(), this.pressureConfig);
+  }
+
+  getTotalSize(): number {
+    return this.checkpoint?.segments.reduce((sum, s) => sum + s.size, 0) ?? 0;
+  }
+
+  // ── Status ───────────────────────────────────────────────
+
+  getStatus(): {
+    seq: number;
+    activeSegment: string;
+    segmentCount: number;
+    totalSize: number;
+    diskPressure: DiskPressureStatus;
+  } {
+    return {
+      seq: this.seq,
+      activeSegment: this.checkpoint?.activeSegment ?? "",
+      segmentCount: this.checkpoint?.segments.length ?? 0,
+      totalSize: this.getTotalSize(),
+      diskPressure: this.getDiskPressure(),
+    };
+  }
+
+  // ── Private: Locking ─────────────────────────────────────
+
+  private async acquireLock(): Promise<void> {
+    const lockPath = join(this.walDir, "wal.lock");
+    const pidPath = join(this.walDir, "wal.pid");
+
+    this.lockHandle = await open(lockPath, "w");
+
+    if (flock) {
+      try {
+        await flock(this.lockHandle.fd, LOCK_EX | LOCK_NB);
+      } catch (e: unknown) {
+        const err = e as NodeJS.ErrnoException;
+        if (err.code === "EAGAIN" || err.code === "EWOULDBLOCK") {
+          await this.lockHandle.close();
+          this.lockHandle = null;
+
+          if (existsSync(pidPath)) {
+            const existingPid = await readFile(pidPath, "utf-8");
+            throw new PersistenceError(
+              "WAL_LOCK_FAILED",
+              `WAL locked by process ${existingPid.trim()}.`,
+            );
+          }
+          throw new PersistenceError("WAL_LOCK_FAILED", "WAL locked by another process.");
+        }
+      }
+    }
+
+    // PID-file fallback
+    if (existsSync(pidPath)) {
+      const existingPid = await readFile(pidPath, "utf-8");
+      const pid = parseInt(existingPid.trim(), 10);
+
+      try {
+        process.kill(pid, 0);
+        if (!flock) {
+          if (this.lockHandle) {
+            await this.lockHandle.close();
+            this.lockHandle = null;
+          }
+          throw new PersistenceError("WAL_LOCK_FAILED", `WAL locked by process ${pid}.`);
+        }
+      } catch (e: unknown) {
+        if ((e as NodeJS.ErrnoException).code !== "ESRCH") throw e;
+        // Dead process, take over
+      }
+    }
+
+    const tempPid = `${pidPath}.tmp.${process.pid}`;
+    await writeFile(tempPid, process.pid.toString(), "utf-8");
+    await rename(tempPid, pidPath);
+  }
+
+  private async releaseLock(): Promise<void> {
+    const pidPath = join(this.walDir, "wal.pid");
+
+    if (this.lockHandle) {
+      try {
+        if (flock) await flock(this.lockHandle.fd, LOCK_UN);
+        await this.lockHandle.close();
+        this.lockHandle = null;
+      } catch {
+        /* ok */
+      }
+    }
+
+    try {
+      const existingPid = await readFile(pidPath, "utf-8");
+      if (parseInt(existingPid.trim(), 10) === process.pid) {
+        await unlink(pidPath);
+      }
+    } catch {
+      /* ok */
+    }
+  }
+
+  // ── Private: Checkpoint ──────────────────────────────────
+
+  private async loadCheckpoint(): Promise<void> {
+    const cpPath = join(this.walDir, "checkpoint.json");
+
+    if (existsSync(cpPath)) {
+      const content = await readFile(cpPath, "utf-8");
+      try {
+        const parsed = JSON.parse(content);
+        // Validate required shape before assignment
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          Array.isArray(parsed.segments) &&
+          typeof parsed.lastSeq === "number"
+        ) {
+          this.checkpoint = parsed;
+        } else {
+          this.checkpoint = this.emptyCheckpoint();
+        }
+      } catch {
+        // Corrupt checkpoint file — start fresh
+        this.checkpoint = this.emptyCheckpoint();
+      }
+    } else {
+      this.checkpoint = this.emptyCheckpoint();
+      await this.saveCheckpoint();
+    }
+  }
+
+  private emptyCheckpoint(): WALCheckpoint {
+    return {
+      lastSeq: 0,
+      activeSegment: "",
+      segments: [],
+      lastCheckpointAt: new Date().toISOString(),
+      rotationPhase: "none",
+    };
+  }
+
+  private async saveCheckpoint(): Promise<void> {
+    if (!this.checkpoint) return;
+
+    const cpPath = join(this.walDir, "checkpoint.json");
+    const tmpPath = `${cpPath}.tmp`;
+
+    this.checkpoint.lastCheckpointAt = new Date().toISOString();
+    await writeFile(tmpPath, JSON.stringify(this.checkpoint, null, 2), "utf-8");
+    await this.fsyncFile(tmpPath);
+    await rename(tmpPath, cpPath);
+  }
+
+  // ── Private: Segments ────────────────────────────────────
+
+  private async createNewSegment(): Promise<void> {
+    const segId = `segment-${Date.now()}.wal`;
+    const segPath = join(this.walDir, segId);
+
+    await writeFile(segPath, "", "utf-8");
+
+    this.checkpoint!.segments.push({
+      id: segId,
+      path: segPath,
+      size: 0,
+      entries: 0,
+      createdAt: new Date().toISOString(),
+    });
+    this.checkpoint!.activeSegment = segId;
+    this.currentSegmentPath = segPath;
+    this.currentSegmentSize = 0;
+
+    await this.saveCheckpoint();
+  }
+
+  private async maybeRotate(): Promise<void> {
+    if (!this.currentSegmentPath) return;
+
+    const active = this.checkpoint!.segments.find((s) => s.id === this.checkpoint!.activeSegment);
+    if (!active) return;
+
+    const age = Date.now() - new Date(active.createdAt).getTime();
+    if (this.currentSegmentSize >= this.maxSegmentSize || age >= this.maxSegmentAge) {
+      await this.rotate();
+    }
+  }
+
+  private async rotate(): Promise<void> {
+    this.checkpoint!.rotationPhase = "checkpoint_written";
+    await this.saveCheckpoint();
+
+    this.checkpoint!.rotationPhase = "rotating";
+    const active = this.checkpoint!.segments.find((s) => s.id === this.checkpoint!.activeSegment);
+    if (active) active.closedAt = new Date().toISOString();
+
+    await this.createNewSegment();
+    await this.cleanupOldSegments();
+
+    this.checkpoint!.rotationPhase = "none";
+    await this.saveCheckpoint();
+  }
+
+  private async recoverFromInterruptedRotation(): Promise<void> {
+    if (this.checkpoint!.rotationPhase === "checkpoint_written") {
+      this.checkpoint!.rotationPhase = "none";
+    } else if (this.checkpoint!.rotationPhase === "rotating") {
+      await this.createNewSegment();
+      await this.cleanupOldSegments();
+      this.checkpoint!.rotationPhase = "none";
+    }
+    await this.saveCheckpoint();
+  }
+
+  private async cleanupOldSegments(): Promise<void> {
+    const closed = this.checkpoint!.segments.filter((s) => s.closedAt);
+    if (closed.length <= this.maxSegments) return;
+
+    closed.sort((a, b) => new Date(a.closedAt!).getTime() - new Date(b.closedAt!).getTime());
+
+    const toRemove = closed.slice(0, closed.length - this.maxSegments);
+    for (const seg of toRemove) {
+      try {
+        const segPath = join(this.walDir, seg.id);
+        await unlink(segPath);
+      } catch {
+        /* ok */
+      }
+      const idx = this.checkpoint!.segments.findIndex((s) => s.id === seg.id);
+      if (idx !== -1) this.checkpoint!.segments.splice(idx, 1);
+    }
+  }
+
+  // ── Private: Fsync ───────────────────────────────────────
+
+  private async fsyncFile(filePath: string): Promise<void> {
+    try {
+      const fd = await open(filePath, "r");
+      try {
+        await fd.sync();
+      } finally {
+        await fd.close();
+      }
+    } catch {
+      /* Fsync may not be supported */
+    }
+  }
+}
+
+/**
+ * Create a WALManager with default config.
+ */
+export function createWALManager(walDir: string): WALManager {
+  return new WALManager({ walDir });
+}

--- a/.claude/lib/persistence/wal/wal-pressure.ts
+++ b/.claude/lib/persistence/wal/wal-pressure.ts
@@ -1,0 +1,36 @@
+/**
+ * WAL Disk Pressure Monitoring.
+ *
+ * Two-threshold hysteresis:
+ *   normal → warning (at warningBytes) → critical (at criticalBytes)
+ *
+ * Warning triggers early compaction; critical rejects new writes.
+ */
+
+export type DiskPressureStatus = "normal" | "warning" | "critical";
+
+export interface DiskPressureConfig {
+  /** Bytes threshold for warning level. Default: 100MB */
+  warningBytes: number;
+  /** Bytes threshold for critical level. Default: 150MB */
+  criticalBytes: number;
+}
+
+const DEFAULT_PRESSURE_CONFIG: DiskPressureConfig = {
+  warningBytes: 100 * 1024 * 1024, // 100MB
+  criticalBytes: 150 * 1024 * 1024, // 150MB
+};
+
+/**
+ * Evaluate disk pressure level from total WAL size.
+ */
+export function evaluateDiskPressure(
+  totalBytes: number,
+  config?: Partial<DiskPressureConfig>,
+): DiskPressureStatus {
+  const c = { ...DEFAULT_PRESSURE_CONFIG, ...config };
+
+  if (totalBytes >= c.criticalBytes) return "critical";
+  if (totalBytes >= c.warningBytes) return "warning";
+  return "normal";
+}


### PR DESCRIPTION
## Summary

Upstream the portable persistence framework from loa-beauvoir ([PR #25](https://github.com/0xHoneyJar/loa-beauvoir/pull/25)) into `.claude/lib/persistence/` so all Loa-mounted repos can access it via `/update-loa`.

- **Origin**: Prototyped in [loa-finn PR #5](https://github.com/0xHoneyJar/loa-finn/pull/5), extracted in [loa-beauvoir PR #25](https://github.com/0xHoneyJar/loa-beauvoir/pull/25), upstreamed here
- **Why**: loa-finn and loa-beauvoir both need these patterns — single source of truth eliminates drift
- **Impact**: After merge, `loa-finn` and `loa-beauvoir` can both `/update-loa` to get the shared library, then wire it via a thin adapter (like loa-beauvoir's `persistence-init.ts`)

## What's included

7 portable persistence patterns (32 files, ~5,100 LOC, 56 tests):

| Module | Description |
|--------|-------------|
| `circuit-breaker.ts` | CLOSED→OPEN→HALF-OPEN state machine |
| `wal/` | Append-only log with segment rotation, checksums, compaction, disk pressure |
| `checkpoint/` | Two-phase commit protocol with mount-based storage |
| `recovery/` | Multi-source cascade (mount→git→template) with Ed25519 manifest signing |
| `beads/` | WAL adapter and recovery handler for beads_rust integration |
| `learning/` | Learning store with 4-gate quality scoring |
| `identity/` | BEAUVOIR.md parser with FileWatcher hot-reload |

## Design principles

- **Zero container dependencies** — all config via constructor injection, no `process.env`
- **Interface-driven** — `ICheckpointStorage`, `IRecoverySource`, `IBeadsWAL`, etc.
- **Comprehensive tests** — 8 test suites covering all modules
- **Clean barrel exports** — single `index.ts` with all public types

## Downstream consumers

| Repo | Adapter | Status |
|------|---------|--------|
| loa-beauvoir | `deploy/loa-identity/persistence-init.ts` | Already wired (PR #25) |
| loa-finn | `src/persistence-init.ts` (planned) | Will wire after `/update-loa` |

## Checklist

- [x] Commits are clean and focused (single commit, 32 files)
- [x] No sensitive data in commits (one test assertion references "BEGIN PRIVATE KEY" — test fixture only)
- [x] DCO sign-off present
- [x] Test suites included (8 suites, 56 tests)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>