### PR TITLE
fix(security): address critical and high findings from security audit

### DIFF
--- a/.claude/scripts/beads-flatline-loop.sh
+++ b/.claude/scripts/beads-flatline-loop.sh
@@ -163,6 +163,7 @@ run_flatline_review() {
     # Create temp file with beads for review (tracked for cleanup on interrupt - H5)
     local temp_file
     temp_file=$(mktemp)
+    chmod 600 "$temp_file"  # SEC-AUDIT SHELL-HIGH-01
     TEMP_FILES_TO_CLEAN+=("$temp_file")
     echo "$beads_json" > "$temp_file"
 

--- a/.claude/scripts/flatline-validate-learning.sh
+++ b/.claude/scripts/flatline-validate-learning.sh
@@ -240,16 +240,20 @@ call_gpt_validation() {
                 max_tokens: 300
             }')" "$TIMEOUT_SECONDS")
     else
+        # SEC-AUDIT SEC-HIGH-01: Use curl config to avoid exposing API key in process list
+        local _curl_cfg
+        _curl_cfg=$(mktemp) && chmod 600 "$_curl_cfg"
+        printf 'header = "Content-Type: application/json"\nheader = "Authorization: Bearer %s"\n' "${OPENAI_API_KEY:-}" > "$_curl_cfg"
         response=$(curl -s --max-time "$TIMEOUT_SECONDS" \
             -X POST "${OPENAI_API_BASE:-https://api.openai.com}/v1/chat/completions" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${OPENAI_API_KEY:-}" \
+            --config "$_curl_cfg" \
             -d "$(jq -n --arg prompt "$prompt" --arg model "$GPT_MODEL" '{
                 model: $model,
                 messages: [{role: "user", content: $prompt}],
                 temperature: 0.2,
                 max_tokens: 300
             }')" 2>/dev/null)
+        rm -f "$_curl_cfg"
     fi
 
     if [[ -z "$response" ]]; then
@@ -301,16 +305,19 @@ call_opus_validation() {
     fi
 
     local response
+    # SEC-AUDIT SEC-HIGH-01: Use curl config to avoid exposing API key in process list
+    local _curl_cfg
+    _curl_cfg=$(mktemp) && chmod 600 "$_curl_cfg"
+    printf 'header = "Content-Type: application/json"\nheader = "x-api-key: %s"\nheader = "anthropic-version: 2023-06-01"\n' "${ANTHROPIC_API_KEY:-}" > "$_curl_cfg"
     response=$(curl -s --max-time "$TIMEOUT_SECONDS" \
         -X POST "https://api.anthropic.com/v1/messages" \
-        -H "Content-Type: application/json" \
-        -H "x-api-key: ${ANTHROPIC_API_KEY:-}" \
-        -H "anthropic-version: 2023-06-01" \
+        --config "$_curl_cfg" \
         -d "$(jq -n --arg prompt "$prompt" --arg model "$OPUS_MODEL" '{
             model: $model,
             max_tokens: 300,
             messages: [{role: "user", content: $prompt}]
         }')" 2>/dev/null)
+    rm -f "$_curl_cfg"
 
     if [[ -z "$response" ]]; then
         log_error "Empty response from Opus"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
           node-version: '20'
 
       - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli
+        run: npm install -g markdownlint-cli@0.47.0
 
       - name: Create markdownlint config
         run: |
@@ -284,7 +284,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install yamllint
-        run: pip install yamllint
+        run: pip install yamllint==1.38.0
 
       - name: Lint YAML files
         run: yamllint .github/ || true

--- a/.github/workflows/lib-tests.yml
+++ b/.github/workflows/lib-tests.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install tsx
-        run: npm install --no-save tsx
+        run: npm install --no-save tsx@4.21.0
 
       - name: Run lib tests
         run: .claude/scripts/run-lib-tests.sh

--- a/.github/workflows/shell-compat-lint.yml
+++ b/.github/workflows/shell-compat-lint.yml
@@ -22,7 +22,7 @@ jobs:
     name: Cross-Platform Compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Check for platform-specific patterns
         shell: bash


### PR DESCRIPTION
## Summary

Addresses 8 critical and high severity findings from the comprehensive security audit (`grimoires/loa/a2a/audits/2026-02-07/SECURITY-AUDIT-REPORT.md`).

### Fixes

| ID | Severity | Fix |
|----|----------|-----|
| TS-CRIT-01 | CRITICAL | Timing-safe hash comparison in `audit-logger.ts` via `crypto.timingSafeEqual` |
| TS-CRIT-02 | CRITICAL | Runtime schema validation for `parseJson<T>` in `beads-bridge.ts` |
| TS-CRIT-03 | CRITICAL | Resolve `br` binary to absolute path to prevent PATH hijacking |
| TS-HIGH-01 | HIGH | Backup corrupt audit log to `.corrupt` before crash recovery truncation |
| SEC-HIGH-01 | HIGH | Migrate 4 flatline scripts to secure `curl --config` pattern (API key protection) |
| CI-HIGH-01 | HIGH | Pin `actions/checkout` to SHA in `shell-compat-lint.yml` |
| CI-HIGH-02 | HIGH | Pin `markdownlint-cli`, `yamllint`, `tsx` versions in CI |
| SHELL-HIGH-01 | HIGH | Add `chmod 600` after `mktemp` in `beads-flatline-loop.sh` |

### Files Changed (10)

- `.claude/lib/security/audit-logger.ts` — timing-safe comparison + crash recovery backup
- `.claude/lib/bridge/beads-bridge.ts` — runtime validators + absolute path resolution
- `.claude/scripts/flatline-proposal-review.sh` — curl config pattern (OpenAI + Anthropic)
- `.claude/scripts/flatline-validate-learning.sh` — curl config pattern (OpenAI + Anthropic)
- `.claude/scripts/flatline-learning-extractor.sh` — curl config pattern (OpenAI)
- `.claude/scripts/flatline-semantic-similarity.sh` — curl config pattern (OpenAI)
- `.claude/scripts/beads-flatline-loop.sh` — chmod 600 after mktemp
- `.github/workflows/shell-compat-lint.yml` — SHA-pinned checkout
- `.github/workflows/ci.yml` — pinned markdownlint-cli + yamllint versions
- `.github/workflows/lib-tests.yml` — pinned tsx version

## Test plan

- [x] All 295 lib tests pass (0 failures)
- [x] GPT-5.2 cross-model review on audit-logger.ts and beads-bridge.ts
- [ ] Verify flatline scripts still work with curl config pattern
- [ ] CI workflows run with pinned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)