### PR TITLE
fix(event-bus): add bash version guard for non-bash shell sourcing (#230)

### DIFF
--- a/.claude/scripts/lib/event-bus.sh
+++ b/.claude/scripts/lib/event-bus.sh
@@ -49,6 +49,18 @@
 #
 # Sources: Issue #161 (Event Bus Architecture), Issue #162 (Construct Manifest Standard)
 
+# Guard: This script uses bash-specific features (BASH_SOURCE, FD redirection
+# with 200>, declare -F, process substitution). Sourcing from zsh or other
+# shells will produce cryptic errors. Detect and fail early with guidance.
+# Fixes #230.
+if [ -z "${BASH_VERSION:-}" ]; then
+    echo "ERROR: event-bus.sh requires bash. Current shell: $(ps -o comm= -p $$ 2>/dev/null || echo unknown)" >&2
+    echo "  When sourcing: bash -c 'source .claude/scripts/lib/event-bus.sh && ...'" >&2
+    echo "  When executing: bash .claude/scripts/lib/event-bus.sh <command>" >&2
+    # 'return' exits when sourced, 'exit' exits when executed
+    return 3 2>/dev/null || exit 3
+fi
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary

- Adds a POSIX-compatible guard at the top of `event-bus.sh` that detects non-bash shells and exits with an actionable error message
- Prevents cryptic failures when sourced from zsh (macOS default) or other POSIX shells
- Uses `[ -z "${BASH_VERSION:-}" ]` (POSIX) not `[[ ]]` (bashism) so the guard itself works in any shell
- Uses `return 3 2>/dev/null || exit 3` to handle both sourcing and execution contexts

**Note**: The primary PATH/flock issue from #230 was already fixed in PR #231. This addresses the remaining bash-only syntax concern.

Closes #230

## Test plan

- [x] `bash -n` syntax validation passes
- [x] `bash -c 'source event-bus.sh && ...'` — guard does NOT trigger (correct)
- [x] `sh -c '. event-bus.sh'` — guard triggers with clear error message
- [x] `bash event-bus.sh --help` — direct execution still works
- [x] Error message shows current shell name and provides both sourcing and execution remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)