### PR TITLE
fix(bridgebuilder): --pr flag now filters PRs in pipeline

### DIFF
--- a/.claude/skills/bridgebuilder-review/dist/config.js
+++ b/.claude/skills/bridgebuilder-review/dist/config.js
@@ -250,6 +250,7 @@ export async function resolveConfig(cliArgs, env, yamlConfig) {
         excludePatterns: yaml.exclude_patterns ?? DEFAULTS.excludePatterns,
         sanitizerMode: yaml.sanitizer_mode ?? DEFAULTS.sanitizerMode,
         maxRuntimeMinutes: yaml.max_runtime_minutes ?? DEFAULTS.maxRuntimeMinutes,
+        ...(cliArgs.pr != null ? { targetPr: cliArgs.pr } : {}),
     };
     const provenance = {
         repos: reposSource,
@@ -280,8 +281,9 @@ export function formatEffectiveConfig(config, provenance) {
     const repoSrc = p ? ` (${p.repos})` : "";
     const modelSrc = p ? ` (${p.model})` : "";
     const drySrc = p ? ` (${p.dryRun})` : "";
+    const prFilter = config.targetPr != null ? `, target_pr=#${config.targetPr}` : "";
     return (`[bridgebuilder] Config: repos=[${repoNames}]${repoSrc}, ` +
         `model=${config.model}${modelSrc}, max_prs=${config.maxPrs}, ` +
-        `dry_run=${config.dryRun}${drySrc}, sanitizer_mode=${config.sanitizerMode}`);
+        `dry_run=${config.dryRun}${drySrc}, sanitizer_mode=${config.sanitizerMode}${prFilter}`);
 }
 //# sourceMappingURL=config.js.map

--- a/.claude/skills/bridgebuilder-review/dist/core/template.js
+++ b/.claude/skills/bridgebuilder-review/dist/core/template.js
@@ -18,6 +18,10 @@ export class PRReviewTemplate {
         for (const { owner, repo } of this.config.repos) {
             const prs = await this.git.listOpenPRs(owner, repo);
             for (const pr of prs.slice(0, this.config.maxPrs)) {
+                // Skip PRs that don't match --pr filter
+                if (this.config.targetPr != null && pr.number !== this.config.targetPr) {
+                    continue;
+                }
                 const files = await this.git.getPRFiles(owner, repo, pr.number);
                 // Canonical hash: sha256(headSha + "\n" + sorted filenames)
                 // Excludes patch content — only structural identity

--- a/.claude/skills/bridgebuilder-review/dist/core/types.d.ts
+++ b/.claude/skills/bridgebuilder-review/dist/core/types.d.ts
@@ -17,6 +17,7 @@ export interface BridgebuilderConfig {
     excludePatterns: string[];
     sanitizerMode: "default" | "strict";
     maxRuntimeMinutes: number;
+    targetPr?: number;
 }
 export interface ReviewItem {
     owner: string;

--- a/.claude/skills/bridgebuilder-review/resources/config.ts
+++ b/.claude/skills/bridgebuilder-review/resources/config.ts
@@ -309,6 +309,7 @@ export async function resolveConfig(
     excludePatterns: yaml.exclude_patterns ?? DEFAULTS.excludePatterns,
     sanitizerMode: yaml.sanitizer_mode ?? DEFAULTS.sanitizerMode,
     maxRuntimeMinutes: yaml.max_runtime_minutes ?? DEFAULTS.maxRuntimeMinutes,
+    ...(cliArgs.pr != null ? { targetPr: cliArgs.pr } : {}),
   };
 
   const provenance: ConfigProvenance = {
@@ -359,9 +360,10 @@ export function formatEffectiveConfig(
   const repoSrc = p ? ` (${p.repos})` : "";
   const modelSrc = p ? ` (${p.model})` : "";
   const drySrc = p ? ` (${p.dryRun})` : "";
+  const prFilter = config.targetPr != null ? `, target_pr=#${config.targetPr}` : "";
   return (
     `[bridgebuilder] Config: repos=[${repoNames}]${repoSrc}, ` +
     `model=${config.model}${modelSrc}, max_prs=${config.maxPrs}, ` +
-    `dry_run=${config.dryRun}${drySrc}, sanitizer_mode=${config.sanitizerMode}`
+    `dry_run=${config.dryRun}${drySrc}, sanitizer_mode=${config.sanitizerMode}${prFilter}`
   );
 }

--- a/.claude/skills/bridgebuilder-review/resources/core/template.ts
+++ b/.claude/skills/bridgebuilder-review/resources/core/template.ts
@@ -30,6 +30,10 @@ export class PRReviewTemplate {
       const prs = await this.git.listOpenPRs(owner, repo);
 
       for (const pr of prs.slice(0, this.config.maxPrs)) {
+        // Skip PRs that don't match --pr filter
+        if (this.config.targetPr != null && pr.number !== this.config.targetPr) {
+          continue;
+        }
         const files = await this.git.getPRFiles(owner, repo, pr.number);
 
         // Canonical hash: sha256(headSha + "\n" + sorted filenames)

--- a/.claude/skills/bridgebuilder-review/resources/core/types.ts
+++ b/.claude/skills/bridgebuilder-review/resources/core/types.ts
@@ -15,6 +15,7 @@ export interface BridgebuilderConfig {
   excludePatterns: string[];
   sanitizerMode: "default" | "strict";
   maxRuntimeMinutes: number;
+  targetPr?: number;
 }
 
 export interface ReviewItem {


### PR DESCRIPTION
## Summary

Fixes #257 — the `--pr N` flag was parsed but never propagated to the review pipeline. `resolveItems()` fetched ALL open PRs regardless, causing wrong PRs to be processed first and early exit on unrelated failures.

## Changes

| File | Change |
|------|--------|
| `core/types.ts` | Add `targetPr?: number` to `BridgebuilderConfig` |
| `config.ts` | Pass `cliArgs.pr` into config object in `resolveConfig()` |
| `core/template.ts` | Filter by `config.targetPr` in `resolveItems()` loop |
| `config.ts` | Log `target_pr=#N` in `formatEffectiveConfig()` when set |

## Root Cause

`parseCLIArgs()` correctly parsed `--pr 256` into `cliArgs.pr = 256`, and `resolveRepos()` validated that only one repo was configured. But `cliArgs.pr` was never passed into the `BridgebuilderConfig` object, so `PRReviewTemplate.resolveItems()` had no knowledge of the filter and iterated all open PRs.

## Fix

Three-point fix following the data flow:

1. **Type**: Add `targetPr?: number` to `BridgebuilderConfig` interface
2. **Config**: Spread `{ targetPr: cliArgs.pr }` into config when `cliArgs.pr` is set
3. **Template**: In `resolveItems()`, `continue` past PRs where `pr.number !== config.targetPr`

## Test plan

- [ ] `--pr 256` only reviews PR #256 (not all open PRs)
- [ ] Without `--pr`, all open PRs are still reviewed (no regression)
- [ ] Config log shows `target_pr=#256` when flag is used
- [ ] `--pr` with multiple repos still throws validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)