### PR TITLE
fix(flatline): model validation, timeout, stderr capture, call stagger

### DIFF
--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -185,8 +185,9 @@ get_model_secondary() {
     read_config '.flatline_protocol.models.secondary' 'gpt-5.2'
 }
 
-# Valid model names accepted by model-adapter.sh.legacy MODEL_PROVIDERS registry
-VALID_FLATLINE_MODELS="opus gpt-5.2 gpt-5.2-codex gpt-5.3-codex claude-opus-4.6 claude-opus-4.5 gemini-2.0"
+# Valid model names accepted by model-adapter.sh.legacy MODEL_PROVIDERS registry.
+# Keep in sync with MODEL_PROVIDERS in model-adapter.sh.legacy (line ~69).
+VALID_FLATLINE_MODELS=(opus gpt-5.2 gpt-5.2-codex gpt-5.3-codex claude-opus-4.6 claude-opus-4.5 gemini-2.0)
 
 validate_model() {
     local model="$1"
@@ -194,12 +195,12 @@ validate_model() {
 
     if [[ -z "$model" ]]; then
         error "Flatline model '$config_key' is empty. Set flatline_protocol.models.$config_key in .loa.config.yaml"
-        error "Valid models: $VALID_FLATLINE_MODELS"
+        error "Valid models: ${VALID_FLATLINE_MODELS[*]}"
         return 1
     fi
 
     local valid=false
-    for valid_model in $VALID_FLATLINE_MODELS; do
+    for valid_model in "${VALID_FLATLINE_MODELS[@]}"; do
         if [[ "$model" == "$valid_model" ]]; then
             valid=true
             break
@@ -208,7 +209,7 @@ validate_model() {
 
     if [[ "$valid" != "true" ]]; then
         error "Unknown flatline model: '$model' (from flatline_protocol.models.$config_key in .loa.config.yaml)"
-        error "Valid models: $VALID_FLATLINE_MODELS"
+        error "Valid models: ${VALID_FLATLINE_MODELS[*]}"
         error "Note: '$model' may be an agent alias, not a model name. Check .claude/defaults/model-config.yaml for alias mappings."
         return 1
     fi


### PR DESCRIPTION
## Summary

Fixes 4 sub-issues from #305 — Flatline Protocol fails on installs where `.loa.config.yaml` has `secondary: reviewer` (an agent alias, not a model name):

- **Model validation**: `validate_model()` rejects invalid names before API calls with actionable error pointing to config file
- **Timeout increase**: `DEFAULT_MODEL_TIMEOUT` raised from 60s to 120s (Opus responses take 50-80s under load)
- **Stderr capture**: Phase 1 calls redirect stderr to temp files instead of `/dev/null`; stderr logged on failure
- **Call stagger**: 2s delay between review and skeptic waves to avoid same-provider rate-limit contention

## Bridgebuilder Review Summary

| Iteration | Score | Findings | Key Changes |
|-----------|-------|----------|-------------|
| 1 | 4 | 1 MEDIUM, 2 LOW, 3 PRAISE | Initial review of hardening changes |
| 2 | 0 | 1 PRAISE | All findings resolved (array conversion, test extraction) |
| 3 | 0 | 1 PRAISE | **FLATLINE — convergence confirmed** |

**Total findings addressed**: 3 (1 MEDIUM + 2 LOW from iter-1)

### Key Fixes Applied (Bridge Iterations)
- Converted `VALID_FLATLINE_MODELS` from space-separated string to bash array
- Added cross-reference comment to `MODEL_PROVIDERS` in `model-adapter.sh.legacy`
- Replaced per-test sed extraction with shared awk-based `setup()` helper

## Test plan

- [x] 13 BATS tests pass (`tests/unit/flatline-model-validation.bats`)
- [x] Valid models accepted: `opus`, `gpt-5.2`, `claude-opus-4.6`, `gemini-2.0`
- [x] Invalid models rejected: `reviewer`, `skeptic`, `""`, `nonexistent`
- [x] Error message includes valid model list and config file location
- [x] `DEFAULT_MODEL_TIMEOUT` >= 120
- [x] No `2>/dev/null` on Phase 1 `call_model` lines
- [x] Stderr capture files referenced for all 4 calls
- [x] Stagger `sleep` present between wave 1 and wave 2
- [x] Existing bridge-orchestrator tests unaffected (10/11 pass, 1 pre-existing failure)

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>