### PR TITLE
fix(post-merge): git identity, cycle classification, discord webhook

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -65,7 +65,7 @@ jobs:
           # Classify based on labels first, then title
           if echo "$LABELS" | grep -qi "cycle"; then
             PR_TYPE="cycle"
-          elif echo "$TITLE" | grep -qE "^(Run Mode|Sprint Plan|feat\(sprint)"; then
+          elif echo "$TITLE" | grep -qE "^(Run Mode|Sprint Plan|feat\(sprint|feat\(cycle)"; then
             PR_TYPE="cycle"
           elif echo "$TITLE" | grep -qE "^fix"; then
             PR_TYPE="bugfix"
@@ -92,6 +92,11 @@ jobs:
 
       - name: Install jq
         run: sudo apt-get install -y jq
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Compute semver
         id: semver
@@ -153,6 +158,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Check API key
         id: check-key
@@ -226,7 +236,7 @@ jobs:
           (needs.simple-release.result == 'failure' || needs.full-pipeline.result == 'failure') &&
           env.DISCORD_WEBHOOK_URL != ''
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.MELANGE_DISCORD_WEBHOOK }}
         run: |
           PAYLOAD=$(jq -n \
             --arg pr "${{ needs.classify.outputs.pr_number }}" \


### PR DESCRIPTION
## Summary

- **Add git identity config** to both `simple-release` and `full-pipeline` jobs — fixes `fatal: empty ident name` on `git tag -a` (root cause of all 7 failures)
- **Extend cycle classification regex** to match `feat(cycle-...)` commit messages — previously only matched `feat(sprint-...)`
- **Fix Discord webhook secret name** from `DISCORD_WEBHOOK_URL` to `MELANGE_DISCORD_WEBHOOK` (matching actual repo secret)

## Context

All 7 post-merge pipeline runs since PR #302 merged have failed at the `Create tag` step:

```
fatal: empty ident name (for <runner@...>) not allowed
```

GitHub Actions runners don't have a default git committer identity, but `git tag -a` (annotated tags) requires one.

Additionally, cycle PRs like `feat(cycle-012): Flatline Red Team...` were misclassified as `other` because the regex only matched `feat(sprint-...)`.

## Remaining Setup (not in this PR)

| Item | Status | Impact |
|------|--------|--------|
| `ANTHROPIC_API_KEY` secret | Not configured | Full pipeline falls back to shell-only (no RTFM) |

## Test plan

- [ ] Merge this PR and verify the post-merge pipeline succeeds (it will self-test by running on this merge)
- [ ] Verify tag is created for this fix
- [ ] Verify Discord notification fires if pipeline fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)