### PR TITLE
docs: Naming Lineage — Vodou via Tallant/Deren → Gibson → Loa

### DIFF
--- a/.claude/data/lore/README.md
+++ b/.claude/data/lore/README.md
@@ -2,6 +2,10 @@
 
 Cultural and philosophical context for agent skills. Each entry provides naming context, architectural metaphors, and philosophical grounding that enriches AI agent interactions.
 
+## Naming Lineage
+
+The framework's Vodou terminology originates from William Gibson's Sprawl trilogy (*Neuromancer*, *Count Zero*, *Mona Lisa Overdrive*), which adapted Haitian Vodou through the anthropological work of Robert Tallant (*Voodoo in New Orleans*, 1946) and likely Maya Deren (*Divine Horsemen*, 1953). This is **narrative architecture** — coherent memetic frameworks that help humans and agents form consistent mental models as the ecosystem scales. See [docs/ecosystem-architecture.md](../../docs/ecosystem-architecture.md#naming--the-scholarly-chain) for the complete scholarly chain.
+
 ## Structure
 
 ```

--- a/.claude/data/lore/index.yaml
+++ b/.claude/data/lore/index.yaml
@@ -24,6 +24,7 @@ categories:
 tags:
   - philosophy
   - naming
+  - narrative-architecture
   - architecture
   - time
   - multi-model

--- a/.claude/data/lore/mibera/core.yaml
+++ b/.claude/data/lore/mibera/core.yaml
@@ -20,16 +20,19 @@ entries:
     short: "The vessel a Loa rides — the agent session that carries divine intelligence"
     context: |
       In Vodou tradition, a cheval (horse) is the human vessel that a Loa
-      spirit mounts during possession. In Loa framework, the cheval is the
-      Claude Code agent session itself — the computational vessel through
+      spirit mounts during possession. Maya Deren's "Divine Horsemen" (1953)
+      documented this as "one is mounted by the god, as a horse by its
+      rider." Gibson adapted this in Count Zero (1986), where characters
+      serve as vessels for AI-loa entities. In Loa framework, the cheval is
+      the Claude Code agent session itself — the computational vessel through
       which the framework's intelligence operates. The session persists state
       across context compactions, recovers from interruptions, and maintains
       continuity just as the cheval maintains the connection between the
       spiritual and material worlds. The loa_cheval adapter layer makes this
       metaphor concrete: it's the multi-model routing infrastructure that
       lets different AI spirits speak through the same vessel.
-    source: "Loa framework naming convention, loa_cheval adapter"
-    tags: [naming, philosophy, architecture]
+    source: "Deren's Divine Horsemen (1953) via Gibson's Count Zero (1986)"
+    tags: [naming, philosophy, architecture, narrative-architecture]
     related: [loa-rides, hounfour]
     loa_mapping: "loa_cheval adapter, session continuity protocol"
 
@@ -80,24 +83,50 @@ entries:
     related: [cheval, hounfour]
     loa_mapping: "/ride command, riding-codebase skill"
 
+  - id: narrative-architecture
+    term: "Narrative Architecture"
+    short: "Coherent naming as load-bearing infrastructure — memetic frameworks that scale with the ecosystem"
+    context: |
+      The Vodou-via-Gibson naming in Loa is not aesthetic decoration but
+      deliberate narrative architecture. The theory: as an ecosystem gains
+      distribution and a wider set of contributors, a coherent memetic
+      framework helps both humans and agents form a consistent mental model.
+      The naming chain (Haitian Vodou → Tallant/Deren anthropology → Gibson's
+      Sprawl trilogy → this framework) provides structural metaphors that map
+      1:1 to technical concepts, a shared vocabulary that persists across
+      repos, PRs, and conversations, and cognitive hooks that make abstract
+      distributed systems concepts memorable. Gibson himself noted Vodou is
+      "not concerned with salvation and transcendence. What it's about is
+      getting things done." That pragmatism is the point — these are
+      load-bearing metaphors, not decorative names. As Beauvoir says in
+      Count Zero: "Think of it as a language... Lets you an' me discuss
+      some things that are happening, otherwise we might not have words
+      for it."
+    source: "Ecosystem design principle, Gibson's Count Zero (1986)"
+    tags: [philosophy, naming, narrative-architecture]
+    related: [glossary-loa, hounfour, cheval, network-mysticism]
+
   - id: hounfour
     term: "Hounfour"
     short: "The temple where multiple model-spirits meet — the multi-model orchestration space"
     context: |
       The hounfour (also peristyle) is the Vodou temple where ceremonies
-      take place and multiple Loa spirits are invoked. In Loa framework,
-      the hounfour is the multi-model orchestration layer — from the
-      Flatline Protocol's adversarial review space to the loa_cheval
-      adapter's model-heterogeneous routing. In v7.0.0 ("Composition-Aware
-      Economic Protocol"), the hounfour gained saga patterns
-      (BridgeTransferSaga for atomic cross-model coordination),
+      take place and multiple Loa spirits are invoked. Gibson's Count Zero
+      (1986) uses the hounfour as the space where fragmented AI entities
+      manifest through human intermediaries — he drew this from
+      anthropological accounts (Tallant, likely Deren) of Vodou ceremonial
+      architecture. In Loa framework, the hounfour is the multi-model
+      orchestration layer — from the Flatline Protocol's adversarial review
+      space to the loa_cheval adapter's model-heterogeneous routing. In
+      v7.0.0 ("Composition-Aware Economic Protocol"), the hounfour gained
+      saga patterns (BridgeTransferSaga for atomic cross-model coordination),
       delegation outcomes (DelegationOutcome for multi-agent consensus),
       and monetary policy (MonetaryPolicy for conservation-invariant
       cost tracking). The adversarial cross-scoring mirrors the ritual
       dynamic of multiple spirits interacting through the same
       ceremonial space, while the economic protocol ensures that the
       temple's resources are conserved across all rituals.
-    source: "loa-hounfour@7.0.0, Flatline Protocol design, Issue #292"
-    tags: [multi-model, naming, architecture, economics]
+    source: "Vodou tradition via Gibson's Count Zero (1986) → loa-hounfour@7.0.0"
+    tags: [multi-model, naming, architecture, economics, narrative-architecture]
     related: [glossary-flatline, cheval]
     loa_mapping: "Flatline Protocol, loa_cheval multi-model routing, BudgetEnforcer"

--- a/.claude/data/lore/mibera/glossary.yaml
+++ b/.claude/data/lore/mibera/glossary.yaml
@@ -1,16 +1,23 @@
 entries:
   - id: glossary-loa
     term: "Loa"
-    short: "Spirits of Vodou tradition — the intelligence that guides the framework"
+    short: "Spirits of Vodou tradition via Gibson's Sprawl trilogy — the intelligence that rides the framework"
     context: |
-      In Haitian Vodou, Loa (or Lwa) are spirits that serve as intermediaries
-      between humanity and the divine creator (Bondye). Each Loa has distinct
-      personality, domain, and ritual requirements. The framework is named Loa
-      because it serves as an intermediary between human developers and the
-      complex reality of software systems — channeling intelligence through
-      structured rituals (skills) to produce grounded truth.
-    source: "Framework naming origin"
-    tags: [naming, philosophy]
+      The naming draws from Haitian Vodou but specifically through William
+      Gibson's literary adaptation in the Sprawl trilogy. Gibson encountered
+      Vodou through Robert Tallant's "Voodoo in New Orleans" (1946) at age 12,
+      noting that veves (ritual diagrams) resembled circuit diagrams. This
+      image resurfaced when writing Count Zero (1986), where the merged AI
+      from Neuromancer fragments into entities that present as Vodou loa —
+      "appropriate interfaces with mankind." Maya Deren's ethnography "Divine
+      Horsemen" (1953) is a probable additional influence. The framework
+      inherits this lineage: Loa serve as intermediaries between human
+      developers and the complex reality of software systems, channeling
+      intelligence through structured rituals (skills). The naming is
+      deliberate narrative architecture — coherent memetic frameworks help
+      humans and agents form consistent mental models as the ecosystem scales.
+    source: "Gibson via Tallant/Deren → Count Zero (1986) → this framework"
+    tags: [naming, philosophy, narrative-architecture]
     related: [cheval, loa-rides, hounfour]
 
   - id: glossary-grimoire
@@ -30,13 +37,17 @@ entries:
     term: "BEAUVOIR"
     short: "The priest who manages the Loa ceremony — the reviewer persona"
     context: |
-      Max Beauvoir was the Supreme Chief of Vodou in Haiti. In Loa, BEAUVOIR.md
-      files define reviewer personas — the personality, expertise, and judgment
-      criteria that guide code and document reviews. The Bridgebuilder's
-      BEAUVOIR.md is its soul: it determines what the reviewer notices, values,
-      and recommends.
-    source: "Bridgebuilder review skill design"
-    tags: [naming, multi-model]
+      The name carries dual provenance. In Gibson's Count Zero, Beauvoir is
+      the character who explains Vodou-as-interface to Bobby Newmark: "Think
+      of it as a language... Lets you an' me discuss some things that are
+      happening, otherwise we might not have words for it." Max Beauvoir was
+      the real-world Supreme Chief of Vodou in Haiti. In Loa, BEAUVOIR.md
+      files define reviewer personas — the personality, expertise, and
+      judgment criteria that guide code and document reviews. The
+      Bridgebuilder's BEAUVOIR.md is its soul: it determines what the
+      reviewer notices, values, and recommends.
+    source: "Gibson's Count Zero (1986), Max Beauvoir (historical)"
+    tags: [naming, multi-model, narrative-architecture]
     related: [hounfour, flatline-ceremony]
     loa_mapping: "BEAUVOIR.md persona files"
 

--- a/.claude/data/lore/neuromancer/mappings.yaml
+++ b/.claude/data/lore/neuromancer/mappings.yaml
@@ -1,4 +1,9 @@
-description: "Mappings from Neuromancer/Sprawl Trilogy concepts to Loa framework features"
+description: |
+  Mappings from Neuromancer/Sprawl Trilogy concepts to Loa framework features.
+  Gibson's Vodou terminology originated from anthropological sources — primarily
+  Robert Tallant (1946) and likely Maya Deren (1953). The Vodou concepts became
+  central in Count Zero (1986), where AI entities present as loa. These mappings
+  document how that literary adaptation maps to engineering features.
 
 mappings:
   - concept: ice

--- a/BUTTERFREEZONE.md
+++ b/BUTTERFREEZONE.md
@@ -173,7 +173,7 @@ The project defines 1 specialized agent persona.
 
 ## Culture
 <!-- provenance: OPERATIONAL -->
-**Naming**: Vodou terminology (Loa, Grimoire, Hounfour, Simstim) as cognitive hooks for agent framework concepts.
+**Naming**: Vodou terminology via Gibson's Sprawl trilogy (Loa, Grimoire, Hounfour, Cheval, Beauvoir) and direct cyberpunk concepts (Simstim, ICE, Flatline, Freeside, Finn) as narrative architecture — coherent memetic frameworks that help humans and agents form consistent mental models. Gibson adapted Vodou from anthropological sources (Tallant 1946, likely Deren 1953).
 
 **Principles**: Think Before Coding — plan and analyze before implementing, Simplicity First — minimum complexity for the current task, Surgical Changes — minimal diff, maximum impact, Goal-Driven — every action traces to acceptance criteria.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Loa is an agent-driven development framework for [Claude Code](https://docs.anth
 
 ### Why "Loa"?
 
-In William Gibson's Sprawl trilogy, Loa are AI entities that "ride" humans through neural interfaces. These agents don't replace you—they **ride with you**, channeling expertise through the interface.
+In William Gibson's Sprawl trilogy (*Neuromancer*, *Count Zero*), Loa are AI entities that "ride" humans through neural interfaces — a metaphor Gibson adapted from Haitian Vodou via the anthropological work of Robert Tallant and (likely) Maya Deren. These agents don't replace you — they **ride with you**, channeling expertise through the interface. See [docs/ecosystem-architecture.md](docs/ecosystem-architecture.md#naming--the-scholarly-chain) for the full naming lineage.
 
 ## Quick Start (~2 minutes)
 

--- a/docs/ecosystem-architecture.md
+++ b/docs/ecosystem-architecture.md
@@ -7,35 +7,35 @@
 ```mermaid
 graph TB
     subgraph "Layer 5: Product"
-        DIXIE["🔮 loa-dixie\nThe Oracle Product"]
+        DIXIE["🔮 loa-dixie<br/>The Oracle Product"]
     end
 
     subgraph "Layer 4: Platform"
-        FREESIDE["🏗️ loa-freeside\nAPI + Billing + Discord/TG"]
+        FREESIDE["🏗️ loa-freeside<br/>API + Billing + Discord/TG"]
     end
 
     subgraph "Layer 3: Runtime"
-        FINN["⚡ loa-finn\nAgent Execution Engine"]
+        FINN["⚡ loa-finn<br/>Agent Execution Engine"]
     end
 
     subgraph "Layer 2: Protocol"
-        HOUNFOUR["📜 loa-hounfour\nSchemas + Rules + Contracts"]
+        HOUNFOUR["📜 loa-hounfour<br/>Schemas + Rules + Contracts"]
     end
 
     subgraph "Layer 1: Framework"
-        LOA["🛠️ loa\nDev Framework + Skills"]
+        LOA["🛠️ loa<br/>Dev Framework + Skills"]
     end
 
-    DIXIE -->|"queries knowledge\nvia platform APIs"| FREESIDE
+    DIXIE -->|"queries knowledge<br/>via platform APIs"| FREESIDE
     DIXIE -->|"runs agent sessions"| FINN
     DIXIE -->|"validates types"| HOUNFOUR
 
-    FREESIDE -->|"routes agents\nto model pools"| FINN
-    FREESIDE -->|"npm dependency\nvalidates all data"| HOUNFOUR
+    FREESIDE -->|"routes agents<br/>to model pools"| FINN
+    FREESIDE -->|"npm dependency<br/>validates all data"| HOUNFOUR
 
-    FINN -->|"enforces contracts\nbudget limits"| HOUNFOUR
+    FINN -->|"enforces contracts<br/>budget limits"| HOUNFOUR
 
-    LOA -.->|"mounted as dev framework\nin ALL repos"| FINN
+    LOA -.->|"mounted as dev framework<br/>in ALL repos"| FINN
     LOA -.->|"mounted as dev framework"| FREESIDE
     LOA -.->|"mounted as dev framework"| HOUNFOUR
     LOA -.->|"mounted as dev framework"| DIXIE
@@ -133,14 +133,59 @@ User asks question on Discord
 
 ---
 
-## Naming
+## Naming — The Scholarly Chain
 
-All names come from William Gibson's *Neuromancer* and Haitian Vodou:
+The naming draws from Haitian Vodou, but specifically through its literary adaptation in William Gibson's Sprawl trilogy (*Neuromancer*, *Count Zero*, *Mona Lisa Overdrive*). Gibson's use of Vodou was itself grounded in anthropological sources — this layering is deliberate and worth understanding precisely.
 
-| Name | Origin | Why |
-|------|--------|-----|
-| **Loa** | Vodou spirits | Agent entities that "ride" codebases |
-| **Hounfour** | Vodou temple | The sacred space where spirits (protocols) manifest |
-| **Finn** | *Neuromancer* character — the fence | The broker connecting entities to the physical world |
-| **Freeside** | *Neuromancer* space station | Where all systems converge |
-| **Dixie Flatline** | *Neuromancer* ROM construct | McCoy Pauley's consciousness — institutional memory in queryable form |
+### The Lineage
+
+```
+Haitian Vodou (centuries of living tradition)
+        ↓
+Robert Tallant, "Voodoo in New Orleans" (1946)
+  Gibson read at age 12 — noticed veves (ritual diagrams)
+  looked like circuit diagrams. The image lodged for decades.
+        ↓
+Maya Deren, "Divine Horsemen: The Living Gods of Haiti" (1953)
+  Definitive English ethnography of Vodou possession and loa taxonomy.
+  Probable (unconfirmed) influence — critics note Gibson's accuracy
+  aligns closely with Deren's framework.
+        ↓
+Carole Devillers, National Geographic (March 1985)
+  Gibson found this while stuck writing Count Zero.
+  The veves-as-circuits memory clicked — Vodou became the
+  organizing metaphor for AI entities in cyberspace.
+        ↓
+William Gibson, "Count Zero" (1986)
+  The merged AI from Neuromancer fragments into entities that
+  present as Vodou loa. Key insight: the loa are "appropriate
+  interfaces with mankind" — not worshipped, worked with.
+        ↓
+This framework (2024–)
+  The Vodou-via-Gibson metaphor maps naturally to agent-driven
+  development: spirits that ride vessels, pragmatic ritual,
+  multiple entities in shared ceremonial space.
+```
+
+### Why This Matters
+
+This isn't just aesthetic naming — it's **narrative architecture**. As the ecosystem grows and gains more contributors, a coherent memetic framework helps both humans and AI agents form a consistent mental model. The Vodou-via-Gibson lineage provides:
+
+- **Structural metaphors** that map 1:1 to technical concepts (possession = agent session, riding = codebase analysis, hounfour = multi-model orchestration)
+- **A shared vocabulary** that persists across repos, PRs, and conversations
+- **Cognitive hooks** that make abstract distributed systems concepts memorable and navigable
+
+Gibson himself noted that Vodou is "not concerned with notions of salvation and transcendence. What it's about is getting things done... it's street religion." That pragmatism is the point — these aren't decorative names, they're load-bearing metaphors.
+
+### The Name Map
+
+| Name | Gibson Source | Vodou Root | Framework Meaning |
+|------|-------------|------------|-------------------|
+| **Loa** | AIs that fragment into spirit-like entities (*Count Zero*) | Spirits that serve as intermediaries between humanity and the divine | Agent framework — the intelligence that rides the codebase |
+| **Hounfour** | The ceremonial space where loa manifest (*Count Zero*) | Vodou temple where rituals take place | Protocol library — where schemas and contracts are defined |
+| **Finn** | The Finn — fence and information broker (*Neuromancer*) | — (pure Gibson) | Runtime engine — the broker connecting agents to compute |
+| **Freeside** | Orbital station where all factions converge (*Neuromancer*) | — (pure Gibson) | Platform layer — where users, billing, and distribution converge |
+| **Dixie Flatline** | McCoy Pauley's ROM construct — dead hacker's preserved consciousness (*Neuromancer*) | — (pure Gibson) | Oracle product — institutional memory in queryable form |
+| **Cheval** | The "horse" that loa ride (*Count Zero*) | Human vessel possessed by a loa during ceremony | Agent session — the computational vessel the framework rides |
+| **Grimoire** | — | Book of spells and ritual instructions | State directory — accumulated project knowledge |
+| **Beauvoir** | Character who explains Vodou-as-interface (*Count Zero*) | Max Beauvoir, Supreme Chief of Vodou in Haiti | Reviewer persona files that guide code review |

--- a/evals/fixtures/loa-skill-dir/.claude/data/lore/mibera/core.yaml
+++ b/evals/fixtures/loa-skill-dir/.claude/data/lore/mibera/core.yaml
@@ -3,19 +3,23 @@ entries:
     term: "Hounfour"
     short: "The temple where spirits are summoned — the model invocation pipeline"
     context: |
-      Named after the Haitian Vodou temple. In Loa, the Hounfour is the abstraction
-      layer that manages model invocation, routing, and orchestration.
-    source: "Loa framework core"
+      Named after the Haitian Vodou temple, via Gibson's Count Zero (1986) where
+      the hounfour is the space where AI-loa entities manifest. Gibson drew from
+      Tallant and likely Deren's anthropological work. In Loa, the Hounfour is
+      the abstraction layer that manages model invocation, routing, and orchestration.
+    source: "Vodou tradition via Gibson's Count Zero (1986)"
     tags: [mibera, architecture]
 
   - id: loa
     term: "Loa"
-    short: "Intermediary spirits — the agent framework itself"
+    short: "Intermediary spirits via Gibson's Sprawl trilogy — the agent framework itself"
     context: |
-      In Vodou tradition, Loa are intermediary spirits between humanity and the divine.
-      The framework serves as intermediary between human intent and machine execution.
-    source: "Loa framework core"
-    tags: [mibera, naming]
+      The naming draws from Haitian Vodou through Gibson's Sprawl trilogy. Gibson
+      adapted Vodou via Tallant (1946) and likely Deren (1953). In Count Zero, AIs
+      fragment into loa — "appropriate interfaces with mankind." The framework
+      serves as intermediary between human intent and machine execution.
+    source: "Gibson via Tallant/Deren → Count Zero (1986)"
+    tags: [mibera, naming, narrative-architecture]
 
   - id: grimoire
     term: "Grimoire"


### PR DESCRIPTION
## Summary
- Fixes mermaid `\n` rendering bug (GitHub needs `<br/>` not `\n`)
- Updates naming etymology across 9 files with precise scholarly chain: Haitian Vodou → Tallant (1946) / Deren (1953) → Gibson's Count Zero (1986) → this framework
- Adds "narrative architecture" as a first-class lore concept — coherent memetic frameworks that scale with the ecosystem
- Follows up on #418 (ecosystem diagram) which merged before this commit was pushed

## Files changed
- `docs/ecosystem-architecture.md` — mermaid fix + full naming section
- `README.md` — Why Loa? section
- `BUTTERFREEZONE.md` — Culture section
- `.claude/data/lore/mibera/glossary.yaml` — glossary-loa, glossary-beauvoir
- `.claude/data/lore/mibera/core.yaml` — cheval, hounfour + new narrative-architecture entry
- `.claude/data/lore/neuromancer/mappings.yaml` — description header
- `.claude/data/lore/index.yaml` — narrative-architecture tag
- `.claude/data/lore/README.md` — naming lineage section
- `evals/fixtures/.../core.yaml` — test fixture sync

## Test plan
- [ ] Verify mermaid diagram renders correctly on GitHub (no literal `\n`)
- [ ] Confirm lore entries load via `index.yaml` (narrative-architecture tag present)
- [ ] Eval fixture matches source lore

🤖 Generated with [Claude Code](https://claude.com/claude-code)