### PR TITLE
fix(simstim): add Flatline readiness check to Phase 0 preflight

### DIFF
--- a/.claude/loa/reference/flatline-reference.md
+++ b/.claude/loa/reference/flatline-reference.md
@@ -61,6 +61,29 @@ Multi-model adversarial review using Claude Opus 4.6 + GPT-5.3-codex + Gemini 2.
 .claude/scripts/flatline-rollback.sh single --integration-id <id> --run-id <run-id>
 ```
 
+## Readiness Check (v1.64.0, #430)
+
+Validates Flatline can execute before a workflow starts. Called automatically by simstim preflight (Phase 0) and available for any workflow boundary.
+
+```bash
+# Quick check
+.claude/scripts/flatline-readiness.sh
+
+# JSON output for scripting
+.claude/scripts/flatline-readiness.sh --json
+```
+
+| Status | Exit Code | Meaning |
+|--------|-----------|---------|
+| `READY` | 0 | All configured provider keys available |
+| `DISABLED` | 1 | `flatline_protocol.enabled: false` in config |
+| `NO_API_KEYS` | 2 | No provider API keys set |
+| `DEGRADED` | 3 | Some but not all provider keys present |
+
+Reads configured models (primary/secondary/tertiary) from `.loa.config.yaml`, maps each to its provider (Anthropic, OpenAI, Google), and checks the corresponding API key env vars. Reports `READY` only when all configured providers have keys.
+
+**Why this exists**: Simstim Phase 0 previously did not validate Flatline readiness. Agents could inherit stale "skip" decisions from previous cycles, causing Flatline phases to be skipped even when API keys were available. This check ensures each cycle validates independently.
+
 ## Usage
 
 ```bash

--- a/.claude/loa/reference/scripts-reference.md
+++ b/.claude/loa/reference/scripts-reference.md
@@ -37,6 +37,13 @@ Core scripts in `.claude/scripts/`. Run any script with `--help` for usage detai
 |--------|---------|
 | `mermaid-url.sh` | Beautiful Mermaid preview URL generation |
 
+## Preflight Checks
+
+| Script | Purpose |
+|--------|---------|
+| `beads/beads-health.sh` | Beads infrastructure health check |
+| `flatline-readiness.sh` | Flatline Protocol readiness validation (v1.64.0, #430) |
+
 ## Integrations
 
 | Script | Purpose |


### PR DESCRIPTION
## Summary

- Adds `flatline-readiness.sh` script (mirrors `beads-health.sh` pattern) to validate Flatline Protocol can execute before a workflow starts
- Integrates readiness check into `simstim-orchestrator.sh` `preflight()` function — each cycle validates API keys and config independently
- Updates SKILL.md to document the new Phase 0 check and explicitly warn agents not to carry skip decisions from previous cycles
- Adds documentation to `flatline-reference.md` and `scripts-reference.md`

## Problem

Simstim Phase 0 (PREFLIGHT) did not validate Flatline readiness. When starting a new cycle, the agent read `.run/simstim-state.json` from the previous cycle which had `"flatline_prd": "skipped"`. The agent carried this assumption forward and skipped all three Flatline phases without checking whether API keys were actually available.

In the observed case, `OPENAI_API_KEY` was set, `flatline_protocol.enabled: true`, and the orchestrator was fully functional — but Flatline was skipped anyway.

## Fix

New readiness check script returns one of four statuses:

| Status | Meaning |
|--------|---------|
| `READY` | Both OpenAI + Anthropic keys available |
| `DEGRADED` | Single provider only |
| `NO_API_KEYS` | No provider keys set |
| `DISABLED` | Flatline disabled in config |

The orchestrator logs the result to trajectory and includes `flatline_status` in the preflight response, so agents have explicit signal rather than relying on stale state.

## Test plan

- [ ] Run `flatline-readiness.sh --json` with both keys set → expect `READY`
- [ ] Run with only `OPENAI_API_KEY` set → expect `DEGRADED`
- [ ] Run with no keys → expect `NO_API_KEYS`
- [ ] Run with `flatline_protocol.enabled: false` → expect `DISABLED`
- [ ] Run `/simstim` and verify preflight logs Flatline status
- [ ] Verify stale simstim-state.json from previous cycle does not affect readiness

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>