### PR TITLE
chore: update loa-hounfour version pins to v8.3.1

### DIFF
--- a/.claude/data/lore/mibera/core.yaml
+++ b/.claude/data/lore/mibera/core.yaml
@@ -122,11 +122,14 @@ entries:
       saga patterns (BridgeTransferSaga for atomic cross-model coordination),
       delegation outcomes (DelegationOutcome for multi-agent consensus),
       and monetary policy (MonetaryPolicy for conservation-invariant
-      cost tracking). The adversarial cross-scoring mirrors the ritual
-      dynamic of multiple spirits interacting through the same
-      ceremonial space, while the economic protocol ensures that the
-      temple's resources are conserved across all rituals.
-    source: "Vodou tradition via Gibson's Count Zero (1986) → loa-hounfour@7.0.0"
+      cost tracking). In v8.x, the commons module added GovernedResource<T>
+      (typed governance primitives), consumer contracts for cross-repo
+      schema validation, and chain-bound hashing for tamper-evident audit
+      trails. The adversarial cross-scoring mirrors the ritual dynamic of
+      multiple spirits interacting through the same ceremonial space,
+      while the economic protocol ensures that the temple's resources
+      are conserved across all rituals.
+    source: "Vodou tradition via Gibson's Count Zero (1986) → loa-hounfour@8.3.1"
     tags: [multi-model, naming, architecture, economics, narrative-architecture]
     related: [glossary-flatline, cheval]
     loa_mapping: "Flatline Protocol, loa_cheval multi-model routing, BudgetEnforcer"

--- a/.claude/data/model-permissions.yaml
+++ b/.claude/data/model-permissions.yaml
@@ -1,14 +1,14 @@
 # =============================================================================
-# Per-Model Capability Constraints (Hounfour v7+ CapabilityScopedTrust vocabulary)
+# Per-Model Capability Constraints (Hounfour v8+ CapabilityScopedTrust vocabulary)
 # =============================================================================
-# trust_scopes: 7-dimensional trust model per loa-hounfour v7.0.0+
+# trust_scopes: 7-dimensional trust model per loa-hounfour v8.3.1+
 # trust_level: retained as backward-compatible summary field
 #
 # Dimensions: data_access, financial, delegation, model_selection,
 #             governance, external_communication, context_access
 # Values: high | medium | none (+ limited for delegation)
 #
-# context_access (epistemic dimension, v7.0.0):
+# context_access (epistemic dimension, v7.0.0+):
 #   Sub-fields: architecture, business_logic, security, lore
 #   Values: full | summary | redacted | none
 #   Controls what knowledge a model receives in its context window.

--- a/.claude/schemas/invariants.schema.json
+++ b/.claude/schemas/invariants.schema.json
@@ -14,7 +14,7 @@
     "protocol": {
       "type": "string",
       "pattern": "^loa-hounfour@[0-9]+\\.[0-9]+\\.[0-9]+$",
-      "description": "Ecosystem protocol version for traceability (e.g., loa-hounfour@7.0.0)"
+      "description": "Ecosystem protocol version for traceability (e.g., loa-hounfour@8.3.1)"
     },
     "invariants": {
       "type": "array",

--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -55,15 +55,15 @@ butterfreezone:
     - repo: 0xHoneyJar/loa-finn
       role: runtime
       interface: hounfour-router
-      protocol: loa-hounfour@5.0.0
+      protocol: loa-hounfour@8.3.1
     - repo: 0xHoneyJar/loa-hounfour
       role: protocol
       interface: npm-package
-      protocol: loa-hounfour@7.0.0
+      protocol: loa-hounfour@8.3.1
     - repo: 0xHoneyJar/arrakis
       role: distribution
       interface: jwt-auth
-      protocol: loa-hounfour@7.0.0
+      protocol: loa-hounfour@8.3.1
   culture:
     naming_etymology: "Vodou terminology (Loa, Grimoire, Hounfour, Simstim) as cognitive hooks for agent framework concepts"
     principles:

--- a/.loa.config.yaml.example
+++ b/.loa.config.yaml.example
@@ -542,15 +542,15 @@ butterfreezone:
     - repo: 0xHoneyJar/loa-finn
       role: runtime
       interface: hounfour-router
-      protocol: loa-hounfour@4.6.0
+      protocol: loa-hounfour@8.3.1
     - repo: 0xHoneyJar/loa-hounfour
       role: protocol
       interface: npm-package
-      protocol: loa-hounfour@4.6.0
+      protocol: loa-hounfour@8.3.1
     - repo: 0xHoneyJar/arrakis
       role: distribution
       interface: jwt-auth
-      protocol: loa-hounfour@4.6.0
+      protocol: loa-hounfour@8.3.1
   culture:                                # Cultural BUTTERFREEZONE (v1.40.0)
     # Optional section communicating project principles, naming, methodology.
     # Provenance: OPERATIONAL. Omitted when not configured.

--- a/BUTTERFREEZONE.md
+++ b/BUTTERFREEZONE.md
@@ -10,15 +10,15 @@ ecosystem:
   - repo: 0xHoneyJar/loa-finn
     role: runtime
     interface: hounfour-router
-    protocol: loa-hounfour@5.0.0
+    protocol: loa-hounfour@8.3.1
   - repo: 0xHoneyJar/loa-hounfour
     role: protocol
     interface: npm-package
-    protocol: loa-hounfour@7.0.0
+    protocol: loa-hounfour@8.3.1
   - repo: 0xHoneyJar/arrakis
     role: distribution
     interface: jwt-auth
-    protocol: loa-hounfour@7.0.0
+    protocol: loa-hounfour@8.3.1
 capability_requirements:
   - filesystem: read
   - filesystem: write (scope: state)

--- a/docs/architecture/capability-schema.md
+++ b/docs/architecture/capability-schema.md
@@ -158,7 +158,7 @@ trust_gradient:
 
 ### Trust Scopes (Hounfour v6+)
 
-The `trust_scopes` field provides 6-dimensional trust classification per loa-hounfour v6.0.0 `CapabilityScopedTrust`. Each dimension independently controls a class of operations:
+The `trust_scopes` field provides 6-dimensional trust classification per loa-hounfour v6.0.0+ `CapabilityScopedTrust` (extended in v8.x with `GovernedResource<T>` governance primitives). Each dimension independently controls a class of operations:
 
 | Dimension | Controls | Example |
 |-----------|----------|---------|
@@ -220,17 +220,20 @@ This schema follows the same forward-compatibility contract as the mesh schema:
 - **Consumers MUST ignore unknown fields** (forward compatibility)
 - Planned additions for v1.1: `model` capability scopes for fine-grained pool selection, `billing_tier` per-skill aggregation
 
-## Hounfour v7 Type Mapping
+## Hounfour v7–v8 Type Mapping
 
-Loa doesn't instantiate hounfour protocol types directly — it implements equivalent patterns that correspond to v7.0.0 types. This table documents the structural correspondence:
+Loa doesn't instantiate hounfour protocol types directly — it implements equivalent patterns that correspond to v7.0.0–v8.3.1 types. This table documents the structural correspondence:
 
-| Hounfour v7 Type | Loa Pattern | Loa File | Notes |
-|------------------|-------------|----------|-------|
-| `BridgeTransferSaga` | Retry chains with fallback/downgrade | `.claude/adapters/loa_cheval/routing/chains.py` | Garcia-Molina saga pattern: provider failure → fallback → compensating action |
-| `DelegationOutcome` | Flatline consensus scoring | `.claude/scripts/flatline-orchestrator.sh` | Multi-model cross-scoring → HIGH_CONSENSUS / DISPUTED / BLOCKER |
-| `MonetaryPolicy` | `RemainderAccumulator` + `BudgetEnforcer` | `.claude/adapters/loa_cheval/metering/budget.py` | Conservation invariant: total_in == total_distributed + remainder |
-| `PermissionBoundary` | MAY/MUST/NEVER constraint grants | `.claude/data/constraints.json` | Permission scape rendered into CLAUDE.loa.md |
-| `GovernanceProposal` | Flatline scoring with BLOCKER threshold | `.claude/scripts/flatline-orchestrator.sh` | BLOCKER (>700 skeptic score) halts autonomous workflows |
+| Hounfour Type | Version | Loa Pattern | Loa File | Notes |
+|---------------|---------|-------------|----------|-------|
+| `BridgeTransferSaga` | v7+ | Retry chains with fallback/downgrade | `.claude/adapters/loa_cheval/routing/chains.py` | Garcia-Molina saga pattern: provider failure → fallback → compensating action |
+| `DelegationOutcome` | v7+ | Flatline consensus scoring | `.claude/scripts/flatline-orchestrator.sh` | Multi-model cross-scoring → HIGH_CONSENSUS / DISPUTED / BLOCKER |
+| `MonetaryPolicy` | v7+ | `RemainderAccumulator` + `BudgetEnforcer` | `.claude/adapters/loa_cheval/metering/budget.py` | Conservation invariant: total_in == total_distributed + remainder |
+| `PermissionBoundary` | v7+ | MAY/MUST/NEVER constraint grants | `.claude/data/constraints.json` | Permission scape rendered into CLAUDE.loa.md |
+| `GovernanceProposal` | v7+ | Flatline scoring with BLOCKER threshold | `.claude/scripts/flatline-orchestrator.sh` | BLOCKER (>700 skeptic score) halts autonomous workflows |
+| `GovernedResource<T>` | v8.0+ | Three-Zone Model governance | `.claude/loa/CLAUDE.loa.md` | System/State/App zones as governed resource boundaries |
+| `ConsumerContract` | v8.3+ | Structural correspondence (this table) | `docs/architecture/capability-schema.md` | Loa declares which hounfour types it structurally implements |
+| `computeDampenedScore()` | v8.3+ | — | — | Not yet consumed; candidate for bridge flatline detection |
 
 ### Conservation Invariant
 
@@ -251,6 +254,9 @@ This is not coincidental — it's the same pattern (double-entry accounting / co
 | v5.0.0 | Multi-Model | Provider registry, adapter pattern, thinking config | loa-finn runtime integration |
 | v6.0.0 | Capability-Scoped Trust | `trust_scopes` (6-dimensional), `CapabilityScopedTrust` | model-permissions.yaml migration |
 | v7.0.0 | Composition-Aware Economic Protocol | `BridgeTransferSaga`, `DelegationOutcome`, `MonetaryPolicy`, `PermissionBoundary`, `GovernanceProposal`, 8 new evaluator builtins (23→31) | Type mapping documented above |
+| v8.0.0 | Commons Protocol | `GovernedResource<T>`, 21 governance substrate schemas, `ConservationLaw`, `AuditTrail`, `StateMachine` | Three-Zone Model as governance boundaries |
+| v8.2.0 | Commons + ModelPerformance | `ModelPerformanceEvent`, `QualityObservation`, Governance Enforcement SDK, `evaluateGovernanceMutation()` | Flatline cross-scoring as quality observation |
+| v8.3.x | Pre-Launch Hardening | `ConsumerContract`, `computeDampenedScore()`, `GovernedResourceBase`, x402 payment schemas, `computeChainBoundHash()`, `validateDomainTag()` | Consumer contract pattern; dampened scoring candidate for flatline |
 
 ## Related Documents
 

--- a/docs/ecosystem-architecture.md
+++ b/docs/ecosystem-architecture.md
@@ -54,7 +54,7 @@ graph TB
 | 5 — Product | `loa-dixie` | dNFT Oracle — first product customer | Designed |
 | 4 — Platform | `loa-freeside` | API, Discord/TG, token-gating, billing, IaC | Designed |
 | 3 — Runtime | `loa-finn` | Persistent sessions, tool sandbox, memory | Designed |
-| 2 — Protocol | `loa-hounfour` | Schemas, state machines, model routing contracts | Designed |
+| 2 — Protocol | `loa-hounfour` | Schemas, state machines, model routing contracts | **Shipping** (v8.3.1) |
 | 1 — Framework | `loa` | Agent dev framework, skills, Bridgebuilder | **Shipping** |
 
 Each layer depends only on layers below it. Protocol contracts flow upward: lower layers define contracts, upper layers consume them.

--- a/tests/unit/invariant-verification.bats
+++ b/tests/unit/invariant-verification.bats
@@ -80,7 +80,7 @@ teardown() {
     # Create invariants file with a reference to a non-existent function
     cat > "${TMPDIR_BATS}/bad-symbol.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants:
   - id: INV-099
     description: "Test invariant with missing symbol reference"
@@ -101,7 +101,7 @@ YAML
 @test "missing function reports as FAIL in JSON" {
     cat > "${TMPDIR_BATS}/bad-symbol.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants:
   - id: INV-099
     description: "Test invariant with missing symbol reference"
@@ -128,7 +128,7 @@ YAML
 @test "detects missing file" {
     cat > "${TMPDIR_BATS}/bad-file.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants:
   - id: INV-098
     description: "Test invariant with missing file reference"
@@ -149,7 +149,7 @@ YAML
 @test "missing file reports as FAIL in JSON" {
     cat > "${TMPDIR_BATS}/bad-file.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants:
   - id: INV-098
     description: "Test invariant with missing file reference"
@@ -176,7 +176,7 @@ YAML
 @test "handles empty invariants gracefully" {
     cat > "${TMPDIR_BATS}/empty.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants: []
 YAML
 
@@ -187,7 +187,7 @@ YAML
 @test "empty invariants JSON output" {
     cat > "${TMPDIR_BATS}/empty.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants: []
 YAML
 
@@ -203,7 +203,7 @@ YAML
 @test "cross-repo references are SKIPped not FAILed" {
     cat > "${TMPDIR_BATS}/cross-repo.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants:
   - id: INV-097
     description: "Test invariant with cross-repo reference"
@@ -229,7 +229,7 @@ YAML
 @test "cross-repo skip includes repo name in detail" {
     cat > "${TMPDIR_BATS}/cross-repo.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants:
   - id: INV-097
     description: "Test invariant with cross-repo reference"
@@ -260,7 +260,7 @@ YAML
 @test "exit 1 for any-fail" {
     cat > "${TMPDIR_BATS}/failing.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants:
   - id: INV-096
     description: "Test invariant that will fail"
@@ -290,7 +290,7 @@ YAML
 @test "mixed pass and fail reports correct counts" {
     cat > "${TMPDIR_BATS}/mixed.yaml" <<'YAML'
 schema_version: 1
-protocol: loa-hounfour@7.0.0
+protocol: loa-hounfour@8.3.1
 invariants:
   - id: INV-095
     description: "Mixed test invariant — one pass one fail"


### PR DESCRIPTION
## Summary

- Update all loa-hounfour protocol version pins from v7.0.0 (and v4.6.0/v5.0.0 in stale locations) to v8.3.1
- Update capability-schema.md type mapping table with v8.x types (`GovernedResource<T>`, `ConsumerContract`, `computeDampenedScore()`)
- Extend version lineage table with v8.0.0, v8.2.0, v8.3.x entries
- Update ecosystem-architecture.md: hounfour status from "Designed" to "Shipping (v8.3.1)"
- Update lore entry with v8.x commons additions

## Context

Hounfour has shipped 3 major releases since loa's references were last updated:
- **v8.0.0** — Commons Protocol (GovernedResource, ConservationLaw, AuditTrail)
- **v8.2.0** — ModelPerformanceEvent, Governance Enforcement SDK
- **v8.3.1** — Pre-launch hardening (ConsumerContract, dampenedScore, x402 schemas)

Loa doesn't npm-install hounfour — it implements structural correspondence patterns. This is a **docs/config-only change** with zero runtime impact.

## Test plan

- [x] `bats tests/unit/invariant-verification.bats` — same results as main (3 pre-existing failures unchanged)
- [x] No runtime code modified
- [x] 9 files, 48 insertions, 39 deletions


🤖 Generated with [Claude Code](https://claude.com/claude-code)