### PR TITLE
feat(hounfour): add Gemini 3.1 Pro support

### DIFF
--- a/.claude/adapters/tests/test_google_adapter.py
+++ b/.claude/adapters/tests/test_google_adapter.py
@@ -58,6 +58,12 @@ def _make_google_config(**overrides):
                 context_window=2097152,
                 extra={"thinking_level": "medium"},
             ),
+            "gemini-3.1-pro-preview": ModelConfig(
+                capabilities=["chat", "thinking_traces"],
+                context_window=1048576,
+                pricing={"input_per_mtok": 2000000, "output_per_mtok": 12000000},
+                extra={"thinking_level": "high"},
+            ),
         },
     )
     defaults.update(overrides)
@@ -166,6 +172,11 @@ class TestBuildThinkingConfig:
     def test_gemini3_default_level(self):
         config = _default_model_config(extra={})
         result = _build_thinking_config("gemini-3-flash", config)
+        assert result == {"thinkingConfig": {"thinkingLevel": "high"}}
+
+    def test_gemini31_thinking_level(self):
+        config = _default_model_config(extra={"thinking_level": "high"})
+        result = _build_thinking_config("gemini-3.1-pro-preview", config)
         assert result == {"thinkingConfig": {"thinkingLevel": "high"}}
 
     def test_gemini25_thinking_budget(self):

--- a/.claude/adapters/tests/test_trust_scopes.py
+++ b/.claude/adapters/tests/test_trust_scopes.py
@@ -264,6 +264,13 @@ class TestGoogleModelScopes(unittest.TestCase):
             with self.subTest(dimension=dim):
                 self.assertEqual(scopes.get(dim), "none")
 
+    def test_gemini_31_pro_all_none(self):
+        entry = self.models.get("google:gemini-3.1-pro-preview", {})
+        scopes = entry.get("trust_scopes", {})
+        for dim in VALID_DIMENSIONS:
+            with self.subTest(dimension=dim):
+                self.assertEqual(scopes.get(dim), "none")
+
     def test_deep_research_delegation_limited(self):
         """Deep Research has delegation: limited (autonomous web search)."""
         entry = self.models.get("google:deep-research-pro", {})

--- a/.claude/data/model-permissions.yaml
+++ b/.claude/data/model-permissions.yaml
@@ -228,6 +228,34 @@ model_permissions:
       reasoning with redacted business logic. All operational trust_scopes none.
 
   # -------------------------------------------------------------------------
+  # Google Gemini 3.1 Pro Preview — Remote model, advanced reasoning
+  # -------------------------------------------------------------------------
+  google:gemini-3.1-pro-preview:
+    trust_level: standard
+    trust_scopes:
+      data_access: none
+      financial: none
+      delegation: none
+      model_selection: none
+      governance: none
+      external_communication: none
+      context_access:
+        architecture: full
+        business_logic: redacted
+        security: none
+        lore: full
+    execution_mode: remote_model
+    capabilities:
+      file_read: false
+      file_write: false
+      command_execution: false
+      network_access: false
+    notes: >
+      Gemini 3.1 Pro with 2x reasoning improvement over 3 Pro. Uses
+      thinkingLevel config format. Architecture-aware reasoning with
+      redacted business logic. All operational trust_scopes none.
+
+  # -------------------------------------------------------------------------
   # Google Gemini 3 Flash — Remote model, fast generation
   # -------------------------------------------------------------------------
   google:gemini-3-flash:

--- a/.claude/defaults/model-config.yaml
+++ b/.claude/defaults/model-config.yaml
@@ -61,6 +61,14 @@ providers:
           output_per_mtok: 15000000  # $15.00 per million tokens
         extra:
           thinking_level: "high"
+      gemini-3.1-pro-preview:
+        capabilities: [chat, thinking_traces]
+        context_window: 1048576
+        pricing:
+          input_per_mtok: 2000000    # $2.00 per million tokens
+          output_per_mtok: 12000000  # $12.00 per million tokens
+        extra:
+          thinking_level: "high"
       deep-research-pro:
         capabilities: [chat, thinking_traces, deep_research]
         context_window: 1048576
@@ -100,6 +108,7 @@ aliases:
   reasoning: "openai:gpt-5.3-codex"    # Reasoning/skeptic model
   cheap: "anthropic:claude-sonnet-4-6"  # Budget-conscious model
   opus: "anthropic:claude-opus-4-6"     # High-quality model
+  gemini-3.1-pro: "google:gemini-3.1-pro-preview"  # Gemini 3.1 Pro alias
   deep-thinker: "google:gemini-3-pro"   # Deep thinking with Gemini 3
   fast-thinker: "google:gemini-3-flash" # Fast thinking with Gemini 3
   researcher: "google:deep-research-pro" # Deep Research model

--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -228,7 +228,7 @@ get_max_iterations() {
 
 # Valid model names accepted by model-adapter.sh.legacy MODEL_PROVIDERS registry.
 # Keep in sync with MODEL_PROVIDERS in model-adapter.sh.legacy (line ~69).
-VALID_FLATLINE_MODELS=(opus gpt-5.2 gpt-5.3-codex claude-opus-4.6 claude-opus-4.5 gemini-2.0 gemini-2.5-flash gemini-2.5-pro gemini-3-flash gemini-3-pro)
+VALID_FLATLINE_MODELS=(opus gpt-5.2 gpt-5.3-codex claude-opus-4.6 claude-opus-4.5 gemini-2.0 gemini-2.5-flash gemini-2.5-pro gemini-3-flash gemini-3-pro gemini-3.1-pro)
 
 validate_model() {
     local model="$1"

--- a/.claude/scripts/model-adapter.sh
+++ b/.claude/scripts/model-adapter.sh
@@ -108,6 +108,7 @@ declare -A MODEL_TO_ALIAS=(
     ["gemini-2.5-pro"]="google:gemini-2.5-pro"
     ["gemini-3-flash"]="google:gemini-3-flash"
     ["gemini-3-pro"]="google:gemini-3-pro"
+    ["gemini-3.1-pro"]="google:gemini-3.1-pro-preview"
 )
 
 # =============================================================================

--- a/.claude/scripts/model-adapter.sh.legacy
+++ b/.claude/scripts/model-adapter.sh.legacy
@@ -81,6 +81,7 @@ declare -A MODEL_PROVIDERS=(
     ["gemini-2.5-pro"]="google"
     ["gemini-3-flash"]="google"
     ["gemini-3-pro"]="google"
+    ["gemini-3.1-pro"]="google"
 )
 
 declare -A MODEL_IDS=(
@@ -95,6 +96,7 @@ declare -A MODEL_IDS=(
     ["gemini-2.5-pro"]="gemini-2.5-pro"
     ["gemini-3-flash"]="gemini-3-flash"
     ["gemini-3-pro"]="gemini-3-pro"
+    ["gemini-3.1-pro"]="gemini-3.1-pro-preview"
 )
 
 # Cost per 1K tokens (approximate, 2026-02 pricing)
@@ -111,6 +113,7 @@ declare -A COST_INPUT=(
     ["gemini-2.5-pro"]="0.00125"
     ["gemini-3-flash"]="0.0002"
     ["gemini-3-pro"]="0.0025"
+    ["gemini-3.1-pro"]="0.002"
 )
 
 declare -A COST_OUTPUT=(
@@ -125,6 +128,7 @@ declare -A COST_OUTPUT=(
     ["gemini-2.5-pro"]="0.01"
     ["gemini-3-flash"]="0.0008"
     ["gemini-3-pro"]="0.015"
+    ["gemini-3.1-pro"]="0.012"
 )
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds `gemini-3.1-pro-preview` (Google's latest reasoning model) across all Loa model registries
- Provides alias `gemini-3.1-pro` for user-facing config
- Gemini 3 Pro Preview is **deprecated March 9, 2026** — this enables the migration path

## Changes

| File | What |
|------|------|
| `model-config.yaml` | Model entry: 1M context, $2/$12 MTok pricing, `thinkingLevel: high` |
| `model-permissions.yaml` | Trust scope entry (all scopes `none`, standard remote model) |
| `flatline-orchestrator.sh` | Added `gemini-3.1-pro` to `VALID_FLATLINE_MODELS` |
| `model-adapter.sh` | Added `MODEL_TO_ALIAS` mapping |
| `model-adapter.sh.legacy` | Added to all 4 registry maps (`PROVIDERS`, `IDS`, `COST_INPUT`, `COST_OUTPUT`) |
| `test_google_adapter.py` | Added model to fixtures + thinking config test |
| `test_trust_scopes.py` | Added trust scope validation test |

## Why no Python adapter changes?

`google_adapter.py` uses `model_id.startswith("gemini-3")` for thinking config detection — `gemini-3.1-pro-preview` matches this prefix automatically.

## Usage

```yaml
# .loa.config.yaml
hounfour:
  flatline_tertiary_model: gemini-3.1-pro
```

## Test plan

- [ ] Verify `gemini-3.1-pro` passes `validate_model()` in flatline-orchestrator
- [ ] Verify `MODEL_TO_ALIAS` mapping resolves correctly
- [ ] Verify thinking config produces `thinkingLevel: high` for `gemini-3.1-pro-preview`
- [ ] Verify trust scope test passes for `google:gemini-3.1-pro-preview`
- [ ] Verify `validate_model_registry()` passes (all 4 maps consistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)