### PR TITLE
fix(update-loa): BUTTERFREEZONE.md merge=ours + Phase 5.3 content-replacement detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 
 README.md merge=ours
 CHANGELOG.md merge=ours
+BUTTERFREEZONE.md merge=ours
 
 # =============================================================================
 # STATE ZONE FILES (grimoires/)

--- a/tests/unit/gitattributes-merge-protection.bats
+++ b/tests/unit/gitattributes-merge-protection.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Tests for .gitattributes merge=ours protection
+# Verifies project identity files are protected from upstream overwrites
+# Fixes: #439 — BUTTERFREEZONE.md collateral content overwrite
+
+setup() {
+  GITATTRIBUTES="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/.gitattributes"
+  UPDATE_LOA="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/.claude/commands/update-loa.md"
+}
+
+# =============================================================================
+# .gitattributes — Project Identity Files
+# =============================================================================
+
+@test "BUTTERFREEZONE.md has merge=ours in .gitattributes" {
+  grep -qF "BUTTERFREEZONE.md merge=ours" "$GITATTRIBUTES"
+}
+
+@test "README.md has merge=ours in .gitattributes" {
+  grep -qF "README.md merge=ours" "$GITATTRIBUTES"
+}
+
+@test "CHANGELOG.md has merge=ours in .gitattributes" {
+  grep -qF "CHANGELOG.md merge=ours" "$GITATTRIBUTES"
+}
+
+@test "all three identity files are in the same section" {
+  # All identity files should appear between "PROJECT IDENTITY" and "STATE ZONE" headers
+  local section
+  section=$(awk '/PROJECT IDENTITY/,/STATE ZONE/' "$GITATTRIBUTES")
+  echo "$section" | grep -qF "README.md merge=ours"
+  echo "$section" | grep -qF "CHANGELOG.md merge=ours"
+  echo "$section" | grep -qF "BUTTERFREEZONE.md merge=ours"
+}
+
+# =============================================================================
+# Phase 5.3 — Content Replacement Detection
+# =============================================================================
+
+@test "Phase 5.3 documents content-replacement detection (--diff-filter=M)" {
+  grep -qF "diff-filter=M" "$UPDATE_LOA"
+}
+
+@test "Phase 5.3 lists identity files for content-replacement check" {
+  grep -q "README.md.*CHANGELOG.md.*BUTTERFREEZONE.md" "$UPDATE_LOA"
+}
+
+@test "Phase 5.3 references issue #439" {
+  grep -qF "#439" "$UPDATE_LOA"
+}
+
+@test "Phase 5.3 explains why --diff-filter=D is insufficient" {
+  grep -q "diff-filter=D.*cannot catch\|invisible to.*diff-filter=D\|modified, not deleted" "$UPDATE_LOA"
+}


### PR DESCRIPTION
## Summary

Fixes #439 — BUTTERFREEZONE.md collateral content overwrite during `/update-loa`.

Two independent fixes:

- **`.gitattributes`**: Add `BUTTERFREEZONE.md merge=ours` alongside README.md and CHANGELOG.md. This is the primary fix — prevents merge conflicts on project identity files entirely.
- **Phase 5.3**: Extend collateral safeguard to detect content replacements (`--diff-filter=M`) on identity files, not just deletions (`--diff-filter=D`). Defense-in-depth for when `--theirs` conflict resolution silently replaces downstream content.

## Root Cause

1. Phase 5.3 only scanned `git diff --cached --diff-filter=D` (deletions). Content replacements via merge conflict resolution are invisible to this filter.
2. BUTTERFREEZONE.md was not listed in `.gitattributes` with `merge=ours`, unlike README.md and CHANGELOG.md which had this protection.
3. BUTTERFREEZONE is a project identity file — it describes YOUR project, not the framework. Upstream's version is always wrong for downstream.

## Changes

| File | Change |
|------|--------|
| `.gitattributes` | +1 line: `BUTTERFREEZONE.md merge=ours` |
| `.claude/commands/update-loa.md` | Extended Phase 5.3 with identity file content-replacement detection |
| `tests/unit/gitattributes-merge-protection.bats` | 8 new tests |

## Test plan

- [x] 8/8 bats tests passing (`bats tests/unit/gitattributes-merge-protection.bats`)
- [x] Verifies `.gitattributes` protection for all 3 identity files
- [x] Verifies Phase 5.3 documents `--diff-filter=M` detection
- [x] Verifies identity file list consistency between `.gitattributes` and Phase 5.3

🤖 Generated autonomously with Run Mode