### PR TITLE
fix(lib): SCRIPT_DIR clobbering in lib/ breaks callers (#432)

### DIFF
--- a/.claude/scripts/lib/api-resilience.sh
+++ b/.claude/scripts/lib/api-resilience.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_API_RESILIENCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Configuration (can be overridden via environment or .loa.config.yaml)
 API_MAX_RETRIES="${LOA_API_MAX_RETRIES:-3}"
@@ -25,8 +25,8 @@ BUDGET_STATE_FILE="${LOA_BUDGET_STATE_FILE:-grimoires/loa/a2a/compound/.budget-s
 DEAD_LETTER_FILE="${LOA_DEAD_LETTER_FILE:-grimoires/loa/a2a/compound/dead-letter.jsonl}"
 
 # Source common utilities if available
-if [[ -f "${SCRIPT_DIR}/common.sh" ]]; then
-    source "${SCRIPT_DIR}/common.sh"
+if [[ -f "${_API_RESILIENCE_DIR}/common.sh" ]]; then
+    source "${_API_RESILIENCE_DIR}/common.sh"
 fi
 
 # Logging functions

--- a/.claude/scripts/lib/context-isolation-lib.sh
+++ b/.claude/scripts/lib/context-isolation-lib.sh
@@ -13,11 +13,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_CTX_ISO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source bootstrap for PROJECT_ROOT if available
-if [[ -f "$SCRIPT_DIR/../bootstrap.sh" ]]; then
-    source "$SCRIPT_DIR/../bootstrap.sh"
+if [[ -f "$_CTX_ISO_DIR/../bootstrap.sh" ]]; then
+    source "$_CTX_ISO_DIR/../bootstrap.sh"
 fi
 
 PROJECT_ROOT="${PROJECT_ROOT:-$(pwd)}"

--- a/.claude/scripts/lib/event-bus.sh
+++ b/.claude/scripts/lib/event-bus.sh
@@ -63,7 +63,7 @@ fi
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_EVENT_BUS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # =============================================================================
 # Configuration

--- a/.claude/scripts/lib/event-registry.sh
+++ b/.claude/scripts/lib/event-registry.sh
@@ -26,11 +26,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_EVENT_REGISTRY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source event bus
-if [[ -f "${SCRIPT_DIR}/event-bus.sh" ]]; then
-    source "${SCRIPT_DIR}/event-bus.sh"
+if [[ -f "${_EVENT_REGISTRY_DIR}/event-bus.sh" ]]; then
+    source "${_EVENT_REGISTRY_DIR}/event-bus.sh"
 fi
 
 # =============================================================================

--- a/.claude/scripts/lib/schema-validator.sh
+++ b/.claude/scripts/lib/schema-validator.sh
@@ -4,12 +4,12 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCHEMA_DIR="${SCRIPT_DIR}/../../schemas"
+_SCHEMA_VALIDATOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA_DIR="${_SCHEMA_VALIDATOR_DIR}/../../schemas"
 
 # Source common utilities if available
-if [[ -f "${SCRIPT_DIR}/common.sh" ]]; then
-    source "${SCRIPT_DIR}/common.sh"
+if [[ -f "${_SCHEMA_VALIDATOR_DIR}/common.sh" ]]; then
+    source "${_SCHEMA_VALIDATOR_DIR}/common.sh"
 fi
 
 # Logging functions (if not already defined)

--- a/.claude/scripts/lib/validation-history.sh
+++ b/.claude/scripts/lib/validation-history.sh
@@ -21,8 +21,8 @@
 set -euo pipefail
 
 # Configuration
-SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
-PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+_VALIDATION_HISTORY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$_VALIDATION_HISTORY_DIR/../../.." && pwd)}"
 COMPOUND_DIR="${PROJECT_ROOT}/grimoires/loa/a2a/compound"
 HISTORY_FILE="${COMPOUND_DIR}/.validation-history"
 TIMESTAMPS_FILE="${COMPOUND_DIR}/.validation-timestamps"

--- a/.claude/scripts/tests/unit/test-script-dir-isolation.bats
+++ b/.claude/scripts/tests/unit/test-script-dir-isolation.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# test-script-dir-isolation.bats — Regression test for bug-432
+# Ensures that sourcing lib/ files does NOT clobber a caller's SCRIPT_DIR.
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_TMPDIR"
+    mkdir -p "$BATS_TEST_TMPDIR/grimoires/loa/a2a/compound"
+    mkdir -p "$BATS_TEST_TMPDIR/grimoires/loa/a2a/events"
+}
+
+# Helper: source a lib file and check that SCRIPT_DIR survives
+assert_script_dir_preserved() {
+    local lib_file="$1"
+    local caller_dir="/some/caller/directory"
+
+    # Set SCRIPT_DIR as a caller would
+    SCRIPT_DIR="$caller_dir"
+
+    # Source the library
+    source "$lib_file"
+
+    # Verify SCRIPT_DIR was NOT overwritten
+    if [[ "$SCRIPT_DIR" != "$caller_dir" ]]; then
+        echo "SCRIPT_DIR was clobbered by $(basename "$lib_file")"
+        echo "  Expected: $caller_dir"
+        echo "  Got:      $SCRIPT_DIR"
+        return 1
+    fi
+    return 0
+}
+
+@test "sourcing context-isolation-lib.sh preserves caller SCRIPT_DIR" {
+    assert_script_dir_preserved "$BATS_TEST_DIRNAME/../../lib/context-isolation-lib.sh"
+}
+
+@test "sourcing api-resilience.sh preserves caller SCRIPT_DIR" {
+    assert_script_dir_preserved "$BATS_TEST_DIRNAME/../../lib/api-resilience.sh"
+}
+
+@test "sourcing event-bus.sh preserves caller SCRIPT_DIR" {
+    assert_script_dir_preserved "$BATS_TEST_DIRNAME/../../lib/event-bus.sh"
+}
+
+@test "sourcing schema-validator.sh preserves caller SCRIPT_DIR" {
+    assert_script_dir_preserved "$BATS_TEST_DIRNAME/../../lib/schema-validator.sh"
+}
+
+@test "sourcing event-registry.sh preserves caller SCRIPT_DIR" {
+    assert_script_dir_preserved "$BATS_TEST_DIRNAME/../../lib/event-registry.sh"
+}
+
+@test "sourcing validation-history.sh preserves caller SCRIPT_DIR" {
+    assert_script_dir_preserved "$BATS_TEST_DIRNAME/../../lib/validation-history.sh"
+}
+
+@test "no lib file in .claude/scripts/lib/ uses bare SCRIPT_DIR assignment" {
+    local lib_dir="$BATS_TEST_DIRNAME/../../lib"
+    # Check that no lib file assigns to bare SCRIPT_DIR (only prefixed variants allowed)
+    # Exclude comments (lines starting with #) and usage examples
+    local violations
+    violations=$(grep -rn '^[^#]*SCRIPT_DIR=' "$lib_dir"/*.sh 2>/dev/null | grep -v '_.*_DIR=' || true)
+    if [[ -n "$violations" ]]; then
+        echo "Found bare SCRIPT_DIR assignments in lib files:"
+        echo "$violations"
+        return 1
+    fi
+}


### PR DESCRIPTION
## Summary

- Renames `SCRIPT_DIR` to file-specific prefixed variables in all 6 library files under `.claude/scripts/lib/` to eliminate namespace collision when sourced by callers
- Fixes critical bug where `flatline-orchestrator.sh` (and other callers) had their `SCRIPT_DIR` overwritten from `.claude/scripts/` to `.claude/scripts/lib/`, breaking all subsequent path resolution
- Adds 7-test regression suite verifying sourcing lib files does not clobber caller's `SCRIPT_DIR`

## Variable Renames

| File | Old | New |
|------|-----|-----|
| `context-isolation-lib.sh` | `SCRIPT_DIR` | `_CTX_ISO_DIR` |
| `api-resilience.sh` | `SCRIPT_DIR` | `_API_RESILIENCE_DIR` |
| `event-bus.sh` | `SCRIPT_DIR` | `_EVENT_BUS_DIR` |
| `schema-validator.sh` | `SCRIPT_DIR` | `_SCHEMA_VALIDATOR_DIR` |
| `event-registry.sh` | `SCRIPT_DIR` | `_EVENT_REGISTRY_DIR` |
| `validation-history.sh` | `SCRIPT_DIR` | `_VALIDATION_HISTORY_DIR` |

## Test plan

- [x] 7/7 regression tests pass (`test-script-dir-isolation.bats`)
- [x] Each lib file verified to not clobber caller SCRIPT_DIR
- [x] Grep confirms no bare `SCRIPT_DIR` assignments remain in lib/
- [x] Existing test suites pass (construct-manifest 17/17)
- [x] Caller verification: `flatline-orchestrator.sh` SCRIPT_DIR preserved through lib sourcing

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)