### PR TITLE
fix(constructs): auth fallback in browse, symlink + construct.yaml in loader

### DIFF
--- a/.claude/scripts/constructs-browse.sh
+++ b/.claude/scripts/constructs-browse.sh
@@ -144,6 +144,25 @@ fetch_packs() {
         fi
     fi
 
+    # Auth-related failure (401/403/502) — retry without auth header
+    # This handles invalid/expired/test API keys gracefully since the
+    # constructs list endpoint is public and doesn't require auth
+    if [[ -n "$api_key" ]] && [[ "$http_code" =~ ^(401|403|502|000)$ || -z "$http_code" ]]; then
+        echo "  Auth failed (HTTP $http_code), retrying without credentials..." >&2
+        response=$(curl -s -f -w "\n%{http_code}" "${registry_url}/constructs?type=pack" 2>/dev/null) || true
+        http_code=$(echo "$response" | tail -n1)
+        response=$(echo "$response" | sed '$d')
+
+        if [[ "$http_code" == "200" ]] && [[ -n "$response" ]]; then
+            if echo "$response" | jq -e '.data' &>/dev/null; then
+                ensure_cache_dir
+                echo "$response" > "$cache_file"
+                echo "$response"
+                return 0
+            fi
+        fi
+    fi
+
     # Check for specific error codes
     local error_code
     error_code=$(echo "$response" | jq -r '.error.code // empty' 2>/dev/null)
@@ -196,6 +215,20 @@ fetch_pack_info() {
     if [[ "$http_code" == "200" ]] && [[ -n "$response" ]]; then
         echo "$response"
         return 0
+    fi
+
+    # Auth-related failure — retry without auth header
+    # The constructs detail endpoint is public and doesn't require auth
+    if [[ -n "$api_key" ]] && [[ "$http_code" =~ ^(401|403|502|000)$ || -z "$http_code" ]]; then
+        echo "  Auth failed (HTTP $http_code), retrying without credentials..." >&2
+        response=$(curl -s -f -w "\n%{http_code}" "${registry_url}/constructs/${slug}" 2>/dev/null) || true
+        http_code=$(echo "$response" | tail -n1)
+        response=$(echo "$response" | sed '$d')
+
+        if [[ "$http_code" == "200" ]] && [[ -n "$response" ]]; then
+            echo "$response"
+            return 0
+        fi
     fi
 
     # Handle errors gracefully

--- a/.claude/scripts/constructs-loader.sh
+++ b/.claude/scripts/constructs-loader.sh
@@ -98,7 +98,8 @@ discover_skills() {
     fi
 
     # Find all directories that look like skills (have index.yaml or SKILL.md)
-    find "$skills_dir" -mindepth 2 -maxdepth 2 -type d 2>/dev/null | while read -r skill_dir; do
+    # -L follows symlinks so construct packs installed via symlink are discovered
+    find -L "$skills_dir" -mindepth 2 -maxdepth 2 -type d 2>/dev/null | while read -r skill_dir; do
         # Check if it looks like a skill directory
         if [[ -f "$skill_dir/index.yaml" ]] || [[ -f "$skill_dir/SKILL.md" ]]; then
             # Extract vendor/skill name from path
@@ -177,9 +178,10 @@ discover_packs() {
         return 0
     fi
 
-    # Find all directories with manifest.json
-    find "$packs_dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | while read -r pack_dir; do
-        if [[ -f "$pack_dir/manifest.json" ]]; then
+    # Find all directories with manifest.json or construct.yaml
+    # -L follows symlinks so construct packs installed via symlink are discovered
+    find -L "$packs_dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | while read -r pack_dir; do
+        if [[ -f "$pack_dir/manifest.json" ]] || [[ -f "$pack_dir/construct.yaml" ]]; then
             basename "$pack_dir"
         fi
     done


### PR DESCRIPTION
## Summary

Two bug fixes in System Zone scripts consumed by all Loa framework users:

- **constructs-browse.sh**: Add unauthenticated retry when auth fails (401/403/502/000) in `fetch_packs()` and `fetch_pack_info()`. The constructs endpoints are public — invalid, expired, or test API keys should not block browsing. When auth fails, the script now retries without credentials before falling through to error handling.

- **constructs-loader.sh**: Use `find -L` (follow symlinks) in `discover_skills()` and `discover_packs()` so construct packs installed via symlink are discovered. Also accept `construct.yaml` alongside `manifest.json` in `discover_packs()` to support the newer construct manifest format.

## Changes

| File | Change |
|------|--------|
| `.claude/scripts/constructs-browse.sh` | Auth fallback retry in `fetch_packs()` and `fetch_pack_info()` |
| `.claude/scripts/constructs-loader.sh` | `find -L` for symlink traversal, `construct.yaml` recognition |

## Downstream reference

0xHoneyJar/loa-constructs#159

## Test plan

- [ ] Run `constructs-browse.sh list` with an invalid `LOA_CONSTRUCTS_API_KEY` — should retry unauthenticated and succeed
- [ ] Run `constructs-browse.sh info observer` with an invalid API key — should retry and succeed
- [ ] Symlink a construct pack into `.claude/constructs/packs/` and verify `constructs-loader.sh list-packs` discovers it
- [ ] Place a pack with only `construct.yaml` (no `manifest.json`) and verify `constructs-loader.sh list-packs` discovers it
- [ ] Verify existing behavior unchanged when no API key is set (no retry attempted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)