### PR TITLE
fix(mount): curl -o flag before -- sentinel (#461)

### DIFF
--- a/.claude/scripts/mount-loa.sh
+++ b/.claude/scripts/mount-loa.sh
@@ -39,7 +39,7 @@ if [[ -z "${BASH_SOURCE[0]:-}" ]] && [[ -z "${_LOA_MOUNT_REEXEC:-}" ]]; then
   mkdir -p "$_loa_tmpdir/lib"
   _loa_ok=true
   for _f in mount-loa.sh mount-submodule.sh compat-lib.sh; do
-    if ! curl -fsSL -- "$_loa_base/$_f" -o "$_loa_tmpdir/$_f"; then
+    if ! curl -fsSL -o "$_loa_tmpdir/$_f" -- "$_loa_base/$_f"; then
       _loa_ok=false
     fi
   done
@@ -55,7 +55,7 @@ if [[ -z "${BASH_SOURCE[0]:-}" ]] && [[ -z "${_LOA_MOUNT_REEXEC:-}" ]]; then
 
   # Download auxiliary scripts (non-fatal if missing in older versions)
   for _f in bootstrap.sh bash-version-guard.sh lib/symlink-manifest.sh; do
-    curl -fsSL -- "$_loa_base/$_f" -o "$_loa_tmpdir/$_f" 2>/dev/null || true
+    curl -fsSL -o "$_loa_tmpdir/$_f" -- "$_loa_base/$_f" 2>/dev/null || true
   done
   chmod +x "$_loa_tmpdir"/*.sh "$_loa_tmpdir/lib"/*.sh 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

Fixes #461 — `mount-loa.sh` curl commands placed `--` (end-of-options) before `-o`, causing curl to treat the output path as a URL to fetch.

## Changes

2 lines in `.claude/scripts/mount-loa.sh`:

```diff
- curl -fsSL -- "$_loa_base/$_f" -o "$_loa_tmpdir/$_f"
+ curl -fsSL -o "$_loa_tmpdir/$_f" -- "$_loa_base/$_f"
```

The `--` sentinel is preserved (protects against hostile `$_loa_ref` values) but moved after `-o` so curl correctly interprets the output flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)