### PR TITLE
fix(bridgebuilder): Issue #464 A1+A2+A3 follow-ups

### DIFF
--- a/.claude/skills/bridgebuilder-review/resources/__tests__/multi-model.test.ts
+++ b/.claude/skills/bridgebuilder-review/resources/__tests__/multi-model.test.ts
@@ -271,3 +271,84 @@ This PR has several issues worth addressing.
     assert.equal(findings.length, 0);
   });
 });
+
+/**
+ * Regression tests for bug-20260413-i464-9d4f51 / Issue #464 A2:
+ *
+ * Multi-model pipeline silently skipped comment posting when the configured
+ * IReviewPoster lacked postComment. HITL could not tell whether comments
+ * failed to post, were blocked, or were simply unsupported. shouldPostComment()
+ * encapsulates the guard and emits a warning when unsupported.
+ */
+describe("shouldPostComment (bug-20260413-i464-9d4f51)", () => {
+  // Import dynamically to avoid pulling executeMultiModelReview's full tree
+  const loadHelper = async () => (await import("../core/multi-model-pipeline.js")).shouldPostComment;
+
+  it("returns true when postComment is defined and not dry-run", async () => {
+    const shouldPostComment = await loadHelper();
+    const warnings: string[] = [];
+    const logger = {
+      info: () => {}, warn: (msg: string) => warnings.push(msg),
+      error: () => {}, debug: () => {},
+    };
+    const poster = {
+      postReview: async () => true,
+      hasExistingReview: async () => false,
+      postComment: async () => true,
+    };
+    const result = shouldPostComment(poster, { dryRun: false }, logger, "per-model");
+    assert.equal(result, true);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("returns false and logs warning when postComment missing in non-dry-run", async () => {
+    const shouldPostComment = await loadHelper();
+    const warnings: string[] = [];
+    const logger = {
+      info: () => {}, warn: (msg: string) => warnings.push(msg),
+      error: () => {}, debug: () => {},
+    };
+    const poster = {
+      postReview: async () => true,
+      hasExistingReview: async () => false,
+      // no postComment
+    };
+    const result = shouldPostComment(poster, { dryRun: false }, logger, "per-model");
+    assert.equal(result, false);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /does not implement postComment/);
+    assert.match(warnings[0], /per-model/);
+  });
+
+  it("returns false with no warning in dry-run mode", async () => {
+    const shouldPostComment = await loadHelper();
+    const warnings: string[] = [];
+    const logger = {
+      info: () => {}, warn: (msg: string) => warnings.push(msg),
+      error: () => {}, debug: () => {},
+    };
+    const poster = {
+      postReview: async () => true,
+      hasExistingReview: async () => false,
+      // no postComment — but dryRun=true so no warning
+    };
+    const result = shouldPostComment(poster, { dryRun: true }, logger, "per-model");
+    assert.equal(result, false);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("includes the context string in the warning message", async () => {
+    const shouldPostComment = await loadHelper();
+    const warnings: string[] = [];
+    const logger = {
+      info: () => {}, warn: (msg: string) => warnings.push(msg),
+      error: () => {}, debug: () => {},
+    };
+    const poster = {
+      postReview: async () => true,
+      hasExistingReview: async () => false,
+    };
+    shouldPostComment(poster, { dryRun: false }, logger, "consensus summary");
+    assert.match(warnings[0], /consensus summary/);
+  });
+});

--- a/.claude/skills/bridgebuilder-review/resources/__tests__/rating-stdin.test.ts
+++ b/.claude/skills/bridgebuilder-review/resources/__tests__/rating-stdin.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import { readRatingWithTimeout } from "../core/rating.js";
+
+/**
+ * Regression tests for bug-20260413-i464-9d4f51 / Issue #464 A1:
+ *
+ * Multi-model pipeline displayed the rating prompt but never read stdin,
+ * leaving FR-5 unimplemented. readRatingWithTimeout() wires a non-blocking
+ * readline reader with a configurable timeout so a valid 1-5 input is
+ * captured and invalid/no input is tolerated gracefully.
+ */
+describe("readRatingWithTimeout", () => {
+  it("captures a valid rating (1-5) from stdin", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+
+    const pending = readRatingWithTimeout({
+      input,
+      output,
+      timeoutMs: 5000,
+    });
+
+    // Simulate user entering "4" and pressing Enter
+    input.write("4\n");
+
+    const result = await pending;
+    assert.equal(result.score, 4);
+    assert.equal(result.timedOut, false);
+  });
+
+  it("returns { score: null, timedOut: true } when timeout elapses", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+
+    // No input written — timeout should fire
+    const result = await readRatingWithTimeout({
+      input,
+      output,
+      timeoutMs: 50,
+    });
+
+    assert.equal(result.score, null);
+    assert.equal(result.timedOut, true);
+  });
+
+  it("returns { score: null } when user presses Enter without input (skip)", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+
+    const pending = readRatingWithTimeout({
+      input,
+      output,
+      timeoutMs: 5000,
+    });
+
+    input.write("\n");
+
+    const result = await pending;
+    assert.equal(result.score, null);
+    assert.equal(result.timedOut, false);
+  });
+
+  it("returns { score: null } for invalid input (non-numeric)", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+
+    const pending = readRatingWithTimeout({
+      input,
+      output,
+      timeoutMs: 5000,
+    });
+
+    input.write("abc\n");
+
+    const result = await pending;
+    assert.equal(result.score, null);
+    assert.equal(result.timedOut, false);
+  });
+
+  it("returns { score: null } for out-of-range input (6)", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+
+    const pending = readRatingWithTimeout({
+      input,
+      output,
+      timeoutMs: 5000,
+    });
+
+    input.write("6\n");
+
+    const result = await pending;
+    assert.equal(result.score, null);
+    assert.equal(result.timedOut, false);
+  });
+});

--- a/.claude/skills/bridgebuilder-review/resources/adapters/google.ts
+++ b/.claude/skills/bridgebuilder-review/resources/adapters/google.ts
@@ -66,6 +66,22 @@ export class GoogleAdapter implements ILLMProvider {
       },
     });
 
+    // API key auth via URL query parameter is Google's required pattern for
+    // the Gemini REST API (https://ai.google.dev/gemini-api/docs/api-key).
+    // Unlike OpenAI (Authorization header) and Anthropic (x-api-key header),
+    // Google's public REST endpoint mandates `?key=`. This is not our design
+    // choice — it is the documented auth mechanism.
+    //
+    // Risk: the key appears in the URL and could leak via HTTP access logs,
+    // proxy logs, CDN logs, or error messages that include the full URL.
+    //
+    // Mitigation: this adapter runs in a server-side CLI context (Node.js
+    // fetch, no browser → no Referer header, no CDN/proxy intermediaries in
+    // typical deployments). `streamUrl` is passed to fetch() and never logged.
+    //
+    // CAUTION: do not add `logger.debug(streamUrl)` or include streamUrl in
+    // any error message. If Google's API evolves to support header-based auth,
+    // migrate to that pattern. See Issue #464 A3.
     const streamUrl = `${API_BASE}/${this.model}:streamGenerateContent?key=${this.apiKey}&alt=sse`;
 
     let lastError: Error | undefined;

--- a/.claude/skills/bridgebuilder-review/resources/core/multi-model-pipeline.ts
+++ b/.claude/skills/bridgebuilder-review/resources/core/multi-model-pipeline.ts
@@ -46,6 +46,27 @@ export interface PipelineAdapters {
 }
 
 /**
+ * Guard helper: returns true when a PR comment should be posted, and logs
+ * a warning if postComment is missing in non-dry-run mode.
+ *
+ * Addresses bug-20260413-i464-9d4f51 / Issue #464 A2: HITL could not
+ * distinguish "comment posting unsupported" from "comment posting failed".
+ */
+export function shouldPostComment(
+  poster: IReviewPoster,
+  config: { dryRun: boolean },
+  logger: ILogger,
+  context: string,
+): boolean {
+  if (config.dryRun) return false;
+  if (!poster.postComment) {
+    logger.warn(`[multi-model] Poster does not implement postComment; ${context} skipped`);
+    return false;
+  }
+  return true;
+}
+
+/**
  * Optional Pass-2 enrichment context. When provided, executeMultiModelReview()
  * invokes ONE designated "writer" model to produce a human-readable consensus
  * review with metaphors, FAANG parallels, and teachable moments.
@@ -181,7 +202,7 @@ export async function executeMultiModelReview(
 
       // Post per-model comment
       let posted = false;
-      if (!config.dryRun && poster.postComment) {
+      if (shouldPostComment(poster, config, logger, "per-model comment") && poster.postComment) {
         try {
           const commentBody = formatModelComment(
             ma.provider,
@@ -278,7 +299,11 @@ export async function executeMultiModelReview(
 
   // Post consensus summary comment
   let overallPosted = false;
-  if (!config.dryRun && poster.postComment && findingsPerModel.length > 1) {
+  if (
+    shouldPostComment(poster, config, logger, "consensus summary") &&
+    poster.postComment &&
+    findingsPerModel.length > 1
+  ) {
     try {
       overallPosted = await poster.postComment({
         owner: item.owner,

--- a/.claude/skills/bridgebuilder-review/resources/core/rating.ts
+++ b/.claude/skills/bridgebuilder-review/resources/core/rating.ts
@@ -4,6 +4,8 @@
  * Non-blocking with configurable timeout.
  */
 import { appendFile, mkdir } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
 
 export interface RatingEntry {
   timestamp: string;
@@ -114,4 +116,58 @@ export function createRatingEntry(
     category: options?.category ?? "overall",
     comment: options?.comment,
   };
+}
+
+/**
+ * Non-blocking stdin rating capture with timeout.
+ *
+ * Addresses bug-20260413-i464-9d4f51 / Issue #464 A1: the multi-model
+ * pipeline displayed the rating prompt but never read stdin, leaving
+ * FR-5 unimplemented.
+ *
+ * Resolves when either:
+ *   - User enters a value + Enter (score parsed via parseRatingInput)
+ *   - Timeout elapses ({ score: null, timedOut: true })
+ *
+ * Never throws. Never blocks beyond `timeoutMs`. Safe for autonomous mode.
+ *
+ * @param options.input - Readable stream (default: process.stdin)
+ * @param options.output - Writable stream for readline (default: process.stderr)
+ * @param options.timeoutMs - Timeout in milliseconds
+ */
+export async function readRatingWithTimeout(options: {
+  input?: Readable;
+  output?: Writable;
+  timeoutMs: number;
+}): Promise<{ score: number | null; timedOut: boolean }> {
+  const input = options.input ?? process.stdin;
+  const output = options.output ?? process.stderr;
+
+  return new Promise((resolve) => {
+    const rl = createInterface({ input, output, terminal: false });
+    let settled = false;
+
+    const finish = (result: { score: number | null; timedOut: boolean }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        rl.close();
+      } catch {
+        // ignore close errors — best-effort cleanup
+      }
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => finish({ score: null, timedOut: true }), options.timeoutMs);
+
+    rl.once("line", (line: string) => {
+      finish({ score: parseRatingInput(line), timedOut: false });
+    });
+
+    rl.once("close", () => {
+      // Stream closed before any input — treat as skip
+      finish({ score: null, timedOut: false });
+    });
+  });
 }

--- a/.claude/skills/bridgebuilder-review/resources/main.ts
+++ b/.claude/skills/bridgebuilder-review/resources/main.ts
@@ -19,7 +19,12 @@ import {
 import type { BridgebuilderConfig, RunSummary } from "./core/types.js";
 import { executeMultiModelReview } from "./core/multi-model-pipeline.js";
 import { ProgressReporter } from "./core/progress.js";
-import { buildRatingPrompt, storeRating, createRatingEntry } from "./core/rating.js";
+import {
+  buildRatingPrompt,
+  storeRating,
+  createRatingEntry,
+  readRatingWithTimeout,
+} from "./core/rating.js";
 import { truncateFiles } from "./core/truncation.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -335,16 +340,29 @@ async function main(): Promise<void> {
     progress.reportComplete(Date.now() - now.getTime(), config.multiModel.models.length);
     progress.stop();
 
-    // Rating prompt (Fix #2) — non-blocking, respects timeout
+    // Rating prompt — non-blocking, respects timeout (Issue #464 A1)
     if (config.multiModel.rating.enabled) {
-      const ratingPrompt = buildRatingPrompt(
-        runId,
-        config.multiModel.models.map((m) => m.model_id).join(", "),
-        1,
-      );
+      const modelsLabel = config.multiModel.models.map((m) => m.model_id).join(", ");
+      const ratingPrompt = buildRatingPrompt(runId, modelsLabel, 1);
       console.error(ratingPrompt);
-      // In autonomous mode, rating is logged but not awaited for stdin
-      // The prompt is displayed; the caller can provide input or skip
+
+      try {
+        const { score, timedOut } = await readRatingWithTimeout({
+          timeoutMs: config.multiModel.rating.timeout_seconds * 1000,
+        });
+        if (score !== null) {
+          const entry = createRatingEntry(runId, 1, modelsLabel, score);
+          await storeRating(entry);
+          console.error(`[bridgebuilder] Rating stored: ${score}/5`);
+        } else if (timedOut) {
+          console.error(`[bridgebuilder] Rating prompt timed out after ${config.multiModel.rating.timeout_seconds}s`);
+        } else {
+          console.error("[bridgebuilder] Rating skipped");
+        }
+      } catch (err) {
+        // Rating must never crash the pipeline — log and continue
+        console.error(`[bridgebuilder] Rating capture failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
 
     console.log(JSON.stringify({ runId, mode: "multi-model", items: items.length }, null, 2));


### PR DESCRIPTION
## Summary

Closes three HIGH-severity follow-up findings from [#464](https://github.com/0xHoneyJar/loa/issues/464) Part A, identified by the multi-model Bridgebuilder's review of PR #463.

- **A1 — Rating stdin capture (FR-5 gap)**: `main.ts` displayed the rating prompt but never read stdin. New `readRatingWithTimeout()` in `core/rating.ts` wires a non-blocking readline + timeout race. On valid 1-5 input → `createRatingEntry()` + `storeRating()`. On timeout/skip → continue silently. Wrapped in try/catch so rating failure never crashes the pipeline.
- **A2 — `postComment` silent-skip warning**: New exported `shouldPostComment()` guard emits `logger.warn` when `poster.postComment` is undefined in non-dry-run mode. Closes observability gap where HITL couldn't tell if posting was unsupported vs failed.
- **A3 — Google URL-key auth docblock**: 15-line comment at `google.ts:69` explaining Google's required auth pattern, leak risk, CLI-context mitigation, and explicit caution against logging `streamUrl`.

## Test plan

- [x] 593 tests passing, 0 regressions (baseline was 584 before this branch)
- [x] 9 new tests: 5 in `rating-stdin.test.ts`, 4 in `multi-model.test.ts` (shouldPostComment suite)
- [x] TypeScript strict check clean (`npx tsc --noEmit`)
- [x] `/review-sprint sprint-bug-104` approved ("All good with noted concerns")
- [x] `/audit-sprint sprint-bug-104` approved ("APPROVED - 0 findings")
- [ ] Manual CI pass before merge

## Loa process

Full cycle followed:
1. `/bug` triage → `sprint-bug-104` (bug-20260413-i464-9d4f51)
2. `/implement sprint-bug-104` → 593 tests passing
3. `/review-sprint sprint-bug-104` → approved
4. `/audit-sprint sprint-bug-104` → approved, COMPLETED marker written

## Issue #464 status after this PR

- ✅ A1 — Rating stdin capture
- ✅ A2 — postComment silent-skip warning
- ✅ A3 — Google auth docblock
- 🔄 A4 — Cross-repo context wiring (next sprint)
- 🔄 A5 — Lore loading (next sprint)
- 🔄 Amendment 1 — Post-PR Bridgebuilder orchestration (next cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)