### PR TITLE
fix(red-team): wire invoke_live to model-invoke, add mock banner (sprint-bug-102)

### DIFF
--- a/.claude/scripts/red-team-model-adapter.sh
+++ b/.claude/scripts/red-team-model-adapter.sh
@@ -3,8 +3,16 @@
 # red-team-model-adapter.sh — Model adapter for red team pipeline
 # =============================================================================
 # Thin adapter between pipeline phases and model invocation.
-# Currently: returns mock responses from fixtures.
-# Future: delegates to cheval.py via Hounfour model routing.
+# Two modes:
+#   --mock  returns fixture data (or minimal empty response); emits a visible
+#           WARNING banner so callers understand output is not live analysis
+#   --live  delegates to `.claude/scripts/model-invoke` (cheval.py) using
+#           role→agent mapping and model→provider:model-id mapping
+#
+# Default mode when neither flag is passed is computed by detect_default_mode:
+#   live  if hounfour.flatline_routing: true AND model-invoke is executable
+#         AND at least one provider API key is present
+#   mock  otherwise
 #
 # Exit codes:
 #   0  Success
@@ -18,6 +26,33 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/bootstrap.sh"
 
 FIXTURES_DIR="$PROJECT_ROOT/.claude/data/red-team-fixtures"
+MODEL_INVOKE="$SCRIPT_DIR/model-invoke"
+CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
+
+# Role → agent alias mapping for model-invoke routing.
+# Red team doesn't have dedicated agent bindings yet; reuse flatline aliases
+# whose personas are closest in spirit (attacker=skeptic, evaluator=reviewer,
+# defender=dissenter). Callers can override via --model if different model
+# selection is needed.
+declare -A ROLE_TO_AGENT=(
+    ["attacker"]="flatline-skeptic"
+    ["evaluator"]="flatline-reviewer"
+    ["defender"]="flatline-dissenter"
+)
+
+# Legacy model name → provider:model-id for model-invoke --model override.
+# Mirrors flatline-orchestrator.sh MODEL_TO_PROVIDER_ID.
+declare -A MODEL_TO_PROVIDER_ID=(
+    ["gpt"]="openai:gpt-5.3-codex"
+    ["gpt-5.2"]="openai:gpt-5.2"
+    ["gpt-5.3-codex"]="openai:gpt-5.3-codex"
+    ["opus"]="anthropic:claude-opus-4-6"
+    ["claude-opus-4.6"]="anthropic:claude-opus-4-6"
+    ["gemini"]="google:gemini-2.5-pro"
+    ["gemini-2.5-pro"]="google:gemini-2.5-pro"
+    ["kimi"]="kimi:kimi-k2"
+    ["qwen"]="qwen:qwen3-coder-plus"
+)
 
 # =============================================================================
 # Logging
@@ -79,12 +114,33 @@ load_fixture() {
 # Mock invocation
 # =============================================================================
 
+emit_mock_banner() {
+    local role="$1"
+    local model="$2"
+    # Explicit, unmissable banner so callers (and humans reading logs) know
+    # the output is fixture data, not real model analysis.
+    cat >&2 <<BANNER
+==============================================================================
+WARNING: red-team adapter running in MOCK mode (role=$role model=$model)
+  Output is FIXTURE data, not real model analysis.
+  Findings are not specific to your document.
+  To enable live model invocation:
+    1. Set hounfour.flatline_routing: true in .loa.config.yaml
+    2. Export a provider API key (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY)
+    3. Ensure .claude/scripts/model-invoke is executable
+  Or pass --live explicitly to this adapter.
+==============================================================================
+BANNER
+}
+
 invoke_mock() {
     local role="$1"
     local model="$2"
     local prompt_file="$3"
     local output_file="$4"
     local budget="$5"
+
+    emit_mock_banner "$role" "$model"
 
     local fixture_data
     fixture_data=$(load_fixture "$role" "$model") || {
@@ -159,17 +215,199 @@ invoke_mock() {
 }
 
 # =============================================================================
-# Live invocation (future — Hounfour/cheval.py)
+# Live invocation — delegates to model-invoke (cheval.py)
 # =============================================================================
+
+# Detect whether at least one provider API key is set. Used by
+# detect_default_mode to decide whether live mode is feasible.
+has_any_api_key() {
+    [[ -n "${ANTHROPIC_API_KEY:-}" ]] && return 0
+    [[ -n "${OPENAI_API_KEY:-}" ]] && return 0
+    [[ -n "${GOOGLE_API_KEY:-}" ]] && return 0
+    [[ -n "${GEMINI_API_KEY:-}" ]] && return 0
+    return 1
+}
+
+# Read hounfour.flatline_routing from config, honoring env override.
+# Red team lives under the same routing flag because both subsystems
+# share the cheval.py invocation path.
+is_routing_enabled() {
+    if [[ "${HOUNFOUR_FLATLINE_ROUTING:-}" == "true" ]]; then
+        return 0
+    fi
+    if [[ "${HOUNFOUR_FLATLINE_ROUTING:-}" == "false" ]]; then
+        return 1
+    fi
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        return 1
+    fi
+    local value
+    value=$(yq '.hounfour.flatline_routing // false' "$CONFIG_FILE" 2>/dev/null || echo "false")
+    [[ "$value" == "true" ]]
+}
+
+# Decide default mode when caller passes neither --live nor --mock.
+# Returns: echoes "live" or "mock".
+detect_default_mode() {
+    if is_routing_enabled && [[ -x "$MODEL_INVOKE" ]] && has_any_api_key; then
+        echo "live"
+    else
+        echo "mock"
+    fi
+}
+
+# Wrap model-invoke content into the response shape the pipeline expects.
+# Attackers/defenders emit JSON findings; we parse them if valid, otherwise
+# pass through the raw content as a single free-text attack/design entry so
+# the pipeline can still complete.
+wrap_live_response() {
+    local role="$1"
+    local model="$2"
+    local content="$3"
+    local tokens_input="$4"
+    local tokens_output="$5"
+    local output_file="$6"
+
+    local total_tokens=$((tokens_input + tokens_output))
+
+    # If content parses as JSON, merge it into the response envelope;
+    # otherwise wrap it as a free-text note.
+    local parsed
+    if parsed=$(echo "$content" | jq -c . 2>/dev/null) && [[ -n "$parsed" && "$parsed" != "null" ]]; then
+        # Strip markdown fences if the model wrapped JSON in ```json ... ```
+        :
+    else
+        # Try to extract JSON from a fenced code block
+        parsed=$(echo "$content" | sed -n '/```json/,/```/p' | sed '1d;$d' | jq -c . 2>/dev/null || echo "")
+    fi
+
+    case "$role" in
+        attacker)
+            if [[ -n "$parsed" ]] && echo "$parsed" | jq -e '.attacks' >/dev/null 2>&1; then
+                echo "$parsed" | jq \
+                    --arg m "$model" \
+                    --argjson t "$total_tokens" \
+                    '. + {model: $m, tokens_used: $t, mock: false}' > "$output_file"
+            else
+                jq -n --arg m "$model" --arg c "$content" --argjson t "$total_tokens" '{
+                    attacks: [],
+                    summary: $c,
+                    models_used: 1,
+                    tokens_used: $t,
+                    model: $m,
+                    mock: false,
+                    note: "Model returned non-JSON content; raw content in summary field"
+                }' > "$output_file"
+            fi
+            ;;
+        evaluator)
+            if [[ -n "$parsed" ]]; then
+                echo "$parsed" | jq \
+                    --arg m "$model" \
+                    --argjson t "$total_tokens" \
+                    '. + {evaluated: true, model: $m, tokens_used: $t, mock: false}' > "$output_file"
+            else
+                jq -n --arg m "$model" --arg c "$content" --argjson t "$total_tokens" '{
+                    attacks: [],
+                    evaluated: true,
+                    summary: $c,
+                    tokens_used: $t,
+                    model: $m,
+                    mock: false
+                }' > "$output_file"
+            fi
+            ;;
+        defender)
+            if [[ -n "$parsed" ]] && echo "$parsed" | jq -e '.counter_designs' >/dev/null 2>&1; then
+                echo "$parsed" | jq \
+                    --arg m "$model" \
+                    --argjson t "$total_tokens" \
+                    '. + {model: $m, tokens_used: $t, mock: false}' > "$output_file"
+            else
+                jq -n --arg m "$model" --arg c "$content" --argjson t "$total_tokens" '{
+                    counter_designs: [],
+                    summary: $c,
+                    tokens_used: $t,
+                    model: $m,
+                    mock: false,
+                    note: "Model returned non-JSON content; raw content in summary field"
+                }' > "$output_file"
+            fi
+            ;;
+    esac
+}
 
 invoke_live() {
     local role="$1"
     local model="$2"
+    local prompt_file="$3"
+    local output_file="$4"
+    local budget="$5"
+    local timeout="$6"
 
-    error "Live model invocation requires cheval.py (Hounfour integration)"
-    error "Install Hounfour and configure model routing first"
-    error "See: grimoires/loa/sdd.md Section 6 — Hounfour Integration"
-    return 1
+    if [[ ! -x "$MODEL_INVOKE" ]]; then
+        error "Live mode requires executable model-invoke at: $MODEL_INVOKE"
+        return 1
+    fi
+    if ! has_any_api_key; then
+        error "Live mode requires at least one provider API key"
+        error "  Set ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY, or GEMINI_API_KEY"
+        return 1
+    fi
+
+    local agent="${ROLE_TO_AGENT[$role]:-flatline-reviewer}"
+    local model_override="${MODEL_TO_PROVIDER_ID[$model]:-$model}"
+
+    log "Live invocation: role=$role agent=$agent model=$model_override"
+
+    local response_file
+    response_file=$(mktemp)
+    local stderr_file
+    stderr_file=$(mktemp)
+    local exit_code=0
+
+    "$MODEL_INVOKE" \
+        --agent "$agent" \
+        --input "$prompt_file" \
+        --model "$model_override" \
+        --output-format json \
+        --json-errors \
+        --timeout "$timeout" \
+        > "$response_file" 2>"$stderr_file" || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        error "model-invoke failed (exit $exit_code) for role=$role model=$model"
+        if [[ -s "$stderr_file" ]]; then
+            error "stderr: $(head -c 500 "$stderr_file")"
+        fi
+        rm -f "$response_file" "$stderr_file"
+        return "$exit_code"
+    fi
+
+    # Parse model-invoke JSON envelope
+    local content tokens_input tokens_output
+    content=$(jq -r '.content // empty' "$response_file" 2>/dev/null || echo "")
+    tokens_input=$(jq -r '.usage.input_tokens // 0' "$response_file" 2>/dev/null || echo 0)
+    tokens_output=$(jq -r '.usage.output_tokens // 0' "$response_file" 2>/dev/null || echo 0)
+
+    if [[ -z "$content" ]]; then
+        error "model-invoke returned empty content"
+        rm -f "$response_file" "$stderr_file"
+        return 5
+    fi
+
+    wrap_live_response "$role" "$model" "$content" "$tokens_input" "$tokens_output" "$output_file"
+
+    # Budget check
+    local total_tokens=$((tokens_input + tokens_output))
+    if [[ "$budget" -gt 0 ]] && (( total_tokens > budget )); then
+        log "Budget exceeded: ${total_tokens} tokens > budget ${budget}"
+        rm -f "$response_file" "$stderr_file"
+        return 2
+    fi
+
+    rm -f "$response_file" "$stderr_file"
+    return 0
 }
 
 # =============================================================================
@@ -231,13 +469,22 @@ run_self_test() {
         fail=$((fail + 1))
     fi
 
-    # Test 4: Live mode returns error
-    if "$0" --role attacker --model opus --prompt-file "$tmpdir/prompt.md" --output-file "$tmpdir/out4.json" --live 2>/dev/null; then
-        echo "  FAIL: Live mode should fail without cheval.py"
-        fail=$((fail + 1))
-    else
-        echo "  PASS: Live mode correctly errors without cheval.py"
+    # Test 4: Live mode errors gracefully when no API key is available.
+    # (Pre-fix this was "Live mode returns error — cheval.py not available".
+    # Post-fix live is wired, but without API keys it must still fail cleanly.)
+    (
+        unset ANTHROPIC_API_KEY OPENAI_API_KEY GOOGLE_API_KEY GEMINI_API_KEY
+        if "$0" --role attacker --model opus --prompt-file "$tmpdir/prompt.md" --output-file "$tmpdir/out4.json" --live 2>/dev/null; then
+            exit 1
+        fi
+        exit 0
+    )
+    if [[ $? -eq 0 ]]; then
+        echo "  PASS: Live mode errors cleanly when no API keys are set"
         pass=$((pass + 1))
+    else
+        echo "  FAIL: Live mode should fail with exit non-zero when API keys missing"
+        fail=$((fail + 1))
     fi
 
     # Test 5: Fixture loading (if fixtures exist)
@@ -276,7 +523,7 @@ main() {
     local output_file=""
     local budget=0
     local timeout=300
-    local mode="mock"
+    local mode=""   # empty = detect default based on config + env
     local self_test=false
 
     while [[ $# -gt 0 ]]; do
@@ -319,10 +566,17 @@ main() {
         exit 1
     fi
 
+    # Resolve default mode when neither --mock nor --live was passed
+    if [[ -z "$mode" ]]; then
+        mode=$(detect_default_mode)
+        log "Auto-detected mode: $mode (pass --live or --mock to override)"
+    fi
+
     # Dispatch to invocation mode
     case "$mode" in
         mock) invoke_mock "$role" "$model" "$prompt_file" "$output_file" "$budget" ;;
-        live) invoke_live "$role" "$model" ;;
+        live) invoke_live "$role" "$model" "$prompt_file" "$output_file" "$budget" "$timeout" ;;
+        *) error "Unknown mode: $mode"; exit 1 ;;
     esac
 }
 

--- a/.claude/scripts/red-team-model-adapter.sh
+++ b/.claude/scripts/red-team-model-adapter.sh
@@ -77,8 +77,10 @@ Options:
   --output-file PATH   Output file for response (required)
   --budget TOKENS      Token budget (0 = unlimited)
   --timeout SECONDS    Timeout in seconds (default: 300)
-  --mock               Use fixture data (default)
-  --live               Use real model via cheval.py (not yet implemented)
+  --mock               Use fixture data (emits WARNING banner on stderr)
+  --live               Use real model via model-invoke (cheval.py)
+                       Requires: hounfour.flatline_routing:true + API key
+                       (default: auto-detect from config + env)
   --self-test          Run built-in validation
   -h, --help           Show this help
 USAGE

--- a/.claude/scripts/red-team-pipeline.sh
+++ b/.claude/scripts/red-team-pipeline.sh
@@ -16,6 +16,12 @@ source "$SCRIPT_DIR/bootstrap.sh"
 SANITIZER="$SCRIPT_DIR/red-team-sanitizer.sh"
 SCORING_ENGINE="$SCRIPT_DIR/scoring-engine.sh"
 REPORT_GEN="$SCRIPT_DIR/red-team-report.sh"
+MODEL_INVOKE="$SCRIPT_DIR/model-invoke"
+
+# Adapter mode flag (--live or --mock). Resolved once in main() and passed
+# explicitly to every adapter invocation so the mode is never silently
+# defaulted by the adapter itself. See sprint-bug-102.
+ADAPTER_MODE_FLAG=""
 
 # Config
 CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
@@ -145,6 +151,38 @@ render_counter_template() {
         { print }
     ' "$output_file" > "$tmpwork" && mv "$tmpwork" "$output_file"
     rm -f "$tmpwork"
+}
+
+# =============================================================================
+# Adapter mode resolution
+# =============================================================================
+
+# Decide --live vs --mock once per pipeline run, based on env + config.
+# Live requires: hounfour.flatline_routing: true AND model-invoke executable
+# AND at least one provider API key. Otherwise fall back to mock with a
+# visible warning.
+resolve_adapter_mode() {
+    local routing_enabled=false
+    if [[ "${HOUNFOUR_FLATLINE_ROUTING:-}" == "true" ]]; then
+        routing_enabled=true
+    elif [[ "${HOUNFOUR_FLATLINE_ROUTING:-}" == "false" ]]; then
+        routing_enabled=false
+    elif [[ -f "$CONFIG_FILE" ]]; then
+        local v
+        v=$(yq '.hounfour.flatline_routing // false' "$CONFIG_FILE" 2>/dev/null || echo "false")
+        [[ "$v" == "true" ]] && routing_enabled=true
+    fi
+
+    local has_key=false
+    if [[ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GOOGLE_API_KEY:-}${GEMINI_API_KEY:-}" ]]; then
+        has_key=true
+    fi
+
+    if [[ "$routing_enabled" == "true" ]] && [[ -x "$MODEL_INVOKE" ]] && [[ "$has_key" == "true" ]]; then
+        echo "--live"
+    else
+        echo "--mock"
+    fi
 }
 
 # =============================================================================
@@ -314,7 +352,8 @@ run_phase1_attacks() {
             --prompt-file "$prompt_file" \
             --output-file "$attacker_output" \
             --budget "$BUDGET_LIMIT" \
-            --timeout "$timeout" 2>/dev/null || {
+            --timeout "$timeout" \
+            "$ADAPTER_MODE_FLAG" 2>/dev/null || {
             log "Phase 1: Model adapter failed, using empty result"
             jq -n '{ attacks: [], summary: "Model adapter failed", models_used: 0, tokens_used: 0 }' > "$result_file"
             PHASE1_MS=$(phase_elapsed_ms "$phase_start")
@@ -381,7 +420,8 @@ run_phase2_validation() {
             --prompt-file "$sanitized_attacks" \
             --output-file "$result_file" \
             --budget "$BUDGET_LIMIT" \
-            --timeout "$timeout" 2>/dev/null || {
+            --timeout "$timeout" \
+            "$ADAPTER_MODE_FLAG" 2>/dev/null || {
             log "Phase 2: Model adapter failed, using unsanitized attacks"
             cp "$sanitized_attacks" "$result_file"
         }
@@ -526,7 +566,8 @@ run_phase4_counter_design() {
                 --prompt-file "$counter_prompt" \
                 --output-file "$result_file" \
                 --budget "$BUDGET_LIMIT" \
-                --timeout 300 2>/dev/null || {
+                --timeout 300 \
+                "$ADAPTER_MODE_FLAG" 2>/dev/null || {
                 log "Phase 4: Model adapter failed"
                 jq '. + {counter_designs: []}' "$consensus_file" > "$result_file"
             }
@@ -605,6 +646,11 @@ main() {
 
     # Initialize budget tracking
     init_budget "$execution_mode" "$budget"
+
+    # Resolve adapter mode (--live or --mock) once per pipeline run so
+    # every phase invocation uses the same mode. Never silently default.
+    ADAPTER_MODE_FLAG=$(resolve_adapter_mode)
+    log "Adapter mode: $ADAPTER_MODE_FLAG"
 
     # Phase 0: Input sanitization
     local phase0_start

--- a/.claude/scripts/red-team-pipeline.sh
+++ b/.claude/scripts/red-team-pipeline.sh
@@ -650,7 +650,23 @@ main() {
     # Resolve adapter mode (--live or --mock) once per pipeline run so
     # every phase invocation uses the same mode. Never silently default.
     ADAPTER_MODE_FLAG=$(resolve_adapter_mode)
+    # Defensive: guarantee a valid flag even if resolve_adapter_mode
+    # produced empty output (e.g., yq failure on malformed config).
+    if [[ "$ADAPTER_MODE_FLAG" != "--live" && "$ADAPTER_MODE_FLAG" != "--mock" ]]; then
+        ADAPTER_MODE_FLAG="--mock"
+    fi
     log "Adapter mode: $ADAPTER_MODE_FLAG"
+
+    # Surface the mock warning at the pipeline level too, so users who
+    # run the pipeline directly (child stderr is /dev/null on adapter
+    # calls for noise control) still see why output looks like fixture.
+    if [[ "$ADAPTER_MODE_FLAG" == "--mock" ]]; then
+        cat >&2 <<'MOCKNOTE'
+[red-team] NOTE: running in MOCK mode — output is fixture data, not live model
+           analysis. To enable live: hounfour.flatline_routing: true + provider
+           API key (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY).
+MOCKNOTE
+    fi
 
     # Phase 0: Input sanitization
     local phase0_start

--- a/.loa.config.yaml.example
+++ b/.loa.config.yaml.example
@@ -1247,6 +1247,41 @@ flatline_protocol:
       - "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
 # -----------------------------------------------------------------------------
+# Red Team — Generative Adversarial Security Design (cycle-012, sprint-bug-102)
+# -----------------------------------------------------------------------------
+# Invoked via /red-team. Generates creative attack scenarios against design
+# documents (PRD/SDD) and synthesizes architectural counter-designs.
+#
+# IMPORTANT: Live model invocation requires:
+#   1. hounfour.flatline_routing: true  (see Hounfour section above)
+#   2. At least one provider API key: ANTHROPIC_API_KEY / OPENAI_API_KEY /
+#      GOOGLE_API_KEY / GEMINI_API_KEY
+#   3. .claude/scripts/model-invoke is executable
+#
+# When any of those is missing, the pipeline falls back to MOCK mode (fixture
+# data). Mock mode emits a visible WARNING banner so results aren't mistaken
+# for real analysis. To force a mode explicitly, the adapter accepts --live
+# or --mock.
+red_team:
+  enabled: false                # Opt-in — set true to enable /red-team
+  mode: standard                # quick | standard | deep (see SKILL.md)
+  thresholds:
+    confirmed_attack: 700       # Both models >700 → CONFIRMED_ATTACK
+    theoretical: 400
+    human_review_gate: 800      # Severity >800 requires human acknowledgment
+  budgets:
+    quick_max_tokens: 50000
+    standard_max_tokens: 200000
+    deep_max_tokens: 500000
+  # Optional: route red team through Hounfour (same routing as Flatline).
+  # If unset, inherits from hounfour.flatline_routing. Set false here to
+  # force mock mode even when Flatline runs live.
+  # routing_enabled: true
+  simstim:
+    auto_trigger: false         # Run as Phase 4.5 of /simstim
+    phase: post_sdd
+
+# -----------------------------------------------------------------------------
 # Autonomous Flatline Mode (v1.22.0)
 # -----------------------------------------------------------------------------
 # Enable Flatline Protocol to operate within autonomous workflows (/autonomous,

--- a/tests/unit/red-team-model-adapter.bats
+++ b/tests/unit/red-team-model-adapter.bats
@@ -48,12 +48,12 @@ teardown() {
     # Force live mode with a prompt that would route through model-invoke.
     # With no API key set, this must fail — but NOT with the stub message.
     unset ANTHROPIC_API_KEY OPENAI_API_KEY GOOGLE_API_KEY GEMINI_API_KEY
-    run "$ADAPTER" \
-        --role attacker \
-        --model opus \
-        --prompt-file "$TEST_TMPDIR/prompt.md" \
-        --output-file "$TEST_TMPDIR/out.json" \
-        --live
+    # Explicit 2>&1 merge for portability across BATS versions (Bridgebuilder F1):
+    # default merge behavior varies by version; explicit merge is bulletproof.
+    run bash -c "'$ADAPTER' --role attacker --model opus \
+        --prompt-file '$TEST_TMPDIR/prompt.md' \
+        --output-file '$TEST_TMPDIR/out.json' \
+        --live 2>&1"
     # Negative: must not contain the legacy stub error string
     [[ "$output" != *"requires cheval.py (Hounfour integration)"* ]]
     [[ "$output" != *"Install Hounfour and configure model routing first"* ]]
@@ -109,7 +109,11 @@ teardown() {
     [ "$missing_count" -eq 0 ]
     # And if $ADAPTER_MODE_FLAG is the mechanism, the pipeline must resolve
     # it to a literal --live or --mock (defensive guard in main()).
-    grep -qE 'ADAPTER_MODE_FLAG=("--live"|"--mock"|\$\(resolve_adapter_mode)' "$PIPELINE"
+    # Bridgebuilder F4: split into explicit alternatives to avoid the
+    # unescaped-paren ERE group bug in the previous regex.
+    grep -qE 'ADAPTER_MODE_FLAG="--live"' "$PIPELINE" \
+        || grep -qE 'ADAPTER_MODE_FLAG="--mock"' "$PIPELINE" \
+        || grep -qE 'ADAPTER_MODE_FLAG=\$\(resolve_adapter_mode\)' "$PIPELINE"
 }
 
 # -----------------------------------------------------------------------------
@@ -118,12 +122,13 @@ teardown() {
 # Pre-fix: invoke_mock silently returns fixture data. Post-fix: it must emit
 # a clear banner so users understand the output is not from a live model.
 @test "mock mode emits a visible WARNING banner on stderr" {
-    run "$ADAPTER" \
-        --role attacker \
-        --model opus \
-        --prompt-file "$TEST_TMPDIR/prompt.md" \
-        --output-file "$TEST_TMPDIR/out.json" \
-        --mock
+    # Explicit 2>&1 merge for BATS version portability (Bridgebuilder F2):
+    # older BATS may not merge streams by default. Explicit merge guarantees
+    # stderr content lands in $output regardless of framework version.
+    run bash -c "'$ADAPTER' --role attacker --model opus \
+        --prompt-file '$TEST_TMPDIR/prompt.md' \
+        --output-file '$TEST_TMPDIR/out.json' \
+        --mock 2>&1"
     [ "$status" -eq 0 ]
     # Banner must mention the critical words: MOCK and WARNING (or equivalent)
     [[ "$output" == *"MOCK"* ]] || [[ "$output" == *"mock mode"* ]]

--- a/tests/unit/red-team-model-adapter.bats
+++ b/tests/unit/red-team-model-adapter.bats
@@ -57,12 +57,15 @@ teardown() {
     # Negative: must not contain the legacy stub error string
     [[ "$output" != *"requires cheval.py (Hounfour integration)"* ]]
     [[ "$output" != *"Install Hounfour and configure model routing first"* ]]
-    # Positive: must exit non-zero (model-invoke path refuses without API key)
-    [ "$status" -ne 0 ]
-    # Positive: stderr must indicate the live path was taken — either a
-    # model-invoke/API-key-related error or the "requires at least one
-    # provider API key" message from our has_any_api_key guard.
-    [[ "$output" == *"API key"* ]] || [[ "$output" == *"model-invoke"* ]] || [[ "$output" == *"api_key"* ]]
+    # Positive: exit 1 (not any non-zero) — the live path's API-key guard
+    # specifically returns 1 via has_any_api_key failure.
+    [ "$status" -eq 1 ]
+    # Positive: assert the EXACT contractual error prefix emitted by
+    # invoke_live's has_any_api_key guard. No OR-chain — the adapter is
+    # contractually required to emit this specific string. If it changes,
+    # the contract changed and the test should fail to force a review.
+    # (Bridgebuilder pass-3 F2: replaced permissive OR chain with canonical match.)
+    [[ "$output" == *"Live mode requires at least one provider API key"* ]]
 }
 
 # -----------------------------------------------------------------------------
@@ -129,9 +132,16 @@ teardown() {
         --prompt-file "$2" --output-file "$3" --mock 2>&1' \
         _ "$ADAPTER" "$TEST_TMPDIR/prompt.md" "$TEST_TMPDIR/out.json"
     [ "$status" -eq 0 ]
-    # Banner must mention the critical words: MOCK and WARNING (or equivalent)
-    [[ "$output" == *"MOCK"* ]] || [[ "$output" == *"mock mode"* ]]
-    [[ "$output" == *"WARNING"* ]] || [[ "$output" == *"not real"* ]] || [[ "$output" == *"fixture"* ]]
+    # Bridgebuilder pass-3 F3: assert the exact canonical banner line,
+    # no OR-chain. The banner is defined in emit_mock_banner() and its
+    # first header line is invariant. If the banner text changes,
+    # emit_mock_banner() is the single source of truth and this assertion
+    # must update — keeping test and implementation locked together.
+    [[ "$output" == *"WARNING: red-team adapter running in MOCK mode"* ]]
+    # Also verify the banner includes actionable remediation guidance
+    # (the "To enable live model invocation" section is part of the
+    # canonical banner body, not optional).
+    [[ "$output" == *"To enable live model invocation:"* ]]
 }
 
 # -----------------------------------------------------------------------------
@@ -169,7 +179,15 @@ teardown() {
 # Verify the adapter's own self-test still passes after the fix.
 @test "adapter self-test passes end-to-end" {
     run "$ADAPTER" --self-test
+    # Bridgebuilder pass-3 F6: the old assertion was vacuously satisfiable.
+    # `[[ output != *FAIL* ]] || [[ output == *"0 failed"* ]]` would accept
+    # output like "3 FAIL, 0 failed" because the second clause matches.
+    # Tighter contract: exit 0 is the real signal (self-test returns 0
+    # only when every sub-test passes); also assert the canonical summary
+    # line "0 failed" explicitly, which the self-test always emits last.
     [ "$status" -eq 0 ]
-    [[ "$output" == *"passed"* ]]
-    [[ "$output" != *"FAIL"* ]] || [[ "$output" == *"0 failed"* ]]
+    [[ "$output" == *"0 failed"* ]]
+    # Must NOT contain a non-zero failure count. Using a regex to reject
+    # any digit 1-9 preceding " failed" (would catch "3 failed", "12 failed", etc.)
+    ! [[ "$output" =~ [1-9][0-9]*" failed" ]]
 }

--- a/tests/unit/red-team-model-adapter.bats
+++ b/tests/unit/red-team-model-adapter.bats
@@ -48,12 +48,12 @@ teardown() {
     # Force live mode with a prompt that would route through model-invoke.
     # With no API key set, this must fail — but NOT with the stub message.
     unset ANTHROPIC_API_KEY OPENAI_API_KEY GOOGLE_API_KEY GEMINI_API_KEY
-    # Explicit 2>&1 merge for portability across BATS versions (Bridgebuilder F1):
-    # default merge behavior varies by version; explicit merge is bulletproof.
-    run bash -c "'$ADAPTER' --role attacker --model opus \
-        --prompt-file '$TEST_TMPDIR/prompt.md' \
-        --output-file '$TEST_TMPDIR/out.json' \
-        --live 2>&1"
+    # Explicit 2>&1 merge for BATS version portability (pass-2 F1/F2).
+    # Positional args (not string interpolation) avoid shell-quoting injection
+    # if paths ever contain single quotes (pass-3 HIGH finding).
+    run bash -c '"$1" --role attacker --model opus \
+        --prompt-file "$2" --output-file "$3" --live 2>&1' \
+        _ "$ADAPTER" "$TEST_TMPDIR/prompt.md" "$TEST_TMPDIR/out.json"
     # Negative: must not contain the legacy stub error string
     [[ "$output" != *"requires cheval.py (Hounfour integration)"* ]]
     [[ "$output" != *"Install Hounfour and configure model routing first"* ]]
@@ -122,13 +122,12 @@ teardown() {
 # Pre-fix: invoke_mock silently returns fixture data. Post-fix: it must emit
 # a clear banner so users understand the output is not from a live model.
 @test "mock mode emits a visible WARNING banner on stderr" {
-    # Explicit 2>&1 merge for BATS version portability (Bridgebuilder F2):
-    # older BATS may not merge streams by default. Explicit merge guarantees
-    # stderr content lands in $output regardless of framework version.
-    run bash -c "'$ADAPTER' --role attacker --model opus \
-        --prompt-file '$TEST_TMPDIR/prompt.md' \
-        --output-file '$TEST_TMPDIR/out.json' \
-        --mock 2>&1"
+    # Explicit 2>&1 merge for BATS version portability (pass-2 F1/F2).
+    # Positional args (not string interpolation) avoid shell-quoting injection
+    # if paths ever contain single quotes (pass-3 HIGH finding).
+    run bash -c '"$1" --role attacker --model opus \
+        --prompt-file "$2" --output-file "$3" --mock 2>&1' \
+        _ "$ADAPTER" "$TEST_TMPDIR/prompt.md" "$TEST_TMPDIR/out.json"
     [ "$status" -eq 0 ]
     # Banner must mention the critical words: MOCK and WARNING (or equivalent)
     [[ "$output" == *"MOCK"* ]] || [[ "$output" == *"mock mode"* ]]

--- a/tests/unit/red-team-model-adapter.bats
+++ b/tests/unit/red-team-model-adapter.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# =============================================================================
+# red-team-model-adapter.bats — sprint-bug-102 regression tests
+# =============================================================================
+# Bug: red-team skill always runs in mock mode.
+#
+# Verifies:
+#   1. invoke_live routes through model-invoke (not stubbed error)
+#   2. Pipeline passes an explicit --live or --mock flag (not implicit default)
+#   3. Mock mode emits a visible WARNING banner to stderr
+#   4. Config example documents the red_team block
+#   5. Default mode resolves to live when hounfour.flatline_routing is true
+#      AND model-invoke is executable; otherwise mock
+#
+# These tests FAIL against the pre-fix adapter and PASS after sprint-bug-102.
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export SCRIPT_DIR="$PROJECT_ROOT/.claude/scripts"
+    export ADAPTER="$SCRIPT_DIR/red-team-model-adapter.sh"
+    export PIPELINE="$SCRIPT_DIR/red-team-pipeline.sh"
+    export CONFIG_EXAMPLE="$PROJECT_ROOT/.loa.config.yaml.example"
+    TEST_TMPDIR=$(mktemp -d)
+    export TEST_TMPDIR
+    echo "Test prompt content" > "$TEST_TMPDIR/prompt.md"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+# -----------------------------------------------------------------------------
+# T1: invoke_live is wired (not a stub that always errors)
+# -----------------------------------------------------------------------------
+# Pre-fix: invoke_live returns exit 1 with "requires cheval.py" regardless of
+# whether cheval.py exists. Post-fix: it delegates to model-invoke.
+#
+# We can't make real network calls in unit tests, so we assert the adapter
+# recognises --live as a valid path that EITHER succeeds OR fails with a
+# model-invoke-related error (exit code 1-7 per SDD §4.2.2), not the
+# "requires cheval.py (Hounfour integration)" stub message.
+@test "invoke_live does not return the 'requires cheval.py' stub error" {
+    # Force live mode with a prompt that would route through model-invoke.
+    # With no API key set, this must fail — but NOT with the stub message.
+    unset ANTHROPIC_API_KEY OPENAI_API_KEY GOOGLE_API_KEY GEMINI_API_KEY
+    run "$ADAPTER" \
+        --role attacker \
+        --model opus \
+        --prompt-file "$TEST_TMPDIR/prompt.md" \
+        --output-file "$TEST_TMPDIR/out.json" \
+        --live
+    # Must not contain the legacy stub error string
+    [[ "$output" != *"requires cheval.py (Hounfour integration)"* ]]
+    [[ "$output" != *"Install Hounfour and configure model routing first"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# T2: Pipeline passes explicit --live or --mock flag to the adapter
+# -----------------------------------------------------------------------------
+# Pre-fix: three invocation sites at red-team-pipeline.sh:311,378,523
+# call the adapter with no mode flag, so the adapter defaults to mock.
+# Post-fix: every call site MUST pass --live or --mock explicitly.
+@test "pipeline passes explicit --live or --mock flag to adapter" {
+    # Count invocations that DO pass a mode flag
+    explicit_count=$(grep -cE '\-\-(live|mock)' "$PIPELINE")
+    # Count MODEL_ADAPTER invocation sites (lines starting with "$MODEL_ADAPTER")
+    invoke_count=$(grep -cE '^\s*"\$MODEL_ADAPTER"' "$PIPELINE")
+    [ "$invoke_count" -ge 3 ]
+    # Every invocation site must pair with an explicit flag
+    [ "$explicit_count" -ge "$invoke_count" ]
+}
+
+# -----------------------------------------------------------------------------
+# T3: Mock mode emits a visible WARNING banner on stderr
+# -----------------------------------------------------------------------------
+# Pre-fix: invoke_mock silently returns fixture data. Post-fix: it must emit
+# a clear banner so users understand the output is not from a live model.
+@test "mock mode emits a visible WARNING banner on stderr" {
+    run "$ADAPTER" \
+        --role attacker \
+        --model opus \
+        --prompt-file "$TEST_TMPDIR/prompt.md" \
+        --output-file "$TEST_TMPDIR/out.json" \
+        --mock
+    [ "$status" -eq 0 ]
+    # Banner must mention the critical words: MOCK and WARNING (or equivalent)
+    [[ "$output" == *"MOCK"* ]] || [[ "$output" == *"mock mode"* ]]
+    [[ "$output" == *"WARNING"* ]] || [[ "$output" == *"not real"* ]] || [[ "$output" == *"fixture"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# T4: .loa.config.yaml.example documents the red_team block
+# -----------------------------------------------------------------------------
+# Pre-fix: example config has zero mentions of red_team. Post-fix: the
+# example must include a commented template so mounted projects can enable it.
+@test ".loa.config.yaml.example documents the red_team configuration block" {
+    grep -qE '^red_team:|^\s*red_team:' "$CONFIG_EXAMPLE"
+}
+
+# -----------------------------------------------------------------------------
+# T5: Default mode resolves correctly based on environment
+# -----------------------------------------------------------------------------
+# Post-fix: when no --live/--mock flag is passed, the adapter checks
+# hounfour.flatline_routing and model-invoke availability to pick a default.
+# With --mock explicit, mock mode is always selected.
+@test "explicit --mock always selects mock mode regardless of config" {
+    run "$ADAPTER" \
+        --role defender \
+        --model opus \
+        --prompt-file "$TEST_TMPDIR/prompt.md" \
+        --output-file "$TEST_TMPDIR/out.json" \
+        --mock
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_TMPDIR/out.json" ]
+    # Output must include mock=true
+    result=$(jq -r '.mock' "$TEST_TMPDIR/out.json")
+    [ "$result" = "true" ]
+}
+
+# -----------------------------------------------------------------------------
+# T6: Self-test passes (adapter integrity)
+# -----------------------------------------------------------------------------
+# Verify the adapter's own self-test still passes after the fix.
+@test "adapter self-test passes end-to-end" {
+    run "$ADAPTER" --self-test
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"passed"* ]]
+    [[ "$output" != *"FAIL"* ]] || [[ "$output" == *"0 failed"* ]]
+}

--- a/tests/unit/red-team-model-adapter.bats
+++ b/tests/unit/red-team-model-adapter.bats
@@ -40,6 +40,10 @@ teardown() {
 # recognises --live as a valid path that EITHER succeeds OR fails with a
 # model-invoke-related error (exit code 1-7 per SDD §4.2.2), not the
 # "requires cheval.py (Hounfour integration)" stub message.
+#
+# Bridgebuilder F1 (medium): negative-only assertion is insufficient — added
+# positive check that the live path actually requires API-key validation,
+# confirming model-invoke was invoked rather than the stub being silently removed.
 @test "invoke_live does not return the 'requires cheval.py' stub error" {
     # Force live mode with a prompt that would route through model-invoke.
     # With no API key set, this must fail — but NOT with the stub message.
@@ -50,9 +54,15 @@ teardown() {
         --prompt-file "$TEST_TMPDIR/prompt.md" \
         --output-file "$TEST_TMPDIR/out.json" \
         --live
-    # Must not contain the legacy stub error string
+    # Negative: must not contain the legacy stub error string
     [[ "$output" != *"requires cheval.py (Hounfour integration)"* ]]
     [[ "$output" != *"Install Hounfour and configure model routing first"* ]]
+    # Positive: must exit non-zero (model-invoke path refuses without API key)
+    [ "$status" -ne 0 ]
+    # Positive: stderr must indicate the live path was taken — either a
+    # model-invoke/API-key-related error or the "requires at least one
+    # provider API key" message from our has_any_api_key guard.
+    [[ "$output" == *"API key"* ]] || [[ "$output" == *"model-invoke"* ]] || [[ "$output" == *"api_key"* ]]
 }
 
 # -----------------------------------------------------------------------------
@@ -61,14 +71,45 @@ teardown() {
 # Pre-fix: three invocation sites at red-team-pipeline.sh:311,378,523
 # call the adapter with no mode flag, so the adapter defaults to mock.
 # Post-fix: every call site MUST pass --live or --mock explicitly.
+#
+# Bridgebuilder F2 (medium): previous version counted --live/--mock mentions
+# anywhere in the file (including comments and help text). This version uses
+# a multiline-aware check: every block that starts with "$MODEL_ADAPTER"
+# and ends at the first blank line must contain --live or --mock.
 @test "pipeline passes explicit --live or --mock flag to adapter" {
-    # Count invocations that DO pass a mode flag
-    explicit_count=$(grep -cE '\-\-(live|mock)' "$PIPELINE")
-    # Count MODEL_ADAPTER invocation sites (lines starting with "$MODEL_ADAPTER")
-    invoke_count=$(grep -cE '^\s*"\$MODEL_ADAPTER"' "$PIPELINE")
+    # For every line that invokes `"$MODEL_ADAPTER" \`, scan the following
+    # block of continuation lines (ending at the first line without a
+    # trailing backslash) and confirm the mode flag — either literal
+    # --live/--mock or the $ADAPTER_MODE_FLAG variable — appears inside it.
+    invoke_count=0
+    missing_count=0
+    in_block=0
+    found_flag=0
+    while IFS= read -r line; do
+        if [[ "$in_block" -eq 1 ]]; then
+            # Inside a continuation block
+            if [[ "$line" == *"--live"* ]] || [[ "$line" == *"--mock"* ]] || [[ "$line" == *'$ADAPTER_MODE_FLAG'* ]]; then
+                found_flag=1
+            fi
+            # End of block: line doesn't end in backslash
+            if [[ "$line" != *"\\" ]]; then
+                if [[ "$found_flag" -eq 0 ]]; then
+                    missing_count=$((missing_count + 1))
+                fi
+                in_block=0
+                found_flag=0
+            fi
+        elif [[ "$line" == *'"$MODEL_ADAPTER"'*'\' ]]; then
+            invoke_count=$((invoke_count + 1))
+            in_block=1
+            found_flag=0
+        fi
+    done < "$PIPELINE"
     [ "$invoke_count" -ge 3 ]
-    # Every invocation site must pair with an explicit flag
-    [ "$explicit_count" -ge "$invoke_count" ]
+    [ "$missing_count" -eq 0 ]
+    # And if $ADAPTER_MODE_FLAG is the mechanism, the pipeline must resolve
+    # it to a literal --live or --mock (defensive guard in main()).
+    grep -qE 'ADAPTER_MODE_FLAG=("--live"|"--mock"|\$\(resolve_adapter_mode)' "$PIPELINE"
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Bug Fix: Red-team skill always runs in mock mode

**Bug ID**: 20260413-94473f
**Sprint**: sprint-bug-102
**Source**: `/run --bug` → `/bug` triage → `/run sprint-bug-102`

## Summary

`/red-team` silently ran in mock mode on every invocation. Two root causes:

1. **`invoke_live()` in `red-team-model-adapter.sh` was a stub** — returned `exit 1` with a "requires cheval.py (Hounfour integration)" error, even though `cheval.py` has been functional and in-use by Flatline and Bridgebuilder for months.
2. **The pipeline never passed `--live`/`--mock` explicitly** — all three adapter call sites (phases 1/2/4) relied on the adapter's default, which was hardcoded to `mock`.

Result: users running `/red-team` against their SDD in any codebase got either (a) Loa-specific fixture attacks unrelated to their document, or (b) empty `attacks: []` if fixtures were missing. The feature looked like it was running but produced no real analysis.

## Fix

- **Wire `invoke_live()` to `.claude/scripts/model-invoke`** using role→agent and model→provider:model-id maps (mirrors `flatline-orchestrator.sh` pattern)
- **Config-driven default mode detection** — live when `hounfour.flatline_routing: true` AND model-invoke executable AND provider API key present; mock otherwise (safe default)
- **Unmissable WARNING banner on stderr** whenever mock mode is used, with the three steps to enable live mode
- **Pipeline propagates explicit `--live`/`--mock`** to all three adapter call sites
- **New `red_team:` block in `.loa.config.yaml.example`** (was absent; mounted projects had no template)
- **Pipeline-level mock notice** so users see the banner even when adapter stderr is suppressed

## Confidence Signals

| Signal | Value |
|--------|-------|
| Reproduction strength | strong (direct code-path analysis) |
| Test type | unit (BATS) |
| Risk level | medium (adds external network egress via model-invoke) |
| Files changed | 4 code + 1 test |
| Lines changed | +503 / -18 |

## Test Plan

- [x] BATS regression suite (`tests/unit/red-team-model-adapter.bats`): 6/6 green (4 failed pre-fix)
- [x] Adapter self-test (`--self-test`): 5/5 green
- [x] End-to-end pipeline smoke test (no API keys): falls back to mock, emits banner, exits 0 with valid JSON
- [x] Regression check on adjacent suites: `model-adapter-aliases.bats`, `flatline-model-validation.bats` all pass
- [ ] Human verification: run `/red-team grimoires/loa/sdd.md --mode quick` against this repo with live API keys to confirm real attacks are generated

## Quality Gates

- [x] Senior lead review: **All good (with noted concerns addressed)** — cheap improvements landed in commit `a08d9ab`
- [x] Security audit: **APPROVED - LETS FUCKING GO** — no blocking findings; 2 informational LOW items noted (pre-existing)

## Artifacts

- Triage: `grimoires/loa/a2a/bug-20260413-94473f/triage.md` (local, gitignored)
- Sprint plan: `grimoires/loa/a2a/bug-20260413-94473f/sprint.md` (local, gitignored)
- Implementation report: `grimoires/loa/a2a/bug-20260413-94473f/reviewer.md` (local, gitignored)
- Review verdict: `grimoires/loa/a2a/bug-20260413-94473f/engineer-feedback.md` (local, gitignored)
- Audit verdict: `grimoires/loa/a2a/bug-20260413-94473f/auditor-sprint-feedback.md` (local, gitignored)

## Status: READY FOR HUMAN REVIEW

Refs: #467 (multi-model roadmap context)

:robot: Generated autonomously via `/run sprint-bug-102`