### PR TITLE
feat(simstim): git-aware sync_run_mode fallback (closes #474)

### DIFF
--- a/.claude/scripts/simstim-orchestrator.sh
+++ b/.claude/scripts/simstim-orchestrator.sh
@@ -428,6 +428,58 @@ set_expected_plan_id() {
         '{expected_plan_id: $plan_id, implementation_started_at: $ts}'
 }
 
+# =============================================================================
+# Git-aware completion inference (Issue #474)
+# =============================================================================
+# Returns 0 (true) when git history shows enough sprint commits to consider
+# the run-mode state stale. Returns non-zero otherwise (run is genuinely
+# in-flight, or git evidence is insufficient to override the state file).
+#
+# Sets globals when returning true (caller reads them):
+#   GIT_INFERRED_COMMITS_FOUND     — number of matching commits seen
+#   GIT_INFERRED_COMMITS_EXPECTED  — number expected from sprint plan total
+#   GIT_INFERRED_BASE_BRANCH       — branch we diff'd against
+#
+# The check is a safe fallback, not a default change: it only fires when
+# the state field already says RUNNING. When state and git agree (e.g.,
+# a genuine in-flight run with no commits yet), the existing behavior is
+# preserved.
+git_inferred_completion_check() {
+    GIT_INFERRED_COMMITS_FOUND=0
+    GIT_INFERRED_COMMITS_EXPECTED=0
+    GIT_INFERRED_BASE_BRANCH=""
+
+    # Need both files to do meaningful inference
+    [[ -f "$RUN_MODE_STATE" ]] || return 1
+
+    # Resolve sprint count from run-mode state (sprints.total or sprints.list length)
+    local expected
+    expected=$(jq -r '.sprints.total // (.sprints.list | length) // 0' "$RUN_MODE_STATE" 2>/dev/null || echo 0)
+    [[ "$expected" -gt 0 ]] || return 1
+
+    # Resolve base branch (default to "main" if not configurable)
+    local base_branch
+    base_branch=$(yq '.run_mode.git.base_branch // "main"' "$PROJECT_ROOT/.loa.config.yaml" 2>/dev/null || echo "main")
+    [[ -z "$base_branch" || "$base_branch" == "null" ]] && base_branch="main"
+    GIT_INFERRED_BASE_BRANCH="$base_branch"
+
+    # Resolve grep pattern (configurable; default matches conventional sprint commits)
+    local grep_pattern
+    # Default pattern uses escaped parens for grep -E (ERE) compatibility.
+    # Users can override via .loa.config.yaml run_mode.git.sprint_commit_pattern.
+    grep_pattern=$(yq '.run_mode.git.sprint_commit_pattern // "^feat\\(sprint-"' "$PROJECT_ROOT/.loa.config.yaml" 2>/dev/null || echo '^feat\(sprint-')
+    [[ -z "$grep_pattern" || "$grep_pattern" == "null" ]] && grep_pattern='^feat\(sprint-'
+
+    # Count matching commits between base_branch and HEAD
+    local found
+    found=$(git log --oneline --pretty=format:'%s' "${base_branch}..HEAD" 2>/dev/null | grep -cE "$grep_pattern" || echo 0)
+    GIT_INFERRED_COMMITS_FOUND=$found
+    GIT_INFERRED_COMMITS_EXPECTED=$expected
+
+    # Inference passes when git evidence meets or exceeds expected sprint count
+    [[ "$found" -ge "$expected" ]]
+}
+
 sync_run_mode() {
     # Check simstim state file exists
     if [[ ! -f "$STATE_FILE" ]]; then
@@ -452,8 +504,38 @@ sync_run_mode() {
     local run_mode_state
     run_mode_state=$(jq -r '.state // "unknown"' "$RUN_MODE_STATE")
 
-    # Don't sync if still running
+    # Don't sync if still running — but cross-check git history first.
+    # Issue #474: when a session loses context mid-implementation, the run-mode
+    # state file can show RUNNING even though git history shows all sprint
+    # commits already landed. Trusting only the state file forces operators
+    # into --force-phase as a last resort. Cross-referencing git as a
+    # secondary source of truth resolves this automatically.
     if [[ "$run_mode_state" == "RUNNING" ]]; then
+        if git_inferred_completion_check; then
+            local commits_found commits_expected base_branch
+            commits_found="$GIT_INFERRED_COMMITS_FOUND"
+            commits_expected="$GIT_INFERRED_COMMITS_EXPECTED"
+            base_branch="$GIT_INFERRED_BASE_BRANCH"
+
+            # Update run-mode state to reflect git reality
+            jq --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+                '.state = "JACKED_OUT" | .git_inferred = true | .git_inferred_at = $ts' \
+                "$RUN_MODE_STATE" > "${RUN_MODE_STATE}.tmp" && \
+                mv "${RUN_MODE_STATE}.tmp" "$RUN_MODE_STATE"
+
+            jq -n \
+                --argjson found "$commits_found" \
+                --argjson expected "$commits_expected" \
+                --arg base "$base_branch" \
+                '{
+                    synced: true,
+                    reason: "git_inferred_completion",
+                    commits_found: $found,
+                    commits_expected: $expected,
+                    base_branch: $base
+                }'
+            return 0
+        fi
         echo '{"synced": false, "reason": "still_running"}'
         return 0
     fi

--- a/.claude/scripts/simstim-orchestrator.sh
+++ b/.claude/scripts/simstim-orchestrator.sh
@@ -470,9 +470,14 @@ git_inferred_completion_check() {
     grep_pattern=$(yq '.run_mode.git.sprint_commit_pattern // "^feat\\(sprint-"' "$PROJECT_ROOT/.loa.config.yaml" 2>/dev/null || echo '^feat\(sprint-')
     [[ -z "$grep_pattern" || "$grep_pattern" == "null" ]] && grep_pattern='^feat\(sprint-'
 
-    # Count matching commits between base_branch and HEAD
+    # Count matching commits between base_branch and HEAD.
+    # `grep -c` exits 1 when zero matches — `|| true` swallows that so the
+    # subsequent arithmetic compare sees a clean integer. (Using `|| echo 0`
+    # here would double-print when grep ALSO printed its own "0".)
     local found
-    found=$(git log --oneline --pretty=format:'%s' "${base_branch}..HEAD" 2>/dev/null | grep -cE "$grep_pattern" || echo 0)
+    found=$(git log --pretty=format:'%s' "${base_branch}..HEAD" 2>/dev/null | grep -cE "$grep_pattern" || true)
+    # Safety net: if `found` is empty for any reason, treat as zero.
+    [[ -z "$found" ]] && found=0
     GIT_INFERRED_COMMITS_FOUND=$found
     GIT_INFERRED_COMMITS_EXPECTED=$expected
 

--- a/.claude/skills/run-mode/SKILL.md
+++ b/.claude/skills/run-mode/SKILL.md
@@ -624,6 +624,9 @@ run_mode:
   git:
     branch_prefix: "feature/"
     create_draft_pr: true
+    # Git-aware sync fallback (Issue #474, cycle-056)
+    base_branch: "main"                     # Branch to diff against
+    sprint_commit_pattern: '^feat\(sprint-' # grep -E pattern for sprint commits
 ```
 
 ## Error Recovery
@@ -634,3 +637,48 @@ On any error:
 3. Use `/run-resume` to continue
 4. Use `/run-resume --reset-ice` if circuit breaker tripped
 5. Clean up with `rm -rf .run/` to start fresh
+
+### Git-Aware State Sync (cycle-056, Issue #474)
+
+When context compaction or session loss leaves `.run/sprint-plan-state.json`
+stuck at `state: "RUNNING"` with `0` completed sprints — even though git
+history shows all sprint commits already landed — `simstim-orchestrator.sh
+--sync-run-mode` now cross-references git as a secondary source of truth
+before returning `still_running`.
+
+**When the fallback fires** (all three conditions must hold):
+
+1. `sprint-plan-state.json` shows `state: "RUNNING"` (the normal trigger)
+2. `sprints.total` (or `sprints.list` length) resolves to a positive integer
+3. `git log ${base_branch}..HEAD` shows at least `sprints.total` commits
+   matching `run_mode.git.sprint_commit_pattern`
+
+When satisfied, the fallback:
+
+- Updates `.run/sprint-plan-state.json` to `state: "JACKED_OUT"` with
+  `git_inferred: true` and an ISO-8601 `git_inferred_at` timestamp
+- Returns `{ "synced": true, "reason": "git_inferred_completion",
+  "commits_found": N, "commits_expected": M, "base_branch": "main" }`
+
+**When the fallback does NOT fire**:
+
+- In-flight runs with no commits yet → existing `still_running` preserved
+- Partial runs (`commits_found < commits_expected`) → existing `still_running` preserved
+- State field already shows `JACKED_OUT`/`HALTED` → existing validation flow (not the RUNNING branch)
+
+**Configuration** (under `run_mode.git`):
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `base_branch` | `"main"` | Branch to diff against |
+| `sprint_commit_pattern` | `'^feat\(sprint-'` | `grep -E` pattern. Override if your project uses a different convention. |
+
+**Known limitation**: counts matching commits, so a sprint that produced
+multiple matching commits (e.g., review-feedback fix commits with the same
+prefix) can cause early satisfaction. Empirically rare — squash-merge
+workflows produce one commit per sprint. Consider using beads
+(`br list --status closed`) as an authoritative alternative in a future
+enhancement if this becomes a problem.
+
+Replaces the previous requirement to use `--force-phase complete --yes` as
+a last-resort escape hatch after session loss.

--- a/.loa.config.yaml.example
+++ b/.loa.config.yaml.example
@@ -511,6 +511,13 @@ run_mode:
     auto_push: true
     # Always create PRs as drafts - this is hardcoded and cannot be changed
     create_draft_pr: true
+    # Git-aware sync_run_mode (Issue #474)
+    # Branch to diff against when inferring sprint completion from git history.
+    base_branch: "main"
+    # Regex pattern (grep -E) for sprint commit messages. Default matches
+    # conventional commit markers like "feat(sprint-1): implementation".
+    # Override if your project uses a different commit convention.
+    sprint_commit_pattern: '^feat\(sprint-'
 
 # -----------------------------------------------------------------------------
 # BUTTERFREEZONE — Agent-Grounded README (v1.35.0)

--- a/tests/unit/sync-run-mode-git-aware.bats
+++ b/tests/unit/sync-run-mode-git-aware.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# =============================================================================
+# sync-run-mode-git-aware.bats — Issue #474 regression tests
+# =============================================================================
+# Verifies that sync_run_mode cross-references git history when the run-mode
+# state file shows RUNNING. Three scenarios:
+#   1. State RUNNING + git shows enough sprint commits → synced=true
+#   2. State RUNNING + git shows zero sprint commits   → still_running (preserved)
+#   3. State RUNNING + git shows partial commits       → still_running (preserved)
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT
+    PROJECT_ROOT=$(mktemp -d)
+    export STATE_FILE="$PROJECT_ROOT/.run/simstim-state.json"
+    export RUN_MODE_STATE="$PROJECT_ROOT/.run/sprint-plan-state.json"
+    mkdir -p "$PROJECT_ROOT/.run"
+
+    # Init git repo so `git log` works
+    cd "$PROJECT_ROOT"
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "init" > README.md
+    git add README.md
+    git commit -q -m "initial commit"
+
+    # Empty .loa.config.yaml so yq fallbacks fire
+    touch .loa.config.yaml
+
+    # Minimal simstim-state.json so sync_run_mode passes its initial existence check
+    cat > "$STATE_FILE" <<'EOF'
+{
+  "phase": "implementation",
+  "sync_attempts": 0
+}
+EOF
+
+    # Use the script's CLI surface directly. PROJECT_ROOT redirects all
+    # state file paths to our temp dir.
+    SCRIPT="$BATS_TEST_DIRNAME/../../.claude/scripts/simstim-orchestrator.sh"
+
+    # The script computes PROJECT_ROOT from its own location; override it so
+    # state files land in our test sandbox instead of the real repo.
+    export LOA_PROJECT_ROOT_OVERRIDE="$PROJECT_ROOT"
+}
+
+teardown() {
+    cd /
+    rm -rf "$PROJECT_ROOT"
+}
+
+# Helper: write a sprint-plan-state.json with the given state and sprint count
+write_state() {
+    local state="$1"
+    local total="$2"
+    local plan_id="${3:-plan-test-001}"
+    cat > "$RUN_MODE_STATE" <<EOF
+{
+  "plan_id": "$plan_id",
+  "state": "$state",
+  "sprints": { "total": $total }
+}
+EOF
+}
+
+# Helper: create a feature branch and add N commits matching the default sprint pattern
+make_sprint_commits() {
+    local n="$1"
+    git checkout -q -b feature/test-branch
+    for i in $(seq 1 "$n"); do
+        echo "sprint $i" > "sprint-${i}.txt"
+        git add "sprint-${i}.txt"
+        git commit -q -m "feat(sprint-${i}): implementation"
+    done
+}
+
+# T1: stale state + sufficient commits → git_inferred_completion
+@test "git-aware sync: stale RUNNING with N sprint commits returns synced=true" {
+    write_state "RUNNING" 3
+    make_sprint_commits 3
+
+    # Source the script and call sync_run_mode directly
+    set +e
+    output=$(env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode 2>/dev/null)
+    set -e
+
+    [[ "$output" == *'"synced": true'* ]] || [[ "$output" == *'"synced":true'* ]]
+    [[ "$output" == *"git_inferred_completion"* ]]
+    [[ "$output" == *'"commits_found": 3'* ]] || [[ "$output" == *'"commits_found":3'* ]]
+}
+
+# T2: in-flight state (no commits) → still_running preserved
+@test "git-aware sync: RUNNING with zero sprint commits returns still_running" {
+    write_state "RUNNING" 3
+    # No sprint commits — only the initial commit on main
+
+    set +e
+    output=$(env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode 2>/dev/null)
+    set -e
+
+    [[ "$output" == *"still_running"* ]]
+    [[ "$output" != *"git_inferred_completion"* ]]
+}
+
+# T3: partial commits (less than expected) → still_running preserved
+@test "git-aware sync: RUNNING with partial commits returns still_running" {
+    write_state "RUNNING" 5
+    make_sprint_commits 2  # 2 commits, 5 expected
+
+    set +e
+    output=$(env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode 2>/dev/null)
+    set -e
+
+    [[ "$output" == *"still_running"* ]]
+    [[ "$output" != *"git_inferred_completion"* ]]
+}
+
+# T4: state file updated to JACKED_OUT with git_inferred flag on success
+@test "git-aware sync: success case marks RUN_MODE_STATE as JACKED_OUT with git_inferred flag" {
+    write_state "RUNNING" 2
+    make_sprint_commits 2
+
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode >/dev/null 2>&1
+
+    [ "$(jq -r '.state' "$RUN_MODE_STATE")" = "JACKED_OUT" ]
+    [ "$(jq -r '.git_inferred' "$RUN_MODE_STATE")" = "true" ]
+    # git_inferred_at must be a valid ISO timestamp string
+    inferred_at=$(jq -r '.git_inferred_at' "$RUN_MODE_STATE")
+    [[ "$inferred_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+# T5: sprints.list length used when sprints.total absent (backward compat)
+@test "git-aware sync: falls back to sprints.list length when total absent" {
+    cat > "$RUN_MODE_STATE" <<EOF
+{
+  "plan_id": "plan-test-002",
+  "state": "RUNNING",
+  "sprints": { "list": [{"id":"a"},{"id":"b"}] }
+}
+EOF
+    make_sprint_commits 2
+
+    set +e
+    output=$(env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode 2>/dev/null)
+    set -e
+
+    [[ "$output" == *"git_inferred_completion"* ]]
+    [[ "$output" == *'"commits_expected": 2'* ]] || [[ "$output" == *'"commits_expected":2'* ]]
+}


### PR DESCRIPTION
Closes #474. When run-mode state file shows stale RUNNING after context compaction but git shows all sprint commits landed, `--sync-run-mode` now cross-references git history via configurable pattern (default `^feat\(sprint-`) and marks the state JACKED_OUT with a `git_inferred: true` flag.

## Quality Gates
- Senior review: APPROVED (with 3 concerns addressed in bd40803: grep double-zero bug, dead --oneline flag, docs added to run-mode/SKILL.md)
- Security audit: APPROVED — Clear on all 5 vectors (command injection, races, path traversal, secrets, TOCTOU). One informational note on `.tmp` filename not using `$$` suffix; orchestrator is single-session so not a real issue.
- Tests: 5/5 BATS green

Refs: #474