### PR TITLE
feat(skills): structural AC verification gate at /implement (closes #475)

### DIFF
--- a/.claude/skills/implementing-tasks/SKILL.md
+++ b/.claude/skills/implementing-tasks/SKILL.md
@@ -362,14 +362,44 @@ Implement sprint tasks from `grimoires/loa/sprint.md` with production-grade code
 ## Verification (E - Easy to Verify)
 **Success** = All acceptance criteria met + comprehensive tests pass + detailed report at expected path
 
-Report MUST include:
+Report MUST include (in this order, enforced):
 - Executive Summary
+- **AC Verification** (REQUIRED — Issue #475, see structural rule below)
 - Tasks Completed (files/lines modified, approach, test coverage)
 - Technical Highlights (architecture, performance, security, integrations)
 - Testing Summary (test files, scenarios, how to run)
 - Known Limitations
 - Verification Steps for reviewer
 - Feedback Addressed section (if iteration after feedback)
+
+### AC Verification Gate (cycle-057, closes #475)
+
+Before writing the `COMPLETED` marker for a sprint, the implementation report
+MUST contain an `## AC Verification` section that walks every acceptance
+criterion from `grimoires/loa/sprint.md`. Each AC requires:
+
+1. **Verbatim quote** — copy the AC text from sprint.md, not a paraphrase
+2. **Status marker** — one of `✓ Met` / `✗ Not met` / `⚠ Partial` / `⏸ [ACCEPTED-DEFERRED]`
+3. **File:line evidence** — for every `Met` claim, a specific path and line
+   pointing to the symbol, assertion, or test that proves the AC is honored
+4. **Deferral rationale** — `[ACCEPTED-DEFERRED]` requires a matching entry
+   in `grimoires/loa/NOTES.md` under the Decision Log
+
+**Skill behavior enforcement**:
+
+- **DO NOT** write a `COMPLETED` marker if any AC has status `✗ Not met` or
+  `⚠ Partial` without an accompanying scope-split to a follow-up sprint task
+- **DO NOT** silently mark ACs as deferred — always pair with a NOTES.md entry
+- **DO NOT** write generic evidence like "implemented in src/batch/" — provide
+  specific file:line references with enough context that the reviewer can
+  verify the AC is honored without re-reading the whole implementation
+
+This gate catches SDD-implementation drift at implement time rather than
+letting it slip through to `/review-sprint`, saving the fix-loop round trip.
+Karpathy-aligned: goal-driven verification, not just code written.
+
+See `resources/templates/implementation-report.md` for the structured
+`## AC Verification` template.
 
 ## Reproducibility (R - Reproducible Results)
 - Write tests with specific assertions: NOT "it works" → "returns 200 status, response includes user.id field"

--- a/.claude/skills/implementing-tasks/resources/templates/implementation-report.md
+++ b/.claude/skills/implementing-tasks/resources/templates/implementation-report.md
@@ -18,6 +18,47 @@
 
 ---
 
+## AC Verification (REQUIRED — Issue #475)
+
+Before this sprint can be marked complete, every acceptance criterion from
+`grimoires/loa/sprint.md` MUST be walked explicitly below. Copy each AC
+verbatim (no paraphrase), mark its status, and provide file:line evidence
+for every `Met` claim. Reviewer will reject missing or unverified ACs.
+
+### Task {N.M} — Acceptance Criteria
+
+**AC-{N.M}.1**: "{verbatim acceptance criterion from sprint.md}"
+- Status: `✓ Met` | `✗ Not met` | `⚠ Partial` | `⏸ [ACCEPTED-DEFERRED]`
+- Evidence: `{path/to/file.ts:LINE}` — {exact symbol or assertion that proves it}
+- Test: `{path/to/test.ts:LINE}` — {test name that exercises it}
+- Notes: {only if Partial/Deferred — explain why and link to decision in NOTES.md}
+
+**AC-{N.M}.2**: "{next verbatim criterion}"
+- Status: ...
+- Evidence: ...
+
+*(Repeat per AC for every task in this sprint.)*
+
+### Deferral Policy
+
+- `✗ Not met` blocks sprint completion. No COMPLETED marker may be written.
+- `⏸ [ACCEPTED-DEFERRED]` requires a matching decision entry in
+  `grimoires/loa/NOTES.md` under "Decision Log" with rationale. Reviewer
+  validates the deferral is logged; an AC cannot be deferred silently.
+- `⚠ Partial` is treated as `✗ Not met` unless paired with an explicit
+  scope-split to a follow-up sprint task with its own sprint plan reference.
+
+### Anti-Vacuous-Satisfaction Rules
+
+Evidence lines must be specific enough that a reviewer can verify without
+re-reading the whole implementation:
+
+- **Good**: `src/batch/runner.ts:42 — pool = new Pool({ user: process.env.BATCH_DB_USER })` (specific symbol, quoted code)
+- **Bad**: "Implemented in src/batch/" (no line, no evidence)
+- **Bad**: "Done" (no file, no assertion)
+
+---
+
 ## Tasks Completed
 
 ### Task {N.M}: {Task Name}

--- a/.claude/skills/reviewing-code/SKILL.md
+++ b/.claude/skills/reviewing-code/SKILL.md
@@ -296,10 +296,17 @@ Review sprint implementation for completeness, quality, security. Either approve
 - DO check that proper documentation was updated if integration context requires
 - DO verify context links are preserved (Discord threads, Linear issues) if required
 - DO read ALL context docs before reviewing
+- **DO check for `## AC Verification` section in `reviewer.md`** (cycle-057, Issue #475).
+  Return CHANGES_REQUIRED automatically when:
+  - The `## AC Verification` section is missing entirely
+  - Any AC shows `✗ Not met` without a scope-split to a follow-up sprint task
+  - Any AC shows `⏸ [ACCEPTED-DEFERRED]` without a matching Decision Log entry in `grimoires/loa/NOTES.md`
+  - Evidence for a `Met` claim is vague ("implemented in src/", "done", "yes") — demand file:line + specific symbol
 
 ## Verification (E - Easy to Verify)
 **Approval criteria** (ALL must be true):
-- All sprint tasks completed + all acceptance criteria met
+- `## AC Verification` section is present and complete — every AC from `sprint.md` walked verbatim
+- All sprint tasks completed + all acceptance criteria met (status `✓ Met` or valid `⏸ [ACCEPTED-DEFERRED]`)
 - Code quality is production-ready (readable, maintainable, follows conventions)
 - Tests are comprehensive and meaningful (happy paths, errors, edge cases)
 - No security issues (no hardcoded secrets, proper input validation, auth/authz correct)


### PR DESCRIPTION
Closes #475. Adds a prompt-level gate requiring implementing-tasks to walk every acceptance criterion verbatim with file:line evidence before writing COMPLETED marker. No scripts, no new tests — structural discipline enforced by the review skill.

Catches SDD→implementation drift one cycle earlier than today's implement→review loop.

Refs: #475