### PR TITLE
fix(flatline): cycle-062 follow-ups — review-mode wiring, inquiry tests, default case

### DIFF
--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -147,6 +147,13 @@ detect_silent_noop_flatline() {
                 exit 7
             fi
             ;;
+        *)
+            # Defense-in-depth: unknown mode should never reach the helper,
+            # but if it does, refuse rather than silently skip validation.
+            error "Silent no-op helper called with unknown mode: $mode"
+            error "Expected one of: red-team, inquiry, review."
+            exit 7
+            ;;
     esac
 }
 
@@ -1791,6 +1798,12 @@ main() {
                 cost_usd: ($cost_cents / 100)
             }
         }')
+
+    # cycle-062 follow-up (#485): silent-no-op detection for review mode.
+    # Wires the helper branch that was defined but previously unused.
+    if [[ "$detect_silent_noop" == "true" ]]; then
+        detect_silent_noop_flatline "review" "$final_result"
+    fi
 
     # Log to trajectory
     log_trajectory "complete" "$final_result"

--- a/tests/unit/flatline-jq-construction.bats
+++ b/tests/unit/flatline-jq-construction.bats
@@ -129,6 +129,75 @@ setup() {
     [ "$status" -eq 7 ]
 }
 
+# T13 (follow-up): helper accepts valid inquiry-mode result
+@test "flatline: detect_silent_noop_flatline accepts valid inquiry-mode JSON" {
+    run bash -c "
+        awk '/^detect_silent_noop_flatline\\(\\)/,/^}$/' '$ORCH' > /tmp/silent-noop-helper.sh
+        error() { echo \"ERROR: \$*\" >&2; }
+        export -f error
+        source /tmp/silent-noop-helper.sh
+        detect_silent_noop_flatline inquiry '{\"orchestrator_mode\":\"inquiry\",\"findings\":[]}'
+    "
+    [ "$status" -eq 0 ]
+}
+
+# T14 (follow-up): helper rejects inquiry result missing orchestrator_mode
+@test "flatline: detect_silent_noop_flatline rejects inquiry result missing orchestrator_mode" {
+    run bash -c "
+        awk '/^detect_silent_noop_flatline\\(\\)/,/^}$/' '$ORCH' > /tmp/silent-noop-helper.sh
+        error() { echo \"ERROR: \$*\" >&2; }
+        export -f error
+        source /tmp/silent-noop-helper.sh
+        detect_silent_noop_flatline inquiry '{\"mode\":\"inquiry\"}'
+    "
+    # Wrong field name (.mode vs .orchestrator_mode) — must be rejected.
+    [ "$status" -eq 7 ]
+}
+
+# T15 (follow-up): helper accepts valid review-mode result
+@test "flatline: detect_silent_noop_flatline accepts valid review-mode JSON" {
+    run bash -c "
+        awk '/^detect_silent_noop_flatline\\(\\)/,/^}$/' '$ORCH' > /tmp/silent-noop-helper.sh
+        error() { echo \"ERROR: \$*\" >&2; }
+        export -f error
+        source /tmp/silent-noop-helper.sh
+        detect_silent_noop_flatline review '{\"phase\":\"sdd\",\"timestamp\":\"2026-04-14T00:00:00Z\"}'
+    "
+    [ "$status" -eq 0 ]
+}
+
+# T16 (follow-up): helper rejects review result missing phase
+@test "flatline: detect_silent_noop_flatline rejects review result missing phase" {
+    run bash -c "
+        awk '/^detect_silent_noop_flatline\\(\\)/,/^}$/' '$ORCH' > /tmp/silent-noop-helper.sh
+        error() { echo \"ERROR: \$*\" >&2; }
+        export -f error
+        source /tmp/silent-noop-helper.sh
+        detect_silent_noop_flatline review '{\"timestamp\":\"2026-04-14T00:00:00Z\"}'
+    "
+    [ "$status" -eq 7 ]
+}
+
+# T17 (follow-up): helper rejects unknown mode (default case branch)
+@test "flatline: detect_silent_noop_flatline rejects unknown mode" {
+    run bash -c "
+        awk '/^detect_silent_noop_flatline\\(\\)/,/^}$/' '$ORCH' > /tmp/silent-noop-helper.sh
+        error() { echo \"ERROR: \$*\" >&2; }
+        export -f error
+        source /tmp/silent-noop-helper.sh
+        detect_silent_noop_flatline quantum-mode '{\"phase\":\"x\",\"timestamp\":\"y\"}'
+    "
+    [ "$status" -eq 7 ]
+    [[ "$output" == *"unknown mode"* ]]
+}
+
+# T18 (follow-up): silent-no-op detection invoked in review mode
+@test "flatline: silent-no-op detection invoked in review mode" {
+    # Simple presence check — the helper is called with "review" in the review
+    # mode code path. Paired with T6/T7/T8 which cover red-team/inquiry.
+    grep -qF 'detect_silent_noop_flatline "review"' "$ORCH"
+}
+
 teardown() {
     rm -f /tmp/silent-noop-helper.sh
 }


### PR DESCRIPTION
## Summary

Three non-blocking follow-ups from sub-agent review on #488:

1. **Wire `detect_silent_noop_flatline "review"` into review-mode code path**. The helper branch was defined but never invoked. Now called after Phase 5 integrate jq construction (flatline-orchestrator.sh:1804-1806).
2. **Add inquiry-mode and review-mode behavioral tests**. Previously only red-team had accept/reject coverage.
3. **Add default `*) ;;` branch** to `detect_silent_noop_flatline`'s case statement. Defense-in-depth — unknown modes now exit 7 with a clear error.

## Test count

13 → 19, all passing.

```
ok 14 flatline: detect_silent_noop_flatline accepts valid inquiry-mode JSON
ok 15 flatline: detect_silent_noop_flatline rejects inquiry result missing orchestrator_mode
ok 16 flatline: detect_silent_noop_flatline accepts valid review-mode JSON
ok 17 flatline: detect_silent_noop_flatline rejects review result missing phase
ok 18 flatline: detect_silent_noop_flatline rejects unknown mode
ok 19 flatline: silent-no-op detection invoked in review mode
```

## Test plan

- [x] `bats tests/unit/flatline-jq-construction.bats` — 19/19 passing
- [x] `bash -n .claude/scripts/flatline-orchestrator.sh` — syntax OK

Related: #485 (cycle-062)

🤖 Generated with [Claude Code](https://claude.com/claude-code)