### PR TITLE
feat(simstim): state-machine coalescer + --archive-completed

### DIFF
--- a/.claude/scripts/simstim-orchestrator.sh
+++ b/.claude/scripts/simstim-orchestrator.sh
@@ -15,6 +15,7 @@
 #   simstim-orchestrator.sh --complete [--pr-url <url>]
 #   simstim-orchestrator.sh --set-expected-plan-id      # Store plan_id before /run sprint-plan
 #   simstim-orchestrator.sh --sync-run-mode             # Sync run-mode completion state
+#   simstim-orchestrator.sh --archive-completed         # Archive terminal state (cycle-063)
 #   simstim-orchestrator.sh --force-phase <phase> --yes # Force phase transition (escape hatch)
 #
 # Exit codes:
@@ -485,6 +486,128 @@ git_inferred_completion_check() {
     [[ "$found" -ge "$expected" ]]
 }
 
+# =============================================================================
+# Terminal-state coalescer (cycle-063, RFC-060 Friction 1+2)
+# =============================================================================
+# When the state machine transitions to a terminal condition (COMPLETED,
+# AWAITING_HITL, or HALTED), enforce invariants so the state file is
+# internally consistent:
+#
+#   - .state       = target_state
+#   - .phase       = "complete" for COMPLETED/AWAITING_HITL (HALTED preserves
+#                    current phase so operators can resume)
+#   - .completed_at = terminal timestamp (set regardless of state variant)
+#
+# Without this, sync_run_mode could set .state = "COMPLETED" while leaving
+# .phase = "implementation" and .completed_at unset — a silent inconsistency
+# that confuses the next operator reading the state file.
+#
+# Arguments:
+#   $1 - target_state (COMPLETED | AWAITING_HITL | HALTED)
+#   $2 - extra_jq_filter (optional additional filter to apply atomically)
+#
+# Callers pass any extra jq filter fragment they want composed into the same
+# atomic update (e.g., sync_run_mode composes implementation.status + pr_url).
+# =============================================================================
+coalesce_terminal_state() {
+    local target_state="$1"
+    local extra_filter="${2:-}"
+
+    local target_phase
+    case "$target_state" in
+        COMPLETED|AWAITING_HITL)
+            target_phase="complete"
+            ;;
+        HALTED)
+            # HALTED preserves current phase so operators can resume.
+            # Use a jq self-reference to keep .phase unchanged.
+            target_phase=""
+            ;;
+        *)
+            error "coalesce_terminal_state: unknown target_state '$target_state'"
+            exit 1
+            ;;
+    esac
+
+    local timestamp
+    timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    local phase_filter=""
+    if [[ -n "$target_phase" ]]; then
+        phase_filter='| .phase = $target_phase'
+    fi
+
+    local composed_filter=".state = \$target_state $phase_filter | .completed_at = \$ts"
+    if [[ -n "$extra_filter" ]]; then
+        composed_filter+=" | $extra_filter"
+    fi
+
+    atomic_jq_update "$STATE_FILE" \
+        --arg target_state "$target_state" \
+        --arg target_phase "$target_phase" \
+        --arg ts "$timestamp" \
+        "$composed_filter"
+
+    echo "$timestamp"
+}
+
+# =============================================================================
+# Archive terminal state file (cycle-063, RFC-060 Friction 1)
+# =============================================================================
+# Moves a terminal-state simstim-state.json to .run/archive/simstim-{id}-{ts}.json
+# so a fresh /simstim invocation can start without state collision.
+#
+# Refuses (exit 1) when state is not terminal — prevents accidental loss of
+# in-flight work. Idempotent: a second call after archive-already-done
+# returns {"archived": false, "reason": "no_state_file"}.
+# =============================================================================
+archive_completed() {
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo '{"archived": false, "reason": "no_state_file"}'
+        return 0
+    fi
+
+    # Validate JSON first — a corrupt file shouldn't be silently archived.
+    if ! jq empty "$STATE_FILE" 2>/dev/null; then
+        error "State file exists but is not valid JSON: $STATE_FILE"
+        exit 1
+    fi
+
+    local current_state
+    current_state=$(jq -r '.state // "unknown"' "$STATE_FILE")
+
+    case "$current_state" in
+        COMPLETED|AWAITING_HITL|HALTED)
+            ;; # fall through to archive
+        *)
+            jq -n --arg state "$current_state" \
+                '{archived: false, reason: "state_not_terminal", state: $state}'
+            return 1
+            ;;
+    esac
+
+    local simstim_id
+    simstim_id=$(jq -r '.simstim_id // "unknown"' "$STATE_FILE")
+
+    local archive_dir="$PROJECT_ROOT/.run/archive"
+    mkdir -p "$archive_dir"
+
+    local timestamp
+    timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+
+    local archive_path="$archive_dir/simstim-${simstim_id}-${timestamp}.json"
+    mv "$STATE_FILE" "$archive_path"
+
+    # Best-effort: remove the backup too, if it exists.
+    [[ -f "$STATE_BACKUP" ]] && rm -f "$STATE_BACKUP"
+
+    jq -n \
+        --arg path "$archive_path" \
+        --arg state "$current_state" \
+        --arg id "$simstim_id" \
+        '{archived: true, archive_path: $path, state: $state, simstim_id: $id}'
+}
+
 sync_run_mode() {
     # Check simstim state file exists
     if [[ ! -f "$STATE_FILE" ]]; then
@@ -621,19 +744,24 @@ sync_run_mode() {
 
     backup_state
 
-    local timestamp
-    timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    # cycle-063: delegate to coalescer so .state, .phase, and .completed_at
+    # move together. Extra filter handles simstim-specific fields
+    # (implementation status, pr_url, sync_attempts counter reset).
+    #
+    # Note: $ts is available from coalesce_terminal_state's --arg; we reuse
+    # it for the implementation.synced_at marker via the composed filter.
+    local extra_filter
+    extra_filter=".phases.implementation.status = \"$impl_status\""
+    extra_filter+=" | .phases.implementation.synced_at = \$ts"
+    if [[ -n "$pr_url" ]]; then
+        extra_filter+=" | .pr_url = \"$pr_url\""
+    else
+        extra_filter+=" | .pr_url = null"
+    fi
+    extra_filter+=" | .sync_attempts = 0"
 
-    atomic_jq_update "$STATE_FILE" \
-        --arg state "$simstim_state" \
-        --arg impl_status "$impl_status" \
-        --arg pr_url "$pr_url" \
-        --arg ts "$timestamp" \
-        '.state = $state |
-         .phases.implementation.status = $impl_status |
-         .phases.implementation.synced_at = $ts |
-         .pr_url = (if $pr_url == "" then null else $pr_url end) |
-         .sync_attempts = 0'
+    local timestamp
+    timestamp=$(coalesce_terminal_state "$simstim_state" "$extra_filter")
 
     log_trajectory "run_mode_synced" "$(jq -n \
         --arg run_mode_state "$run_mode_state" \
@@ -1340,6 +1468,11 @@ main() {
             ;;
         --sync-run-mode)
             sync_run_mode
+            ;;
+        --archive-completed)
+            # cycle-063 (RFC-060 Friction 1): archive a terminal-state
+            # simstim-state.json so a fresh /simstim can start cleanly.
+            archive_completed
             ;;
         --force-phase)
             if [[ $# -lt 1 ]]; then

--- a/.claude/scripts/simstim-orchestrator.sh
+++ b/.claude/scripts/simstim-orchestrator.sh
@@ -503,15 +503,27 @@ git_inferred_completion_check() {
 # that confuses the next operator reading the state file.
 #
 # Arguments:
-#   $1 - target_state (COMPLETED | AWAITING_HITL | HALTED)
-#   $2 - extra_jq_filter (optional additional filter to apply atomically)
+#   $1           - target_state (COMPLETED | AWAITING_HITL | HALTED)
+#   $2           - extra_jq_filter (optional jq filter fragment)
+#   $3, $4, ...  - additional --arg NAME VALUE pairs forwarded to jq so the
+#                  caller can reference variables (e.g., $impl_status) in its
+#                  extra_filter using jq's safe parameter binding. This avoids
+#                  bash string interpolation into the filter, matching the
+#                  project convention: "NEVER interpolate user input into jq
+#                  filter strings — use --arg parameter binding" (MEMORY.md).
 #
-# Callers pass any extra jq filter fragment they want composed into the same
-# atomic update (e.g., sync_run_mode composes implementation.status + pr_url).
+# Example:
+#   coalesce_terminal_state "COMPLETED" '.pr_url = $pr_url' \
+#       --arg pr_url "$pr_url_value"
 # =============================================================================
 coalesce_terminal_state() {
     local target_state="$1"
     local extra_filter="${2:-}"
+    shift
+    if [[ $# -gt 0 ]]; then
+        shift
+    fi
+    local -a extra_args=("$@")
 
     local target_phase
     case "$target_state" in
@@ -546,6 +558,7 @@ coalesce_terminal_state() {
         --arg target_state "$target_state" \
         --arg target_phase "$target_phase" \
         --arg ts "$timestamp" \
+        ${extra_args[@]+"${extra_args[@]}"} \
         "$composed_filter"
 
     echo "$timestamp"
@@ -588,6 +601,13 @@ archive_completed() {
 
     local simstim_id
     simstim_id=$(jq -r '.simstim_id // "unknown"' "$STATE_FILE")
+
+    # Sanitize simstim_id for filesystem safety — strip any character outside
+    # [A-Za-z0-9_-]. Defends against a crafted state file with path-traversal
+    # characters (e.g., simstim_id = "../../etc/passwd") causing the mv to
+    # write outside .run/archive/. An empty result falls back to "unknown".
+    simstim_id="${simstim_id//[^A-Za-z0-9_-]/}"
+    simstim_id="${simstim_id:-unknown}"
 
     local archive_dir="$PROJECT_ROOT/.run/archive"
     mkdir -p "$archive_dir"
@@ -748,20 +768,19 @@ sync_run_mode() {
     # move together. Extra filter handles simstim-specific fields
     # (implementation status, pr_url, sync_attempts counter reset).
     #
-    # Note: $ts is available from coalesce_terminal_state's --arg; we reuse
-    # it for the implementation.synced_at marker via the composed filter.
+    # All dynamic values flow through jq --arg parameter binding — matches
+    # the project convention from MEMORY.md ("NEVER interpolate user input
+    # into jq filter strings"). $ts is reused from the coalescer's own --arg.
     local extra_filter
-    extra_filter=".phases.implementation.status = \"$impl_status\""
-    extra_filter+=" | .phases.implementation.synced_at = \$ts"
-    if [[ -n "$pr_url" ]]; then
-        extra_filter+=" | .pr_url = \"$pr_url\""
-    else
-        extra_filter+=" | .pr_url = null"
-    fi
-    extra_filter+=" | .sync_attempts = 0"
+    extra_filter='.phases.implementation.status = $impl_status'
+    extra_filter+=' | .phases.implementation.synced_at = $ts'
+    extra_filter+=' | .pr_url = (if $pr_url == "" then null else $pr_url end)'
+    extra_filter+=' | .sync_attempts = 0'
 
     local timestamp
-    timestamp=$(coalesce_terminal_state "$simstim_state" "$extra_filter")
+    timestamp=$(coalesce_terminal_state "$simstim_state" "$extra_filter" \
+        --arg impl_status "$impl_status" \
+        --arg pr_url "$pr_url")
 
     log_trajectory "run_mode_synced" "$(jq -n \
         --arg run_mode_state "$run_mode_state" \

--- a/tests/unit/simstim-state-coalescer.bats
+++ b/tests/unit/simstim-state-coalescer.bats
@@ -246,6 +246,67 @@ EOF
 }
 
 # =============================================================================
+# T_inj: pr_url with jq-injection chars is stored verbatim, not executed
+# =============================================================================
+@test "coalescer: pr_url with injection chars is bound via --arg (not interpolated)" {
+    write_simstim_state "implementation"
+
+    # Craft a pr_url that would inject an extra jq expression if the filter
+    # composed it via bash string interpolation instead of --arg binding.
+    cat > "$RUN_MODE_STATE" <<EOF
+{
+  "plan_id": "plan-test-001",
+  "state": "JACKED_OUT",
+  "sprints": { "total": 1 },
+  "pr_url": "evil\" | .secret_leak = \"pwned",
+  "timestamps": {
+    "started": "2026-04-14T00:05:00Z",
+    "last_activity": "2026-04-14T00:30:00Z"
+  }
+}
+EOF
+
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode >/dev/null 2>&1
+
+    # The injection attempt must be stored as a literal string, NOT executed
+    # as a jq operation. Confirm by:
+    #   1. .pr_url contains the raw string (verbatim)
+    #   2. .secret_leak field does NOT exist (not injected)
+    local stored_pr_url
+    stored_pr_url=$(jq -r '.pr_url' "$STATE_FILE")
+    [[ "$stored_pr_url" == 'evil" | .secret_leak = "pwned' ]]
+
+    local injected
+    injected=$(jq -r 'has("secret_leak")' "$STATE_FILE")
+    [ "$injected" = "false" ]
+}
+
+# =============================================================================
+# T_trav: simstim_id with path-traversal chars is sanitized for archive path
+# =============================================================================
+@test "archive: simstim_id with path-traversal chars is sanitized" {
+    write_simstim_state "complete"
+    # Poison simstim_id with path-traversal characters
+    jq '.state = "COMPLETED" | .simstim_id = "../../etc/passwd"' "$STATE_FILE" \
+        > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --archive-completed >/dev/null 2>&1
+
+    # Archive must land strictly inside .run/archive/, not elsewhere
+    [ -d "$PROJECT_ROOT/.run/archive" ]
+    # No file should have been written outside the archive dir
+    [ ! -f "$PROJECT_ROOT/etc/passwd" ]
+    [ ! -f "/tmp/pwned" ]
+    # The archived file must exist inside .run/archive/
+    local archive_count
+    archive_count=$(ls "$PROJECT_ROOT/.run/archive/" | wc -l | tr -d ' ')
+    [ "$archive_count" -ge 1 ]
+    # Filename must not contain ../ — sanitization should have stripped slashes
+    ! ls "$PROJECT_ROOT/.run/archive/" | grep -q '\.\./'
+    ! ls "$PROJECT_ROOT/.run/archive/" | grep -q '/'
+}
+
+# =============================================================================
 # T12: archive path contains timestamp for traceability
 # =============================================================================
 @test "archive: path includes ISO-like timestamp" {

--- a/tests/unit/simstim-state-coalescer.bats
+++ b/tests/unit/simstim-state-coalescer.bats
@@ -1,0 +1,259 @@
+#!/usr/bin/env bats
+# =============================================================================
+# simstim-state-coalescer.bats — cycle-063 regression tests
+# =============================================================================
+# RFC-060 Frictions 1+2 fix: when sync_run_mode transitions to a terminal
+# state (COMPLETED, AWAITING_HITL, HALTED), the state file must reach an
+# internally consistent terminal condition:
+#
+#   - .state set to the target terminal value
+#   - .phase advanced to "complete" for COMPLETED/AWAITING_HITL
+#     (HALTED preserves current phase to enable operator resume)
+#   - .completed_at timestamp populated
+#
+# Plus new --archive-completed flag that moves terminal state files to
+# .run/archive/simstim-{id}-{ts}.json for clean fresh starts.
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT
+    PROJECT_ROOT=$(mktemp -d)
+    export STATE_FILE="$PROJECT_ROOT/.run/simstim-state.json"
+    export RUN_MODE_STATE="$PROJECT_ROOT/.run/sprint-plan-state.json"
+    mkdir -p "$PROJECT_ROOT/.run"
+
+    # Init git repo so git_inferred_completion_check works where invoked
+    cd "$PROJECT_ROOT"
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "init" > README.md
+    git add README.md
+    git commit -q -m "initial commit"
+    touch .loa.config.yaml
+
+    SCRIPT="$BATS_TEST_DIRNAME/../../.claude/scripts/simstim-orchestrator.sh"
+    export LOA_PROJECT_ROOT_OVERRIDE="$PROJECT_ROOT"
+}
+
+teardown() {
+    cd /
+    rm -rf "$PROJECT_ROOT"
+}
+
+# Helper: seed a simstim state file at a given phase with matching plan_id
+write_simstim_state() {
+    local phase="${1:-implementation}"
+    local plan_id="${2:-plan-test-001}"
+    cat > "$STATE_FILE" <<EOF
+{
+  "schema_version": 1,
+  "simstim_id": "simstim-test-abc123",
+  "state": "RUNNING",
+  "phase": "$phase",
+  "expected_plan_id": "$plan_id",
+  "timestamps": {
+    "started": "2026-04-14T00:00:00Z",
+    "last_activity": "2026-04-14T00:05:00Z"
+  },
+  "phases": {
+    "implementation": { "status": "in_progress", "started_at": "2026-04-14T00:05:00Z" }
+  },
+  "sync_attempts": 0
+}
+EOF
+}
+
+# Helper: seed a run-mode state file in a terminal condition
+write_run_mode_terminal() {
+    local state="$1"
+    local plan_id="${2:-plan-test-001}"
+    cat > "$RUN_MODE_STATE" <<EOF
+{
+  "plan_id": "$plan_id",
+  "state": "$state",
+  "sprints": { "total": 2 },
+  "pr_url": "https://github.com/owner/repo/pull/999",
+  "timestamps": {
+    "started": "2026-04-14T00:05:00Z",
+    "last_activity": "2026-04-14T00:30:00Z"
+  }
+}
+EOF
+}
+
+# =============================================================================
+# T1: sync_run_mode with JACKED_OUT coalesces phase + completed_at
+# =============================================================================
+@test "coalescer: sync with JACKED_OUT sets phase=complete and completed_at" {
+    write_simstim_state "implementation"
+    write_run_mode_terminal "JACKED_OUT"
+
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode >/dev/null 2>&1
+
+    [ "$(jq -r '.state' "$STATE_FILE")" = "COMPLETED" ]
+    [ "$(jq -r '.phase' "$STATE_FILE")" = "complete" ]
+    # completed_at must be a non-null ISO timestamp
+    local completed_at
+    completed_at=$(jq -r '.completed_at' "$STATE_FILE")
+    [[ "$completed_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+# =============================================================================
+# T2: sync_run_mode with READY_FOR_HITL → AWAITING_HITL + phase=complete
+# =============================================================================
+@test "coalescer: sync with READY_FOR_HITL sets AWAITING_HITL with phase=complete" {
+    write_simstim_state "implementation"
+    write_run_mode_terminal "READY_FOR_HITL"
+
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode >/dev/null 2>&1
+
+    [ "$(jq -r '.state' "$STATE_FILE")" = "AWAITING_HITL" ]
+    [ "$(jq -r '.phase' "$STATE_FILE")" = "complete" ]
+    local completed_at
+    completed_at=$(jq -r '.completed_at' "$STATE_FILE")
+    [[ "$completed_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+# =============================================================================
+# T3: sync_run_mode with HALTED → completed_at set but phase preserved
+# =============================================================================
+@test "coalescer: sync with HALTED sets completed_at but preserves phase" {
+    write_simstim_state "implementation"
+    write_run_mode_terminal "HALTED"
+
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode >/dev/null 2>&1
+
+    [ "$(jq -r '.state' "$STATE_FILE")" = "HALTED" ]
+    # HALTED preserves phase so operator can resume from implementation
+    [ "$(jq -r '.phase' "$STATE_FILE")" = "implementation" ]
+    local completed_at
+    completed_at=$(jq -r '.completed_at' "$STATE_FILE")
+    [[ "$completed_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+# =============================================================================
+# T4: sync preserves simstim-specific fields (impl.status, pr_url)
+# =============================================================================
+@test "coalescer: sync composes with simstim-specific fields atomically" {
+    write_simstim_state "implementation"
+    write_run_mode_terminal "JACKED_OUT"
+
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --sync-run-mode >/dev/null 2>&1
+
+    # Simstim-specific fields the extra_filter must preserve/update
+    [ "$(jq -r '.phases.implementation.status' "$STATE_FILE")" = "completed" ]
+    [ "$(jq -r '.pr_url' "$STATE_FILE")" = "https://github.com/owner/repo/pull/999" ]
+    [ "$(jq -r '.sync_attempts' "$STATE_FILE")" = "0" ]
+}
+
+# =============================================================================
+# T5: --archive-completed moves terminal state to archive dir
+# =============================================================================
+@test "archive: moves COMPLETED state to .run/archive/ with simstim_id" {
+    write_simstim_state "complete"
+    # Advance state to terminal
+    jq '.state = "COMPLETED" | .completed_at = "2026-04-14T00:35:00Z"' "$STATE_FILE" \
+        > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+
+    local output
+    output=$(env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --archive-completed 2>&1)
+
+    # Original state file must be gone
+    [ ! -f "$STATE_FILE" ]
+    # Archive dir must exist with at least one file
+    [ -d "$PROJECT_ROOT/.run/archive" ]
+    local archived_count
+    archived_count=$(ls "$PROJECT_ROOT/.run/archive/" | wc -l | tr -d ' ')
+    [ "$archived_count" -ge 1 ]
+    # Archive filename must include simstim_id
+    ls "$PROJECT_ROOT/.run/archive/" | grep -q "simstim-test-abc123"
+    # Output must indicate success
+    [[ "$output" == *'"archived": true'* ]] || [[ "$output" == *'"archived":true'* ]]
+}
+
+# =============================================================================
+# T6: --archive-completed refuses when state is RUNNING
+# =============================================================================
+@test "archive: refuses to archive RUNNING state (exit 1, file preserved)" {
+    write_simstim_state "implementation"
+    # State is RUNNING by default from write_simstim_state helper
+
+    set +e
+    output=$(env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --archive-completed 2>&1)
+    exit_code=$?
+    set -e
+
+    [ "$exit_code" -eq 1 ]
+    # File must still exist
+    [ -f "$STATE_FILE" ]
+    [[ "$output" == *"state_not_terminal"* ]]
+}
+
+# =============================================================================
+# T7: --archive-completed idempotent (no state file → archived: false)
+# =============================================================================
+@test "archive: idempotent — returns no_state_file when already archived" {
+    # No state file exists
+    local output
+    output=$(env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --archive-completed 2>&1)
+
+    [[ "$output" == *'"archived": false'* ]] || [[ "$output" == *'"archived":false'* ]]
+    [[ "$output" == *"no_state_file"* ]]
+}
+
+# =============================================================================
+# T8: --archive-completed handles HALTED state
+# =============================================================================
+@test "archive: HALTED state is also terminal (archivable)" {
+    write_simstim_state "implementation"
+    jq '.state = "HALTED" | .completed_at = "2026-04-14T00:40:00Z"' "$STATE_FILE" \
+        > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --archive-completed >/dev/null 2>&1
+
+    [ ! -f "$STATE_FILE" ]
+    ls "$PROJECT_ROOT/.run/archive/" | grep -q "simstim-test-abc123"
+}
+
+# =============================================================================
+# T9: --archive-completed refuses corrupt JSON
+# =============================================================================
+@test "archive: refuses to archive corrupt JSON (exit 1, file preserved)" {
+    echo "{ not valid json" > "$STATE_FILE"
+
+    set +e
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --archive-completed >/dev/null 2>&1
+    exit_code=$?
+    set -e
+
+    [ "$exit_code" -eq 1 ]
+    [ -f "$STATE_FILE" ]
+}
+
+# =============================================================================
+# T10: CLI flag is documented in usage comment header
+# =============================================================================
+@test "cli: --archive-completed flag appears in script header usage" {
+    grep -q "archive-completed" "$SCRIPT"
+}
+
+# =============================================================================
+# T11: coalesce_terminal_state helper is defined
+# =============================================================================
+@test "coalescer: coalesce_terminal_state function exists" {
+    grep -q "^coalesce_terminal_state()" "$SCRIPT"
+}
+
+# =============================================================================
+# T12: archive path contains timestamp for traceability
+# =============================================================================
+@test "archive: path includes ISO-like timestamp" {
+    write_simstim_state "complete"
+    jq '.state = "COMPLETED"' "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+
+    env PROJECT_ROOT="$PROJECT_ROOT" "$SCRIPT" --archive-completed >/dev/null 2>&1
+
+    # Archive filename format: simstim-{id}-{YYYYMMDDTHHMMSSZ}.json
+    ls "$PROJECT_ROOT/.run/archive/" | grep -qE 'simstim-.*-[0-9]{8}T[0-9]{6}Z\.json$'
+}


### PR DESCRIPTION
## Summary

Closes **RFC-060 Frictions 1 and 2** (#483). When `sync_run_mode` transitioned to a terminal state (COMPLETED, AWAITING_HITL, HALTED), the state file was left internally inconsistent — `.state` advanced but `.phase` stayed at `"implementation"` and `.completed_at` was never populated. This blocked fresh `/simstim` invocations without manual archival gymnastics.

## Changes

**Two surfaces added to `simstim-orchestrator.sh`:**

1. **`coalesce_terminal_state()` helper** — single-place enforcement of the terminal-state invariant. `.state`, `.phase` (advanced to `"complete"` for COMPLETED/AWAITING_HITL), and `.completed_at` move atomically. HALTED preserves `.phase` for resume.

2. **`--archive-completed` CLI flag** — moves terminal state files to `.run/archive/simstim-{id}-{timestamp}.json`. Refuses to archive non-terminal or corrupt state files. Idempotent.

`sync_run_mode` refactored to delegate state+phase+completed_at transitions to the coalescer while composing simstim-specific fields (impl status, pr_url, sync_attempts) into the same atomic update.

## Test plan

- [x] `bats tests/unit/simstim-state-coalescer.bats` — 12/12 passing
- [x] `bats tests/unit/sync-run-mode-git-aware.bats` — 5/5 passing (no regression)
- [x] `bash -n .claude/scripts/simstim-orchestrator.sh` — syntax OK

## Acceptance Criteria

- [x] JACKED_OUT sync → state=COMPLETED, phase=complete, completed_at≠null
- [x] READY_FOR_HITL sync → state=AWAITING_HITL, phase=complete, completed_at≠null
- [x] HALTED sync → state=HALTED, completed_at≠null, phase preserved
- [x] `--archive-completed` moves terminal state to archive dir
- [x] `--archive-completed` refuses RUNNING state (exit 1)
- [x] `--archive-completed` idempotent (no state → archived:false, no_state_file)

Ref: #483 (RFC-060 autopoietic spiral umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)