### PR TITLE
feat(cycle-workspace): per-cycle PRD/SDD/sprint workspace

### DIFF
--- a/.claude/scripts/cycle-workspace.sh
+++ b/.claude/scripts/cycle-workspace.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# =============================================================================
+# cycle-workspace.sh - Per-cycle PRD/SDD/sprint workspace manager (cycle-064)
+# =============================================================================
+# Version: 1.0.0
+# Part of: RFC-060 (#483) autopoietic spiral infrastructure
+#
+# Creates and manages grimoires/loa/cycles/{cycle-id}/{prd,sdd,sprint}.md
+# workspaces. Top-level grimoires/loa/prd.md etc become symlinks to the
+# "active" cycle's files, preserving backward compatibility for all existing
+# consumers while unblocking parallel and historical cycle work.
+#
+# Usage:
+#   cycle-workspace.sh init <cycle-id>
+#       Create cycles/<cycle-id>/ with empty prd/sdd/sprint, set active symlink,
+#       wire top-level *.md symlinks. Auto-migrates pre-existing top-level
+#       regular files into the new cycle dir (no data loss). Idempotent.
+#
+#   cycle-workspace.sh switch <cycle-id>
+#       Point active symlink at an existing cycle dir. Top-level symlinks
+#       follow automatically because they target cycles/active/*.
+#
+#   cycle-workspace.sh list
+#       Print all cycle dirs (one per line).
+#
+#   cycle-workspace.sh active
+#       Print the active cycle id (from the cycles/active symlink).
+#
+#   cycle-workspace.sh status
+#       Print JSON status: active cycle, list of cycles, migration state.
+#
+# Opt-in semantics:
+#   Users who never invoke this script see no behavior change — the single-slot
+#   legacy layout (grimoires/loa/prd.md as a regular file) continues to work.
+#   The moment `init` runs, that top-level file becomes a symlink, and all
+#   future cycles can layer on top without collision.
+#
+# Exit codes:
+#   0 - Success
+#   1 - Validation error (missing args, invalid cycle id)
+#   2 - State error (operation would lose data, operation not applicable)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/bootstrap.sh"
+
+_GRIMOIRE_DIR=$(get_grimoire_dir)
+CYCLES_DIR="$_GRIMOIRE_DIR/cycles"
+ACTIVE_LINK="$CYCLES_DIR/active"
+
+# Per-cycle artifact files that get workspace-split
+ARTIFACTS=(prd.md sdd.md sprint.md)
+
+log() {
+    echo "[cycle-workspace] $*" >&2
+}
+
+error() {
+    echo "ERROR: $*" >&2
+}
+
+usage() {
+    sed -n '/^# Usage:/,/^# Opt-in/p' "${BASH_SOURCE[0]}" \
+        | sed -e '/^# Opt-in/d' -e 's/^# \{0,1\}//'
+}
+
+# Validate cycle-id matches allowed pattern — prevents path traversal and
+# symlink games. Allows cycle-NNN, cycle-YYYYMMDD-HEXHEX, cycle-bug-*, etc.
+validate_cycle_id() {
+    local id="$1"
+    if [[ -z "$id" ]]; then
+        error "cycle-id cannot be empty"
+        return 1
+    fi
+    if [[ ! "$id" =~ ^[A-Za-z0-9_-]+$ ]]; then
+        error "cycle-id must match [A-Za-z0-9_-]+ (got: $id)"
+        return 1
+    fi
+    # Reserved names
+    case "$id" in
+        active|archive|.|..)
+            error "cycle-id '$id' is reserved"
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# Returns the currently active cycle id, or empty string if no active symlink.
+# Uses `readlink` (not `readlink -f`) so we just read the link target, not the
+# resolved path — the target is the cycle-id relative to CYCLES_DIR.
+get_active_cycle() {
+    if [[ ! -L "$ACTIVE_LINK" ]]; then
+        echo ""
+        return 0
+    fi
+    basename "$(readlink "$ACTIVE_LINK")"
+}
+
+# Create a single cycle directory with empty artifact files. Idempotent.
+ensure_cycle_dir() {
+    local id="$1"
+    local cycle_dir="$CYCLES_DIR/$id"
+
+    mkdir -p "$cycle_dir"
+
+    local artifact
+    for artifact in "${ARTIFACTS[@]}"; do
+        local target="$cycle_dir/$artifact"
+        if [[ ! -f "$target" ]]; then
+            # Create an empty stub; the workflow (/simstim etc) will populate.
+            : > "$target"
+        fi
+    done
+}
+
+# Point the active symlink at <id>. Replaces any existing symlink atomically.
+#
+# Note on atomicity: `ln -sfn target link` is the canonical Linux idiom. When
+# `link` is already a symlink, `-f` removes it and `-n` prevents `ln` from
+# dereferencing it and trying to create a link inside the pointed-to dir.
+# Together they give atomic symlink replacement.
+set_active_cycle() {
+    local id="$1"
+    local cycle_dir="$CYCLES_DIR/$id"
+
+    if [[ ! -d "$cycle_dir" ]]; then
+        error "Cycle dir does not exist: $cycle_dir"
+        return 1
+    fi
+
+    ln -sfn "$id" "$ACTIVE_LINK"
+}
+
+# Replace a top-level artifact with a symlink pointing into cycles/active/.
+# If the top-level file is currently a regular file with content, move that
+# content into the active cycle's artifact slot first (no data loss).
+wire_top_level_symlink() {
+    local artifact="$1"
+    local top_level="$_GRIMOIRE_DIR/$artifact"
+    local active_target="$CYCLES_DIR/active/$artifact"
+
+    if [[ -L "$top_level" ]]; then
+        # Already a symlink — check whether it points at the right place.
+        local current_target
+        current_target=$(readlink "$top_level")
+        local desired_rel="cycles/active/$artifact"
+        if [[ "$current_target" != "$desired_rel" ]]; then
+            # Repoint it.
+            rm -f "$top_level"
+            ( cd "$_GRIMOIRE_DIR" && ln -s "$desired_rel" "$artifact" )
+        fi
+        return 0
+    fi
+
+    if [[ -f "$top_level" ]]; then
+        # Migrate: move existing content into active cycle's artifact slot,
+        # but only if the active slot is empty (avoid clobbering real work).
+        if [[ -s "$active_target" ]]; then
+            error "Cannot migrate $artifact: active cycle's slot already has content"
+            error "Resolve manually: compare $top_level vs $active_target"
+            return 2
+        fi
+        mv "$top_level" "$active_target"
+    fi
+
+    # Create the symlink, using a relative path for git/portability.
+    ( cd "$_GRIMOIRE_DIR" && ln -s "cycles/active/$artifact" "$artifact" )
+}
+
+# =============================================================================
+# Commands
+# =============================================================================
+
+cmd_init() {
+    local id="${1:-}"
+    validate_cycle_id "$id" || return 1
+
+    mkdir -p "$CYCLES_DIR"
+    ensure_cycle_dir "$id"
+    set_active_cycle "$id"
+
+    # Wire top-level symlinks for each artifact
+    local artifact
+    for artifact in "${ARTIFACTS[@]}"; do
+        wire_top_level_symlink "$artifact" || return $?
+    done
+
+    jq -n \
+        --arg id "$id" \
+        --arg cycle_dir "$CYCLES_DIR/$id" \
+        '{initialized: true, cycle_id: $id, cycle_dir: $cycle_dir}'
+}
+
+cmd_switch() {
+    local id="${1:-}"
+    validate_cycle_id "$id" || return 1
+
+    if [[ ! -d "$CYCLES_DIR/$id" ]]; then
+        error "Cycle '$id' does not exist. Run: cycle-workspace.sh init $id"
+        return 2
+    fi
+
+    local prior
+    prior=$(get_active_cycle)
+    set_active_cycle "$id"
+
+    jq -n \
+        --arg from "$prior" \
+        --arg to "$id" \
+        '{switched: true, from: (if $from == "" then null else $from end), to: $to}'
+}
+
+cmd_list() {
+    if [[ ! -d "$CYCLES_DIR" ]]; then
+        echo "[]"
+        return 0
+    fi
+
+    find "$CYCLES_DIR" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' 2>/dev/null \
+        | sort \
+        | jq -R . \
+        | jq -s .
+}
+
+cmd_active() {
+    get_active_cycle
+}
+
+cmd_status() {
+    local active
+    active=$(get_active_cycle)
+
+    local cycles_json
+    cycles_json=$(cmd_list)
+
+    # Top-level artifact state: linked | regular | missing
+    local artifacts_json='{}'
+    local artifact
+    for artifact in "${ARTIFACTS[@]}"; do
+        local top="$_GRIMOIRE_DIR/$artifact"
+        local state
+        if [[ -L "$top" ]]; then
+            state="linked"
+        elif [[ -f "$top" ]]; then
+            state="regular"
+        else
+            state="missing"
+        fi
+        artifacts_json=$(echo "$artifacts_json" | jq --arg a "$artifact" --arg s "$state" '. + {($a): $s}')
+    done
+
+    jq -n \
+        --arg active "$active" \
+        --argjson cycles "$cycles_json" \
+        --argjson artifacts "$artifacts_json" \
+        '{
+            active: (if $active == "" then null else $active end),
+            cycles: $cycles,
+            top_level_artifacts: $artifacts
+        }'
+}
+
+# =============================================================================
+# CLI dispatch
+# =============================================================================
+
+main() {
+    local cmd="${1:-}"
+    shift 2>/dev/null || true
+
+    case "$cmd" in
+        init)
+            cmd_init "$@"
+            ;;
+        switch)
+            cmd_switch "$@"
+            ;;
+        list)
+            cmd_list
+            ;;
+        active)
+            cmd_active
+            ;;
+        status)
+            cmd_status
+            ;;
+        -h|--help|help|"")
+            usage
+            [[ -z "$cmd" ]] && exit 1 || exit 0
+            ;;
+        *)
+            error "Unknown command: $cmd"
+            usage >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/scripts/cycle-workspace.sh
+++ b/.claude/scripts/cycle-workspace.sh
@@ -180,10 +180,33 @@ cmd_init() {
 
     mkdir -p "$CYCLES_DIR"
     ensure_cycle_dir "$id"
+
+    # Pre-flight validation: verify every top-level artifact migration is
+    # safe before we mutate anything (review feedback — partial-failure
+    # atomicity). If ANY artifact would collide with the active cycle's
+    # slot, refuse the whole operation up-front.
+    #
+    # Temporarily point active at the target cycle so -s checks inside
+    # wire_top_level_symlink's precheck resolve through the symlink chain.
+    local prior_active
+    prior_active=$(get_active_cycle)
     set_active_cycle "$id"
 
-    # Wire top-level symlinks for each artifact
     local artifact
+    for artifact in "${ARTIFACTS[@]}"; do
+        if ! precheck_top_level_symlink "$artifact"; then
+            # Roll back active symlink so user isn't left with a half-
+            # switched workspace.
+            if [[ -n "$prior_active" ]]; then
+                set_active_cycle "$prior_active"
+            else
+                rm -f "$ACTIVE_LINK"
+            fi
+            return 2
+        fi
+    done
+
+    # All migrations validated — apply them.
     for artifact in "${ARTIFACTS[@]}"; do
         wire_top_level_symlink "$artifact" || return $?
     done
@@ -192,6 +215,27 @@ cmd_init() {
         --arg id "$id" \
         --arg cycle_dir "$CYCLES_DIR/$id" \
         '{initialized: true, cycle_id: $id, cycle_dir: $cycle_dir}'
+}
+
+# Returns 0 if wire_top_level_symlink would succeed, non-zero otherwise.
+# Used by cmd_init to validate the full migration plan before mutating.
+precheck_top_level_symlink() {
+    local artifact="$1"
+    local top_level="$_GRIMOIRE_DIR/$artifact"
+    local active_target="$CYCLES_DIR/active/$artifact"
+
+    if [[ -L "$top_level" ]]; then
+        return 0 # Already a symlink, nothing to migrate
+    fi
+
+    if [[ -f "$top_level" ]] && [[ -s "$active_target" ]]; then
+        # Collision: top-level is a real file AND active slot has content.
+        error "Cannot migrate $artifact: active cycle's slot already has content"
+        error "Resolve manually: compare $top_level vs $active_target"
+        return 2
+    fi
+
+    return 0
 }
 
 cmd_switch() {
@@ -219,7 +263,9 @@ cmd_list() {
         return 0
     fi
 
-    find "$CYCLES_DIR" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' 2>/dev/null \
+    # POSIX-portable: `find -printf '%f'` is GNU-only. Use `basename` via
+    # -exec for BSD/macOS compatibility (review feedback).
+    find "$CYCLES_DIR" -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null \
         | sort \
         | jq -R . \
         | jq -s .

--- a/tests/unit/cycle-workspace.bats
+++ b/tests/unit/cycle-workspace.bats
@@ -257,6 +257,40 @@ teardown() {
 }
 
 # =============================================================================
+# T16 (follow-up): init is atomic — failed migration rolls back cleanly
+# =============================================================================
+@test "init: migration failure rolls back active symlink (atomicity)" {
+    # First init establishes a clean cycle-a workspace
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-a >/dev/null
+
+    # Seed cycle-b's prd slot with content AND plant a conflicting
+    # top-level file. The prd migration will collide; sdd/sprint would
+    # have been fine. Atomicity requires we abort WITHOUT half-wiring.
+    mkdir -p "$LOA_GRIMOIRE_DIR/cycles/cycle-b"
+    echo "cycle-b prd content" > "$LOA_GRIMOIRE_DIR/cycles/cycle-b/prd.md"
+    touch "$LOA_GRIMOIRE_DIR/cycles/cycle-b/sdd.md"
+    touch "$LOA_GRIMOIRE_DIR/cycles/cycle-b/sprint.md"
+
+    # Break the symlink invariant: remove top-level prd.md symlink and
+    # replace with a regular file that would collide with cycle-b's slot.
+    rm -f "$LOA_GRIMOIRE_DIR/prd.md"
+    echo "top-level conflict content" > "$LOA_GRIMOIRE_DIR/prd.md"
+
+    # Attempt init cycle-b — must fail with exit 2
+    set +e
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-b >/dev/null 2>&1
+    exit_code=$?
+    set -e
+    [ "$exit_code" -eq 2 ]
+
+    # Atomicity: active must still point at cycle-a (rolled back)
+    [ "$(readlink "$LOA_GRIMOIRE_DIR/cycles/active")" = "cycle-a" ]
+
+    # Top-level file content must be preserved intact (no data loss)
+    grep -q "top-level conflict content" "$LOA_GRIMOIRE_DIR/prd.md"
+}
+
+# =============================================================================
 # T15: validates usage help output
 # =============================================================================
 @test "cli: help output documents all commands" {

--- a/tests/unit/cycle-workspace.bats
+++ b/tests/unit/cycle-workspace.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+# =============================================================================
+# cycle-workspace.bats — cycle-064 regression tests
+# =============================================================================
+# Verifies the per-cycle workspace manager for RFC-060 #483 Friction 9.
+# Tests init/switch/list/active/status commands against a temp grimoire dir.
+# =============================================================================
+
+setup() {
+    # Create a temp dir that looks like a Loa project root so bootstrap.sh's
+    # _detect_project_root finds it. Putting a .claude/ subdir there makes
+    # the walk-up detection succeed when we cd into it.
+    export PROJECT_ROOT
+    PROJECT_ROOT=$(mktemp -d)
+    mkdir -p "$PROJECT_ROOT/.claude"
+    touch "$PROJECT_ROOT/.loa.config.yaml"
+
+    # Point grimoire inside the fake project so path-lib's workspace check
+    # passes. Path-lib requires LOA_GRIMOIRE_DIR to start with PROJECT_ROOT.
+    export LOA_GRIMOIRE_DIR="$PROJECT_ROOT/grimoires/loa"
+    mkdir -p "$LOA_GRIMOIRE_DIR"
+
+    # Work from the fake project root so git rev-parse and the walk-up
+    # fallback both resolve PROJECT_ROOT correctly.
+    cd "$PROJECT_ROOT"
+    # Init git so bootstrap.sh's git-toplevel strategy lands on this dir
+    # rather than the real Loa repo where bats was invoked from.
+    git init -q -b main
+    git config user.email test@test
+    git config user.name test
+
+    SCRIPT="$BATS_TEST_DIRNAME/../../.claude/scripts/cycle-workspace.sh"
+}
+
+teardown() {
+    cd /
+    rm -rf "$PROJECT_ROOT"
+}
+
+# =============================================================================
+# T1: init creates cycle dir + empty artifacts + active symlink
+# =============================================================================
+@test "init: creates cycle dir with empty artifacts and active symlink" {
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+
+    [ -d "$LOA_GRIMOIRE_DIR/cycles/cycle-test-001" ]
+    [ -f "$LOA_GRIMOIRE_DIR/cycles/cycle-test-001/prd.md" ]
+    [ -f "$LOA_GRIMOIRE_DIR/cycles/cycle-test-001/sdd.md" ]
+    [ -f "$LOA_GRIMOIRE_DIR/cycles/cycle-test-001/sprint.md" ]
+    [ -L "$LOA_GRIMOIRE_DIR/cycles/active" ]
+    [ "$(readlink "$LOA_GRIMOIRE_DIR/cycles/active")" = "cycle-test-001" ]
+}
+
+# =============================================================================
+# T2: init wires top-level symlinks to cycles/active
+# =============================================================================
+@test "init: top-level prd/sdd/sprint become symlinks to cycles/active" {
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+
+    [ -L "$LOA_GRIMOIRE_DIR/prd.md" ]
+    [ -L "$LOA_GRIMOIRE_DIR/sdd.md" ]
+    [ -L "$LOA_GRIMOIRE_DIR/sprint.md" ]
+    [ "$(readlink "$LOA_GRIMOIRE_DIR/prd.md")" = "cycles/active/prd.md" ]
+}
+
+# =============================================================================
+# T3: init auto-migrates pre-existing top-level regular files (no data loss)
+# =============================================================================
+@test "init: migrates pre-existing top-level regular files into cycle dir" {
+    # Create a pre-existing prd.md with content
+    echo "# Legacy PRD content" > "$LOA_GRIMOIRE_DIR/prd.md"
+    echo "# Legacy SDD content" > "$LOA_GRIMOIRE_DIR/sdd.md"
+
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+
+    # Content must now be inside the cycle dir
+    grep -q "Legacy PRD content" "$LOA_GRIMOIRE_DIR/cycles/cycle-test-001/prd.md"
+    grep -q "Legacy SDD content" "$LOA_GRIMOIRE_DIR/cycles/cycle-test-001/sdd.md"
+    # Top-level must now be a symlink pointing at the cycle
+    [ -L "$LOA_GRIMOIRE_DIR/prd.md" ]
+    # Reading through the symlink must surface the legacy content
+    grep -q "Legacy PRD content" "$LOA_GRIMOIRE_DIR/prd.md"
+}
+
+# =============================================================================
+# T4: init is idempotent — re-running leaves state unchanged
+# =============================================================================
+@test "init: idempotent on same cycle-id" {
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+    # Write some content into the active cycle's prd
+    echo "# Cycle 1 work" > "$LOA_GRIMOIRE_DIR/cycles/cycle-test-001/prd.md"
+
+    # Re-run init — must NOT clobber content
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+
+    grep -q "Cycle 1 work" "$LOA_GRIMOIRE_DIR/cycles/cycle-test-001/prd.md"
+}
+
+# =============================================================================
+# T5: switch updates active symlink without recreating content
+# =============================================================================
+@test "switch: updates active symlink to target cycle" {
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-002 >/dev/null
+    # After second init, active points at cycle-test-002
+    [ "$(readlink "$LOA_GRIMOIRE_DIR/cycles/active")" = "cycle-test-002" ]
+
+    # Switch back to cycle-test-001
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" switch cycle-test-001 >/dev/null
+    [ "$(readlink "$LOA_GRIMOIRE_DIR/cycles/active")" = "cycle-test-001" ]
+}
+
+# =============================================================================
+# T6: switch refuses non-existent cycle
+# =============================================================================
+@test "switch: refuses non-existent cycle (exit 2)" {
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+
+    set +e
+    output=$(env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" switch cycle-nonexistent 2>&1)
+    exit_code=$?
+    set -e
+
+    [ "$exit_code" -eq 2 ]
+    [[ "$output" == *"does not exist"* ]]
+}
+
+# =============================================================================
+# T7: list returns all cycles as JSON array
+# =============================================================================
+@test "list: returns JSON array of cycle ids" {
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-a >/dev/null
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-b >/dev/null
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-c >/dev/null
+
+    local output
+    output=$(env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" list)
+
+    # Must be a JSON array
+    echo "$output" | jq -e 'type == "array"' >/dev/null
+    # Must contain our three cycles
+    echo "$output" | jq -e 'contains(["cycle-a", "cycle-b", "cycle-c"])' >/dev/null
+}
+
+# =============================================================================
+# T8: active prints current cycle id
+# =============================================================================
+@test "active: prints current active cycle id" {
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+
+    local output
+    output=$(env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" active)
+    [ "$output" = "cycle-test-001" ]
+}
+
+# =============================================================================
+# T9: active returns empty string when no active symlink
+# =============================================================================
+@test "active: returns empty when no active cycle" {
+    local output
+    output=$(env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" active)
+    [ -z "$output" ]
+}
+
+# =============================================================================
+# T10: status returns JSON with active + cycles + artifact state
+# =============================================================================
+@test "status: returns JSON with active, cycles array, artifact state" {
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+
+    local output
+    output=$(env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" status)
+
+    echo "$output" | jq -e '.active == "cycle-test-001"' >/dev/null
+    echo "$output" | jq -e '.cycles | type == "array"' >/dev/null
+    echo "$output" | jq -e '.top_level_artifacts."prd.md" == "linked"' >/dev/null
+    echo "$output" | jq -e '.top_level_artifacts."sdd.md" == "linked"' >/dev/null
+    echo "$output" | jq -e '.top_level_artifacts."sprint.md" == "linked"' >/dev/null
+}
+
+# =============================================================================
+# T11: validate_cycle_id rejects path-traversal attempts
+# =============================================================================
+@test "init: rejects cycle-id with path-traversal chars" {
+    set +e
+    output=$(env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init "../../etc" 2>&1)
+    exit_code=$?
+    set -e
+
+    [ "$exit_code" -eq 1 ]
+    [[ "$output" == *"must match"* ]]
+    # No cycle dir with traversal chars created
+    [ ! -d "$LOA_GRIMOIRE_DIR/cycles/../../etc" ]
+}
+
+# =============================================================================
+# T12: reserved names are rejected
+# =============================================================================
+@test "init: rejects reserved cycle-id 'active'" {
+    set +e
+    output=$(env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init active 2>&1)
+    exit_code=$?
+    set -e
+
+    [ "$exit_code" -eq 1 ]
+    [[ "$output" == *"reserved"* ]]
+}
+
+# =============================================================================
+# T13: top-level symlink resolves to the active cycle's artifact
+# =============================================================================
+@test "backward-compat: reading through top-level symlink surfaces active cycle content" {
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-001 >/dev/null
+    echo "# Active cycle PRD" > "$LOA_GRIMOIRE_DIR/cycles/cycle-test-001/prd.md"
+
+    # Reading from the top-level path must surface active cycle's content
+    grep -q "Active cycle PRD" "$LOA_GRIMOIRE_DIR/prd.md"
+
+    # Initialize a second cycle and switch to it with different content
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-test-002 >/dev/null
+    echo "# Second cycle PRD" > "$LOA_GRIMOIRE_DIR/cycles/cycle-test-002/prd.md"
+
+    # Top-level must now reflect cycle-002
+    grep -q "Second cycle PRD" "$LOA_GRIMOIRE_DIR/prd.md"
+    ! grep -q "Active cycle PRD" "$LOA_GRIMOIRE_DIR/prd.md"
+
+    # Switch back — top-level should flip
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" switch cycle-test-001 >/dev/null
+    grep -q "Active cycle PRD" "$LOA_GRIMOIRE_DIR/prd.md"
+}
+
+# =============================================================================
+# T14: init refuses to clobber when both top-level AND active cycle have content
+# =============================================================================
+@test "init: refuses to migrate when active cycle's slot already has content" {
+    # Init cycle-a and write content into its slot
+    env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-a >/dev/null
+    echo "# Cycle-a content" > "$LOA_GRIMOIRE_DIR/cycles/cycle-a/prd.md"
+
+    # Now break the invariant by deleting the top-level symlink and making
+    # a regular file with conflicting content.
+    rm -f "$LOA_GRIMOIRE_DIR/prd.md"
+    echo "# Conflicting top-level content" > "$LOA_GRIMOIRE_DIR/prd.md"
+
+    # Re-init cycle-a — should refuse the migration for prd.md (active slot
+    # already has content; clobbering it would lose work).
+    set +e
+    output=$(env LOA_GRIMOIRE_DIR="$LOA_GRIMOIRE_DIR" "$SCRIPT" init cycle-a 2>&1)
+    exit_code=$?
+    set -e
+
+    [ "$exit_code" -eq 2 ]
+    [[ "$output" == *"already has content"* ]]
+    # Top-level file must remain intact (no data loss)
+    [ -f "$LOA_GRIMOIRE_DIR/prd.md" ]
+    grep -q "Conflicting top-level content" "$LOA_GRIMOIRE_DIR/prd.md"
+}
+
+# =============================================================================
+# T15: validates usage help output
+# =============================================================================
+@test "cli: help output documents all commands" {
+    local output
+    output=$("$SCRIPT" --help 2>&1)
+
+    [[ "$output" == *"init"* ]]
+    [[ "$output" == *"switch"* ]]
+    [[ "$output" == *"list"* ]]
+    [[ "$output" == *"active"* ]]
+    [[ "$output" == *"status"* ]]
+}


### PR DESCRIPTION
## Summary

Closes **RFC-060 Friction 9** (#483). The single-slot canonical layout (`grimoires/loa/{prd,sdd,sprint}.md`) forces each `/simstim` cycle to overwrite the previous cycle's artifacts, blocking parallel cycles and historical review.

## Layout

```
grimoires/loa/
├── cycles/
│   ├── cycle-001/
│   │   ├── prd.md
│   │   ├── sdd.md
│   │   └── sprint.md
│   ├── cycle-002/
│   │   └── ...
│   └── active → cycle-002/        (symlink)
├── prd.md → cycles/active/prd.md  (symlink)
├── sdd.md → cycles/active/sdd.md  (symlink)
└── sprint.md → cycles/active/sprint.md  (symlink)
```

## Commands

| Command | Purpose |
|---------|---------|
| `init <id>` | Create cycle dir, set active, wire top-level symlinks. Auto-migrates pre-existing top-level regular files (no data loss). Idempotent. |
| `switch <id>` | Atomically update active symlink (`ln -sfn` idiom). |
| `list` | JSON array of cycle dirs. |
| `active` | Print active cycle id. |
| `status` | Full JSON status with active, cycles, and artifact state. |

## Opt-in

Users who never invoke the script see no behavior change. The moment `init` runs, the layout transitions to the workspace model and top-level symlinks take over. All existing consumers (`/simstim`, `/plan-and-analyze`, `/architect`, `/sprint-plan`) continue to read `grimoires/loa/prd.md` unchanged.

## Safety

- Strict cycle-id validation `[A-Za-z0-9_-]+` — rejects `../`, `/`, spaces, etc.
- Reserved names `active`, `archive`, `.`, `..` rejected
- Migration refuses to clobber when active slot already has content (user must resolve merge manually)

## Test plan

- [x] `bats tests/unit/cycle-workspace.bats` — 15/15 passing
- [x] `bash -n .claude/scripts/cycle-workspace.sh` — syntax OK

Ref: #483 (RFC-060 autopoietic spiral umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)