### PR TITLE
feat(spiral): pipeline profiles + off-hours scheduling

### DIFF
--- a/.claude/scripts/spiral-evidence.sh
+++ b/.claude/scripts/spiral-evidence.sh
@@ -2,8 +2,8 @@
 # =============================================================================
 # spiral-evidence.sh — Evidence verification + Flight Recorder for Spiral Harness
 # =============================================================================
-# Version: 1.0.0
-# Part of: Spiral Harness Architecture (cycle-071)
+# Version: 1.1.0
+# Part of: Spiral Harness Architecture (cycle-071, cost optimization cycle-072)
 #
 # Provides:
 #   - Append-only flight recorder (JSONL)
@@ -273,6 +273,85 @@ _summarize_flatline() {
             ([(.arbiter_rejected // .blockers // [])[] | "- " + (.concern // .description // "No description")] | join("\n"))
         else "- None" end)
     ' "$flatline_json" 2>/dev/null || echo ""
+}
+
+# =============================================================================
+# Deterministic Pre-Checks (cycle-072 cost optimization)
+# Fail fast at $0 cost before spending $2-4 on LLM review/audit sessions.
+# =============================================================================
+
+# Validate planning artifacts exist before implementation phase
+# Returns: 0 if ready, 1 if missing required artifacts
+_pre_check_implementation() {
+    local ok=0
+
+    if [[ ! -f "grimoires/loa/prd.md" ]]; then
+        echo "PRE-CHECK FAIL: grimoires/loa/prd.md not found" >&2
+        ok=1
+    fi
+    if [[ ! -f "grimoires/loa/sdd.md" ]]; then
+        echo "PRE-CHECK FAIL: grimoires/loa/sdd.md not found" >&2
+        ok=1
+    fi
+    if [[ ! -f "grimoires/loa/sprint.md" ]]; then
+        echo "PRE-CHECK FAIL: grimoires/loa/sprint.md not found" >&2
+        ok=1
+    fi
+
+    # Sprint plan must have acceptance criteria (checkboxes)
+    if [[ -f "grimoires/loa/sprint.md" ]]; then
+        if ! grep -qE '^\- \[' "grimoires/loa/sprint.md" 2>/dev/null; then
+            echo "PRE-CHECK WARN: sprint.md has no acceptance criteria checkboxes" >&2
+        fi
+    fi
+
+    [[ -n "$_FLIGHT_RECORDER" ]] && \
+        _record_action "PRE_CHECK" "evidence-gate" "implementation_ready" "" "" "" 0 0 0 \
+            "$([ "$ok" -eq 0 ] && echo 'PASS' || echo 'FAIL')"
+
+    return "$ok"
+}
+
+# Validate implementation output before spending $2-4 on LLM review/audit
+# Checks: branch has commits, diff is non-empty, tests exist, no obvious secrets
+# Returns: 0 if ready for review, 1 if structural issues detected
+_pre_check_review() {
+    local branch="${BRANCH:-HEAD}"
+    local issues=0
+
+    # 1. Branch has commits ahead of main
+    local ahead
+    ahead=$(git rev-list --count "main..${branch}" 2>/dev/null || echo "0")
+    if [[ "$ahead" -eq 0 ]]; then
+        echo "PRE-CHECK FAIL: no commits ahead of main on $branch" >&2
+        issues=$((issues + 1))
+    fi
+
+    # 2. Git diff is non-empty (actual code changes exist)
+    local diff_lines
+    diff_lines=$(git diff "main...${branch}" --stat 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$diff_lines" -eq 0 ]]; then
+        echo "PRE-CHECK FAIL: no diff between main and $branch" >&2
+        issues=$((issues + 1))
+    fi
+
+    # 3. Tests exist in the diff (warn, not block)
+    if ! git diff "main...${branch}" --name-only 2>/dev/null | grep -qiE 'test|spec|\.bats'; then
+        echo "PRE-CHECK WARN: no test files in diff (expected for most tasks)" >&2
+    fi
+
+    # 4. No obvious secrets in diff (block on match)
+    if git diff "main...${branch}" 2>/dev/null | \
+        grep -qiE '(password|secret|api_key|private_key)\s*[:=]\s*["\x27][^"\x27]{8,}'; then
+        echo "PRE-CHECK FAIL: possible secret detected in diff" >&2
+        issues=$((issues + 1))
+    fi
+
+    [[ -n "$_FLIGHT_RECORDER" ]] && \
+        _record_action "PRE_CHECK" "evidence-gate" "review_ready" "" "" "" 0 0 0 \
+            "$([ "$issues" -eq 0 ] && echo 'PASS' || echo "FAIL:${issues}_issues")"
+
+    [[ "$issues" -eq 0 ]]
 }
 
 # =============================================================================

--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -2,8 +2,8 @@
 # =============================================================================
 # spiral-harness.sh — Evidence-Gated Orchestrator for /spiral
 # =============================================================================
-# Version: 1.0.0
-# Part of: Spiral Harness Architecture (cycle-071)
+# Version: 1.1.0
+# Part of: Spiral Harness Architecture (cycle-071, cost optimization cycle-072)
 #
 # Replaces monolithic claude -p dispatch with sequenced phases + evidence gates.
 # Each phase is a separate claude -p call. Quality gates run in bash (unskippable).
@@ -58,6 +58,42 @@ AUDIT_BUDGET=$(_read_harness_config "spiral.harness.audit_budget_usd" "2")
 EXECUTOR_MODEL=$(_read_harness_config "spiral.harness.executor_model" "sonnet")
 ADVISOR_MODEL=$(_read_harness_config "spiral.harness.advisor_model" "opus")
 
+# Pipeline Profiles (cycle-072): match intensity to task complexity
+# full    = all 3 Flatline gates + Opus advisor ($15, architecture/security)
+# standard = Sprint Flatline only + Opus advisor ($12, most features) [DEFAULT]
+# light   = no Flatline + Sonnet advisor ($8, bug fixes/flags/config)
+PIPELINE_PROFILE=$(_read_harness_config "spiral.harness.pipeline_profile" "standard")
+
+# Resolve profile to concrete settings
+_resolve_profile() {
+    case "$PIPELINE_PROFILE" in
+        full)
+            FLATLINE_GATES="prd,sdd,sprint"
+            # advisor stays as configured (Opus)
+            ;;
+        standard)
+            FLATLINE_GATES="sprint"
+            # advisor stays as configured (Opus)
+            ;;
+        light)
+            FLATLINE_GATES=""
+            ADVISOR_MODEL="$EXECUTOR_MODEL"  # Sonnet reviews too
+            ;;
+        *)
+            log "Unknown profile '$PIPELINE_PROFILE', falling back to standard"
+            PIPELINE_PROFILE="standard"
+            FLATLINE_GATES="sprint"
+            ;;
+    esac
+}
+_resolve_profile
+
+# Check if a Flatline gate should run for the given phase
+_should_run_flatline() {
+    local phase="$1"
+    [[ ",$FLATLINE_GATES," == *",$phase,"* ]]
+}
+
 log() { echo "[harness] $*" >&2; }
 error() { echo "ERROR: $*" >&2; }
 
@@ -80,6 +116,7 @@ while [[ $# -gt 0 ]]; do
         --branch) BRANCH="$2"; shift 2 ;;
         --budget) TOTAL_BUDGET="$2"; shift 2 ;;
         --seed-context) SEED_CONTEXT="$2"; shift 2 ;;
+        --profile) PIPELINE_PROFILE="$2"; _resolve_profile; shift 2 ;;
         *) error "Unknown option: $1"; exit 2 ;;
     esac
 done
@@ -100,7 +137,8 @@ EVIDENCE_DIR="$CYCLE_DIR/evidence"
 mkdir -p "$EVIDENCE_DIR"
 _init_flight_recorder "$CYCLE_DIR"
 
-log "Harness starting: cycle=$CYCLE_ID branch=$BRANCH budget=\$${TOTAL_BUDGET}"
+log "Harness starting: cycle=$CYCLE_ID branch=$BRANCH budget=\$${TOTAL_BUDGET} profile=$PIPELINE_PROFILE"
+log "Flatline gates: ${FLATLINE_GATES:-none}  Advisor: $ADVISOR_MODEL"
 
 # =============================================================================
 # Claude -p Invocation Helper
@@ -335,35 +373,66 @@ _run_gate() {
 
 main() {
     local pr_url=""
+    local prd_findings="" sdd_findings=""
+
+    _record_action "CONFIG" "spiral-harness" "profile" "" "" "" 0 0 0 \
+        "profile=$PIPELINE_PROFILE gates=${FLATLINE_GATES:-none} advisor=$ADVISOR_MODEL"
 
     # ── Phase 1: Discovery ──────────────────────────────────────────────
-    log "Phase 1/6: DISCOVERY"
+    log "Phase 1: DISCOVERY"
     _phase_discovery || { error "Discovery failed"; exit 1; }
 
-    # ── Gate 1: Flatline PRD ────────────────────────────────────────────
-    _run_gate "FLATLINE_PRD" _gate_flatline "prd" "grimoires/loa/prd.md" || exit 1
-    local prd_findings
-    prd_findings=$(_summarize_flatline "$EVIDENCE_DIR/flatline-prd.json")
+    # ── Gate 1: Flatline PRD (conditional) ──────────────────────────────
+    if _should_run_flatline "prd"; then
+        _run_gate "FLATLINE_PRD" _gate_flatline "prd" "grimoires/loa/prd.md" || exit 1
+        prd_findings=$(_summarize_flatline "$EVIDENCE_DIR/flatline-prd.json")
+    else
+        log "Skipping Flatline PRD (profile=$PIPELINE_PROFILE)"
+        _record_action "GATE_prd" "spiral-harness" "skipped" "" "" "" 0 0 0 "profile=$PIPELINE_PROFILE"
+    fi
 
     # ── Phase 2: Architecture ───────────────────────────────────────────
-    log "Phase 2/6: ARCHITECTURE"
+    log "Phase 2: ARCHITECTURE"
     _phase_architecture "$prd_findings" || { error "Architecture failed"; exit 1; }
 
-    # ── Gate 2: Flatline SDD ────────────────────────────────────────────
-    _run_gate "FLATLINE_SDD" _gate_flatline "sdd" "grimoires/loa/sdd.md" || exit 1
-    local sdd_findings
-    sdd_findings=$(_summarize_flatline "$EVIDENCE_DIR/flatline-sdd.json")
+    # ── Gate 2: Flatline SDD (conditional) ──────────────────────────────
+    if _should_run_flatline "sdd"; then
+        _run_gate "FLATLINE_SDD" _gate_flatline "sdd" "grimoires/loa/sdd.md" || exit 1
+        sdd_findings=$(_summarize_flatline "$EVIDENCE_DIR/flatline-sdd.json")
+    else
+        log "Skipping Flatline SDD (profile=$PIPELINE_PROFILE)"
+        _record_action "GATE_sdd" "spiral-harness" "skipped" "" "" "" 0 0 0 "profile=$PIPELINE_PROFILE"
+    fi
 
     # ── Phase 3: Planning ───────────────────────────────────────────────
-    log "Phase 3/6: PLANNING"
+    log "Phase 3: PLANNING"
     _phase_planning "$sdd_findings" || { error "Planning failed"; exit 1; }
 
-    # ── Gate 3: Flatline Sprint ─────────────────────────────────────────
-    _run_gate "FLATLINE_SPRINT" _gate_flatline "sprint" "grimoires/loa/sprint.md" || exit 1
+    # ── Gate 3: Flatline Sprint (conditional) ───────────────────────────
+    if _should_run_flatline "sprint"; then
+        _run_gate "FLATLINE_SPRINT" _gate_flatline "sprint" "grimoires/loa/sprint.md" || exit 1
+    else
+        log "Skipping Flatline Sprint (profile=$PIPELINE_PROFILE)"
+        _record_action "GATE_sprint" "spiral-harness" "skipped" "" "" "" 0 0 0 "profile=$PIPELINE_PROFILE"
+    fi
+
+    # ── Pre-check: Deterministic validation before Implementation ───────
+    log "Pre-check: validating planning artifacts"
+    if ! _pre_check_implementation; then
+        error "Pre-check failed: planning artifacts incomplete"
+        exit 1
+    fi
 
     # ── Phase 4: Implementation ─────────────────────────────────────────
-    log "Phase 4/6: IMPLEMENTATION"
+    log "Phase 4: IMPLEMENTATION"
     _phase_implement || { error "Implementation failed"; exit 1; }
+
+    # ── Pre-check: Deterministic validation before Review ───────────────
+    log "Pre-check: validating implementation before review"
+    if ! _pre_check_review; then
+        error "Pre-check failed: implementation has structural issues"
+        exit 1
+    fi
 
     # ── Gate 4: Independent Review (fresh session) ──────────────────────
     _run_gate "REVIEW" _gate_review || {
@@ -378,10 +447,10 @@ main() {
     }
 
     # ── Phase 5: PR Creation (bash — deterministic) ─────────────────────
-    log "Phase 5/6: PR CREATION"
+    log "Phase 5: PR CREATION"
     pr_url=$(gh pr create \
         --title "feat($CYCLE_ID): $(echo "$TASK" | head -c 60)" \
-        --body "Autonomous spiral cycle. See flight recorder for evidence trail." \
+        --body "Autonomous spiral cycle. Profile: $PIPELINE_PROFILE. See flight recorder for evidence trail." \
         --draft 2>/dev/null || true)
 
     if [[ -n "$pr_url" ]]; then
@@ -397,7 +466,7 @@ main() {
     # ── Finalize ────────────────────────────────────────────────────────
     _finalize_flight_recorder "$CYCLE_DIR"
 
-    log "Harness complete: cycle=$CYCLE_ID"
+    log "Harness complete: cycle=$CYCLE_ID profile=$PIPELINE_PROFILE"
     log "Flight recorder: $CYCLE_DIR/flight-recorder.jsonl"
     log "Evidence: $EVIDENCE_DIR/"
     [[ -n "$pr_url" ]] && log "PR: $pr_url"

--- a/.claude/scripts/spiral-orchestrator.sh
+++ b/.claude/scripts/spiral-orchestrator.sh
@@ -402,6 +402,36 @@ check_hitl_halt() {
     [[ -f "$HALT_SENTINEL" ]]
 }
 
+# check_token_window — cycle-072 scheduling
+# Returns 0 (STOP) if current time is past the configured scheduling window end.
+# Returns 1 (CONTINUE) if no window configured or still within window.
+check_token_window() {
+    local window_end_utc
+    window_end_utc=$(read_config "spiral.scheduling.windows[0].end_utc" "")
+    [[ -z "$window_end_utc" ]] && return 1  # No window configured — never triggers
+
+    # Parse HH:MM into today's epoch
+    local today_date now_epoch end_epoch
+    today_date=$(date -u +%Y-%m-%d)
+    now_epoch=$(date -u +%s)
+    end_epoch=$(date -u -d "${today_date}T${window_end_utc}:00Z" +%s 2>/dev/null \
+        || date -u -j -f "%Y-%m-%dT%H:%MZ" "${today_date}T${window_end_utc}Z" +%s 2>/dev/null \
+        || echo "0")
+
+    if [[ "$end_epoch" -eq 0 ]]; then
+        log "WARNING: could not parse scheduling window end '$window_end_utc'"
+        return 1  # Can't parse — don't trigger
+    fi
+
+    if [[ "$now_epoch" -ge "$end_epoch" ]]; then
+        log_trajectory "token_window_exhausted" \
+            "$(jq -n --arg end "$window_end_utc" --arg now "$(date -u +%H:%M)" \
+                '{decision: "stop", window_end: $end, current_time: $now}')"
+        return 0
+    fi
+    return 1
+}
+
 # check_quality_gate — FR-2 (cycle-067)
 # Returns 0 if gate should STOP spiral (fail-closed on missing/invalid).
 # Returns 1 if spiral should CONTINUE.
@@ -478,6 +508,10 @@ evaluate_stopping_conditions() {
     fi
     if check_wall_clock; then
         echo "wall_clock_exhausted"
+        return 0
+    fi
+    if check_token_window; then
+        echo "token_window_exhausted"
         return 0
     fi
     echo ""

--- a/.claude/scripts/spiral-orchestrator.sh
+++ b/.claude/scripts/spiral-orchestrator.sh
@@ -404,8 +404,14 @@ check_hitl_halt() {
 
 # check_token_window — cycle-072 scheduling
 # Returns 0 (STOP) if current time is past the configured scheduling window end.
-# Returns 1 (CONTINUE) if no window configured or still within window.
+# Returns 1 (CONTINUE) if no window configured, continuous mode, or still within window.
 check_token_window() {
+    # Continuous mode: operator wants scheduler to keep running without time bounds.
+    # Other stopping conditions (cost, cycles, wall-clock, HITL halt) still apply.
+    local strategy
+    strategy=$(read_config "spiral.scheduling.strategy" "fill")
+    [[ "$strategy" == "continuous" ]] && return 1  # Never triggers — run until other conditions stop
+
     local window_end_utc
     window_end_utc=$(read_config "spiral.scheduling.windows[0].end_utc" "")
     [[ -z "$window_end_utc" ]] && return 1  # No window configured — never triggers

--- a/.claude/scripts/spiral-scheduler.sh
+++ b/.claude/scripts/spiral-scheduler.sh
@@ -102,7 +102,12 @@ trap 'rm -f "$LOCK_FILE"' EXIT
 # =============================================================================
 
 # Verify we're within a configured scheduling window
+# strategy=continuous bypasses window check entirely
 _in_window() {
+    local strategy
+    strategy=$(_read_config "spiral.scheduling.strategy" "fill")
+    [[ "$strategy" == "continuous" ]] && return 0  # Continuous mode — always in window
+
     local start_utc end_utc
     start_utc=$(_read_config "spiral.scheduling.windows[0].start_utc" "")
     end_utc=$(_read_config "spiral.scheduling.windows[0].end_utc" "")

--- a/.claude/scripts/spiral-scheduler.sh
+++ b/.claude/scripts/spiral-scheduler.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# =============================================================================
+# spiral-scheduler.sh — Off-Hours Scheduling Wrapper for /spiral
+# =============================================================================
+# Version: 1.0.0
+# Part of: Spiral Cost Optimization (cycle-072)
+#
+# Entry point for scheduled (cron/trigger) spiral execution. Checks for
+# an existing HALTED spiral to resume, or starts a new one from backlog.
+# Designed to be invoked by CronCreate or RemoteTrigger during off-hours
+# token allowance windows.
+#
+# Usage:
+#   spiral-scheduler.sh [--profile standard] [--max-cycles 3]
+#
+# Scheduling (inside Claude Code):
+#   CronCreate: schedule "0 2 * * *", task "spiral-scheduler.sh"
+#   /schedule:  /schedule create --name spiral-nightly --cron "0 2 * * *"
+#
+# Exit codes:
+#   0   — Completed (spiral finished or halted at window end)
+#   1   — Error (config, state, or dispatch failure)
+#   2   — Scheduling disabled in config
+#   3   — Already running (PID guard)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/bootstrap.sh" 2>/dev/null || true
+
+STATE_FILE="${PROJECT_ROOT:-.}/.run/spiral-state.json"
+CONFIG="${PROJECT_ROOT:-.}/.loa.config.yaml"
+LOCK_FILE="${PROJECT_ROOT:-.}/.run/spiral-scheduler.lock"
+
+log() { echo "[scheduler] $(date -u +%H:%M:%SZ) $*" >&2; }
+error() { echo "ERROR: $*" >&2; }
+
+# =============================================================================
+# Config
+# =============================================================================
+
+_read_config() {
+    local key="$1" default="$2"
+    [[ ! -f "$CONFIG" ]] && { echo "$default"; return 0; }
+    local value
+    value=$(yq eval ".$key // null" "$CONFIG" 2>/dev/null || echo "null")
+    [[ "$value" == "null" || -z "$value" ]] && { echo "$default"; return 0; }
+    echo "$value"
+}
+
+# =============================================================================
+# Arguments
+# =============================================================================
+
+PROFILE=$(_read_config "spiral.harness.pipeline_profile" "standard")
+MAX_CYCLES=$(_read_config "spiral.scheduling.max_cycles_per_window" "3")
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --profile) PROFILE="$2"; shift 2 ;;
+        --max-cycles) MAX_CYCLES="$2"; shift 2 ;;
+        *) error "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# =============================================================================
+# Guards
+# =============================================================================
+
+# Check scheduling is enabled
+scheduling_enabled=$(_read_config "spiral.scheduling.enabled" "false")
+if [[ "$scheduling_enabled" != "true" ]]; then
+    log "Scheduling disabled (spiral.scheduling.enabled != true)"
+    exit 2
+fi
+
+# Check spiral is enabled
+spiral_enabled=$(_read_config "spiral.enabled" "false")
+if [[ "$spiral_enabled" != "true" ]]; then
+    log "Spiral disabled (spiral.enabled != true)"
+    exit 2
+fi
+
+# PID guard — prevent double execution
+if [[ -f "$LOCK_FILE" ]]; then
+    existing_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
+        log "Already running (PID $existing_pid)"
+        exit 3
+    fi
+    log "Stale lock file (PID $existing_pid not running), cleaning up"
+    rm -f "$LOCK_FILE"
+fi
+
+# Write PID lock
+echo "$$" > "$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"' EXIT
+
+# =============================================================================
+# Window Check
+# =============================================================================
+
+# Verify we're within a configured scheduling window
+_in_window() {
+    local start_utc end_utc
+    start_utc=$(_read_config "spiral.scheduling.windows[0].start_utc" "")
+    end_utc=$(_read_config "spiral.scheduling.windows[0].end_utc" "")
+
+    [[ -z "$start_utc" || -z "$end_utc" ]] && return 0  # No window = always OK
+
+    local today now_epoch start_epoch end_epoch
+    today=$(date -u +%Y-%m-%d)
+    now_epoch=$(date -u +%s)
+    start_epoch=$(date -u -d "${today}T${start_utc}:00Z" +%s 2>/dev/null || echo "0")
+    end_epoch=$(date -u -d "${today}T${end_utc}:00Z" +%s 2>/dev/null || echo "0")
+
+    [[ "$start_epoch" -eq 0 || "$end_epoch" -eq 0 ]] && return 0  # Parse fail = allow
+
+    [[ "$now_epoch" -ge "$start_epoch" && "$now_epoch" -lt "$end_epoch" ]]
+}
+
+if ! _in_window; then
+    log "Outside scheduling window, exiting"
+    exit 0
+fi
+
+log "Scheduling window active. Profile=$PROFILE MaxCycles=$MAX_CYCLES"
+
+# =============================================================================
+# Dispatch: Resume or Start
+# =============================================================================
+
+if [[ -f "$STATE_FILE" ]]; then
+    state=$(jq -r '.state' "$STATE_FILE" 2>/dev/null || echo "unknown")
+    case "$state" in
+        HALTED)
+            log "Found HALTED spiral, resuming"
+            "$SCRIPT_DIR/spiral-orchestrator.sh" --resume
+            exit $?
+            ;;
+        RUNNING)
+            log "Spiral already RUNNING (stale state?), skipping"
+            exit 3
+            ;;
+        COMPLETED|FAILED)
+            log "Previous spiral $state, starting fresh"
+            ;;
+        *)
+            log "Unknown state '$state', starting fresh"
+            ;;
+    esac
+fi
+
+# Start a new spiral
+log "Starting new spiral: profile=$PROFILE max-cycles=$MAX_CYCLES"
+"$SCRIPT_DIR/spiral-orchestrator.sh" \
+    --start \
+    --max-cycles "$MAX_CYCLES" \
+    --budget-cents "$(_read_config "spiral.max_total_budget_usd" "50")00"
+
+exit $?

--- a/.claude/skills/spiraling/SKILL.md
+++ b/.claude/skills/spiraling/SKILL.md
@@ -2,20 +2,16 @@
 
 ## Status
 
-**MVP scaffolding (v0.1.0)**. This skill provides the state machine, stopping-condition enforcement, and CLI surface for `/spiral`. **Cycle dispatch is not yet wired** — `--start` initializes state and validates config but does not yet invoke embedded `/simstim` cycles. That lands in a follow-up cycle (067+).
-
-Use this skill today for:
-- Understanding the spiral state model
-- Testing stopping-condition logic
-- Preparing `.loa.config.yaml` for production use
-
-Full autonomous multi-cycle dispatch coming soon.
+**Production (v1.1.0)**. Full autonomous multi-cycle dispatch with evidence-gated harness, pipeline profiles for cost optimization, and off-hours scheduling.
 
 ## Reference
 
 - RFC-060 design doc: `grimoires/loa/proposals/rfc-060-spiral.md`
+- Harness architecture: `grimoires/loa/proposals/spiral-harness-architecture.md`
+- Cost optimization: `grimoires/loa/proposals/spiral-cost-optimization.md`
+- Benchmark report: `grimoires/loa/reports/spiral-harness-benchmark-report.md`
 - Umbrella issue: #483
-- Script: `.claude/scripts/spiral-orchestrator.sh`
+- Scripts: `.claude/scripts/spiral-orchestrator.sh`, `spiral-harness.sh`, `spiral-scheduler.sh`
 
 ## Usage
 
@@ -135,9 +131,59 @@ All spiral events log to `grimoires/loa/a2a/trajectory/spiral-{date}.jsonl`:
 
 `/spiral` is the meta-layer that composes these. It does NOT reimplement any of them.
 
-## Known Limitations (v0.1.0)
+## Pipeline Profiles (cycle-072)
 
-- Embedded `/simstim` dispatch is stubbed — `--start` initializes state only
-- SEED phase context-loading not yet wired (blocked on vision registry graduation #486)
-- No auto-retry on embedded cycle failure (operator resolves, then `--resume`)
+Match pipeline intensity to task complexity. Default: `standard`.
+
+| Profile | Flatline Gates | Advisor Model | Budget | Use For |
+|---------|----------------|---------------|--------|---------|
+| `full` | PRD + SDD + Sprint | Opus | $15 | Architecture, security-critical |
+| `standard` | Sprint only | Opus | $12 | Feature work (default) |
+| `light` | None | Sonnet | $8 | Bug fixes, flags, config |
+
+```bash
+# Override per-cycle via CLI
+spiral-harness.sh --task "..." --profile light ...
+
+# Or set default in config
+spiral.harness.pipeline_profile: standard
+```
+
+**Rationale**: Benchmark data (PRs #503/#504) proved PRD/SDD Flatline gates generate debate but don't improve final output for bounded tasks. Sprint Flatline catches AC gaps — never skip. Review+Audit independence is essential.
+
+## Off-Hours Scheduling (cycle-072)
+
+Run spiral cycles during AFK/sleep windows against included token allowances.
+
+```yaml
+spiral:
+  scheduling:
+    enabled: true
+    windows:
+      - start_utc: "02:00"        # When to begin
+        end_utc: "08:00"          # When to halt gracefully
+        days: [mon, tue, wed, thu, fri]
+    strategy: fill                  # Use full window
+    max_cycles_per_window: 3
+```
+
+**How it works**:
+1. Cron fires at window start (e.g., 02:00 UTC)
+2. `spiral-scheduler.sh` checks for HALTED spiral to resume, or starts new one
+3. Spiral runs until `token_window_exhausted` stopping condition fires at window end
+4. Next window: picks up where it stopped via `--resume`
+
+Schedule via Claude Code:
+```bash
+# Session-scoped (leave Claude Code open)
+CronCreate: schedule "0 2 * * *", task "spiral-scheduler.sh"
+
+# Persistent (runs even offline)
+/schedule create --name spiral-nightly --cron "0 2 * * *"
+```
+
+## Known Limitations
+
 - Single-operator, single-repo only
+- Scheduling requires Claude Code session (CronCreate) or remote trigger (/schedule)
+- Token window tracking uses wall-clock time, not actual token counts (Anthropic API does not expose remaining quota programmatically)

--- a/.claude/skills/spiraling/SKILL.md
+++ b/.claude/skills/spiraling/SKILL.md
@@ -163,7 +163,7 @@ spiral:
       - start_utc: "02:00"        # When to begin
         end_utc: "08:00"          # When to halt gracefully
         days: [mon, tue, wed, thu, fri]
-    strategy: fill                  # Use full window
+    strategy: fill                  # "fill" | "single" | "continuous" (ignores window, runs until cost/cycles/halt)
     max_cycles_per_window: 3
 ```
 
@@ -187,3 +187,4 @@ CronCreate: schedule "0 2 * * *", task "spiral-scheduler.sh"
 - Single-operator, single-repo only
 - Scheduling requires Claude Code session (CronCreate) or remote trigger (/schedule)
 - Token window tracking uses wall-clock time, not actual token counts (Anthropic API does not expose remaining quota programmatically)
+- `strategy: continuous` ignores scheduling windows — spiral runs until cost budget, cycle budget, wall-clock, or HITL halt stops it

--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -125,6 +125,18 @@ spiral:
     # ~60% cost reduction vs all-Opus. See https://claude.com/blog/the-advisor-strategy
     executor_model: sonnet           # PRD, SDD, Sprint, Implementation
     advisor_model: opus              # Review, Audit (judgment quality)
+    # Pipeline Profiles (cycle-072): full | standard | light
+    pipeline_profile: standard       # Sprint Flatline only + Opus advisor ($12)
+
+  # Off-Hours Scheduling (cycle-072)
+  scheduling:
+    enabled: false
+    windows:
+      - start_utc: "02:00"
+        end_utc: "08:00"
+        days: [mon, tue, wed, thu, fri]
+    strategy: fill
+    max_cycles_per_window: 3
 
 # Prompt Isolation (v1.42.0 — cycle-042)
 # De-authorization wrappers for untrusted content in LLM prompts.

--- a/.loa.config.yaml.example
+++ b/.loa.config.yaml.example
@@ -1684,7 +1684,7 @@ spiral:
       - start_utc: "02:00"          # When to begin (HH:MM UTC)
         end_utc: "08:00"            # When to halt gracefully
         days: [mon, tue, wed, thu, fri]
-    strategy: fill                   # "fill" = use full window; "single" = one cycle only
+    strategy: fill                   # "fill" = use full window; "single" = one cycle; "continuous" = ignore window, run until other conditions stop
     max_cycles_per_window: 3         # Safety cap per scheduling window
 
 # Prompt Isolation (v1.42.0)

--- a/.loa.config.yaml.example
+++ b/.loa.config.yaml.example
@@ -1648,6 +1648,45 @@ spiral:
   # HITL halt sentinel — creating this file mid-spiral halts gracefully.
   halt_sentinel: ".run/spiral-halt"
 
+  # ── Evidence-Gated Harness (cycle-071) ──────────────────────────────
+  # Phase-as-subprocess: each phase is a separate claude -p call.
+  # Gate-as-script: Flatline/Review/Audit run in bash (LLM cannot skip).
+  harness:
+    enabled: true                    # Use harness vs monolithic dispatch
+    max_phase_retries: 3             # Retries per gate on failure
+
+    # Per-phase budget caps (claude -p --max-budget-usd)
+    planning_budget_usd: 1           # PRD, SDD, Sprint (each)
+    implement_budget_usd: 5          # Code + tests + commit
+    review_budget_usd: 2             # Independent review session
+    audit_budget_usd: 2              # Independent audit session
+
+    # Advisor Strategy: Sonnet executes (~5x cheaper), Opus judges.
+    # See: grimoires/loa/reports/spiral-harness-benchmark-report.md
+    executor_model: sonnet           # PRD, SDD, Sprint, Implementation
+    advisor_model: opus              # Review, Audit (judgment quality)
+
+    # Pipeline Profiles (cycle-072): match intensity to task complexity.
+    # full     = all 3 Flatline gates + Opus advisor ($15 budget)
+    # standard = Sprint Flatline only + Opus advisor ($12 budget) [DEFAULT]
+    # light    = no Flatline + Sonnet advisor ($8 budget)
+    # Override per-cycle: --profile light
+    pipeline_profile: standard
+
+  # ── Off-Hours Scheduling (cycle-072) ────────────────────────────────
+  # Run spiral cycles during AFK/sleep windows against included token
+  # allowances instead of burning paid overage.
+  # Entry point: .claude/scripts/spiral-scheduler.sh
+  # Schedule via: CronCreate, RemoteTrigger, or /schedule skill
+  scheduling:
+    enabled: false                   # Must opt-in
+    windows:
+      - start_utc: "02:00"          # When to begin (HH:MM UTC)
+        end_utc: "08:00"            # When to halt gracefully
+        days: [mon, tue, wed, thu, fri]
+    strategy: fill                   # "fill" = use full window; "single" = one cycle only
+    max_cycles_per_window: 3         # Safety cap per scheduling window
+
 # Prompt Isolation (v1.42.0)
 # De-authorization wrappers for untrusted content in LLM prompts.
 # Wraps external/user content in de-authorization envelope that prevents

--- a/grimoires/loa/proposals/spiral-cost-optimization.md
+++ b/grimoires/loa/proposals/spiral-cost-optimization.md
@@ -1,0 +1,54 @@
+# Proposal: Spiral Cost Optimization + Off-Hours Scheduling
+
+**Date**: 2026-04-15
+**Author**: Cost analysis session
+**Status**: Approved
+**Depends on**: v1.88.0 (spiral harness shipped)
+
+---
+
+## Problem
+
+A single spiral cycle costs ~$15-20 ($12 harness budget + $3-4 Flatline API). A 3-cycle spiral runs $45-60. Every cycle runs the full 9-phase pipeline regardless of task complexity. The user also has unused token allowance windows during AFK/sleep time.
+
+## Solution: Four Tiers
+
+### Tier 1: Pipeline Profiles
+
+Three profiles that match pipeline intensity to task complexity:
+
+| Profile | Phases | Flatline Gates | Advisor | Budget | Use For |
+|---------|--------|----------------|---------|--------|---------|
+| `full` | 9 | PRD + SDD + Sprint | Opus | $15 | Architecture, security-critical |
+| `standard` | 7 | Sprint only | Opus | $12 | Feature work (default) |
+| `light` | 6 | None | Sonnet | $8 | Bug fixes, flags, config |
+
+**Evidence**: Benchmark data shows PRD/SDD Flatline gates generated 9-15 blockers across runs, but both implementations passed Review+Audit first try regardless. Sprint Flatline catches AC gaps — never skip.
+
+### Tier 2: Deterministic Pre-Gates
+
+Bash pre-checks before expensive LLM Review/Audit sessions:
+- Git diff exists and is non-empty
+- Sprint.md has acceptance criteria checkboxes
+- Tests exist in the diff
+- No secrets detected in diff
+
+Fails fast at $0 cost instead of discovering these at $2-4 per LLM session.
+
+### Tier 3: Flatline Prompt Caching
+
+Structure Flatline API calls to use Claude's prompt caching (0.1x cost on cache reads, 5-minute TTL). Three gates fire within 8 minutes — second and third gates read from cache. Saves ~$1.15/cycle.
+
+### Tier 4: Off-Hours Scheduling
+
+Use Claude Code scheduling primitives (CronCreate / RemoteTrigger) to run spiral cycles during AFK/sleep windows. New `check_token_window()` stopping condition halts at window end. Spiral resumes next window via `--resume`.
+
+## Projected Savings
+
+| Profile | Before | After | Reduction |
+|---------|--------|-------|-----------|
+| `full` | $15-20 | $14-17 | 10-15% |
+| `standard` | $15-20 | $10-13 | 30-35% |
+| `light` | $15-20 | $6-8 | 55-60% |
+
+With off-hours scheduling, token spend moves from paid overage to included allowance.


### PR DESCRIPTION
## Summary

- **Pipeline profiles** (`full`/`standard`/`light`) match harness intensity to task complexity — `standard` is the new default, skipping PRD/SDD Flatline gates that the benchmark proved are insurance, not load-bearing
- **Deterministic pre-checks** fail fast at $0 cost before spending $2-4 on LLM review/audit sessions — validates diff exists, tests present, no secrets
- **Off-hours scheduling** via `spiral-scheduler.sh` + `check_token_window()` stopping condition — run cycles during sleep/AFK windows against included token allowances
- **Design proposal** at `grimoires/loa/proposals/spiral-cost-optimization.md`

### Cost Impact

| Profile | Before | After | Savings |
|---------|--------|-------|---------|
| `full` (architecture) | $15-20 | $14-17 | 10-15% |
| `standard` (features) | $15-20 | $10-13 | **30-35%** |
| `light` (bugs/flags) | $15-20 | $6-8 | **55-60%** |

### Files Changed (8 files, +530/-35)

| File | Change |
|------|--------|
| `spiral-harness.sh` | Pipeline profiles, conditional Flatline gates, profile CLI flag |
| `spiral-evidence.sh` | `_pre_check_implementation()`, `_pre_check_review()` |
| `spiral-orchestrator.sh` | `check_token_window()` stopping condition |
| `spiral-scheduler.sh` | **New** — cron/trigger wrapper for off-hours dispatch |
| `SKILL.md` | Pipeline profiles + scheduling documentation |
| `.loa.config.yaml` | `pipeline_profile: standard`, scheduling config |
| `.loa.config.yaml.example` | Full harness + scheduling config with comments |
| `spiral-cost-optimization.md` | **New** — design proposal |

## Test plan

- [ ] `bash -n` passes on all 4 scripts (verified)
- [ ] `yq` reads pipeline_profile and scheduling config correctly (verified)
- [ ] `_should_run_flatline "sprint"` returns true for standard profile
- [ ] `_should_run_flatline "prd"` returns false for standard profile
- [ ] `_pre_check_review` fails when no commits ahead of main
- [ ] `check_token_window` returns 1 (continue) when no window configured
- [ ] Scheduling: verify `spiral-scheduler.sh` exits 2 when scheduling disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)