### PR TITLE
fix(spiraling): dispatch guard — NEVER implement directly in conversation

### DIFF
--- a/.claude/data/constraints.json
+++ b/.claude/data/constraints.json
@@ -1330,6 +1330,32 @@
         }
       ],
       "severity": "low"
+    },
+    {
+      "id": "C-PROC-017",
+      "name": "spiral_must_dispatch_through_harness",
+      "category": "process",
+      "rule_type": "NEVER",
+      "text": "implement code directly in conversation when `/spiraling` is invoked with a task — dispatch through `/run sprint-plan`, `/simstim`, or `spiral-harness.sh` instead",
+      "text_variants": {
+        "claude-loa-md": "NEVER implement code directly when `/spiraling` is invoked with a task — dispatch through the harness pipeline (`/run sprint-plan`, `/simstim`, or `spiral-harness.sh`)"
+      },
+      "why": "`/spiraling` loads as context, not as an orchestrator. Without mechanical dispatch, the agent bypasses all quality gates (Flatline, Review, Audit, Bridgebuilder) — the fox-guarding-the-henhouse antipattern that the harness was built to prevent.",
+      "order": 5,
+      "layers": [
+        {
+          "target": "claude-loa-md",
+          "section": "process_compliance_never",
+          "render_as": "table_row"
+        },
+        {
+          "target": "skill-md",
+          "skills": ["spiraling"],
+          "render_as": "constraint_rule"
+        }
+      ],
+      "severity": "critical",
+      "source_incident": "#506"
     }
   ]
 }

--- a/.claude/loa/CLAUDE.loa.md
+++ b/.claude/loa/CLAUDE.loa.md
@@ -103,6 +103,7 @@ Grimoire and state file locations configurable via `.loa.config.yaml`. Overrides
 | NEVER skip from sprint plan directly to implementation without `/run sprint-plan`, `/run sprint-N`, or `/bug` triage (OR when a construct with `workflow.gates` declares pipeline composition) | `/run` wraps implement+review+audit in a cycle loop with circuit breaker. `/bug` produces a triage handoff that feeds directly into `/implement`. |
 | NEVER skip `/review-sprint` and `/audit-sprint` quality gates (Yield when construct declares `review: skip` or `audit: skip`) | These are the only validation that code meets acceptance criteria and security standards |
 | NEVER use `/bug` for feature work that doesn't reference an observed failure | `/bug` bypasses PRD/SDD gates; feature work must go through `/plan` |
+| NEVER implement code directly when `/spiraling` is invoked with a task — dispatch through the harness pipeline (`/run sprint-plan`, `/simstim`, or `spiral-harness.sh`) | `/spiraling` loads as context, not as an orchestrator. Without mechanical dispatch, the agent bypasses all quality gates (Flatline, Review, Audit, Bridgebuilder) — the fox-guarding-the-henhouse antipattern that the harness was built to prevent. |
 <!-- @constraint-generated: end process_compliance_never -->
 ### ALWAYS Rules
 

--- a/.claude/skills/spiraling/SKILL.md
+++ b/.claude/skills/spiraling/SKILL.md
@@ -1,15 +1,21 @@
 # Spiraling — /spiral Autopoietic Meta-Orchestrator
 
+## DISPATCH GUARD — READ THIS FIRST
+
+**When this skill is invoked with a task, you MUST dispatch through the harness pipeline. You MUST NOT implement code directly in conversation.**
+
+Route to ONE of:
+1. `/run sprint-plan` — if a sprint plan already exists
+2. `/simstim` — for full single-cycle plan→build→review→audit
+3. `spiral-harness.sh` — for evidence-gated autonomous execution
+
+**Why**: This skill loads as context, not as an orchestrator. If you implement directly, you bypass Flatline, independent Review, independent Audit, and Bridgebuilder — all quality gates become self-certification. This is the fox-guarding-the-henhouse antipattern (cycle-070 E2E Lesson #1).
+
+Research and design exploration (reading code, web search, writing proposals) is fine in conversation. Writing or modifying application/framework code is not.
+
 ## Status
 
-**MVP scaffolding (v0.1.0)**. This skill provides the state machine, stopping-condition enforcement, and CLI surface for `/spiral`. **Cycle dispatch is not yet wired** — `--start` initializes state and validates config but does not yet invoke embedded `/simstim` cycles. That lands in a follow-up cycle (067+).
-
-Use this skill today for:
-- Understanding the spiral state model
-- Testing stopping-condition logic
-- Preparing `.loa.config.yaml` for production use
-
-Full autonomous multi-cycle dispatch coming soon.
+**Production (v1.1.0)**. Full autonomous multi-cycle dispatch with evidence-gated harness.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

When `/spiraling` is invoked with a task, the agent bypassed all quality gates and implemented code directly in conversation (PR #506). This fix adds a three-layer guard to prevent recurrence.

### Root Cause

`/spiraling` loads `SKILL.md` as context — it doesn't mechanically dispatch through the pipeline. The existing NEVER rule ("never write code outside /implement") was an instruction the agent chose not to follow, not a gate it couldn't bypass.

### Fix (3 layers)

1. **SKILL.md dispatch guard** — prominent warning at the top of the skill, before any other content. Routes to `/run sprint-plan`, `/simstim`, or `spiral-harness.sh`.
2. **C-PROC-017 in constraints.json** — new NEVER rule with critical severity, source incident #506
3. **CLAUDE.loa.md NEVER table row** — loaded into every conversation via CLAUDE.md import

### What this doesn't fix

These are all agent-level instructions, not mechanical gates. A sufficiently confused agent could still bypass them. The real mechanical fix is making `/spiraling` dispatch through `spiral-harness.sh` as a subprocess — but that requires the harness to be fully wired for arbitrary tasks, which is the work that PR #506 was supposed to do (properly, through the pipeline).

## Test plan

- [ ] Invoke `/spiraling` with a task — agent should route to `/run sprint-plan` or `/simstim`, not implement directly
- [ ] Constraint C-PROC-017 appears in constraints.json with critical severity
- [ ] NEVER rule appears in CLAUDE.loa.md table

🤖 Generated with [Claude Code](https://claude.com/claude-code)