### PR TITLE
feat(harness): Bridgebuilder kaironic fix loop (cycle-074) (#512)

### DIFF
--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -57,6 +57,10 @@ IMPLEMENT_BUDGET=$(_read_harness_config "spiral.harness.implement_budget_usd" "5
 REVIEW_BUDGET=$(_read_harness_config "spiral.harness.review_budget_usd" "2")
 AUDIT_BUDGET=$(_read_harness_config "spiral.harness.audit_budget_usd" "2")
 
+# BB Fix Loop config (cycle-074): budget and iteration caps for the fix loop
+BB_FIX_BUDGET=$(_read_harness_config "spiral.harness.bb_fix_budget_usd" "3")
+BB_MAX_ITERATIONS=$(_read_harness_config "spiral.harness.bb_max_iterations" "3")
+
 # Advisor Strategy (cycle-071): Sonnet executes, Opus judges
 EXECUTOR_MODEL=$(_read_harness_config "spiral.harness.executor_model" "sonnet")
 ADVISOR_MODEL=$(_read_harness_config "spiral.harness.advisor_model" "opus")
@@ -377,7 +381,9 @@ _gate_bridgebuilder() {
 
     local entry_script="$SCRIPT_DIR/../skills/bridgebuilder-review/resources/entry.sh"
     if [[ -x "$entry_script" ]]; then
-        "$entry_script" --pr "$pr_number" 2>"$EVIDENCE_DIR/bridgebuilder-stderr.log" || true
+        "$entry_script" --pr "$pr_number" \
+            >"$EVIDENCE_DIR/bb-review-iter-1.md" \
+            2>"$EVIDENCE_DIR/bridgebuilder-stderr.log" || true
         _record_action "GATE_BRIDGEBUILDER" "bridgebuilder" "pr_review" "" "" "" 0 0 0 "posted"
     else
         log "Bridgebuilder not available, skipping"
@@ -410,6 +416,487 @@ _run_gate() {
     error "Circuit breaker: $gate_name failed after $MAX_RETRIES attempts"
     return 1
 }
+
+# =============================================================================
+# BB Fix Loop — Supporting Functions (cycle-074)
+# =============================================================================
+
+# _bb_triage_findings <findings_json_path>
+#
+# Classifies findings from a parsed JSON file into actionable and non-actionable.
+# Sets in caller scope:
+#   _BB_ACTIONABLE_IDS   — bash array of finding IDs to fix
+#   _BB_ACTIONABLE_JSON  — JSON array of actionable finding objects
+#   _BB_NONACTIONABLE_JSON — JSON array of non-actionable findings
+#
+# Side effect: PRAISE and LOW findings appended to .run/bridge-lore-candidates.jsonl
+_bb_triage_findings() {
+    local findings_json_path="$1"
+
+    _BB_ACTIONABLE_IDS=()
+    _BB_ACTIONABLE_JSON="[]"
+    _BB_NONACTIONABLE_JSON="[]"
+
+    if [[ ! -f "$findings_json_path" ]]; then
+        log "WARNING: findings file not found: $findings_json_path — treating as zero actionable"
+        return 0
+    fi
+
+    if ! jq empty "$findings_json_path" 2>/dev/null; then
+        log "WARNING: findings file is not valid JSON: $findings_json_path — treating as zero actionable"
+        return 0
+    fi
+
+    local findings_json
+    findings_json=$(jq -c '.findings // []' "$findings_json_path" 2>/dev/null || echo "[]")
+
+    # Classify each finding using jq (no shell interpolation of finding data)
+    _BB_ACTIONABLE_JSON=$(jq -c '[.[] | select(
+        (.severity == "CRITICAL") or
+        (.severity == "HIGH") or
+        (.severity == "MEDIUM" and ((.confidence // 1.0) | . > 0.7))
+    )]' <<< "$findings_json" 2>/dev/null || echo "[]")
+
+    _BB_NONACTIONABLE_JSON=$(jq -c '[.[] | select(
+        (.severity == "LOW") or
+        (.severity == "PRAISE") or
+        (.severity == "VISION") or
+        (.severity == "SPECULATION") or
+        (.severity == "REFRAME") or
+        (.severity == "MEDIUM" and ((.confidence // 1.0) | . <= 0.7))
+    )]' <<< "$findings_json" 2>/dev/null || echo "[]")
+
+    # Build _BB_ACTIONABLE_IDS array
+    local ids_json
+    ids_json=$(jq -r '.[].id' <<< "$_BB_ACTIONABLE_JSON" 2>/dev/null || true)
+    while IFS= read -r id; do
+        [[ -n "$id" ]] && _BB_ACTIONABLE_IDS+=("$id")
+    done <<< "$ids_json"
+
+    # Append PRAISE and LOW to lore candidates (consistent with post-pr-triage.sh)
+    local lore_candidates_file="${PROJECT_ROOT:-.}/.run/bridge-lore-candidates.jsonl"
+    local lore_entries
+    lore_entries=$(jq -c '.[] | select(.severity == "PRAISE" or .severity == "LOW")' \
+        <<< "$findings_json" 2>/dev/null || true)
+    if [[ -n "$lore_entries" ]]; then
+        mkdir -p "$(dirname "$lore_candidates_file")"
+        while IFS= read -r entry; do
+            [[ -n "$entry" ]] && printf '%s\n' "$entry" >> "$lore_candidates_file"
+        done <<< "$lore_entries"
+    fi
+
+    log "Triage complete: ${#_BB_ACTIONABLE_IDS[@]} actionable, $(jq 'length' <<< "$_BB_NONACTIONABLE_JSON") non-actionable"
+    return 0
+}
+
+# _bb_detect_stuck_findings
+#
+# Compares _BB_ACTIONABLE_IDS against _BB_PREV_ACTIONABLE_IDS. Findings
+# appearing in both are "stuck" — added to _BB_STUCK_IDS, BB_FINDING_STUCK
+# flight recorder event emitted for each new stuck finding.
+#
+# Reads from caller scope: _BB_ACTIONABLE_IDS, _BB_PREV_ACTIONABLE_IDS,
+#   _BB_STUCK_IDS, _BB_CURRENT_ITER, _BB_ACTIONABLE_JSON
+_bb_detect_stuck_findings() {
+    for id in ${_BB_ACTIONABLE_IDS[@]+"${_BB_ACTIONABLE_IDS[@]}"}; do
+        # Check if in previous actionable IDs
+        local in_prev=false
+        for prev_id in ${_BB_PREV_ACTIONABLE_IDS[@]+"${_BB_PREV_ACTIONABLE_IDS[@]}"}; do
+            if [[ "$id" == "$prev_id" ]]; then
+                in_prev=true
+                break
+            fi
+        done
+        [[ "$in_prev" == "false" ]] && continue
+
+        # Check if already in stuck list (avoid duplicate events)
+        local already_stuck=false
+        for stuck_id in ${_BB_STUCK_IDS[@]+"${_BB_STUCK_IDS[@]}"}; do
+            if [[ "$id" == "$stuck_id" ]]; then
+                already_stuck=true
+                break
+            fi
+        done
+        [[ "$already_stuck" == "true" ]] && continue
+
+        # New stuck finding
+        _BB_STUCK_IDS+=("$id")
+        local severity
+        severity=$(jq -r --arg fid "$id" '.[] | select(.id == $fid) | .severity // "UNKNOWN"' \
+            <<< "$_BB_ACTIONABLE_JSON" 2>/dev/null || echo "UNKNOWN")
+        _record_action "BB_FINDING_STUCK" "bb-fix-loop" "stuck_detected" "" "" "" 0 0 0 \
+            "id=$id severity=$severity iter=$_BB_CURRENT_ITER"
+        log "Stuck finding detected: $id (severity=$severity, iter=$_BB_CURRENT_ITER)"
+    done
+    return 0
+}
+
+# _bb_dispatch_fix_cycle <iteration_number>
+#
+# Dispatches a claude -p fix cycle for the current batch of actionable findings.
+# Accumulates cost into _BB_SPEND_USD.
+#
+# Reads from caller scope: _BB_ACTIONABLE_JSON, _BB_SPEND_USD, BB_FIX_BUDGET,
+#   EXECUTOR_MODEL, BRANCH, EVIDENCE_DIR, PROJECT_ROOT
+_bb_dispatch_fix_cycle() {
+    local iteration_number="$1"
+
+    # Step A: Write context to temp file
+    local context_file="$EVIDENCE_DIR/bb-fix-context-iter-${iteration_number}.json"
+    printf '%s\n' "$_BB_ACTIONABLE_JSON" > "$context_file"
+
+    # Step B: Resolve file content (first finding, path traversal guard)
+    local finding_file
+    finding_file=$(jq -r '.[0].file // ""' <<< "$_BB_ACTIONABLE_JSON" 2>/dev/null || echo "")
+    local file_snippet=""
+    if [[ -n "$finding_file" ]]; then
+        local resolved
+        resolved=$(realpath --relative-base="${PROJECT_ROOT:-.}" "${PROJECT_ROOT:-.}/$finding_file" 2>/dev/null || true)
+        # If resolved starts with / it escaped the root — discard
+        if [[ "${resolved:0:1}" == "/" ]]; then
+            resolved=""
+        fi
+        if [[ -n "$resolved" && -f "${PROJECT_ROOT:-.}/$resolved" ]]; then
+            file_snippet=$(head -c 4096 "${PROJECT_ROOT:-.}/$resolved" 2>/dev/null || echo "")
+        fi
+    fi
+
+    # Step C: Construct prompt via jq (no shell interpolation of finding data)
+    local fix_prompt
+    fix_prompt=$(jq -n \
+        --argjson findings "$_BB_ACTIONABLE_JSON" \
+        --arg branch "$BRANCH" \
+        --arg file_content "$file_snippet" \
+        '"Fix the following Bridgebuilder findings in the codebase. Commit all changes to branch \($branch). Do not modify planning artifacts (prd.md, sdd.md, sprint.md). Findings: \($findings | tostring). File context: \($file_content)"')
+
+    # Step D: Invoke claude -p
+    local output_file="$EVIDENCE_DIR/bb-fix-output-iter-${iteration_number}.json"
+    local fix_exit=0
+    timeout 1800 \
+        claude -p "$fix_prompt" \
+            --allow-dangerously-skip-permissions \
+            --dangerously-skip-permissions \
+            --max-budget-usd "$BB_FIX_BUDGET" \
+            --model "$EXECUTOR_MODEL" \
+            --output-format json \
+            >"$output_file" 2>"$EVIDENCE_DIR/bb-fix-stderr-iter-${iteration_number}.log" \
+        || fix_exit=$?
+
+    # Step E: Accumulate cost
+    local cycle_cost
+    cycle_cost=$(jq -r '.cost_usd // 0' "$output_file" 2>/dev/null || echo "0")
+    _BB_SPEND_USD=$(echo "${_BB_SPEND_USD:-0} + $cycle_cost" | bc)
+
+    # Step F: Branch safety check before push
+    local current_branch
+    current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [[ "$current_branch" != "$BRANCH" ]]; then
+        log "ERROR: Fix cycle changed branch ($current_branch != $BRANCH), skipping push"
+        _record_action "BB_FIX_CYCLE_COMPLETE" "claude-${EXECUTOR_MODEL}" "fix_cycle" "" "" "" 0 0 0 \
+            "iter=$iteration_number exit=BRANCH_MISMATCH spend_usd=$cycle_cost"
+        return 0
+    fi
+
+    # Step F continued: push changes
+    git push origin "$BRANCH" 2>/dev/null \
+        || log "WARNING: git push failed after fix cycle (iteration $iteration_number)"
+
+    # Step G: Emit BB_FIX_CYCLE_COMPLETE
+    _record_action "BB_FIX_CYCLE_COMPLETE" "claude-${EXECUTOR_MODEL}" "fix_cycle" "" "" "" 0 0 0 \
+        "iter=$iteration_number exit=$fix_exit spend_usd=$cycle_cost"
+
+    return 0
+}
+
+# _bb_post_final_comment <pr_number> <iterations_run> <convergence_state>
+#                         <stop_reason> <resolved_ids_csv> <remaining_ids_with_reasons_json>
+#
+# Posts a markdown summary comment to the PR using gh pr comment.
+_bb_post_final_comment() {
+    local pr_number="$1"
+    local iterations_run="$2"
+    local convergence_state="$3"
+    local stop_reason="$4"
+    local resolved_ids_csv="$5"
+    local remaining_ids_json="$6"
+
+    # Build resolved section
+    local resolved_section
+    if [[ -z "$resolved_ids_csv" ]]; then
+        resolved_section="— none —"
+    else
+        resolved_section=$(printf '%s' "$resolved_ids_csv" | tr ',' '\n' | sed 's/^/- /' | tr '\n' '\n' || echo "- $resolved_ids_csv")
+        resolved_section=$(printf '- %s' "$resolved_ids_csv" | sed 's/,/\n- /g')
+    fi
+
+    # Build remaining section
+    local remaining_section
+    local remaining_count
+    remaining_count=$(jq 'length' <<< "$remaining_ids_json" 2>/dev/null || echo "0")
+    if [[ "$remaining_count" -eq 0 ]]; then
+        remaining_section="— none —"
+    else
+        remaining_section=$(jq -r '.[] | "- \(.id) (\(.reason // "unresolved"))"' \
+            <<< "$remaining_ids_json" 2>/dev/null || echo "- (see findings)")
+    fi
+
+    # Build comment body via jq (no shell interpolation into markdown)
+    local summary_file
+    summary_file=$(mktemp)
+    jq -rn \
+        --arg iterations "$iterations_run" \
+        --arg convergence "$convergence_state" \
+        --arg stop_reason "$stop_reason" \
+        --arg resolved "$resolved_section" \
+        --arg remaining "$remaining_section" \
+        '"## Bridgebuilder Fix Loop Summary\n\n| Field | Value |\n|-------|-------|\n| Iterations | \($iterations) |\n| Convergence | \($convergence) |\n| Stop reason | \($stop_reason) |\n\n### Resolved Findings\n\($resolved)\n\n### Remaining Findings\n\($remaining)"' \
+        > "$summary_file"
+
+    local post_exit=0
+    gh pr comment "$pr_number" --body "$(cat "$summary_file")" 2>/dev/null || post_exit=$?
+    rm -f "$summary_file"
+
+    if [[ "$post_exit" -ne 0 ]]; then
+        log "WARNING: gh pr comment failed (exit=$post_exit) — advisory, not a pipeline failure"
+    fi
+
+    _record_action "BB_POST_COMMENT" "gh-cli" "pr_comment" "" "" "" 0 0 0 \
+        "pr=$pr_number exit=$post_exit stop_reason=$stop_reason"
+
+    return 0
+}
+
+# _phase_bb_fix_loop <pr_number>
+#
+# Top-level BB Fix Loop orchestrator. Runs triage → dispatch → push → re-review
+# → convergence check. Idempotent: resume protocol skips completed iterations.
+_phase_bb_fix_loop() {
+    local pr_number="$1"
+
+    # ── Resume Protocol (T5.2) ──────────────────────────────────────────
+    # Check if loop already completed
+    if grep -q '"phase":"BB_LOOP_COMPLETE"' "$_FLIGHT_RECORDER" 2>/dev/null; then
+        log "BB fix loop already complete (BB_LOOP_COMPLETE found in flight recorder), skipping"
+        return 0
+    fi
+
+    # Count completed iterations from flight recorder
+    local completed_iters
+    completed_iters=$(grep -c '"phase":"BB_FIX_CYCLE_COMPLETE"' "$_FLIGHT_RECORDER" 2>/dev/null || true)
+    completed_iters="${completed_iters:-0}"
+
+    # Initialize accumulators
+    _BB_SPEND_USD="0"
+    _BB_CURRENT_ITER=$((completed_iters + 1))
+    _BB_STUCK_IDS=()
+    _BB_PREV_ACTIONABLE_IDS=()
+    _BB_RESOLVED_IDS=()
+    _BB_REMAINING_IDS=()
+    _BB_ACTIONABLE_IDS=()
+    _BB_ACTIONABLE_JSON="[]"
+    _BB_NONACTIONABLE_JSON="[]"
+
+    # Reconstruct stuck set from flight recorder (replay BB_FINDING_STUCK events)
+    if [[ -f "$_FLIGHT_RECORDER" ]]; then
+        while IFS= read -r event_line; do
+            local stuck_id
+            stuck_id=$(jq -r 'select(.phase == "BB_FINDING_STUCK") | .verdict' <<< "$event_line" 2>/dev/null \
+                | grep -oE 'id=[^ ]+' | cut -d= -f2 || true)
+            [[ -n "$stuck_id" ]] && _BB_STUCK_IDS+=("$stuck_id")
+        done < "$_FLIGHT_RECORDER"
+    fi
+
+    # Reconstruct accumulated spend from completed fix cycles
+    if [[ -f "$_FLIGHT_RECORDER" ]]; then
+        local reconstructed_spend
+        reconstructed_spend=$(jq -rs '[.[] | select(.phase == "BB_FIX_CYCLE_COMPLETE") | .verdict | capture("spend_usd=(?P<c>[0-9.]+)").c | tonumber] | add // 0' "$_FLIGHT_RECORDER" 2>/dev/null || echo "0")
+        _BB_SPEND_USD="${reconstructed_spend:-0}"
+    fi
+
+    log "BB Fix Loop starting: iter=$_BB_CURRENT_ITER spend=\$${_BB_SPEND_USD} budget=\$${BB_FIX_BUDGET} max_iters=$BB_MAX_ITERATIONS"
+
+    # ── Entry Guard ──────────────────────────────────────────────────────
+    local initial_review="$EVIDENCE_DIR/bb-review-iter-1.md"
+    if [[ ! -f "$initial_review" ]]; then
+        log "No initial BB review found (entry.sh may have been skipped), exiting fix loop"
+        _record_action "BB_LOOP_COMPLETE" "bb-fix-loop" "loop_exit" "" "" "" 0 0 0 "reason=no_initial_review"
+        return 0
+    fi
+
+    # Parse initial findings (skip if already exists from resume)
+    local initial_findings="$CYCLE_DIR/bb-findings-iter-1.json"
+    if [[ ! -f "$initial_findings" ]]; then
+        "$SCRIPT_DIR/bridge-findings-parser.sh" \
+            --input "$initial_review" --output "$initial_findings" 2>/dev/null || {
+            log "bridge-findings-parser.sh failed on initial review, exiting fix loop"
+            _record_action "BB_LOOP_COMPLETE" "bb-fix-loop" "loop_exit" "" "" "" 0 0 0 "reason=parser_failure"
+            return 0
+        }
+    fi
+
+    local stop_reason="zero_actionable"
+    local convergence_state="KEEP_ITERATING"
+
+    # ── Main Loop ────────────────────────────────────────────────────────
+    while true; do
+        local findings_path="$CYCLE_DIR/bb-findings-iter-${_BB_CURRENT_ITER}.json"
+
+        # Step a: Triage findings
+        _bb_triage_findings "$findings_path"
+
+        # Step b: Detect stuck findings (skip first iteration — prev list is empty)
+        if [[ ${#_BB_PREV_ACTIONABLE_IDS[@]} -gt 0 ]]; then
+            _bb_detect_stuck_findings
+        fi
+
+        # Step c: Remove stuck findings from actionable list
+        if [[ ${#_BB_STUCK_IDS[@]} -gt 0 ]]; then
+            local filtered_ids=()
+            local filtered_json="[]"
+            for id in ${_BB_ACTIONABLE_IDS[@]+"${_BB_ACTIONABLE_IDS[@]}"}; do
+                local is_stuck=false
+                for stuck_id in ${_BB_STUCK_IDS[@]+"${_BB_STUCK_IDS[@]}"}; do
+                    [[ "$id" == "$stuck_id" ]] && is_stuck=true && break
+                done
+                if [[ "$is_stuck" == "false" ]]; then
+                    filtered_ids+=("$id")
+                    filtered_json=$(jq -c --arg fid "$id" '. + [($fid as $i | ($fid))]' <<< "$filtered_json" 2>/dev/null || echo "$filtered_json")
+                fi
+            done
+            # Replace actionable with filtered (use jq to filter the JSON properly)
+            if [[ ${#_BB_STUCK_IDS[@]} -gt 0 ]]; then
+                local stuck_ids_json
+                stuck_ids_json=$(jq -cn '$ARGS.positional' --args -- ${_BB_STUCK_IDS[@]+"${_BB_STUCK_IDS[@]}"})
+                _BB_ACTIONABLE_JSON=$(jq -c --argjson stuck "$stuck_ids_json" \
+                    '[.[] | select(.id as $id | $stuck | index($id) | not)]' \
+                    <<< "$_BB_ACTIONABLE_JSON" 2>/dev/null || echo "$_BB_ACTIONABLE_JSON")
+            fi
+            _BB_ACTIONABLE_IDS=("${filtered_ids[@]+"${filtered_ids[@]}"}")
+        fi
+
+        # Step e: Zero actionable → converge
+        if [[ ${#_BB_ACTIONABLE_IDS[@]} -eq 0 ]]; then
+            stop_reason="zero_actionable"
+            convergence_state="FLATLINE"
+            _record_action "BB_CONVERGENCE" "bb-fix-loop" "convergence" "" "" "" 0 0 0 \
+                "iter=$_BB_CURRENT_ITER reason=zero_actionable"
+            break
+        fi
+
+        # Step f: Budget check
+        local budget_exceeded
+        budget_exceeded=$(echo "${_BB_SPEND_USD:-0} >= $BB_FIX_BUDGET" | bc 2>/dev/null || echo "0")
+        if [[ "$budget_exceeded" -eq 1 ]]; then
+            stop_reason="budget_exhausted"
+            # Remaining = current actionable (not yet fixed)
+            for id in ${_BB_ACTIONABLE_IDS[@]+"${_BB_ACTIONABLE_IDS[@]}"}; do
+                _BB_REMAINING_IDS+=("$id")
+            done
+            _record_action "BB_BUDGET_EXHAUSTED" "bb-fix-loop" "budget_exhausted" "" "" "" 0 0 0 \
+                "iter=$_BB_CURRENT_ITER spend_usd=$_BB_SPEND_USD budget=$BB_FIX_BUDGET"
+            break
+        fi
+
+        # Step g: Emit BB_FIX_CYCLE_START
+        local actionable_csv
+        actionable_csv=$(IFS=,; echo "${_BB_ACTIONABLE_IDS[*]+"${_BB_ACTIONABLE_IDS[*]}"}")
+        _record_action "BB_FIX_CYCLE_START" "bb-fix-loop" "fix_cycle_start" "" "" "" 0 0 0 \
+            "iter=$_BB_CURRENT_ITER findings=$actionable_csv"
+
+        # Step h: Dispatch fix cycle (includes push)
+        _bb_dispatch_fix_cycle "$_BB_CURRENT_ITER"
+
+        # Step i: Re-invoke entry.sh for next iteration
+        local next_iter
+        next_iter=$((_BB_CURRENT_ITER + 1))
+        local next_review="$EVIDENCE_DIR/bb-review-iter-${next_iter}.md"
+        local entry_script="$SCRIPT_DIR/../skills/bridgebuilder-review/resources/entry.sh"
+        if [[ -x "$entry_script" ]]; then
+            "$entry_script" --pr "$pr_number" \
+                >"$next_review" \
+                2>"$EVIDENCE_DIR/bb-rereview-iter-${next_iter}-stderr.log" || true
+        else
+            log "WARNING: Bridgebuilder entry.sh not available for re-review iter $next_iter"
+            printf '' > "$next_review"
+        fi
+
+        # Step j: Emit BB_REREVIEW
+        _record_action "BB_REREVIEW" "bridgebuilder" "rereview" "" "" "" 0 0 0 \
+            "iter=$_BB_CURRENT_ITER findings_path=$next_review"
+
+        # Step k: Run post-pr-triage.sh
+        "$SCRIPT_DIR/post-pr-triage.sh" --pr "$pr_number" 2>/dev/null || true
+
+        # Step l: Read convergence state
+        local convergence_file="${PROJECT_ROOT:-.}/.run/bridge-triage-convergence.json"
+        convergence_state="KEEP_ITERATING"  # safe default if missing
+        if [[ -f "$convergence_file" ]]; then
+            convergence_state=$(jq -r '.state // "KEEP_ITERATING"' "$convergence_file" 2>/dev/null \
+                || echo "KEEP_ITERATING")
+        fi
+
+        # Step m: FLATLINE → exit
+        if [[ "$convergence_state" == "FLATLINE" ]]; then
+            stop_reason="convergence"
+            _record_action "BB_CONVERGENCE" "bb-fix-loop" "convergence" "" "" "" 0 0 0 \
+                "iter=$_BB_CURRENT_ITER state=FLATLINE"
+            # Track resolved = IDs that were actionable but are now gone
+            for id in ${_BB_ACTIONABLE_IDS[@]+"${_BB_ACTIONABLE_IDS[@]}"}; do
+                _BB_RESOLVED_IDS+=("$id")
+            done
+            break
+        fi
+
+        # Step n: Circuit breaker
+        if [[ "$_BB_CURRENT_ITER" -ge "$BB_MAX_ITERATIONS" ]]; then
+            stop_reason="circuit_breaker"
+            for id in ${_BB_ACTIONABLE_IDS[@]+"${_BB_ACTIONABLE_IDS[@]}"}; do
+                _BB_REMAINING_IDS+=("$id")
+            done
+            _record_action "BB_CIRCUIT_BREAKER" "bb-fix-loop" "circuit_breaker" "" "" "" 0 0 0 \
+                "iter=$_BB_CURRENT_ITER max=$BB_MAX_ITERATIONS"
+            break
+        fi
+
+        # Step o: Parse next findings file (skip if already exists from resume)
+        local next_findings="$CYCLE_DIR/bb-findings-iter-${next_iter}.json"
+        if [[ ! -f "$next_findings" ]]; then
+            "$SCRIPT_DIR/bridge-findings-parser.sh" \
+                --input "$next_review" --output "$next_findings" 2>/dev/null || {
+                log "WARNING: bridge-findings-parser.sh failed for iter $next_iter — treating as zero actionable"
+                printf '{"findings":[],"total":0}' > "$next_findings"
+            }
+        fi
+
+        # Step p: Update prev IDs
+        _BB_PREV_ACTIONABLE_IDS=("${_BB_ACTIONABLE_IDS[@]+"${_BB_ACTIONABLE_IDS[@]}"}")
+
+        # Step q: Increment counter (var=$((var+1)) per shell conventions)
+        _BB_CURRENT_ITER=$((_BB_CURRENT_ITER + 1))
+    done
+
+    # ── Post-loop ────────────────────────────────────────────────────────
+    local resolved_csv
+    resolved_csv=$(IFS=,; echo "${_BB_RESOLVED_IDS[*]+"${_BB_RESOLVED_IDS[*]}"}")
+
+    # Build remaining JSON with reason
+    local remaining_json="[]"
+    for id in ${_BB_REMAINING_IDS[@]+"${_BB_REMAINING_IDS[@]}"}; do
+        remaining_json=$(jq -c --arg fid "$id" --arg reason "$stop_reason" \
+            '. + [{"id": $fid, "reason": $reason}]' <<< "$remaining_json" 2>/dev/null \
+            || echo "$remaining_json")
+    done
+
+    _bb_post_final_comment "$pr_number" "$_BB_CURRENT_ITER" "$convergence_state" \
+        "$stop_reason" "$resolved_csv" "$remaining_json"
+
+    _record_action "BB_LOOP_COMPLETE" "bb-fix-loop" "loop_exit" "" "" "" 0 0 0 \
+        "reason=$stop_reason iters=$_BB_CURRENT_ITER spend_usd=$_BB_SPEND_USD"
+
+    log "BB Fix Loop complete: reason=$stop_reason iters=$_BB_CURRENT_ITER spend=\$${_BB_SPEND_USD}"
+    return 0
+}
+
 
 # =============================================================================
 # Main Pipeline
@@ -531,6 +1018,15 @@ main() {
 
     # ── Gate 6: Bridgebuilder (advisory, not blocking) ──────────────────
     _gate_bridgebuilder "$pr_url"
+
+    # ── Phase 6: BB Fix Loop (no-op when zero actionable findings) ────────
+    local pr_number_for_bb
+    pr_number_for_bb=$(echo "$pr_url" | grep -oE '[0-9]+$')
+    if [[ -n "$pr_number_for_bb" ]]; then
+        _phase_bb_fix_loop "$pr_number_for_bb"
+    else
+        log "Could not extract PR number for BB fix loop, skipping"
+    fi
 
     # ── Cost sidecar (cycle-072: cross-cycle reconciliation) ────────────
     local total_cost

--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -36,6 +36,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source dependencies
 source "$SCRIPT_DIR/bootstrap.sh" 2>/dev/null || true
 source "$SCRIPT_DIR/spiral-evidence.sh"
+source "$SCRIPT_DIR/compat-lib.sh" 2>/dev/null || true
 
 # =============================================================================
 # Configuration
@@ -213,7 +214,7 @@ _invoke_claude() {
     start_sec=$(date +%s)
 
     local exit_code=0
-    timeout "$timeout_sec" \
+    run_with_timeout "$timeout_sec" \
         claude -p "$prompt" \
             --allow-dangerously-skip-permissions \
             --dangerously-skip-permissions \
@@ -541,6 +542,11 @@ _bb_detect_stuck_findings() {
 _bb_dispatch_fix_cycle() {
     local iteration_number="$1"
 
+    # Pre-dispatch budget gate (F-001)
+    if ! _check_budget "$TOTAL_BUDGET"; then
+        return 1
+    fi
+
     # Step A: Write context to temp file
     local context_file="$EVIDENCE_DIR/bb-fix-context-iter-${iteration_number}.json"
     printf '%s\n' "$_BB_ACTIONABLE_JSON" > "$context_file"
@@ -572,7 +578,7 @@ _bb_dispatch_fix_cycle() {
     # Step D: Invoke claude -p
     local output_file="$EVIDENCE_DIR/bb-fix-output-iter-${iteration_number}.json"
     local fix_exit=0
-    timeout 1800 \
+    run_with_timeout 1800 \
         claude -p "$fix_prompt" \
             --allow-dangerously-skip-permissions \
             --dangerously-skip-permissions \
@@ -585,6 +591,7 @@ _bb_dispatch_fix_cycle() {
     # Step E: Accumulate cost
     local cycle_cost
     cycle_cost=$(jq -r '.cost_usd // 0' "$output_file" 2>/dev/null || echo "0")
+    echo "$cycle_cost" | grep -qE '^[0-9]+\.?[0-9]*$' || cycle_cost=0
     _BB_SPEND_USD=$(echo "${_BB_SPEND_USD:-0} + $cycle_cost" | bc)
 
     # Step F: Branch safety check before push
@@ -592,7 +599,7 @@ _bb_dispatch_fix_cycle() {
     current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
     if [[ "$current_branch" != "$BRANCH" ]]; then
         log "ERROR: Fix cycle changed branch ($current_branch != $BRANCH), skipping push"
-        _record_action "BB_FIX_CYCLE_COMPLETE" "claude-${EXECUTOR_MODEL}" "fix_cycle" "" "" "" 0 0 0 \
+        _record_action "BB_FIX_CYCLE_COMPLETE" "claude-${EXECUTOR_MODEL}" "fix_cycle" "" "" "" 0 0 "$cycle_cost" \
             "iter=$iteration_number exit=BRANCH_MISMATCH spend_usd=$cycle_cost"
         return 0
     fi
@@ -602,7 +609,7 @@ _bb_dispatch_fix_cycle() {
         || log "WARNING: git push failed after fix cycle (iteration $iteration_number)"
 
     # Step G: Emit BB_FIX_CYCLE_COMPLETE
-    _record_action "BB_FIX_CYCLE_COMPLETE" "claude-${EXECUTOR_MODEL}" "fix_cycle" "" "" "" 0 0 0 \
+    _record_action "BB_FIX_CYCLE_COMPLETE" "claude-${EXECUTOR_MODEL}" "fix_cycle" "" "" "" 0 0 "$cycle_cost" \
         "iter=$iteration_number exit=$fix_exit spend_usd=$cycle_cost"
 
     return 0
@@ -840,7 +847,12 @@ _phase_bb_fix_loop() {
             "iter=$_BB_CURRENT_ITER findings=$actionable_csv"
 
         # Step h: Dispatch fix cycle (includes push)
-        _bb_dispatch_fix_cycle "$_BB_CURRENT_ITER"
+        if ! _bb_dispatch_fix_cycle "$_BB_CURRENT_ITER"; then
+            stop_reason="budget_exhausted"
+            _record_action "BB_BUDGET_EXHAUSTED" "bb-fix-loop" "budget_exhausted" "" "" "" 0 0 0 \
+                "iter=$_BB_CURRENT_ITER spend_usd=$_BB_SPEND_USD budget=$TOTAL_BUDGET reason=TOTAL_BUDGET_EXCEEDED"
+            break
+        fi
 
         # Step i: Re-invoke entry.sh for next iteration
         local next_iter

--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -625,7 +625,6 @@ _bb_post_final_comment() {
     if [[ -z "$resolved_ids_csv" ]]; then
         resolved_section="— none —"
     else
-        resolved_section=$(printf '%s' "$resolved_ids_csv" | tr ',' '\n' | sed 's/^/- /' | tr '\n' '\n' || echo "- $resolved_ids_csv")
         resolved_section=$(printf '- %s' "$resolved_ids_csv" | sed 's/,/\n- /g')
     fi
 
@@ -664,6 +663,42 @@ _bb_post_final_comment() {
         "pr=$pr_number exit=$post_exit stop_reason=$stop_reason"
 
     return 0
+}
+
+# _bb_track_resolved_incremental
+#
+# Incremental resolved-ID tracking. Called each loop iteration after
+# _bb_triage_findings. Diffs _BB_PREV_ACTIONABLE_IDS against
+# _BB_ACTIONABLE_IDS; IDs that dropped out of the actionable set are
+# appended to _BB_RESOLVED_IDS (with duplicate guard). No-op on the
+# first iteration where prev is empty.
+#
+# Reads/writes in caller scope: _BB_PREV_ACTIONABLE_IDS, _BB_ACTIONABLE_IDS,
+#   _BB_RESOLVED_IDS
+_bb_track_resolved_incremental() {
+    [[ ${#_BB_PREV_ACTIONABLE_IDS[@]} -gt 0 ]] || return 0
+    local _prev_id _cur_id _rid _still_present _already_resolved
+    for _prev_id in "${_BB_PREV_ACTIONABLE_IDS[@]}"; do
+        _still_present=0
+        for _cur_id in ${_BB_ACTIONABLE_IDS[@]+"${_BB_ACTIONABLE_IDS[@]}"}; do
+            if [[ "$_cur_id" == "$_prev_id" ]]; then
+                _still_present=1
+                break
+            fi
+        done
+        if [[ $_still_present -eq 0 ]]; then
+            _already_resolved=0
+            for _rid in ${_BB_RESOLVED_IDS[@]+"${_BB_RESOLVED_IDS[@]}"}; do
+                if [[ "$_rid" == "$_prev_id" ]]; then
+                    _already_resolved=1
+                    break
+                fi
+            done
+            if [[ $_already_resolved -eq 0 ]]; then
+                _BB_RESOLVED_IDS+=("$_prev_id")
+            fi
+        fi
+    done
 }
 
 # _phase_bb_fix_loop <pr_number>
@@ -744,6 +779,9 @@ _phase_bb_fix_loop() {
         # Step a: Triage findings
         _bb_triage_findings "$findings_path"
 
+        # Step a.1: Incremental resolved-ID tracking (diff prev vs current)
+        _bb_track_resolved_incremental
+
         # Step b: Detect stuck findings (skip first iteration — prev list is empty)
         if [[ ${#_BB_PREV_ACTIONABLE_IDS[@]} -gt 0 ]]; then
             _bb_detect_stuck_findings
@@ -752,7 +790,6 @@ _phase_bb_fix_loop() {
         # Step c: Remove stuck findings from actionable list
         if [[ ${#_BB_STUCK_IDS[@]} -gt 0 ]]; then
             local filtered_ids=()
-            local filtered_json="[]"
             for id in ${_BB_ACTIONABLE_IDS[@]+"${_BB_ACTIONABLE_IDS[@]}"}; do
                 local is_stuck=false
                 for stuck_id in ${_BB_STUCK_IDS[@]+"${_BB_STUCK_IDS[@]}"}; do
@@ -760,7 +797,6 @@ _phase_bb_fix_loop() {
                 done
                 if [[ "$is_stuck" == "false" ]]; then
                     filtered_ids+=("$id")
-                    filtered_json=$(jq -c --arg fid "$id" '. + [($fid as $i | ($fid))]' <<< "$filtered_json" 2>/dev/null || echo "$filtered_json")
                 fi
             done
             # Replace actionable with filtered (use jq to filter the JSON properly)

--- a/.claude/scripts/tests/test-bb-integration.sh
+++ b/.claude/scripts/tests/test-bb-integration.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# test-bb-integration.sh — Integration test for _phase_bb_fix_loop
+# Scenario: 1-iteration FLATLINE convergence (3 of 4 findings resolved).
+# Usage: bash test-bb-integration.sh
+# Exit: 0 on all pass, 1 on any failure
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS="$(dirname "$SCRIPT_DIR")/spiral-harness.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+TEST_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# ── Mock Tool Directory ────────────────────────────────────────────────────
+MOCK_BIN="$TEST_TMPDIR/mock-bin"
+mkdir -p "$MOCK_BIN"
+
+# Mock bridge-findings-parser.sh
+# Call 1 (initial, iter 1): F001 HIGH, F002 MEDIUM@0.9, F003 MEDIUM@0.8, F004 PRAISE
+# Call 2+ (re-review): empty
+PARSER_COUNT="$TEST_TMPDIR/parser-count"
+echo "0" > "$PARSER_COUNT"
+cat > "$TEST_TMPDIR/bridge-findings-parser.sh" << 'PARSEREOF'
+#!/usr/bin/env bash
+INPUT=""; OUTPUT=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in --input) INPUT="$2"; shift 2 ;; --output) OUTPUT="$2"; shift 2 ;; *) shift ;; esac
+done
+PCFILE="PCFILE_PLACEHOLDER"
+c=$(cat "$PCFILE" 2>/dev/null || echo "0"); c=$((c + 1)); echo "$c" > "$PCFILE"
+case "$c" in
+  1) printf '{"schema_version":2,"findings":[{"id":"F001","severity":"HIGH","confidence":0.9,"file":"a.sh","title":"H","description":"x","suggestion":"fix","weight":5},{"id":"F002","severity":"MEDIUM","confidence":0.9,"file":"b.sh","title":"M","description":"x","suggestion":"fix","weight":3},{"id":"F003","severity":"MEDIUM","confidence":0.8,"file":"c.sh","title":"M2","description":"x","suggestion":"fix","weight":3},{"id":"F004","severity":"PRAISE","confidence":1.0,"file":"","title":"Nice","description":"nice","suggestion":"","weight":0}],"total":4}' > "$OUTPUT" ;;
+  *) printf '{"schema_version":2,"findings":[],"total":0}' > "$OUTPUT" ;;
+esac
+exit 0
+PARSEREOF
+sed -i "s|PCFILE_PLACEHOLDER|$PARSER_COUNT|g" "$TEST_TMPDIR/bridge-findings-parser.sh"
+chmod +x "$TEST_TMPDIR/bridge-findings-parser.sh"
+
+# Mock claude: returns cost=0.25
+cat > "$MOCK_BIN/claude" << 'CLAUDEEOF'
+#!/usr/bin/env bash
+printf '{"cost_usd": 0.25, "result": "Fixed."}'
+exit 0
+CLAUDEEOF
+chmod +x "$MOCK_BIN/claude"
+
+# Mock gh pr comment
+cat > "$MOCK_BIN/gh" << 'GHEOF'
+#!/usr/bin/env bash
+echo "PR comment posted"
+exit 0
+GHEOF
+chmod +x "$MOCK_BIN/gh"
+
+# Mock git
+cat > "$MOCK_BIN/git" << 'GITEOF'
+#!/usr/bin/env bash
+if [[ "${1:-} ${2:-} ${3:-}" == "rev-parse --abbrev-ref HEAD" ]]; then
+    echo "feat/test-bb"
+elif [[ "${1:-}" == "push" ]]; then
+    echo "pushed"
+else
+    command git "$@" 2>/dev/null || true
+fi
+exit 0
+GITEOF
+chmod +x "$MOCK_BIN/git"
+
+# Mock entry.sh: always produces empty review (FLATLINE after first fix cycle)
+mkdir -p "$TEST_TMPDIR/../skills/bridgebuilder-review/resources"
+cat > "$TEST_TMPDIR/../skills/bridgebuilder-review/resources/entry.sh" << 'ENTRYEOF'
+#!/usr/bin/env bash
+echo "No findings."
+exit 0
+ENTRYEOF
+chmod +x "$TEST_TMPDIR/../skills/bridgebuilder-review/resources/entry.sh"
+
+# Mock post-pr-triage.sh: always returns FLATLINE
+cat > "$TEST_TMPDIR/post-pr-triage.sh" << 'TRIAGEEOF'
+#!/usr/bin/env bash
+CWD_AT_INVOKE="$(pwd)"
+mkdir -p "$CWD_AT_INVOKE/.run"
+printf '{"state":"FLATLINE","ts":"%s"}' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    > "$CWD_AT_INVOKE/.run/bridge-triage-convergence.json"
+exit 0
+TRIAGEEOF
+chmod +x "$TEST_TMPDIR/post-pr-triage.sh"
+
+# ── Test Environment Setup ─────────────────────────────────────────────────
+export PATH="$MOCK_BIN:$PATH"
+
+PROJECT_ROOT="$TEST_TMPDIR"
+EVIDENCE_DIR="$TEST_TMPDIR/evidence"
+CYCLE_DIR="$TEST_TMPDIR"
+BRANCH="feat/test-bb"
+EXECUTOR_MODEL="sonnet"
+BB_FIX_BUDGET="3"
+BB_MAX_ITERATIONS="3"
+_BB_SPEND_USD="0"
+_BB_CURRENT_ITER=1
+_BB_STUCK_IDS=()
+_BB_PREV_ACTIONABLE_IDS=()
+_BB_ACTIONABLE_IDS=()
+_BB_ACTIONABLE_JSON="[]"
+_BB_NONACTIONABLE_JSON="[]"
+_BB_RESOLVED_IDS=()
+_BB_REMAINING_IDS=()
+_FLIGHT_RECORDER="$TEST_TMPDIR/flight-recorder.jsonl"
+touch "$_FLIGHT_RECORDER"
+mkdir -p "$EVIDENCE_DIR" "$TEST_TMPDIR/.run"
+SCRIPT_DIR="$TEST_TMPDIR"
+
+log() { echo "[test] $*" >&2; }
+_record_action() {
+    printf '{"phase":"%s","actor":"%s","action":"%s","verdict":"%s"}\n' \
+        "$1" "$2" "$3" "${10:-}" >> "$_FLIGHT_RECORDER"
+}
+
+# Write initial BB review fixture (cycle-073 representative)
+cat > "$EVIDENCE_DIR/bb-review-iter-1.md" << 'FIXEOF'
+# Bridgebuilder Review — Cycle-073 Fixture
+
+## Finding F001
+Severity: HIGH
+Confidence: 0.9
+File: .claude/scripts/spiral-harness.sh
+Description: High severity issue requiring immediate fix
+
+## Finding F002
+Severity: MEDIUM
+Confidence: 0.9
+File: .claude/scripts/spiral-evidence.sh
+Description: Medium severity issue
+
+## Finding F003
+Severity: MEDIUM
+Confidence: 0.8
+File: .claude/scripts/bridge-findings-parser.sh
+Description: Another medium severity issue
+
+## Finding F004
+Severity: PRAISE
+File:
+Description: Well-structured error handling
+FIXEOF
+
+# Extract and source BB functions
+BB_FUNCS_FILE="$TEST_TMPDIR/bb-funcs.sh"
+python3 -c "
+with open('$HARNESS') as f:
+    content = f.read()
+start = content.find('# BB Fix Loop — Supporting Functions')
+end = content.find('# =============================================================================\n# Main Pipeline', start)
+with open('$BB_FUNCS_FILE', 'w') as out:
+    out.write(content[start:end])
+"
+# shellcheck source=/dev/null
+source "$BB_FUNCS_FILE"
+
+# ── Run Integration Test ───────────────────────────────────────────────────
+echo ""
+echo "=== Integration Test: 1-iteration FLATLINE convergence ==="
+echo ""
+
+# cd to PROJECT_ROOT so post-pr-triage.sh CWD_AT_INVOKE matches PROJECT_ROOT
+cd "$TEST_TMPDIR"
+_phase_bb_fix_loop "42" 2>/dev/null
+
+echo ""
+echo "--- Assertions ---"
+
+# AC1: BB_LOOP_COMPLETE with reason=convergence
+loop_complete_line=$(grep '"BB_LOOP_COMPLETE"' "$_FLIGHT_RECORDER" 2>/dev/null || true)
+if [[ -n "$loop_complete_line" ]] && echo "$loop_complete_line" | grep -q "convergence"; then
+    pass "AC1: BB_LOOP_COMPLETE with reason=convergence"
+else
+    fail "AC1: missing convergence in BB_LOOP_COMPLETE (recorder: $loop_complete_line)"
+fi
+
+# AC2: _BB_RESOLVED_IDS contains at least F001, F002, F003
+resolved_count=0
+for id in ${_BB_RESOLVED_IDS[@]+"${_BB_RESOLVED_IDS[@]}"}; do
+    resolved_count=$((resolved_count + 1))
+done
+[[ "$resolved_count" -ge 3 ]] \
+    && pass "AC2: _BB_RESOLVED_IDS has ≥3 findings (got $resolved_count: ${_BB_RESOLVED_IDS[*]+"${_BB_RESOLVED_IDS[*]}"})" \
+    || fail "AC2: expected ≥3 resolved, got $resolved_count: ${_BB_RESOLVED_IDS[*]:-none}"
+
+# AC3: Iterations ≤ 3
+[[ "$_BB_CURRENT_ITER" -le 3 ]] \
+    && pass "AC3: Iterations ≤ 3 (ran $_BB_CURRENT_ITER)" \
+    || fail "AC3: Too many iterations: $_BB_CURRENT_ITER"
+
+# AC4: Spend ≤ $3.0
+spend_ok=$(echo "${_BB_SPEND_USD:-0} <= 3.0" | bc 2>/dev/null || echo "1")
+[[ "$spend_ok" -eq 1 ]] \
+    && pass "AC4: Spend ≤ \$3.0 (spent \$${_BB_SPEND_USD:-0})" \
+    || fail "AC4: Over budget: \$${_BB_SPEND_USD:-0}"
+
+# AC5: Required event types present
+declare -a REQUIRED_EVENTS=("BB_FIX_CYCLE_START" "BB_FIX_CYCLE_COMPLETE" "BB_REREVIEW" "BB_CONVERGENCE" "BB_LOOP_COMPLETE")
+all_ok=true
+for ev in "${REQUIRED_EVENTS[@]}"; do
+    if grep -q "\"$ev\"" "$_FLIGHT_RECORDER" 2>/dev/null; then
+        : # present
+    else
+        fail "AC5: Missing event: $ev"
+        all_ok=false
+    fi
+done
+[[ "$all_ok" == "true" ]] && pass "AC5: All 5 required event types present"
+
+# AC6: Final PR comment posted
+grep -q '"BB_POST_COMMENT"' "$_FLIGHT_RECORDER" 2>/dev/null \
+    && pass "AC6: Final PR comment posted" \
+    || fail "AC6: No BB_POST_COMMENT recorded"
+
+# AC7: No stuck findings (FLATLINE before any iteration can repeat)
+sc=0
+for s in ${_BB_STUCK_IDS[@]+"${_BB_STUCK_IDS[@]}"}; do sc=$((sc + 1)); done
+[[ "$sc" -eq 0 ]] \
+    && pass "AC7: No stuck findings" \
+    || fail "AC7: Unexpected stuck findings: ${_BB_STUCK_IDS[*]}"
+
+echo ""
+echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+echo ""
+[[ "$FAIL_COUNT" -eq 0 ]]

--- a/.claude/scripts/tests/test-bb-integration.sh
+++ b/.claude/scripts/tests/test-bb-integration.sh
@@ -27,7 +27,8 @@ mkdir -p "$MOCK_BIN"
 # Call 2+ (re-review): empty
 PARSER_COUNT="$TEST_TMPDIR/parser-count"
 echo "0" > "$PARSER_COUNT"
-cat > "$TEST_TMPDIR/bridge-findings-parser.sh" << 'PARSEREOF'
+mkdir -p "$TEST_TMPDIR/bin"
+cat > "$TEST_TMPDIR/bin/bridge-findings-parser.sh" << 'PARSEREOF'
 #!/usr/bin/env bash
 INPUT=""; OUTPUT=""
 while [[ $# -gt 0 ]]; do
@@ -41,8 +42,8 @@ case "$c" in
 esac
 exit 0
 PARSEREOF
-sed -i "s|PCFILE_PLACEHOLDER|$PARSER_COUNT|g" "$TEST_TMPDIR/bridge-findings-parser.sh"
-chmod +x "$TEST_TMPDIR/bridge-findings-parser.sh"
+sed -i "s|PCFILE_PLACEHOLDER|$PARSER_COUNT|g" "$TEST_TMPDIR/bin/bridge-findings-parser.sh"
+chmod +x "$TEST_TMPDIR/bin/bridge-findings-parser.sh"
 
 # Mock claude: returns cost=0.25
 cat > "$MOCK_BIN/claude" << 'CLAUDEEOF'
@@ -75,16 +76,16 @@ GITEOF
 chmod +x "$MOCK_BIN/git"
 
 # Mock entry.sh: always produces empty review (FLATLINE after first fix cycle)
-mkdir -p "$TEST_TMPDIR/../skills/bridgebuilder-review/resources"
-cat > "$TEST_TMPDIR/../skills/bridgebuilder-review/resources/entry.sh" << 'ENTRYEOF'
+mkdir -p "$TEST_TMPDIR/skills/bridgebuilder-review/resources"
+cat > "$TEST_TMPDIR/skills/bridgebuilder-review/resources/entry.sh" << 'ENTRYEOF'
 #!/usr/bin/env bash
 echo "No findings."
 exit 0
 ENTRYEOF
-chmod +x "$TEST_TMPDIR/../skills/bridgebuilder-review/resources/entry.sh"
+chmod +x "$TEST_TMPDIR/skills/bridgebuilder-review/resources/entry.sh"
 
 # Mock post-pr-triage.sh: always returns FLATLINE
-cat > "$TEST_TMPDIR/post-pr-triage.sh" << 'TRIAGEEOF'
+cat > "$TEST_TMPDIR/bin/post-pr-triage.sh" << 'TRIAGEEOF'
 #!/usr/bin/env bash
 CWD_AT_INVOKE="$(pwd)"
 mkdir -p "$CWD_AT_INVOKE/.run"
@@ -92,7 +93,7 @@ printf '{"state":"FLATLINE","ts":"%s"}' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     > "$CWD_AT_INVOKE/.run/bridge-triage-convergence.json"
 exit 0
 TRIAGEEOF
-chmod +x "$TEST_TMPDIR/post-pr-triage.sh"
+chmod +x "$TEST_TMPDIR/bin/post-pr-triage.sh"
 
 # ── Test Environment Setup ─────────────────────────────────────────────────
 export PATH="$MOCK_BIN:$PATH"
@@ -103,6 +104,7 @@ CYCLE_DIR="$TEST_TMPDIR"
 BRANCH="feat/test-bb"
 EXECUTOR_MODEL="sonnet"
 BB_FIX_BUDGET="3"
+TOTAL_BUDGET="10"
 BB_MAX_ITERATIONS="3"
 _BB_SPEND_USD="0"
 _BB_CURRENT_ITER=1
@@ -116,9 +118,10 @@ _BB_REMAINING_IDS=()
 _FLIGHT_RECORDER="$TEST_TMPDIR/flight-recorder.jsonl"
 touch "$_FLIGHT_RECORDER"
 mkdir -p "$EVIDENCE_DIR" "$TEST_TMPDIR/.run"
-SCRIPT_DIR="$TEST_TMPDIR"
+SCRIPT_DIR="$TEST_TMPDIR/bin"
 
 log() { echo "[test] $*" >&2; }
+_check_budget() { return 0; }  # budget always ok in integration test
 _record_action() {
     printf '{"phase":"%s","actor":"%s","action":"%s","verdict":"%s"}\n' \
         "$1" "$2" "$3" "${10:-}" >> "$_FLIGHT_RECORDER"

--- a/.claude/scripts/tests/test-bb-triage.sh
+++ b/.claude/scripts/tests/test-bb-triage.sh
@@ -213,6 +213,39 @@ ev="${ev:-0}"
     && pass "TC-S4: empty prev → no stuck, no events" \
     || fail "TC-S4: stuck=$sc events=$ev"
 
+
+# ── _bb_track_resolved_incremental ────────────────────────────────────────────
+echo ""
+echo "=== _bb_track_resolved_incremental ==="
+echo ""
+
+# TC-R1: multi-iteration incremental resolved tracking
+_BB_PREV_ACTIONABLE_IDS=()
+_BB_ACTIONABLE_IDS=()
+_BB_RESOLVED_IDS=()
+
+# Transition: iter1 [F001,F002,F003] -> iter2 [F002]
+_BB_PREV_ACTIONABLE_IDS=(F001 F002 F003)
+_BB_ACTIONABLE_IDS=(F002)
+_bb_track_resolved_incremental
+
+r1_ok=true
+[[ " ${_BB_RESOLVED_IDS[*]:-} " == *" F001 "* ]] || { r1_ok=false; }
+[[ " ${_BB_RESOLVED_IDS[*]:-} " == *" F003 "* ]] || { r1_ok=false; }
+[[ " ${_BB_RESOLVED_IDS[*]:-} " != *" F002 "* ]] || { r1_ok=false; }
+
+# Transition: iter2 [F002] -> iter3 []
+_BB_PREV_ACTIONABLE_IDS=(F002)
+_BB_ACTIONABLE_IDS=()
+_bb_track_resolved_incremental
+
+[[ " ${_BB_RESOLVED_IDS[*]:-} " == *" F001 "* ]] || { r1_ok=false; }
+[[ " ${_BB_RESOLVED_IDS[*]:-} " == *" F002 "* ]] || { r1_ok=false; }
+[[ " ${_BB_RESOLVED_IDS[*]:-} " == *" F003 "* ]] || { r1_ok=false; }
+[[ ${#_BB_RESOLVED_IDS[@]} -eq 3 ]] || { r1_ok=false; }
+
+"$r1_ok"     && pass "TC-R1: multi-iteration incremental resolved tracking"     || fail "TC-R1: resolved=${_BB_RESOLVED_IDS[*]:-none} count=${#_BB_RESOLVED_IDS[@]}"
+
 # ── Summary ────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"

--- a/.claude/scripts/tests/test-bb-triage.sh
+++ b/.claude/scripts/tests/test-bb-triage.sh
@@ -246,6 +246,28 @@ _bb_track_resolved_incremental
 
 "$r1_ok"     && pass "TC-R1: multi-iteration incremental resolved tracking"     || fail "TC-R1: resolved=${_BB_RESOLVED_IDS[*]:-none} count=${#_BB_RESOLVED_IDS[@]}"
 
+# ── pre-dispatch budget gate ──────────────────────────────────────────────────
+echo ""
+echo "=== pre-dispatch budget gate ==="
+echo ""
+
+# TC-B1: pre-dispatch budget gate — no claude when budget exhausted
+TOTAL_BUDGET="1.00"
+_get_cumulative_cost() { echo "1.50"; }
+_check_budget() {
+    local max_budget="$1"
+    local spent; spent=$(_get_cumulative_cost)
+    [[ $(echo "$spent >= $max_budget" | bc 2>/dev/null || echo 0) -eq 1 ]] && return 1 || return 0
+}
+_claude_was_called=0
+claude() { _claude_was_called=1; return 0; }
+_BB_ACTIONABLE_JSON='[{"id":"F001","severity":"HIGH","confidence":0.9,"file":"a.sh","title":"H","description":"x","suggestion":"fix","weight":5}]'
+dispatch_rc=0
+_bb_dispatch_fix_cycle 1 2>/dev/null || dispatch_rc=$?
+[[ "$dispatch_rc" -ne 0 && "$_claude_was_called" -eq 0 ]] \
+    && pass "TC-B1: pre-dispatch budget gate — non-zero return and claude not invoked" \
+    || fail "TC-B1: expected non-zero return (got $dispatch_rc) and no claude (was_called=$_claude_was_called)"
+
 # ── Summary ────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"

--- a/.claude/scripts/tests/test-bb-triage.sh
+++ b/.claude/scripts/tests/test-bb-triage.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# test-bb-triage.sh — Unit tests for _bb_triage_findings and _bb_detect_stuck_findings
+# Usage: bash test-bb-triage.sh
+# Exit: 0 on all pass, 1 on any failure
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS="$(dirname "$SCRIPT_DIR")/spiral-harness.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+TEST_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# Extract BB functions from harness (between markers)
+BB_FUNCS_FILE="$TEST_TMPDIR/bb-funcs.sh"
+python3 -c "
+import sys
+with open('$HARNESS') as f:
+    content = f.read()
+start = content.find('# BB Fix Loop — Supporting Functions')
+end = content.find('# =============================================================================\n# Main Pipeline', start)
+with open('$BB_FUNCS_FILE', 'w') as out:
+    out.write(content[start:end])
+" 2>/dev/null || {
+    echo "ERROR: Failed to extract BB functions from harness"
+    exit 1
+}
+
+# Provide stubs for harness dependencies, then source BB functions
+PROJECT_ROOT="$TEST_TMPDIR"
+EVIDENCE_DIR="$TEST_TMPDIR/evidence"
+CYCLE_DIR="$TEST_TMPDIR"
+BRANCH="feat/test"
+EXECUTOR_MODEL="sonnet"
+BB_FIX_BUDGET="3"
+BB_MAX_ITERATIONS="3"
+_BB_SPEND_USD="0"
+_BB_CURRENT_ITER=1
+_BB_STUCK_IDS=()
+_BB_PREV_ACTIONABLE_IDS=()
+_BB_ACTIONABLE_IDS=()
+_BB_ACTIONABLE_JSON="[]"
+_FLIGHT_RECORDER="$TEST_TMPDIR/flight-recorder.jsonl"
+touch "$_FLIGHT_RECORDER"
+mkdir -p "$EVIDENCE_DIR" "$TEST_TMPDIR/.run"
+
+log() { : ; }
+_record_action() {
+    echo "{\"phase\":\"$1\",\"actor\":\"$2\",\"action\":\"$3\",\"verdict\":\"${10:-}\"}" \
+        >> "$_FLIGHT_RECORDER"
+}
+
+# shellcheck source=/dev/null
+source "$BB_FUNCS_FILE"
+
+wf() { printf '%s\n' "$2" > "$1"; }  # write findings
+
+# ── _bb_triage_findings ────────────────────────────────────────────────────
+echo ""
+echo "=== _bb_triage_findings ==="
+echo ""
+
+# TC-T1: CRITICAL confidence=0.1 → actionable
+wf "$TEST_TMPDIR/t1.json" '{"findings":[{"id":"F001","severity":"CRITICAL","confidence":0.1,"file":"a.sh","title":"x","description":"x","suggestion":"x","weight":5}],"total":1}'
+_BB_ACTIONABLE_IDS=()
+_bb_triage_findings "$TEST_TMPDIR/t1.json"
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 1 && "${_BB_ACTIONABLE_IDS[0]:-}" == "F001" ]] \
+    && pass "TC-T1: CRITICAL confidence=0.1 → actionable" \
+    || fail "TC-T1: got ids=${_BB_ACTIONABLE_IDS[*]:-none}"
+
+# TC-T2: HIGH no confidence → actionable
+wf "$TEST_TMPDIR/t2.json" '{"findings":[{"id":"F002","severity":"HIGH","file":"b.sh","title":"x","description":"x","suggestion":"x","weight":5}],"total":1}'
+_BB_ACTIONABLE_IDS=()
+_bb_triage_findings "$TEST_TMPDIR/t2.json"
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 1 && "${_BB_ACTIONABLE_IDS[0]:-}" == "F002" ]] \
+    && pass "TC-T2: HIGH no confidence → actionable" \
+    || fail "TC-T2: got ids=${_BB_ACTIONABLE_IDS[*]:-none}"
+
+# TC-T3: MEDIUM confidence=0.8 → actionable
+wf "$TEST_TMPDIR/t3.json" '{"findings":[{"id":"F003","severity":"MEDIUM","confidence":0.8,"file":"c.sh","title":"x","description":"x","suggestion":"x","weight":3}],"total":1}'
+_BB_ACTIONABLE_IDS=()
+_bb_triage_findings "$TEST_TMPDIR/t3.json"
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 1 && "${_BB_ACTIONABLE_IDS[0]:-}" == "F003" ]] \
+    && pass "TC-T3: MEDIUM confidence=0.8 → actionable" \
+    || fail "TC-T3: got ids=${_BB_ACTIONABLE_IDS[*]:-none}"
+
+# TC-T4: MEDIUM confidence=0.7 → non-actionable
+wf "$TEST_TMPDIR/t4.json" '{"findings":[{"id":"F004","severity":"MEDIUM","confidence":0.7,"file":"d.sh","title":"x","description":"x","suggestion":"x","weight":3}],"total":1}'
+_BB_ACTIONABLE_IDS=()
+_bb_triage_findings "$TEST_TMPDIR/t4.json"
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 0 ]] \
+    && pass "TC-T4: MEDIUM confidence=0.7 → non-actionable" \
+    || fail "TC-T4: should be non-actionable, got ${_BB_ACTIONABLE_IDS[*]}"
+
+# TC-T5: MEDIUM no confidence → actionable (default 1.0)
+wf "$TEST_TMPDIR/t5.json" '{"findings":[{"id":"F005","severity":"MEDIUM","file":"e.sh","title":"x","description":"x","suggestion":"x","weight":3}],"total":1}'
+_BB_ACTIONABLE_IDS=()
+_bb_triage_findings "$TEST_TMPDIR/t5.json"
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 1 && "${_BB_ACTIONABLE_IDS[0]:-}" == "F005" ]] \
+    && pass "TC-T5: MEDIUM no confidence → actionable" \
+    || fail "TC-T5: got ids=${_BB_ACTIONABLE_IDS[*]:-none}"
+
+# TC-T6: LOW confidence=0.9 → non-actionable, in lore candidates
+LORE="$TEST_TMPDIR/.run/bridge-lore-candidates.jsonl"
+rm -f "$LORE"
+wf "$TEST_TMPDIR/t6.json" '{"findings":[{"id":"F006","severity":"LOW","confidence":0.9,"file":"f.sh","title":"x","description":"x","suggestion":"x","weight":1}],"total":1}'
+_BB_ACTIONABLE_IDS=()
+_bb_triage_findings "$TEST_TMPDIR/t6.json"
+in_lore=false; [[ -f "$LORE" ]] && grep -q '"F006"' "$LORE" 2>/dev/null && in_lore=true
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 0 && "$in_lore" == "true" ]] \
+    && pass "TC-T6: LOW → non-actionable, in lore candidates" \
+    || fail "TC-T6: actionable=${#_BB_ACTIONABLE_IDS[@]} in_lore=$in_lore"
+
+# TC-T7: PRAISE → non-actionable, in lore candidates
+rm -f "$LORE"
+wf "$TEST_TMPDIR/t7.json" '{"findings":[{"id":"F007","severity":"PRAISE","confidence":1.0,"file":"","title":"Great","description":"nice","suggestion":"","weight":0}],"total":1}'
+_BB_ACTIONABLE_IDS=()
+_bb_triage_findings "$TEST_TMPDIR/t7.json"
+in_lore=false; [[ -f "$LORE" ]] && grep -q '"F007"' "$LORE" 2>/dev/null && in_lore=true
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 0 && "$in_lore" == "true" ]] \
+    && pass "TC-T7: PRAISE → non-actionable, in lore candidates" \
+    || fail "TC-T7: actionable=${#_BB_ACTIONABLE_IDS[@]} in_lore=$in_lore"
+
+# TC-T8: VISION → non-actionable, NOT in lore candidates
+rm -f "$LORE"
+wf "$TEST_TMPDIR/t8.json" '{"findings":[{"id":"F008","severity":"VISION","confidence":0.9,"file":"","title":"v","description":"future","suggestion":"","weight":0}],"total":1}'
+_BB_ACTIONABLE_IDS=()
+_bb_triage_findings "$TEST_TMPDIR/t8.json"
+in_lore=false; [[ -f "$LORE" ]] && grep -q '"F008"' "$LORE" 2>/dev/null && in_lore=true
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 0 && "$in_lore" == "false" ]] \
+    && pass "TC-T8: VISION → non-actionable, NOT in lore" \
+    || fail "TC-T8: actionable=${#_BB_ACTIONABLE_IDS[@]} in_lore=$in_lore"
+
+# TC-T9: Missing 'findings' key → graceful
+wf "$TEST_TMPDIR/t9.json" '{"schema_version":2,"total":0}'
+_BB_ACTIONABLE_IDS=()
+rc=0; _bb_triage_findings "$TEST_TMPDIR/t9.json" || rc=$?
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 0 && "$rc" -eq 0 ]] \
+    && pass "TC-T9: Missing findings key → empty, return 0" \
+    || fail "TC-T9: ids=${#_BB_ACTIONABLE_IDS[@]} rc=$rc"
+
+# TC-T10: Non-existent file → graceful
+_BB_ACTIONABLE_IDS=()
+rc=0; _bb_triage_findings "/tmp/nonexistent-$$-x.json" || rc=$?
+[[ ${#_BB_ACTIONABLE_IDS[@]} -eq 0 && "$rc" -eq 0 ]] \
+    && pass "TC-T10: Non-existent file → empty, return 0" \
+    || fail "TC-T10: ids=${#_BB_ACTIONABLE_IDS[@]} rc=$rc"
+
+# ── _bb_detect_stuck_findings ──────────────────────────────────────────────
+echo ""
+echo "=== _bb_detect_stuck_findings ==="
+echo ""
+
+# TC-S1: F001 in prev + current → stuck, event emitted
+> "$_FLIGHT_RECORDER"
+_BB_PREV_ACTIONABLE_IDS=("F001")
+_BB_ACTIONABLE_IDS=("F001" "F002")
+_BB_STUCK_IDS=()
+_BB_CURRENT_ITER=2
+_BB_ACTIONABLE_JSON='[{"id":"F001","severity":"HIGH"},{"id":"F002","severity":"MEDIUM"}]'
+_bb_detect_stuck_findings
+sc=0; for s in ${_BB_STUCK_IDS[@]+"${_BB_STUCK_IDS[@]}"}; do sc=$((sc+1)); done
+ev=$(grep -c 'BB_FINDING_STUCK' "$_FLIGHT_RECORDER" 2>/dev/null || echo "0")
+[[ "$sc" -eq 1 && "${_BB_STUCK_IDS[0]:-}" == "F001" && "$ev" -ge 1 ]] \
+    && pass "TC-S1: F001 prev+current → stuck, event emitted" \
+    || fail "TC-S1: stuck_count=$sc ids=${_BB_STUCK_IDS[*]:-none} events=$ev"
+
+# TC-S2: F002 current only → not stuck
+> "$_FLIGHT_RECORDER"
+_BB_PREV_ACTIONABLE_IDS=("F001")
+_BB_ACTIONABLE_IDS=("F002")
+_BB_STUCK_IDS=()
+_BB_CURRENT_ITER=2
+_BB_ACTIONABLE_JSON='[{"id":"F002","severity":"MEDIUM"}]'
+_bb_detect_stuck_findings
+sc=0; for s in ${_BB_STUCK_IDS[@]+"${_BB_STUCK_IDS[@]}"}; do sc=$((sc+1)); done
+[[ "$sc" -eq 0 ]] \
+    && pass "TC-S2: F002 current only → not stuck" \
+    || fail "TC-S2: expected 0 stuck, got stuck=${_BB_STUCK_IDS[*]}"
+
+# TC-S3: F001 already in _BB_STUCK_IDS → no duplicate event
+> "$_FLIGHT_RECORDER"
+_BB_PREV_ACTIONABLE_IDS=("F001")
+_BB_ACTIONABLE_IDS=("F001")
+_BB_STUCK_IDS=("F001")
+_BB_CURRENT_ITER=3
+_BB_ACTIONABLE_JSON='[{"id":"F001","severity":"HIGH"}]'
+_bb_detect_stuck_findings
+ev=$(grep -c 'BB_FINDING_STUCK' "$_FLIGHT_RECORDER" 2>/dev/null || true)
+ev="${ev:-0}"
+[[ "$ev" -eq 0 ]] \
+    && pass "TC-S3: already stuck → no duplicate event" \
+    || fail "TC-S3: expected 0 new events, got $ev"
+
+# TC-S4: Empty prev IDs → no stuck
+> "$_FLIGHT_RECORDER"
+_BB_PREV_ACTIONABLE_IDS=()
+_BB_ACTIONABLE_IDS=("F001" "F002")
+_BB_STUCK_IDS=()
+_BB_CURRENT_ITER=1
+_BB_ACTIONABLE_JSON='[{"id":"F001","severity":"HIGH"},{"id":"F002","severity":"MEDIUM"}]'
+_bb_detect_stuck_findings
+sc=0; for s in ${_BB_STUCK_IDS[@]+"${_BB_STUCK_IDS[@]}"}; do sc=$((sc+1)); done
+ev=$(grep -c 'BB_FINDING_STUCK' "$_FLIGHT_RECORDER" 2>/dev/null || true)
+ev="${ev:-0}"
+[[ "$sc" -eq 0 && "$ev" -eq 0 ]] \
+    && pass "TC-S4: empty prev → no stuck, no events" \
+    || fail "TC-S4: stuck=$sc events=$ev"
+
+# ── Summary ────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+echo ""
+[[ "$FAIL_COUNT" -eq 0 ]]


### PR DESCRIPTION
## Summary

Closes #512. Wires the Bridgebuilder kaironic fix loop into `spiral-harness.sh` so that actionable BB findings (CRITICAL/HIGH/MEDIUM with confidence > 0.7) are resolved autonomously via iterative fix cycles instead of being posted as terminal PR advisories.

- **534 lines** added to `.claude/scripts/spiral-harness.sh` — `_bb_triage_findings`, `_bb_detect_stuck_findings`, `_bb_track_resolved_incremental`, `_bb_dispatch_fix_cycle`, `_bb_post_final_comment`, `_phase_bb_fix_loop` + resume protocol + wiring into `main()`
- **22/22 tests** passing — 15 unit tests (triage + stuck + multi-iteration resolved tracking) + 7 integration assertions covering FLATLINE convergence path
- **Config**: `spiral.harness.bb_fix_budget_usd` (default \$3) and `spiral.harness.bb_max_iterations` (default 3)
- **Profile-aware**: uses `\$EXECUTOR_MODEL`, works with full/standard/light
- **Idempotent resume**: `BB_LOOP_COMPLETE` sentinel in flight recorder, skipped-iter detection, spend reconstruction

## Architecture

```
implement → review → audit → PR → bridgebuilder → triage
                                                      ↓
                                       CRITICAL/HIGH/MEDIUM(>0.7) → fix cycle (\$EXECUTOR_MODEL)
                                                      ↓
                                       re-review → convergence OR circuit breaker (3 iter max)
                                                      ↓
                                       post final consolidated comment → BB_LOOP_COMPLETE
```

## Review Approval

Independent review gate (**first-pass APPROVED**) — evidence at `.run/cycles/cycle-074-fixes/evidence/review-stdout.json`. Review doc committed at `grimoires/loa/a2a/engineer-feedback.md` with file:line traceability per AC:

- Shell safety: no \`(( var++ ))\`, no \`eval\`, \`bash -n\` PASS, jq-safe prompt/comment construction, path traversal guard on fix-cycle file context
- All 7 deliverables in #512 traced to code location
- Multi-iteration resolved tracking verified by new TC-R1 test case

## Audit Trail

Two-cycle harness run:

| Cycle | Scope | Cost | Outcome |
|-------|-------|------|---------|
| cycle-074 (standard) | Initial impl | \$11 | Review rejected 3× (real: incremental resolved tracking bug + 2 dead lines) |
| cycle-074-fixes (light) | Surgical fixes per engineer-feedback.md | \$10 | Review APPROVED first pass; budget cap hit exactly at audit gate |

Independent audit will be run via \`/audit-sprint\` as a follow-up step on this PR (harness budget-exhausted before audit gate; not a gate rejection).

Evidence:
- `.run/cycles/cycle-074/` — initial implementation
- `.run/cycles/cycle-074-fixes/` — remediation cycle

## Test Plan

- [x] `bash -n .claude/scripts/spiral-harness.sh` — syntax clean
- [x] `bash .claude/scripts/tests/test-bb-triage.sh` — 15/15 PASS
- [x] `bash .claude/scripts/tests/test-bb-integration.sh` — 7/7 PASS
- [ ] CI: Security Audit workflow PASS
- [ ] CI: BATS Tests PASS (note: pre-existing flaky tests on main — separate follow-up)
- [ ] CI: Secret Scanning PASS
- [ ] `/audit-sprint` follow-up audit — clean verdict

## Follow-ups (out of scope, deferred)

- Issues 4-7 from engineer-feedback.md are LOW/TRIVIAL advisory (reviewer: "don't need to block merge")
- Pre-existing BATS failures on main (`adversarial-review.bats:566` word-splitting, butterfreezone validate, gpt-review config) — non-release-blocking, cycle-075 candidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)