### PR TITLE
fix(tests): avoid ls|wc -l newline bug in secret_scan cleanup (cycle-075 W1d)

### DIFF
--- a/tests/unit/adversarial-review.bats
+++ b/tests/unit/adversarial-review.bats
@@ -559,9 +559,20 @@ EOF
 @test "secret_scan: temp files are cleaned up" {
     local content="AKIAIOSFODNN7EXAMPLE1 is a test key"
     local before_count after_count
-    before_count=$(ls /tmp/tmp.* 2>/dev/null | wc -l || echo 0)
+    local tmp_files
+    # Use shopt nullglob + array to count matching temp files.
+    # Avoids the `ls ... | wc -l || echo 0` pattern, which under
+    # set -o pipefail (enabled by bats) produces "0\n0" when the
+    # pipeline fails — wc's "0" reaches stdout before pipefail
+    # signals failure, then the `|| echo 0` fallback also emits,
+    # and $(...) concatenates both.
+    shopt -s nullglob
+    tmp_files=(/tmp/tmp.*)
+    before_count=${#tmp_files[@]}
     result=$(secret_scan_content "$content")
-    after_count=$(ls /tmp/tmp.* 2>/dev/null | wc -l || echo 0)
+    tmp_files=(/tmp/tmp.*)
+    after_count=${#tmp_files[@]}
+    shopt -u nullglob
     # Should not leak temp files
     [[ "$after_count" -le "$before_count" ]]
 }


### PR DESCRIPTION
## Summary

- **Wave-1d of cycle-075 CI triage**. Fixes 1 pre-existing BATS failure (`adversarial-review.bats:566`, test 65 "secret_scan: temp files are cleaned up").
- Root cause: `$(ls /tmp/tmp.* 2>/dev/null | wc -l || echo 0)` produces `"0\n0"` under `set -o pipefail` (enabled by bats) — `wc`'s stdout reaches the buffer before pipefail signals failure, then the `|| echo 0` fallback also emits, and `$(...)` concatenates both.
- Fix: replace `ls | wc` pattern with `shopt nullglob` + array `${#tmp_files[@]}`. No pipe, no newline-absorption risk, more idiomatic for "count matching files."
- Test-only change. No production scripts touched.

## Evidence (before fix)

```
not ok 65 secret_scan: temp files are cleaned up
# (in test file tests/unit/adversarial-review.bats, line 566)
#   `[[ "$after_count" -le "$before_count" ]]' failed
# [adversarial-review] Secret scan: 1 redaction(s) applied
# /home/runner/work/loa/loa/tests/unit/adversarial-review.bats: line 566: [[: 0
# 0: syntax error in expression (error token is "0")
```

The literal embedded newline in `"0\n0"` is visible in the `[[: 0 / 0: syntax error` split across lines.

## Local verification

```
$ bats tests/unit/adversarial-review.bats
...
ok 65 secret_scan: temp files are cleaned up
...
(69 tests, 0 failures)
```

## Wave-1 companion PRs

- [#517](https://github.com/0xHoneyJar/loa/pull/517) — W1a: `loa-grimoire` → `grimoires/loa` rename in 5 test files (Cluster 1)
- **This PR (W1d)**
- W1b — Cluster 2: invariant + subagent-reports test refactor (pending)
- W1c — Cluster 4: subagent YAML frontmatter validation fix (pending)
- W1e — Cluster B6: `cycle-workspace.sh:92` compat-lib sourcing (pending)

Triage doc: `grimoires/loa/a2a/ci-triage/cycle-075-root-causes.md` (Cluster A).

## Test plan

- [ ] CI passes (test 65 flips fail → pass; no other tests in adversarial-review.bats regress)
- [ ] No production `.claude/scripts/*.sh` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)