### PR TITLE
fix(lint): rephrase comment triggering false-positive readlink -f lint (cycle-075 W1e)

### DIFF
--- a/.claude/scripts/cycle-workspace.sh
+++ b/.claude/scripts/cycle-workspace.sh
@@ -89,8 +89,9 @@ validate_cycle_id() {
 }
 
 # Returns the currently active cycle id, or empty string if no active symlink.
-# Uses `readlink` (not `readlink -f`) so we just read the link target, not the
-# resolved path — the target is the cycle-id relative to CYCLES_DIR.
+# Uses plain `readlink` (without the fully-resolve flag) so we just read the
+# link target, not the resolved path — the target is the cycle-id relative
+# to CYCLES_DIR.
 get_active_cycle() {
     if [[ ! -L "$ACTIVE_LINK" ]]; then
         echo ""


### PR DESCRIPTION
## Summary

- **Wave-1e of cycle-075 CI triage**. Fixes 1 pre-existing Shell Compatibility Lint error on `main` ([run 24444888656](https://github.com/0xHoneyJar/loa/actions/runs/24444888656), job 71418593169).
- Root cause: **lint false positive**. The rule "`readlink -f` without fallback" uses `grep -rn 'readlink -f'` and matches comment text. `cycle-workspace.sh:92` is a comment that literally contains the phrase `readlink -f` while explaining the code deliberately avoids the `-f` flag. The underlying `readlink` call at line 99 is and always was portable (no `-f`).
- Fix: rephrase the comment so the literal string `readlink -f` no longer appears.

## Why not add a real `compat-lib.sh` sourcing fallback?

Considered — rejected. There is no actual non-portable `readlink -f` call in this file. Adding a `source compat-lib.sh` line just to placate the lint would be a dependency added to mask a false positive, not a real fix. The spirit of the lint rule (prevent non-portable shell) is already satisfied by line 99's plain `readlink "$ACTIVE_LINK"` which works on BSD/macOS.

## Alternative considered: fix the lint regex

The deeper fix is to make the Shell Compatibility Lint workflow skip comments. That's a separate, bigger change (touches `.github/workflows/shell-compat-lint.yml`) and would affect other lint rules. Out of scope for this 1-line fix. Worth a follow-up lint hardening issue.

## Verification

```
$ grep -n 'readlink -f' .claude/scripts/cycle-workspace.sh
(no output — no more matches)

$ bash -n .claude/scripts/cycle-workspace.sh
(no output — syntax OK)
```

## Wave-1 companion PRs

- [#517](https://github.com/0xHoneyJar/loa/pull/517) — W1a: `loa-grimoire` → `grimoires/loa` rename in 5 test files (Cluster 1)
- [#518](https://github.com/0xHoneyJar/loa/pull/518) — W1d: `ls|wc` newline absorption fix in `adversarial-review.bats` (Cluster A)
- **This PR (W1e)**
- W1b — Cluster 2: invariant + subagent-reports test refactor (pending)
- W1c — Cluster 4: subagent YAML frontmatter validation fix (pending)

Triage doc: `grimoires/loa/a2a/ci-triage/cycle-075-root-causes.md` (Cluster B6).

## Test plan

- [ ] Shell Compatibility Lint passes (the 1 ERROR drops to 0)
- [ ] 8 warnings remain (not addressed by this PR — documented in triage doc as a separate cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)