### PR TITLE
fix(tests): decouple invariant tests + create subagent-reports placeholder (cycle-075 W1b)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,11 @@ grimoires/loa/a2a/compound/*.json
 grimoires/loa/a2a/compound/review-markers/*
 !grimoires/loa/a2a/compound/.gitkeep
 !grimoires/loa/a2a/compound/review-markers/.gitkeep
+# Subagent reports (runtime outputs; directory is committed as an empty
+# placeholder so subagent write targets exist at framework mount time)
+!grimoires/loa/a2a/subagent-reports/
+grimoires/loa/a2a/subagent-reports/*.md
+!grimoires/loa/a2a/subagent-reports/.gitkeep
 
 # Deployment artifacts (project-specific)
 grimoires/loa/deployment/*

--- a/tests/fixtures/invariants-example.yaml
+++ b/tests/fixtures/invariants-example.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+protocol: loa-hounfour@8.3.1
+# Fixture invariants for testing verify-invariants.sh.
+#
+# References framework files that are stable and exist in the loa repo.
+# Does NOT represent real loa invariants — project-specific invariants.yaml
+# was moved to consumer projects in cycle-035 (#406 "Minimal Footprint by
+# Default — Submodule-First Installation"). This fixture exists only to
+# exercise the verification script's code paths in CI.
+#
+# Adding references: pick symbols that appear as literal text in stable
+# files under .claude/scripts/ or .claude/schemas/. The verification script
+# uses grep, so any textual match counts — function names, variable names,
+# or distinctive strings all work.
+invariants:
+  - id: INV-FIX-001
+    description: "path-lib provides grimoire and ledger path resolution"
+    severity: advisory
+    category: conservation
+    properties:
+      - "get_ledger_path returns canonical ledger.json path"
+      - "get_grimoire_dir resolves the grimoire root"
+    verified_in:
+      - repo: loa
+        file: ".claude/scripts/path-lib.sh"
+        symbol: "get_ledger_path"
+      - repo: loa
+        file: ".claude/scripts/path-lib.sh"
+        symbol: "get_grimoire_dir"
+  - id: INV-FIX-002
+    description: "Bootstrap provides project-root detection function"
+    severity: advisory
+    category: bounded
+    properties:
+      - "bootstrap.sh detects PROJECT_ROOT via _detect_project_root"
+    verified_in:
+      - repo: loa
+        file: ".claude/scripts/bootstrap.sh"
+        symbol: "_detect_project_root"

--- a/tests/unit/invariant-verification.bats
+++ b/tests/unit/invariant-verification.bats
@@ -12,9 +12,13 @@
 setup() {
     export PROJECT_ROOT="${BATS_TEST_DIRNAME}/../.."
     export SCRIPT="${PROJECT_ROOT}/.claude/scripts/verify-invariants.sh"
-    export INVARIANTS_FILE="${PROJECT_ROOT}/grimoires/loa/invariants.yaml"
+    # Project-specific invariants.yaml was moved to consumer repos in cycle-035
+    # (#406 "Minimal Footprint by Default — Submodule-First Installation"). The
+    # verification script is a reusable framework utility; tests exercise it
+    # against a committed fixture rather than consumer-supplied data.
+    export FIXTURE="${PROJECT_ROOT}/tests/fixtures/invariants-example.yaml"
 
-    # Create temp directory for test fixtures
+    # Create temp directory for ad-hoc test fixtures (used by negative-path tests)
     export TMPDIR_BATS="$(mktemp -d)"
 }
 
@@ -30,8 +34,8 @@ teardown() {
     [ -x "$SCRIPT" ]
 }
 
-@test "invariants.yaml exists" {
-    [ -f "$INVARIANTS_FILE" ]
+@test "fixture invariants file exists" {
+    [ -f "$FIXTURE" ]
 }
 
 @test "invariants schema exists" {
@@ -43,33 +47,36 @@ teardown() {
 # =============================================================================
 
 @test "all declared invariants pass in valid codebase" {
-    run "$SCRIPT" --quiet
+    run "$SCRIPT" --file "$FIXTURE" --quiet
     [ "$status" -eq 0 ]
 }
 
 @test "all declared invariants pass (JSON output)" {
-    run "$SCRIPT" --json
+    run "$SCRIPT" --file "$FIXTURE" --json
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.status == "pass"'
     echo "$output" | jq -e '.failures == 0'
 }
 
 @test "JSON output contains check entries for every reference" {
-    run "$SCRIPT" --json
+    run "$SCRIPT" --file "$FIXTURE" --json
     [ "$status" -eq 0 ]
-    # We expect at least 15 checks (17 references in invariants.yaml)
+    # Fixture declares 3 refs across 2 invariants. Assert ≥ 1 to stay robust
+    # against future fixture tweaks while still verifying the checks array is
+    # populated (i.e., script did not short-circuit).
     local count
     count=$(echo "$output" | jq '.checks | length')
-    [ "$count" -ge 15 ]
+    [ "$count" -ge 1 ]
 }
 
-@test "all 5 invariants are verified" {
-    run "$SCRIPT" --json
+@test "all fixture invariants are verified" {
+    run "$SCRIPT" --file "$FIXTURE" --json
     [ "$status" -eq 0 ]
-    # Extract unique INV IDs from check names
+    # Extract unique INV IDs from check names. Fixture has 2 invariants
+    # (INV-FIX-001, INV-FIX-002). Pinned to fixture shape.
     local inv_count
     inv_count=$(echo "$output" | jq '[.checks[].name | split(":")[0]] | unique | length')
-    [ "$inv_count" -eq 5 ]
+    [ "$inv_count" -eq 2 ]
 }
 
 # =============================================================================
@@ -253,7 +260,7 @@ YAML
 # =============================================================================
 
 @test "exit 0 for all-pass" {
-    run "$SCRIPT" --quiet
+    run "$SCRIPT" --file "$FIXTURE" --quiet
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

- **Wave-1b of cycle-075 CI triage**. Fixes 8 pre-existing BATS failures from Cluster 2 (missing committed artifacts). Test-only change except for adding `.gitignore` rules + a `.gitkeep` placeholder. No `.claude/scripts/*.sh` production code touched.
- Two related fixes in one PR, both rooted in "tests expect artifacts that aren't in the repo":
  1. **Invariant tests**: refactor to use committed fixture (the project-specific `invariants.yaml` was deliberately deleted in cycle-035)
  2. **Subagent-reports directory**: create the empty placeholder + `.gitkeep` (runtime output dir that was never committed)

## Git archaeology — why `invariants.yaml` is gone

- **`95f38aa`** (sprint-8, "cross-repository invariant infrastructure", BB-301..BB-306) — introduced `grimoires/loa/invariants.yaml` (126 lines) + `invariants.schema.json` + `verify-invariants.sh` + this test file. 19 BATS tests passing.
- **`0463e21`** (cycle-035, "**Minimal Footprint by Default — Submodule-First Installation**", #406, Feb 24 2026) — **deliberately deleted** `grimoires/loa/invariants.yaml` (all 126 lines) as part of framework extraction. The tests, schema, and `verify-invariants.sh` were NOT cleaned up alongside.

**Inferred intent (HIGH confidence)**: `verify-invariants.sh` is a reusable framework utility; project-specific `invariants.yaml` is consumer-supplied (downstream projects declare their own). Tests should exercise the script against a fixture, not require consumer-supplied data.

## Fix 1 — fixture-based invariant tests

Added `tests/fixtures/invariants-example.yaml` — a minimal 2-invariant/3-ref fixture referencing stable framework files. The verification script already supports a `--file` flag, so the refactor is:

```bash
# Before (depends on deleted file):
run "$SCRIPT" --quiet

# After (uses committed fixture):
run "$SCRIPT" --file "$FIXTURE" --quiet
```

Count assertions were loosened or pinned to the fixture:
- `"at least 15 checks (17 refs in invariants.yaml)"` → `"at least 1 check"` (robust to future fixture tweaks)
- `"all 5 invariants are verified"` → `"all fixture invariants are verified"` pinned to `-eq 2`

**Did NOT restore `grimoires/loa/invariants.yaml`** — its deletion was intentional framework hygiene.

## Fix 2 — subagent-reports placeholder

`grimoires/loa/a2a/subagent-reports/` is a **live, intended** runtime output directory. It's declared as the `output_path:` in all 5 `.claude/subagents/*.md` files and documented in `.claude/subagents/README.md`. The directory simply was never committed.

Created `.gitkeep` placeholder. Updated `.gitignore` following the existing pattern for `grimoires/loa/a2a/compound/` — un-ignore the directory, re-ignore `*.md` runtime writes, un-ignore the `.gitkeep`:

```
!grimoires/loa/a2a/subagent-reports/
grimoires/loa/a2a/subagent-reports/*.md
!grimoires/loa/a2a/subagent-reports/.gitkeep
```

## Local verification

```
$ bats tests/unit/invariant-verification.bats
1..19
(19/19 pass — was 13/19)    # +6 fixed

$ bats tests/unit/subagent-loader.bats
(40/41 pass — was 38/41)    # +2 fixed
```

The remaining 1 failure in `subagent-loader.bats` is test 6 "architecture-validator.md has valid YAML frontmatter" — **W1c scope, landing in #520**, not this PR's scope.

## Files changed

- `tests/fixtures/invariants-example.yaml` (new — 39 lines)
- `tests/unit/invariant-verification.bats` (6 tests refactored to use `--file "$FIXTURE"`)
- `grimoires/loa/a2a/subagent-reports/.gitkeep` (new — empty)
- `.gitignore` (4 new lines, follows existing compound/ pattern)

## Wave-1 companion PRs

- [#517](https://github.com/0xHoneyJar/loa/pull/517) — W1a: `loa-grimoire` → `grimoires/loa` rename (Cluster 1)
- [#518](https://github.com/0xHoneyJar/loa/pull/518) — W1d: `ls|wc` newline bug (Cluster A)
- [#519](https://github.com/0xHoneyJar/loa/pull/519) — W1e: `readlink -f` lint comment fix (Cluster B6)
- [#520](https://github.com/0xHoneyJar/loa/pull/520) — W1c: subagent YAML frontmatter validation (Cluster 4)
- **This PR (W1b)** — Cluster 2

Triage doc: `grimoires/loa/a2a/ci-triage/cycle-075-root-causes.md` (Cluster 2).

## Test plan

- [ ] CI passes (8 tests flip fail → pass across invariant-verification.bats and subagent-loader.bats)
- [ ] subagent-loader test 6 stays red — that's W1c / #520 scope
- [ ] No production `.claude/scripts/*.sh` changes (`git diff main...HEAD -- .claude/scripts/` is empty)
- [ ] `.gitkeep` preserves empty directory shape

## Open question for reviewer

Is `verify-invariants.sh` + the schema still worth keeping in the framework repo? Since cycle-035's direction was framework extraction, this utility might ultimately belong in a per-project `.claude/` or as an optional add-on. Not in scope for this PR — but flagging for future consideration. If you want to remove it entirely, the tests go too (this PR becomes a delete) and the triage doc should be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)