### PR TITLE
fix(tests): isolate PROJECT_ROOT + contract-based path assertions in ledger-lib.bats (cycle-075 W2a)

### DIFF
--- a/tests/unit/ledger-lib.bats
+++ b/tests/unit/ledger-lib.bats
@@ -12,8 +12,14 @@
 # Test setup
 setup() {
     BATS_TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
-    PROJECT_ROOT="$(cd "$BATS_TEST_DIR/../.." && pwd)"
-    SCRIPT="$PROJECT_ROOT/.claude/scripts/ledger-lib.sh"
+    # Real repo root — used only to locate the library under test.
+    # Don't export this as PROJECT_ROOT: path-lib.sh would then resolve
+    # all ledger operations against the real repo, clobbering live data
+    # and breaking test isolation (this was the root cause of the
+    # pre-cycle-075 33-test failure cluster on ledger-lib.bats).
+    local real_repo_root
+    real_repo_root="$(cd "$BATS_TEST_DIR/../.." && pwd)"
+    SCRIPT="$real_repo_root/.claude/scripts/ledger-lib.sh"
 
     # Create temp directory for test artifacts
     export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
@@ -23,6 +29,13 @@ setup() {
     # Create mock project structure
     export TEST_PROJECT="$TEST_TMPDIR/project"
     mkdir -p "$TEST_PROJECT/grimoires/loa/a2a"
+
+    # Critical: export PROJECT_ROOT=TEST_PROJECT so path-lib.sh resolves
+    # ledger paths (via get_ledger_path etc.) WITHIN the isolated test
+    # project. Without this, writes via relative paths go to TEST_PROJECT
+    # but reads via lib functions go to the real repo — the test passes
+    # spuriously or fails mysteriously depending on real-repo state.
+    export PROJECT_ROOT="$TEST_PROJECT"
 
     # Change to test project directory
     cd "$TEST_PROJECT"
@@ -61,7 +74,13 @@ source_lib() {
     local result
     result=$(get_ledger_path)
 
-    [[ "$result" == "grimoires/loa/ledger.json" ]]
+    # Contract-based assertion: returned path resolves to the ledger inside
+    # the active project (relative OR absolute). Avoids coupling the test
+    # to path-lib's implementation detail (absolute vs relative). The
+    # PROJECT_ROOT export in setup() ensures the "active project" is the
+    # isolated test dir.
+    [[ "$result" = */grimoires/loa/ledger.json ]]
+    [[ "$(basename "$result")" = "ledger.json" ]]
 }
 
 @test "ledger_exists returns false when no ledger" {
@@ -388,7 +407,9 @@ source_lib() {
 
     local result
     result=$(get_sprint_directory 5)
-    [[ "$result" == "grimoires/loa/a2a/sprint-5" ]]
+    # Contract-based assertion (see get_ledger_path test for rationale).
+    [[ "$result" = */grimoires/loa/a2a/sprint-5 ]]
+    [[ "$(basename "$result")" = "sprint-5" ]]
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- **Wave-2a of cycle-075 CI triage**. Fixes 33 pre-existing BATS failures in `tests/unit/ledger-lib.bats` (test 1 + 32 cascade failures).
- Test-only change. No production code touched. `get_ledger_path()` retains its absolute-return semantics because that's what every production consumer actually needs.

## TL;DR

The triage doc framed this as "relative-vs-absolute assertion mismatch" — that's true but **incomplete**. Investigation revealed a deeper test-isolation leak: `setup()` was using the real repo's `PROJECT_ROOT` while `cd`ing to `$TEST_PROJECT`. Writes went to the test dir; lib functions read from the real repo. 33 tests failed. More concerning: had `init_ledger` succeeded in the test, it would have **clobbered the real repo's committed `ledger.json`** — a silent test-isolation violation with actual data-loss risk.

## Root cause

```bash
# Old setup() (abbreviated):
PROJECT_ROOT="$(cd "$BATS_TEST_DIR/../.." && pwd)"   # real repo root
SCRIPT="$PROJECT_ROOT/.claude/scripts/ledger-lib.sh" # correct use
...
export TEST_PROJECT="$TEST_TMPDIR/project"
mkdir -p "$TEST_PROJECT/grimoires/loa/a2a"
cd "$TEST_PROJECT"                                    # CWD = isolated test dir
```

`PROJECT_ROOT` served two purposes in the original setup:
1. **Path to the library under test** (sourcing `ledger-lib.sh`) — legitimate, needs real-repo-root.
2. **Inherited by `path-lib.sh`** for resolving data paths — **wrong** — should be `$TEST_PROJECT`.

This made the test environment schizophrenic:
- `jq -r '.version' grimoires/loa/ledger.json` (relative path from CWD) wrote to `$TEST_PROJECT/grimoires/loa/ledger.json`
- `$(get_ledger_path)` (via path-lib) returned `$REAL_REPO/grimoires/loa/ledger.json`
- They're **different files**.

## Fix 1 — isolate `PROJECT_ROOT`

```bash
# New setup() (abbreviated):
local real_repo_root                                    # local, not exported
real_repo_root="$(cd "$BATS_TEST_DIR/../.." && pwd)"
SCRIPT="$real_repo_root/.claude/scripts/ledger-lib.sh"  # sourcing uses local
...
export PROJECT_ROOT="$TEST_PROJECT"                     # path-lib uses test dir
cd "$TEST_PROJECT"
```

This separates "where to source the library" from "where data lives." Library stays in the real repo; data operations all happen within `$TEST_PROJECT`. 32 of the 33 failures resolve from this change alone.

## Fix 2 — contract-based assertions (2 tests)

Two tests hardcoded literal path strings:

```bash
# Before — couples test to path-lib's impl detail (rel vs abs):
[[ "$result" == "grimoires/loa/ledger.json" ]]
[[ "$result" == "grimoires/loa/a2a/sprint-5" ]]

# After — tests the CONTRACT (path resolves to the right file):
[[ "$result" = */grimoires/loa/ledger.json ]]
[[ "$(basename "$result")" = "ledger.json" ]]
```

The contract being verified: "the function returns a path that identifies the ledger file." Whether that path is absolute or relative is an implementation detail that tests shouldn't couple to.

## Why `get_ledger_path()` stays absolute (FAANG analysis)

From the cycle-075 triage doc — short version:
- 26 call sites across production. All use the return value in **I/O context** (read/write/backup/CD). 0 use it for display.
- Absolute is CWD-robust — critical for harness subshells and backgrounded processes
- Relative would silently break any consumer invoked from a CWD ≠ PROJECT_ROOT
- POSIX convention for path-returning APIs is absolute
- Dual-function split (`get_ledger_path_relative`) is YAGNI — 0 real consumers

**The test was wrong, not the function.** Fixed the test.

## Local verification

```
$ bats tests/unit/ledger-lib.bats
(36 tests, 0 failures)    # was 3/36 passing, 33 failing
```

## Files changed

- `tests/unit/ledger-lib.bats` (setup() isolation fix + 2 contract-based assertions)

## Wave-1 companion PRs (already open, for context)

- [#517](https://github.com/0xHoneyJar/loa/pull/517) — W1a Cluster 1
- [#518](https://github.com/0xHoneyJar/loa/pull/518) — W1d Cluster A
- [#519](https://github.com/0xHoneyJar/loa/pull/519) — W1e Cluster B6
- [#520](https://github.com/0xHoneyJar/loa/pull/520) — W1c Cluster 4
- [#521](https://github.com/0xHoneyJar/loa/pull/521) — W1b Cluster 2
- **This PR (W2a)** — Cluster 3 (first Wave-2 PR)

## Test plan

- [ ] CI passes (all 33 failing tests in `ledger-lib.bats` flip fail → pass)
- [ ] No production `.claude/scripts/*.sh` changes (`git diff main...HEAD -- .claude/scripts/` empty)
- [ ] Confirm no other `.bats` file has the same PROJECT_ROOT-leak anti-pattern (worth a follow-up audit — flag as Wave-2 addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)