### PR TITLE
fix(search): 4 bugs in search-orchestrator.sh + JSONL compaction in search-api.sh (cycle-075 W2e)

### DIFF
--- a/.claude/scripts/search-api.sh
+++ b/.claude/scripts/search-api.sh
@@ -107,8 +107,9 @@ grep_to_jsonl() {
             file="${PROJECT_ROOT}/${file}"
         fi
 
-        # Output JSONL - use --arg for strings (jq handles escaping internally)
-        jq -n \
+        # Output JSONL — use -c for compact output (one line per record,
+        # required for JSONL). --arg for strings (jq handles escaping).
+        jq -cn \
             --arg file "${file}" \
             --argjson line "${line}" \
             --arg snippet "${snippet}" \

--- a/.claude/scripts/search-orchestrator.sh
+++ b/.claude/scripts/search-orchestrator.sh
@@ -21,9 +21,16 @@ if [[ -f "${PROJECT_ROOT}/.claude/scripts/preflight.sh" ]]; then
     "${PROJECT_ROOT}/.claude/scripts/preflight.sh" || exit 1
 fi
 
-# Parse arguments
+# Parse arguments.
+# NOTE: use ${2:-} (with default fallback) rather than ${2} — under
+# `set -u` above, accessing $2 when only one arg was passed crashes with
+# "unbound variable" BEFORE the required-arg check below can produce the
+# user-friendly "Error: Query is required" message. With the default
+# fallback, $2 expands to empty string and the -z check handles it
+# gracefully. Same treatment below for other positional args that
+# already use ${N:-DEFAULT} — only $2 was missing its fallback.
 SEARCH_TYPE="${1:-semantic}"  # semantic|hybrid|regex
-QUERY="${2}"
+QUERY="${2:-}"
 SEARCH_PATH="${3:-${PROJECT_ROOT}/src}"
 TOP_K="${4:-20}"
 THRESHOLD="${5:-0.4}"
@@ -54,9 +61,15 @@ if ! [[ "${THRESHOLD}" =~ ^[0-9]*\.?[0-9]+$ ]]; then
     exit 1
 fi
 
-# SECURITY: Validate regex syntax for regex search type (prevents ReDoS)
+# SECURITY: Validate regex syntax for regex search type (prevents ReDoS).
+# grep exit codes: 0 = match, 1 = no match (regex valid), >=2 = error (bad
+# regex). The previous check used `! grep -E "$QUERY" ...` on empty input,
+# which treated "no match in empty string" as failure — rejecting every
+# valid regex that doesn't match "". We only want to reject SYNTAX errors.
 if [[ "${SEARCH_TYPE}" == "regex" ]]; then
-    if ! echo "" | grep -E "${QUERY}" >/dev/null 2>&1; then
+    regex_check_exit=0
+    echo "" | grep -E "${QUERY}" >/dev/null 2>&1 || regex_check_exit=$?
+    if [[ "${regex_check_exit}" -ge 2 ]]; then
         echo "Error: Invalid regex pattern" >&2
         exit 1
     fi
@@ -90,7 +103,7 @@ TRAJECTORY_FILE="${TRAJECTORY_DIR}/$(date +%Y-%m-%d).jsonl"
 mkdir -p "${TRAJECTORY_DIR}"
 
 # Log intent BEFORE search
-jq -n \
+jq -cn \
     --arg ts "$(date -Iseconds)" \
     --arg agent "${LOA_AGENT_NAME:-unknown}" \
     --arg phase "intent" \
@@ -114,7 +127,7 @@ if [[ "${LOA_SEARCH_MODE}" == "ck" ]]; then
                 --threshold "${THRESHOLD}" \
                 --jsonl \
                 "${SEARCH_PATH}" 2>/dev/null || echo "")
-            RESULT_COUNT=$(echo "${SEARCH_RESULTS}" | grep -c '^{' 2>/dev/null || echo 0)
+            RESULT_COUNT=$(printf '%s' "${SEARCH_RESULTS}" | awk '/^{/{c++} END{print c+0}')
             RESULT_COUNT="${RESULT_COUNT:-0}"
             echo "${SEARCH_RESULTS}"
             ;;
@@ -124,7 +137,7 @@ if [[ "${LOA_SEARCH_MODE}" == "ck" ]]; then
                 --threshold "${THRESHOLD}" \
                 --jsonl \
                 "${SEARCH_PATH}" 2>/dev/null || echo "")
-            RESULT_COUNT=$(echo "${SEARCH_RESULTS}" | grep -c '^{' 2>/dev/null || echo 0)
+            RESULT_COUNT=$(printf '%s' "${SEARCH_RESULTS}" | awk '/^{/{c++} END{print c+0}')
             RESULT_COUNT="${RESULT_COUNT:-0}"
             echo "${SEARCH_RESULTS}"
             ;;
@@ -132,7 +145,7 @@ if [[ "${LOA_SEARCH_MODE}" == "ck" ]]; then
             SEARCH_RESULTS=$(ck --regex "${QUERY}" \
                 --jsonl \
                 "${SEARCH_PATH}" 2>/dev/null || echo "")
-            RESULT_COUNT=$(echo "${SEARCH_RESULTS}" | grep -c '^{' 2>/dev/null || echo 0)
+            RESULT_COUNT=$(printf '%s' "${SEARCH_RESULTS}" | awk '/^{/{c++} END{print c+0}')
             RESULT_COUNT="${RESULT_COUNT:-0}"
             echo "${SEARCH_RESULTS}"
             ;;
@@ -157,7 +170,7 @@ else
                     --include="*.sh" --include="*.bash" --include="*.md" --include="*.yaml" \
                     --include="*.yml" --include="*.json" --include="*.toml" \
                     "${SEARCH_PATH}" 2>/dev/null | head -n "${TOP_K}" || echo "")
-                RESULT_COUNT=$(echo "${SEARCH_RESULTS}" | grep -c '.' || echo 0)
+                RESULT_COUNT=$(printf '%s' "${SEARCH_RESULTS}" | awk 'NF{c++} END{print c+0}')
                 echo "${SEARCH_RESULTS}"
             else
                 echo "" # Empty query
@@ -171,7 +184,7 @@ else
                 --include="*.sh" --include="*.bash" --include="*.md" --include="*.yaml" \
                 --include="*.yml" --include="*.json" --include="*.toml" \
                 "${SEARCH_PATH}" 2>/dev/null | head -n "${TOP_K}" || echo "")
-            RESULT_COUNT=$(echo "${SEARCH_RESULTS}" | grep -c '.' || echo 0)
+            RESULT_COUNT=$(printf '%s' "${SEARCH_RESULTS}" | awk 'NF{c++} END{print c+0}')
             echo "${SEARCH_RESULTS}"
             ;;
         *)
@@ -183,7 +196,7 @@ else
 fi
 
 # Log execution result
-jq -n \
+jq -cn \
     --arg ts "$(date -Iseconds)" \
     --arg agent "${LOA_AGENT_NAME:-unknown}" \
     --arg phase "execute" \

--- a/.claude/scripts/search-orchestrator.sh
+++ b/.claude/scripts/search-orchestrator.sh
@@ -61,11 +61,16 @@ if ! [[ "${THRESHOLD}" =~ ^[0-9]*\.?[0-9]+$ ]]; then
     exit 1
 fi
 
-# SECURITY: Validate regex syntax for regex search type (prevents ReDoS).
+# Validate regex syntax for regex search type.
 # grep exit codes: 0 = match, 1 = no match (regex valid), >=2 = error (bad
 # regex). The previous check used `! grep -E "$QUERY" ...` on empty input,
 # which treated "no match in empty string" as failure — rejecting every
 # valid regex that doesn't match "". We only want to reject SYNTAX errors.
+#
+# NOTE: this is NOT ReDoS prevention (the prior comment incorrectly claimed
+# that). Syntactically valid regexes can still be catastrophic-backtracking
+# patterns like `(a+)+$`. Real ReDoS mitigation would require a timeout
+# wrapper or pattern-complexity analysis; tracked as follow-up.
 if [[ "${SEARCH_TYPE}" == "regex" ]]; then
     regex_check_exit=0
     echo "" | grep -E "${QUERY}" >/dev/null 2>&1 || regex_check_exit=$?


### PR DESCRIPTION
## Summary

- **Wave-2e of cycle-075 CI triage**. **Stacked on top of [#517](https://github.com/0xHoneyJar/loa/pull/517) (W1a).** Fixes 4 bugs in `search-orchestrator.sh` + 1 companion bug in `search-api.sh`, all surfaced when W1a's path rename exposed previously-masked logic.
- ⚠️ **Base branch is `fix/cycle-075-w1a-grimoire-path`, not `main`.** Merge W1a first, then rebase this to main.
- All 5 fixes are in production shell scripts (not tests). Same-class bugs I've seen elsewhere in the codebase — worth flagging the patterns for future code review rules.

## Bug catalog

### Bug 1 — `QUERY="${2}"` crashes under `set -u`
Under `set -euo pipefail`, accessing `$2` when only one arg was passed crashes before the script's own required-arg check can run.
**Fix**: `QUERY="${2:-}"` — default fallback to empty, then `-z` check catches it gracefully.

### Bug 2 — `grep -c ... \|\| echo 0` newline pollution under pipefail (5 sites)
Same class as W1d ([#518](https://github.com/0xHoneyJar/loa/pull/518)): when `grep -c` matches 0 lines it exits 1; pipefail triggers; `\|\| echo 0` fires; command substitution concatenates `grep`'s "0" AND echo's "0" into `"0\n0"`. Then `jq --argjson result_count "0\n0"` errors with "Invalid JSON text".
**Fix**: replaced 5 occurrences with `awk '/^{/{c++} END{print c+0}'` — always single integer, never polluted.

### Bug 3 — Regex validation rejects every non-trivial regex
```bash
if ! echo "" | grep -E "${QUERY}" >/dev/null 2>&1; then
    echo "Error: Invalid regex pattern" >&2; exit 1
fi
```
Runs the user's regex against empty string. grep exits 1 on "no match" (regex valid, just doesn't match ""). `!` inverts to truthy. Script rejects every regex that doesn't match empty string — which is every useful regex.
**Fix**: capture grep's exit separately, reject only exit ≥2 (syntax error). 0 (match) and 1 (no match) both pass.

### Bug 4 — Trajectory JSONL written as pretty-printed multi-line JSON (2 sites)
`jq -n '{...}' >> file.jsonl` — JSONL requires one record per line. Multi-line output breaks every grep-based consumer.
**Fix**: `jq -n` → `jq -cn` (compact output). 2 sites.

### Bonus — search-api.sh `grep_to_jsonl()` has the same JSONL bug
Same one-line fix, same bug class. Included here rather than filing a redundant PR.

## Bug patterns worth codifying

Three of the five fixes are instances of **bash bugs that commonly appear in this codebase**:
- Pattern A: `"${N}"` under `set -u` without default fallback → add `${N:-}`
- Pattern B: `cmd | grep -c ... \|\| echo 0` under pipefail → use awk for counting
- Pattern C: `jq -n` writing to `.jsonl` → use `jq -cn`

If these warrant a follow-up shell-lint rule or a protocol doc entry, happy to write one.

## Local verification

```
$ bats tests/unit/search-orchestrator.bats
21 tests, 0 failures    # was 8-14 failing

$ bats tests/unit/search-api.bats
28 tests, 13 failures    # unchanged — remaining tests use buggy
                         # `run cmd | other` pattern; test-side
                         # fix deferred to a separate PR

$ source .claude/scripts/search-api.sh &&
  echo "/p/f.js:42:x" | grep_to_jsonl
{"file":"/p/f.js","line":42,"snippet":"x","score":0.0}
# (compact JSONL verified directly — test-side coverage to follow)
```

## Wave-1 / Wave-2 companion PRs

- [#517](https://github.com/0xHoneyJar/loa/pull/517) W1a Cluster 1 (THIS PR IS BASED ON IT)
- [#518](https://github.com/0xHoneyJar/loa/pull/518) W1d Cluster A
- [#519](https://github.com/0xHoneyJar/loa/pull/519) W1e Cluster B6
- [#520](https://github.com/0xHoneyJar/loa/pull/520) W1c Cluster 4
- [#521](https://github.com/0xHoneyJar/loa/pull/521) W1b Cluster 2
- [#522](https://github.com/0xHoneyJar/loa/pull/522) W2a Cluster 3
- [#523](https://github.com/0xHoneyJar/loa/pull/523) W2c Cluster E deprecation
- **This PR (W2e)** Cluster 8 — surfaced by W1a

## Test plan

- [ ] Merge W1a (#517) first
- [ ] Rebase this PR onto main after that merge
- [ ] CI passes for search-orchestrator.bats (all 21 tests)
- [ ] search-api.bats failures drop by whatever the `-cn` fix enables — remaining failures tracked separately
- [ ] Verify no regression in scripts that source search-api.sh (flatline, bridgebuilder infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)