### PR TITLE
fix(cache): block JSON-style secrets, not just shell-style KEY=value (cycle-075 W2b)

### DIFF
--- a/.claude/scripts/cache-manager.sh
+++ b/.claude/scripts/cache-manager.sh
@@ -20,17 +20,20 @@ DEFAULT_CACHE_ENABLED="true"
 DEFAULT_MAX_SIZE_MB="100"
 DEFAULT_TTL_DAYS="30"
 
-# Secret patterns to detect (simple patterns for shell validation)
+# Secret patterns to detect. Use [=:] character class to match both
+# shell-style (KEY=value) and JSON/YAML-style (KEY: value) key-value
+# pairs. Previously these patterns only matched `=` — missing JSON
+# content, which is the dominant format for cached agent output.
 SECRET_PATTERNS=(
     'PRIVATE.KEY'
     'BEGIN RSA'
     'BEGIN EC PRIVATE'
-    'password.*='
-    'secret.*='
-    'api_key.*='
-    'apikey.*='
-    'access_token.*='
-    'bearer.*='
+    'password.*[=:]'
+    'secret.*[=:]'
+    'api_key.*[=:]'
+    'apikey.*[=:]'
+    'access_token.*[=:]'
+    'bearer.*[=:]'
 )
 
 # Colors for output


### PR DESCRIPTION
## Summary

- **Wave-2b of cycle-075 CI triage**. Fixes 1 pre-existing BATS failure (`cache-manager.bats` test 299 "set rejects secret patterns").
- Security fix in production code: the cache's secret-pattern guard was rejecting shell-style `password=secret123` but missing JSON-style `{"password": "secret123"}` — the dominant format for cached agent output.
- Scope: 6 pattern entries changed in SECRET_PATTERNS array. 7 insertions, 7 deletions. One-character change per pattern (`=` → `[=:]`).

## Root cause

The patterns used literal `=`:
```bash
SECRET_PATTERNS=(
    'password.*='
    'secret.*='
    'api_key.*='
    ...
)
```

Test `@test "set rejects secret patterns"` feeds JSON:
```bash
run "$CACHE_MANAGER" set --key "test-secrets" \
    --condensed '{"password": "secret123"}'
[[ "$status" -ne 0 ]]
```

Colon doesn't match `=`. `detect_secrets` returned 1 (no match), cache accepted the content, exit was 0 — test expected rejection.

## Fix

Changed the 6 `KEY.*=` patterns to `KEY.*[=:]` (character class matching either delimiter). This now catches:

| Form | Matches |
|---|---|
| `password=secret123` (shell/env) | ✓ (`=`) |
| `"password": "secret123"` (JSON) | ✓ (`:`) |
| `password: secret123` (YAML) | ✓ (`:`) |

The 3 pattern entries that match literal key material (`PRIVATE.KEY`, `BEGIN RSA`, `BEGIN EC PRIVATE`) are unchanged — they don't involve key-value delimiters.

## False-positive analysis

Broadening patterns to match `:` will catch more strings. In practice:
- Code comments like `// secret: not relevant here` → flagged (false positive)
- YAML/JSON config with literal secret keys → flagged (correct positive)

This is the correct posture for a security guard on a **cache layer** — cached content is programmatic JSON from agent runs, not human-authored prose. If false-positives become an issue in practice, we can port the allowlist pattern from `adversarial-review.sh` (where it handles legitimate non-secret matches like SHA256 hashes).

## Local verification

```
$ bats tests/unit/cache-manager.bats
(all tests pass)    # was 1 failing

$ bats tests/unit/cache-manager.bats --filter "set rejects secret"
ok 1 set rejects secret patterns
```

## Wave-1/2 companion PRs

- [#517](https://github.com/0xHoneyJar/loa/pull/517) W1a · [#518](https://github.com/0xHoneyJar/loa/pull/518) W1d · [#519](https://github.com/0xHoneyJar/loa/pull/519) W1e · [#520](https://github.com/0xHoneyJar/loa/pull/520) W1c · [#521](https://github.com/0xHoneyJar/loa/pull/521) W1b
- [#522](https://github.com/0xHoneyJar/loa/pull/522) W2a · [#523](https://github.com/0xHoneyJar/loa/pull/523) W2c deprecation · [#524](https://github.com/0xHoneyJar/loa/pull/524) W2e
- **This PR (W2b)** Cluster D

## Test plan

- [ ] CI passes — 1 test flips fail → pass
- [ ] No regression in existing cache-manager tests
- [ ] Consider whether `/cache set` automation currently running in the framework caches any content that would trigger the broader pattern (unlikely — most cache content is already redacted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)