### PR TITLE
fix(scripts): replace grep -c || echo 0 pattern with awk in grounding-check + synthesis-checkpoint (cycle-075 W2f)

### DIFF
--- a/.claude/scripts/grounding-check.sh
+++ b/.claude/scripts/grounding-check.sh
@@ -59,18 +59,25 @@ if [[ ! -f "$TRAJECTORY" ]]; then
     exit 0
 fi
 
-# Count claims by type
-# Look for citation phase entries in trajectory
-total_claims=$(grep -c '"phase":"cite"' "$TRAJECTORY" 2>/dev/null || echo "0")
+# Count claims by type.
+# NOTE: use awk, not `grep -c ... || echo "0"`. The latter produces
+# "0\n0" when grep matches nothing: grep still emits its own "0" on
+# stdout AND exits 1, so the fallback echo also fires and $(...)
+# concatenates both counts. Arithmetic then fails with "syntax error
+# in expression (error token is '0')" on line 70 below. awk always
+# prints a single integer (c+0 → 0 when no matches) and exits 0.
+# Same bug class as W1d (adversarial-review) and W2e (search-
+# orchestrator) in this cycle's CI triage.
+total_claims=$(awk '/"phase":"cite"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
-# Count grounded claims (citation or code_reference)
-grounded_citations=$(grep -c '"grounding":"citation"' "$TRAJECTORY" 2>/dev/null || echo "0")
-grounded_references=$(grep -c '"grounding":"code_reference"' "$TRAJECTORY" 2>/dev/null || echo "0")
-grounded_user_input=$(grep -c '"grounding":"user_input"' "$TRAJECTORY" 2>/dev/null || echo "0")
+# Count grounded claims (citation or code_reference or user_input)
+grounded_citations=$(awk '/"grounding":"citation"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
+grounded_references=$(awk '/"grounding":"code_reference"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
+grounded_user_input=$(awk '/"grounding":"user_input"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 grounded_claims=$((grounded_citations + grounded_references + grounded_user_input))
 
 # Count assumptions (ungrounded claims)
-assumptions=$(grep -c '"grounding":"assumption"' "$TRAJECTORY" 2>/dev/null || echo "0")
+assumptions=$(awk '/"grounding":"assumption"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
 # Handle zero-claim sessions
 if [[ "$total_claims" -eq 0 ]]; then

--- a/.claude/scripts/synthesis-checkpoint.sh
+++ b/.claude/scripts/synthesis-checkpoint.sh
@@ -131,8 +131,8 @@ check_negative_grounding() {
 
     # Count unverified ghost features
     local unverified high_ambiguity
-    unverified=$(grep -c '"status":"unverified"' "$TRAJECTORY" 2>/dev/null || echo "0")
-    high_ambiguity=$(grep -c '"status":"high_ambiguity"' "$TRAJECTORY" 2>/dev/null || echo "0")
+    unverified=$(awk '/"status":"unverified"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
+    high_ambiguity=$(awk '/"status":"high_ambiguity"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
     echo "  Unverified ghosts: $unverified"
     echo "  High ambiguity: $high_ambiguity"
@@ -177,7 +177,7 @@ update_decision_log() {
 
     # Count decisions to sync
     local decision_count
-    decision_count=$(grep -c '"phase":"cite"' "$TRAJECTORY" 2>/dev/null || echo "0")
+    decision_count=$(awk '/"phase":"cite"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
     if [[ "$decision_count" -eq 0 ]]; then
         echo "  Status: SKIPPED (no decisions to sync)"
@@ -284,7 +284,7 @@ verify_edd() {
 
     # Count test scenarios
     local test_scenarios
-    test_scenarios=$(grep -c '"type":"test_scenario"' "$TRAJECTORY" 2>/dev/null || echo "0")
+    test_scenarios=$(awk '/"type":"test_scenario"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
     echo "  Test scenarios documented: $test_scenarios"
     echo "  Minimum required: $EDD_MIN_SCENARIOS"


### PR DESCRIPTION
## Summary

- **Wave-2f of cycle-075 CI triage**. **Stacked on top of [#517](https://github.com/0xHoneyJar/loa/pull/517) (W1a).** Fixes 14+1 previously-hidden failures across `grounding-check.bats` and `synthesis-checkpoint.bats` by repairing the identical `grep -c … || echo 0` arithmetic bug in their upstream scripts.
- ⚠️ Base branch is `fix/cycle-075-w1a-grimoire-path`. Merge W1a first.
- **Third discovery of this bug class in cycle-075.** Pattern is widespread enough to warrant a shell-lint rule.

## Bug pattern

```bash
total_claims=$(grep -c 'pattern' FILE 2>/dev/null || echo "0")
```

When `grep -c` matches zero lines, it still emits `"0"` to stdout AND exits 1 (POSIX). The `|| echo "0"` fallback fires because of the non-zero exit, appending another `"0"`. The command substitution trims trailing newlines, leaving the variable as `"0\n0"`. Downstream arithmetic (`$((a+b))`, `[[ $var -lt N ]]`) then fails with:

```
syntax error in expression (error token is "0")
```

Under `set -u`, dependent variables never get assigned and subsequent references fail with `unbound variable`.

## Fix

Replaced 9 sites across 2 scripts with awk (always exits 0, always prints a single integer):

```bash
total_claims=$(awk '/"phase":"cite"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
```

### `.claude/scripts/grounding-check.sh` — 5 sites
- line 64: `total_claims`
- lines 67-69: `grounded_citations`, `grounded_references`, `grounded_user_input` (all three feed `$(( … + … + … ))` on line 70)
- line 73: `assumptions`

### `.claude/scripts/synthesis-checkpoint.sh` — 4 sites
- lines 134-135: `unverified`, `high_ambiguity`
- line 180: `decision_count`
- line 287: `test_scenarios` (what tripped the failing test)

## Why two scripts, one PR

Same bug class, same one-file-per-script fix. Both were masked by Cluster 1's path mismatch (W1a) — tests trivially passed as "zero-claim session" rather than exercising the real arithmetic paths. Once W1a corrected fixture paths, both scripts' bugs surfaced. Keeping them together preserves the "one logical fix" provenance.

## Pattern tally for cycle-075 (three occurrences of this identical bug class)

| PR | Script | Pattern |
|---|---|---|
| [#518](https://github.com/0xHoneyJar/loa/pull/518) W1d | `tests/unit/adversarial-review.bats` | `ls … \| wc -l … \|\| echo 0` |
| [#524](https://github.com/0xHoneyJar/loa/pull/524) W2e | `search-orchestrator.sh`, `search-api.sh` | `grep -c … \|\| echo 0` |
| **This PR** W2f | `grounding-check.sh`, `synthesis-checkpoint.sh` | `grep -c … \|\| echo 0` |

**Recommendation**: add a CI lint rule flagging `(grep -c .* || echo|ls .* \| wc -l .* || echo)` patterns. Or mandate awk for count extraction in scripts with `set -o pipefail`. Could live in `.github/workflows/shell-compat-lint.yml` as a new rule.

## Local verification

```
$ bats tests/unit/grounding-check.bats
18 tests, 0 failures        # was 14 failing on W1a base

$ bats tests/unit/synthesis-checkpoint.bats
39 tests, 0 failures        # was 1 failing on W1a base
```

## Wave-1/2 companion PRs

- [#517](https://github.com/0xHoneyJar/loa/pull/517) W1a (BASE) · [#518](https://github.com/0xHoneyJar/loa/pull/518) W1d · [#519](https://github.com/0xHoneyJar/loa/pull/519) W1e · [#520](https://github.com/0xHoneyJar/loa/pull/520) W1c · [#521](https://github.com/0xHoneyJar/loa/pull/521) W1b
- [#522](https://github.com/0xHoneyJar/loa/pull/522) W2a · [#523](https://github.com/0xHoneyJar/loa/pull/523) W2c deprecation · [#524](https://github.com/0xHoneyJar/loa/pull/524) W2e · [#525](https://github.com/0xHoneyJar/loa/pull/525) W2b
- **This PR (W2f)** Cluster 7 — surfaced by W1a

## Test plan

- [ ] Merge W1a (#517) first
- [ ] Rebase this PR onto main after that merge
- [ ] CI passes for grounding-check.bats (18/18) and synthesis-checkpoint.bats (39/39)
- [ ] No regressions in scripts that source or invoke grounding-check.sh or synthesis-checkpoint.sh
- [ ] Consider follow-up: add shell-lint rule for the `grep -c … || echo` anti-pattern (scope for next cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)