### PR TITLE
fix(butterfreezone): env-var word budget override + richer test fixture (cycle-075 W2d)

### DIFF
--- a/.claude/scripts/butterfreezone-validate.sh
+++ b/.claude/scripts/butterfreezone-validate.sh
@@ -320,14 +320,21 @@ validate_word_budget() {
 }
 
 # Check 5b: Minimum word count (FR-5: narrative quality gate)
+#
+# Default minimum is 500. Tests (and other callers that legitimately
+# exercise the validator against minimal fixtures) can override via
+# LOA_BUTTERFREEZONE_MIN_WORDS. Production BUTTERFREEZONE.md generation
+# should easily exceed 500 — the override exists purely for fixture-based
+# testing of downstream validators.
 validate_min_words() {
-    local total_words
+    local total_words min_words
     total_words=$(wc -w < "$FILE" 2>/dev/null | tr -d ' ')
+    min_words="${LOA_BUTTERFREEZONE_MIN_WORDS:-500}"
 
-    if (( total_words < 500 )); then
-        log_fail "min_words" "Output too sparse: $total_words words (minimum: 500)" "sparse: $total_words < 500"
+    if (( total_words < min_words )); then
+        log_fail "min_words" "Output too sparse: $total_words words (minimum: $min_words)" "sparse: $total_words < $min_words"
     else
-        log_pass "min_words" "Word count sufficient: $total_words (minimum: 500)"
+        log_pass "min_words" "Word count sufficient: $total_words (minimum: $min_words)"
     fi
 }
 

--- a/.claude/scripts/butterfreezone-validate.sh
+++ b/.claude/scripts/butterfreezone-validate.sh
@@ -330,6 +330,12 @@ validate_min_words() {
     local total_words min_words
     total_words=$(wc -w < "$FILE" 2>/dev/null | tr -d ' ')
     min_words="${LOA_BUTTERFREEZONE_MIN_WORDS:-500}"
+    # Guard against misuse: reject 0, negative, empty, or non-numeric values.
+    # Falls back to the production default (500) so the quality gate cannot
+    # be silently disabled by exporting LOA_BUTTERFREEZONE_MIN_WORDS=0 or a
+    # malformed value. Only positive integers are accepted. (Addresses post-
+    # hoc review finding MEDIUM on PR #527.)
+    [[ "$min_words" =~ ^[1-9][0-9]*$ ]] || min_words=500
 
     if (( total_words < min_words )); then
         log_fail "min_words" "Output too sparse: $total_words words (minimum: $min_words)" "sparse: $total_words < $min_words"

--- a/tests/unit/butterfreezone-validate.bats
+++ b/tests/unit/butterfreezone-validate.bats
@@ -8,6 +8,13 @@ setup() {
     SCRIPT="$PROJECT_ROOT/.claude/scripts/butterfreezone-validate.sh"
     GEN_SCRIPT="$PROJECT_ROOT/.claude/scripts/butterfreezone-gen.sh"
 
+    # Lower the word-count minimum for tests. The mock repo has trivial
+    # content, so butterfreezone-gen naturally produces ~150-word output
+    # — well below the production 500-word quality gate. Override keeps
+    # tests exercising the validator logic without requiring a large
+    # synthetic repo.
+    export LOA_BUTTERFREEZONE_MIN_WORDS=50
+
     export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
     export TEST_TMPDIR="$BATS_TMPDIR/butterfreezone-validate-test-$$"
     mkdir -p "$TEST_TMPDIR"
@@ -33,9 +40,30 @@ teardown() {
     fi
 }
 
-# Helper: generate a valid BUTTERFREEZONE.md
+# Helper: generate a valid BUTTERFREEZONE.md.
+#
+# Also seeds two fixtures the generator doesn't produce for a trivial
+# mock repo:
+#   - .claude/data/core-skills.json (validator warns if missing)
+#   - "## Key Capabilities" section (generator skips for repos with
+#     no real capabilities to describe)
+#
+# Without these, validate exits 2 (warnings) and tests that assert
+# exit 0 fail. The additions make the fixture meet the validator's
+# "clean pass" criteria without requiring a rich synthetic repo.
 generate_valid() {
+    mkdir -p "$MOCK_REPO/.claude/data"
+    echo '{"skills":[]}' > "$MOCK_REPO/.claude/data/core-skills.json"
     "$GEN_SCRIPT" --output "$MOCK_REPO/BUTTERFREEZONE.md" 2>/dev/null
+    if ! grep -q "^## Key Capabilities" "$MOCK_REPO/BUTTERFREEZONE.md"; then
+        cat >> "$MOCK_REPO/BUTTERFREEZONE.md" <<'EOF'
+
+## Key Capabilities
+<!-- provenance: DERIVED -->
+
+- **Test fixture capability**: Placeholder capability for validator tests.
+EOF
+    fi
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- **Wave-2d of cycle-075 CI triage**. Fixes 6 pre-existing `butterfreezone-validate.bats` failures (tests 4, 8, 9, 10, 11, 13).
- Two-part fix: (1) env var override for the word-count minimum, (2) richer test mock via `generate_valid` helper. Production quality gates preserved; tests can now run against minimal fixtures.

## Root cause

`butterfreezone-validate.sh` enforces three quality gates that make sense for production-generated `BUTTERFREEZONE.md` but are impossible for a trivial test mock:

1. **Minimum 500 words** (hardcoded). Test mock has one source file; gen produces ~150 words → hard FAIL.
2. **Presence of `.claude/data/core-skills.json`**. Production repos have this; mock doesn't → WARN.
3. **Presence of `## Key Capabilities` section**. Gen only emits this when the repo has capabilities to describe; a one-file mock has none → WARN.

Cascading effect: the first FAIL (word count) masked the WARNs on #2 and #3. Tests that expected specific exit codes (0 for clean, 2 for warn, 1 for strict-fail) all got the wrong status.

## Fix — two parts

### Part 1 (production): env-var override for word count

`LOA_BUTTERFREEZONE_MIN_WORDS` overrides the hardcoded 500. Default preserved — production quality gate unchanged. Tests and other legitimate consumers validating minimal fixtures can lower it.

```bash
min_words="${LOA_BUTTERFREEZONE_MIN_WORDS:-500}"
if (( total_words < min_words )); then
    log_fail "min_words" "Output too sparse: $total_words words (minimum: $min_words)" ...
```

Test setup() exports `LOA_BUTTERFREEZONE_MIN_WORDS=50` — headroom for the ~150-word mock output.

### Part 2 (tests): richer `generate_valid` helper

Extended to seed the two fixtures the generator doesn't produce for a trivial repo:
- Creates `$MOCK_REPO/.claude/data/core-skills.json` with `{"skills":[]}` (valid JSON, satisfies existence + shape checks)
- Appends `## Key Capabilities` section with one placeholder capability if generator didn't emit one

Both are idempotent.

## Why not lower the 500-word default?

That weakens the production quality gate. BUTTERFREEZONE.md is the agent-facing project README — 500 words is a defensible minimum for "useful context, not stub." The override-for-tests approach preserves that signal while making the test suite runnable against minimal fixtures.

## Local verification

```
$ bats tests/unit/butterfreezone-validate.bats
(all tests pass)    # was 6 failing

$ bats tests/unit/butterfreezone-validate.bats --filter "valid generated"
ok 1 validate: valid generated file passes all checks (exit 0)
```

## Wave-1/2 companion PRs

- [#517](https://github.com/0xHoneyJar/loa/pull/517) W1a · [#518](https://github.com/0xHoneyJar/loa/pull/518) W1d · [#519](https://github.com/0xHoneyJar/loa/pull/519) W1e · [#520](https://github.com/0xHoneyJar/loa/pull/520) W1c · [#521](https://github.com/0xHoneyJar/loa/pull/521) W1b
- [#522](https://github.com/0xHoneyJar/loa/pull/522) W2a · [#523](https://github.com/0xHoneyJar/loa/pull/523) W2c deprecation · [#524](https://github.com/0xHoneyJar/loa/pull/524) W2e · [#525](https://github.com/0xHoneyJar/loa/pull/525) W2b · [#526](https://github.com/0xHoneyJar/loa/pull/526) W2f
- **This PR (W2d)** Cluster C

## Test plan

- [ ] CI passes — 6 tests flip fail → pass
- [ ] Verify no regression in production `butterfreezone-validate` usage (default 500 unchanged)
- [ ] Check that `LOA_BUTTERFREEZONE_MIN_WORDS` doesn't conflict with other env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)