### PR TITLE
fix(scripts): replace grep -c || echo 0 pattern with awk in grounding-check + synthesis-checkpoint (cycle-075 W2f)

### DIFF
--- a/.claude/scripts/grounding-check.sh
+++ b/.claude/scripts/grounding-check.sh
@@ -59,18 +59,25 @@ if [[ ! -f "$TRAJECTORY" ]]; then
     exit 0
 fi
 
-# Count claims by type
-# Look for citation phase entries in trajectory
-total_claims=$(grep -c '"phase":"cite"' "$TRAJECTORY" 2>/dev/null || echo "0")
+# Count claims by type.
+# NOTE: use awk, not `grep -c ... || echo "0"`. The latter produces
+# "0\n0" when grep matches nothing: grep still emits its own "0" on
+# stdout AND exits 1, so the fallback echo also fires and $(...)
+# concatenates both counts. Arithmetic then fails with "syntax error
+# in expression (error token is '0')" on line 70 below. awk always
+# prints a single integer (c+0 → 0 when no matches) and exits 0.
+# Same bug class as W1d (adversarial-review) and W2e (search-
+# orchestrator) in this cycle's CI triage.
+total_claims=$(awk '/"phase":"cite"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
-# Count grounded claims (citation or code_reference)
-grounded_citations=$(grep -c '"grounding":"citation"' "$TRAJECTORY" 2>/dev/null || echo "0")
-grounded_references=$(grep -c '"grounding":"code_reference"' "$TRAJECTORY" 2>/dev/null || echo "0")
-grounded_user_input=$(grep -c '"grounding":"user_input"' "$TRAJECTORY" 2>/dev/null || echo "0")
+# Count grounded claims (citation or code_reference or user_input)
+grounded_citations=$(awk '/"grounding":"citation"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
+grounded_references=$(awk '/"grounding":"code_reference"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
+grounded_user_input=$(awk '/"grounding":"user_input"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 grounded_claims=$((grounded_citations + grounded_references + grounded_user_input))
 
 # Count assumptions (ungrounded claims)
-assumptions=$(grep -c '"grounding":"assumption"' "$TRAJECTORY" 2>/dev/null || echo "0")
+assumptions=$(awk '/"grounding":"assumption"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
 # Handle zero-claim sessions
 if [[ "$total_claims" -eq 0 ]]; then

--- a/.claude/scripts/synthesis-checkpoint.sh
+++ b/.claude/scripts/synthesis-checkpoint.sh
@@ -131,8 +131,8 @@ check_negative_grounding() {
 
     # Count unverified ghost features
     local unverified high_ambiguity
-    unverified=$(grep -c '"status":"unverified"' "$TRAJECTORY" 2>/dev/null || echo "0")
-    high_ambiguity=$(grep -c '"status":"high_ambiguity"' "$TRAJECTORY" 2>/dev/null || echo "0")
+    unverified=$(awk '/"status":"unverified"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
+    high_ambiguity=$(awk '/"status":"high_ambiguity"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
     echo "  Unverified ghosts: $unverified"
     echo "  High ambiguity: $high_ambiguity"
@@ -177,7 +177,7 @@ update_decision_log() {
 
     # Count decisions to sync
     local decision_count
-    decision_count=$(grep -c '"phase":"cite"' "$TRAJECTORY" 2>/dev/null || echo "0")
+    decision_count=$(awk '/"phase":"cite"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
     if [[ "$decision_count" -eq 0 ]]; then
         echo "  Status: SKIPPED (no decisions to sync)"
@@ -284,7 +284,7 @@ verify_edd() {
 
     # Count test scenarios
     local test_scenarios
-    test_scenarios=$(grep -c '"type":"test_scenario"' "$TRAJECTORY" 2>/dev/null || echo "0")
+    test_scenarios=$(awk '/"type":"test_scenario"/{c++} END{print c+0}' "$TRAJECTORY" 2>/dev/null || echo 0)
 
     echo "  Test scenarios documented: $test_scenarios"
     echo "  Minimum required: $EDD_MIN_SCENARIOS"


### PR DESCRIPTION
**Reopened from #526** (auto-closed when its base branch was deleted post-merge of #517).

## Summary

Wave-2f of cycle-075 CI triage. Replaces the `grep -c ... || echo 0` pattern with awk in 9 sites across `grounding-check.sh` (5) and `synthesis-checkpoint.sh` (4). Third discovery of this bug class in cycle-075. Now rebased onto main.

## Bug pattern (recap)

```bash
total_claims=$(grep -c 'pattern' FILE 2>/dev/null || echo "0")
```

Produces `"0\n0"` when grep matches 0 → arithmetic fails with "syntax error in expression". Replaced with awk which always prints a single integer.

## Pattern tally for cycle-075

| PR | Form | Sites |
|---|---|---|
| #518 | `ls \| wc -l \|\| echo 0` | 1 |
| #524 (now #532) | `grep -c \|\| echo 0` | 5 |
| **This PR** | `grep -c \|\| echo 0` | 9 |

Companion follow-up issue [#531](https://github.com/0xHoneyJar/loa/issues/531) tracks adding a shell-lint rule.

## Verification

```
$ bats tests/unit/grounding-check.bats     # 18/18 pass (was 14 failing on main pre-W1a)
$ bats tests/unit/synthesis-checkpoint.bats # 39/39 pass (was 1 failing on main pre-W1a)
```

## References

- Original PR (auto-closed): #526
- Foundation: #517 (now merged as `6fcb739`)
- Triage doc: `grimoires/loa/a2a/ci-triage/cycle-075-root-causes.md` (Cluster 7)