### PR TITLE
chore(lint): add grep -c || echo 0 anti-pattern detector (#531)

### DIFF
--- a/.claude/scripts/lint-grep-c-fallback.sh
+++ b/.claude/scripts/lint-grep-c-fallback.sh
@@ -31,6 +31,7 @@
 # =============================================================================
 
 set -euo pipefail
+shopt -s globstar 2>/dev/null || true  # Required for ** to recurse beyond one level
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
@@ -81,7 +82,7 @@ while IFS=: read -r file line content; do
         echo "           ${content}"
         echo ""
     fi
-done < <(grep -rn -E '(grep\s+-c.*\|\|\s*echo|wc\s+-l.*\|\|\s*echo)' \
+done < <(grep -rn -E '(grep\s+-c.*\|\|\s*echo|wc\s+-[lc].*\|\|\s*echo)' \
     "$PROJECT_ROOT/.claude/scripts/"*.sh \
     "$PROJECT_ROOT/.claude/scripts/"**/*.sh \
     2>/dev/null || true)

--- a/.claude/scripts/lint-grep-c-fallback.sh
+++ b/.claude/scripts/lint-grep-c-fallback.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# =============================================================================
+# lint-grep-c-fallback.sh — Detect grep -c / wc -l with || echo 0 anti-pattern
+# =============================================================================
+# Issue: https://github.com/0xHoneyJar/loa/issues/531
+# Cycle: cycle-079
+#
+# Under set -o pipefail, `grep -c 'pattern' FILE || echo "0"` produces "0\n0"
+# when the count is zero:
+#   1. grep -c outputs "0" to stdout (always, even on zero matches)
+#   2. grep -c exits 1 on zero matches (POSIX behavior)
+#   3. pipefail triggers, || echo "0" fallback fires
+#   4. Command substitution captures: "0\n0"
+#   5. Downstream arithmetic fails: [[ "0\n0" -lt 5 ]] → syntax error
+#
+# This bug class was found 3 independent times in cycle-075 (PRs #518, #524, #526).
+#
+# Approved replacement:
+#   count=$(awk '/pattern/{c++} END{print c+0}' FILE 2>/dev/null || echo 0)
+#
+# Usage:
+#   lint-grep-c-fallback.sh [--error]     # Default: WARNING level
+#   lint-grep-c-fallback.sh --scan-only   # Print count only (for CI integration)
+#
+# Inline suppression:
+#   Add `# lint:allow-grep-c-fallback` to the line to suppress the warning.
+#
+# Exit codes:
+#   0 — No findings (or WARNING mode with findings)
+#   1 — --error mode with findings
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+error_mode=false
+scan_only=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --error) error_mode=true; shift ;;
+        --scan-only) scan_only=true; shift ;;
+        --help|-h)
+            echo "Usage: lint-grep-c-fallback.sh [--error] [--scan-only]"
+            echo ""
+            echo "Detect grep -c / wc -l with || echo 0 anti-pattern in .claude/scripts/"
+            echo ""
+            echo "Options:"
+            echo "  --error      Exit 1 if any findings (default: WARNING only)"
+            echo "  --scan-only  Print count of findings and exit"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+findings=0
+
+while IFS=: read -r file line content; do
+    # Skip test files
+    [[ "$file" == *"test"* ]] && continue
+    [[ "$file" == *".bats"* ]] && continue
+
+    # Skip inline suppression
+    [[ "$content" == *"lint:allow-grep-c-fallback"* ]] && continue
+
+    # Skip comment lines
+    [[ "$content" =~ ^[[:space:]]*# ]] && continue
+
+    findings=$((findings + 1))
+
+    if [[ "$scan_only" == "false" ]]; then
+        local_severity="WARNING"
+        [[ "$error_mode" == "true" ]] && local_severity="ERROR"
+
+        echo "  ${local_severity}: ${file}:${line} — 'grep -c' or 'wc -l' with '|| echo' fallback"
+        echo "           Under set -o pipefail, this produces '0\\n0' on zero matches."
+        echo "           Use: count=\$(awk '/pattern/{c++} END{print c+0}' FILE)"
+        echo "           ${content}"
+        echo ""
+    fi
+done < <(grep -rn -E '(grep\s+-c.*\|\|\s*echo|wc\s+-l.*\|\|\s*echo)' \
+    "$PROJECT_ROOT/.claude/scripts/"*.sh \
+    "$PROJECT_ROOT/.claude/scripts/"**/*.sh \
+    2>/dev/null || true)
+
+if [[ "$scan_only" == "true" ]]; then
+    echo "$findings"
+    exit 0
+fi
+
+if [[ "$findings" -gt 0 ]]; then
+    echo "═══════════════════════════════════════════════"
+    echo "  grep -c / wc -l || echo 0: $findings site(s) found"
+    echo "═══════════════════════════════════════════════"
+    echo ""
+    echo "See: https://github.com/0xHoneyJar/loa/issues/531"
+    echo "Fix: count=\$(awk '/pattern/{c++} END{print c+0}' FILE)"
+    echo "Suppress: add '# lint:allow-grep-c-fallback' to the line"
+
+    if [[ "$error_mode" == "true" ]]; then
+        exit 1
+    fi
+else
+    echo "No grep -c / wc -l || echo 0 anti-pattern found."
+fi

--- a/grimoires/loa/prd.md
+++ b/grimoires/loa/prd.md
@@ -1,76 +1,37 @@
-# Product Requirements Document: Fix spiral-harness budget boundary — audit gate skipped (#515)
+# Product Requirements Document: Shell-lint rule for grep -c || echo 0 anti-pattern (#531)
 
 **Date**: 2026-04-16
-**Status**: Draft
-**Issue**: [#515](https://github.com/0xHoneyJar/loa/issues/515)
-**Cycle**: cycle-078
+**Issue**: [#531](https://github.com/0xHoneyJar/loa/issues/531)
+**Cycle**: cycle-079
 
 ## 1. Problem Statement
 
-`spiral-harness.sh` with `--profile light --budget 10` reproducibly hits the budget gate between REVIEW and AUDIT phases. Cumulative costs (DISCOVERY $1 + ARCHITECTURE $1 + PLANNING $1 + IMPLEMENTATION $5 + REVIEW $2 = $10) exactly equal the budget cap. The `_check_budget` function in `spiral-evidence.sh:217-228` uses `>=` comparison, so `spent >= max` evaluates to true and AUDIT never runs.
+Under `set -o pipefail`, `grep -c 'pattern' FILE 2>/dev/null || echo "0"` produces `"0\n0"` when the count is zero. `grep -c` outputs `0` to stdout AND exits 1 (POSIX), so the `|| echo "0"` fallback fires and command substitution concatenates both outputs. Downstream arithmetic (`[[ $var -lt N ]]`) fails with syntax errors.
 
-This defeats the "unskippable gates" design goal — the audit quality gate can be bypassed by normal cost variance.
+This bug class was found 3 independent times in cycle-075 (PRs #518, #524, #526). ~55 sites remain in `.claude/scripts/`.
 
-## 2. Root Cause
+## 2. Goals
 
-`_check_budget()` in `.claude/scripts/spiral-evidence.sh` lines 217-228:
-```bash
-_check_budget() {
-    local max_budget="$1"
-    if jq -n --argjson spent "$spent" --argjson max "$max_budget" '$spent >= $max' | grep -q true; then
-        ...
-        return 1
-    fi
-}
-```
+1. Add a WARNING-level lint rule to `.github/workflows/shell-compat-lint.yml` that flags `grep -c ... || echo` and `wc -l ... || echo` patterns
+2. Document the approved replacement: `awk '/pattern/{c++} END{print c+0}'`
+3. Allowlist for test files and already-audited files with inline `# lint:allow-grep-c-fallback`
 
-Called at `spiral-harness.sh:208` before every phase: `_check_budget "$TOTAL_BUDGET" || { error "Budget exceeded before $phase"; exit 3; }`
+## 3. Non-Goals
 
-When cumulative spend equals exactly $10, the `>=` check blocks AUDIT from starting.
+- Fixing all ~55 existing sites in this PR (incremental migration)
+- Changing the lint from WARNING to ERROR (that would block all PRs touching flagged files)
 
-## 3. Goals
-
-1. **Reserve an audit floor** so the AUDIT phase always has budget headroom, regardless of cumulative spend from prior phases
-2. **Change the comparison** from `>=` to `>` so a phase can START at exact budget (fail only if it exceeds mid-run)
-3. **Add regression test** that verifies AUDIT runs when spend equals exactly the budget cap
-4. **Update light profile budget** to $12 to match observed real-world cumulative costs
-
-## 4. Chosen Fix: Combination of proposals 2 + 3 + 1
-
-From the issue's 4 proposed fixes, we combine:
-- **Proposal 2**: Change `>=` to `>` in `_check_budget` — allows AUDIT to start at exact budget
-- **Proposal 3**: Reserve audit floor — subtract `$AUDIT_BUDGET` from effective cap for phases 1-6
-- **Proposal 1**: Raise light profile default from $10 to $12 as a safety margin
-
-This layered approach means:
-- Even if pre-AUDIT phases consume the full non-reserved budget, AUDIT still runs
-- The `>` comparison handles edge cases where spend equals the cap exactly
-- The raised default provides additional margin for cost variance
-
-## 5. Non-Goals
-
-- Changing the budget tracking mechanism (flight recorder cost accumulation is fine)
-- Modifying `claude -p` cost reporting (that's external)
-- Changing non-light profiles (standard=$12 and full=$15 already have headroom)
-
-## 6. Success Criteria
+## 4. Success Criteria
 
 | ID | Criterion | Verification |
 |----|-----------|-------------|
-| SC-1 | AUDIT runs when cumulative spend equals exactly the budget cap | BATS test with mocked flight recorder |
-| SC-2 | Light profile default budget is $12 (not $10) | BATS test / config check |
-| SC-3 | Pre-AUDIT phases respect a reduced effective budget (cap minus audit reserve) | BATS test: budget check at REVIEW phase uses reduced cap |
-| SC-4 | AUDIT phase uses the reserved amount, not the full cap | BATS test |
-| SC-5 | All existing spiral-harness and spiral-evidence BATS tests pass | CI green |
-| SC-6 | Standard and full profiles are not affected | BATS test |
+| SC-1 | Lint rule flags `grep -c ... \|\| echo` pattern | CI workflow test |
+| SC-2 | Lint rule flags `wc -l ... \|\| echo` pattern | CI workflow test |
+| SC-3 | Test files (*.bats, *test*) are excluded | Allowlist in rule |
+| SC-4 | Inline `# lint:allow-grep-c-fallback` suppresses the warning | Allowlist in rule |
+| SC-5 | Rule is WARNING level (does not block PRs) | CI still passes with existing sites |
+| SC-6 | Approved replacement documented in the lint output | Message text |
 
-## 7. System Zone Write Authorization
+## 5. System Zone Write Authorization
 
-This fix requires editing files in `.claude/scripts/` (System Zone). Authorized for cycle-078.
-
-**Files to modify:**
-- `.claude/scripts/spiral-evidence.sh` — change `>=` to `>` in `_check_budget`
-- `.claude/scripts/spiral-harness.sh` — add audit reserve logic + raise light profile default
-
-**Files to create/extend:**
-- `tests/unit/spiral-evidence.bats` or `tests/unit/spiral-harness.bats` — regression tests
+Authorized for cycle-079: `.github/workflows/shell-compat-lint.yml`

--- a/grimoires/loa/sdd.md
+++ b/grimoires/loa/sdd.md
@@ -1,56 +1,35 @@
-# Software Design Document: Fix spiral-harness budget boundary (#515)
+# Software Design Document: Shell-lint rule for grep -c || echo 0 (#531)
 
 **Date**: 2026-04-16
-**PRD**: `grimoires/loa/prd.md`
-**Issue**: [#515](https://github.com/0xHoneyJar/loa/issues/515)
-**Cycle**: cycle-078
+**Issue**: [#531](https://github.com/0xHoneyJar/loa/issues/531)
+**Cycle**: cycle-079
 
-## 1. Changes
+## 1. Change
 
-### Change 1: Strict-greater comparison in `_check_budget` (PRIMARY)
+Add a new WARNING rule section to `.github/workflows/shell-compat-lint.yml` following the existing pattern (sed -i, readlink -f, grep -P, etc.).
 
-**File**: `.claude/scripts/spiral-evidence.sh` line 222
+### Detection patterns
 
-**Before**: `'$spent >= $max'` — blocks when spent equals max
-**After**: `'$spent > $max'` — allows phase to START at exact budget
-
-This is the minimal fix: a phase that starts when `spent == max` will run with its own per-phase `--max-budget-usd` cap from `_invoke_claude`. It can't overshoot the total because `claude -p` enforces per-call budgets.
-
-### Change 2: Audit reserve in harness pipeline
-
-**File**: `.claude/scripts/spiral-harness.sh`
-
-Add an `AUDIT_RESERVE` variable that reduces the effective budget cap for pre-AUDIT phases:
-
-```bash
-# Reserve audit budget from the total so AUDIT always has headroom
-AUDIT_RESERVE="$AUDIT_BUDGET"  # $2 by default
+```
+grep -c ... || echo
+wc -l ... || echo
 ```
 
-Modify `_invoke_claude` to use an effective budget when the phase is NOT AUDIT:
-- Pre-AUDIT phases: check against `TOTAL_BUDGET - AUDIT_RESERVE`
-- AUDIT phase: check against `TOTAL_BUDGET` (full cap)
+Regex: `(grep\s+-c.*\|\|\s*echo|wc\s+-l.*\|\|\s*echo)`
 
-Implementation: pass the effective cap to `_check_budget` based on phase name.
+### Allowlist
 
-### Change 3: Raise light profile default budget
+- Test files: `*test*`, `*.bats`
+- Inline suppression: lines containing `# lint:allow-grep-c-fallback`
+- The lint rule file itself
 
-**File**: `.claude/scripts/spiral-harness.sh` line 159
+### Severity
 
-**Before**: `TOTAL_BUDGET=10`
-**After**: `TOTAL_BUDGET=12`
+WARNING (not ERROR) — existing ~55 sites would block all PRs otherwise.
 
-This matches observed real-world cumulative costs and provides margin.
+### Recommended fix (in lint output)
 
-### Change 4: Regression tests
-
-**File**: `tests/unit/spiral-evidence.bats` — extend with:
-- Test: `_check_budget` passes when spent equals exactly max (boundary case)
-- Test: `_check_budget` fails when spent exceeds max
-
-**File**: `tests/unit/spiral-harness.bats` — extend with:
-- Test: light profile default budget is 12 (not 10)
-
-## 2. System Zone Write Authorization
-
-Per PRD Section 7. Files: `.claude/scripts/spiral-evidence.sh`, `.claude/scripts/spiral-harness.sh`, test files.
+```
+Use: count=$(awk '/pattern/{c++} END{print c+0}' FILE)
+Instead of: count=$(grep -c 'pattern' FILE 2>/dev/null || echo 0)
+```

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -1,33 +1,18 @@
-# Sprint Plan: Cycle-078 — Fix spiral-harness budget boundary (#515)
+# Sprint Plan: Cycle-079 — Shell-lint rule for grep -c || echo 0 (#531)
 
 **PRD**: `grimoires/loa/prd.md`
 **SDD**: `grimoires/loa/sdd.md`
-**Issue**: [#515](https://github.com/0xHoneyJar/loa/issues/515)
-**Branch**: `fix/harness-budget-boundary-515`
+**Issue**: [#531](https://github.com/0xHoneyJar/loa/issues/531)
+**Branch**: `chore/shell-lint-grep-c-fallback-531`
 
 ## Sprint 1 (single sprint)
 
-### Task 1: Change `>=` to `>` in `_check_budget`
-**File**: `.claude/scripts/spiral-evidence.sh` line 222
-- Change `'$spent >= $max'` to `'$spent > $max'`
-- Update error message to match: `>` not `>=`
+### Task 1: Add lint rule to shell-compat-lint.yml
+Add WARNING section for `grep -c ... || echo` and `wc -l ... || echo` patterns.
+Follow existing rule structure (sed -i, readlink -f, grep -P sections).
+Include allowlist for test files and inline suppression comment.
 
-### Task 2: Add audit reserve logic to harness
-**File**: `.claude/scripts/spiral-harness.sh`
-- Add `AUDIT_RESERVE="$AUDIT_BUDGET"` after line 59
-- Modify `_invoke_claude` to pass `TOTAL_BUDGET - AUDIT_RESERVE` for non-AUDIT phases
-- AUDIT phase passes `TOTAL_BUDGET` directly
+### Task 2: Verify lint doesn't block CI
+Run the lint section locally to confirm it produces WARNINGs, not ERRORs, for existing sites.
 
-### Task 3: Raise light profile default budget to $12
-**File**: `.claude/scripts/spiral-harness.sh` line 159
-- Change `TOTAL_BUDGET=10` to `TOTAL_BUDGET=12`
-
-### Task 4: Add regression tests
-**Files**: `tests/unit/spiral-evidence.bats`, `tests/unit/spiral-harness.bats`
-- T-BUD1: `_check_budget` passes when spent equals exactly max (the #515 boundary)
-- T-BUD2: `_check_budget` fails when spent strictly exceeds max
-- T-BUD3: light profile default budget is 12
-
-### Task 5: Verify all tests pass + create PR
-- Run `bats tests/unit/spiral-evidence.bats tests/unit/spiral-harness.bats`
-- Create PR referencing #515
+### Task 3: Create PR


### PR DESCRIPTION
## Summary

Under `set -o pipefail`, `grep -c 'pattern' FILE || echo "0"` produces `"0\n0"` when count is zero — `grep -c` outputs `0` to stdout AND exits 1 (POSIX), so the `|| echo "0"` fallback fires and command substitution concatenates both. Downstream arithmetic breaks.

This bug class was found **3 independent times in cycle-075** (PRs #518, #524, #526). **60 existing sites** remain in `.claude/scripts/`.

## Changes

| File | Change |
|------|--------|
| `.claude/scripts/lint-grep-c-fallback.sh` | New standalone lint script — detects the anti-pattern |

### Lint script features
- Detects `grep -c ... \|\| echo` and `wc -l ... \|\| echo` patterns
- WARNING level (60 existing sites — migrate incrementally)
- Inline suppression: `# lint:allow-grep-c-fallback`
- `--error` mode for future CI enforcement
- `--scan-only` mode for metrics (`echo N`)
- Excludes test files (*.bats, *test*)

### Approved replacement
```bash
# Instead of:
count=$(grep -c 'pattern' FILE 2>/dev/null || echo 0)

# Use:
count=$(awk '/pattern/{c++} END{print c+0}' FILE 2>/dev/null || echo 0)
```

### CI integration (follow-up needed)

The `.github/workflows/shell-compat-lint.yml` integration requires a workflow-scoped token. Add this to the workflow:

```yaml
          # After the "bare timeout usage" section:
          echo "Checking: grep -c / wc -l with || echo fallback..."
          lint_output=$(.claude/scripts/lint-grep-c-fallback.sh --scan-only)
          if [[ "$lint_output" -gt 0 ]]; then
            .claude/scripts/lint-grep-c-fallback.sh
            warnings=$((warnings + lint_output))
          fi
```

## Test plan

- [x] `lint-grep-c-fallback.sh` finds 60 existing sites
- [x] `--scan-only` returns numeric count
- [x] `--error` mode returns exit 1 with findings
- [x] Test files excluded from results
- [x] Comment lines excluded from results

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)