### PR TITLE
fix(vision): replace grep -c || echo 0 with awk in vision-lib.sh

### DIFF
--- a/.claude/scripts/vision-lib.sh
+++ b/.claude/scripts/vision-lib.sh
@@ -702,13 +702,13 @@ vision_regenerate_index_stats() {
 
   # Count statuses from the table (grep for status column values)
   local captured exploring proposed implemented deferred archived rejected
-  captured=$(grep -c '| Captured |' "$index_file" 2>/dev/null || echo 0)
-  exploring=$(grep -c '| Exploring |' "$index_file" 2>/dev/null || echo 0)
-  proposed=$(grep -c '| Proposed |' "$index_file" 2>/dev/null || echo 0)
-  implemented=$(grep -c '| Implemented |' "$index_file" 2>/dev/null || echo 0)
-  deferred=$(grep -c '| Deferred |' "$index_file" 2>/dev/null || echo 0)
-  archived=$(grep -c '| Archived |' "$index_file" 2>/dev/null || echo 0)
-  rejected=$(grep -c '| Rejected |' "$index_file" 2>/dev/null || echo 0)
+  captured=$(awk '/\| Captured \|/{c++} END{print c+0}' "$index_file" 2>/dev/null || echo 0)
+  exploring=$(awk '/\| Exploring \|/{c++} END{print c+0}' "$index_file" 2>/dev/null || echo 0)
+  proposed=$(awk '/\| Proposed \|/{c++} END{print c+0}' "$index_file" 2>/dev/null || echo 0)
+  implemented=$(awk '/\| Implemented \|/{c++} END{print c+0}' "$index_file" 2>/dev/null || echo 0)
+  deferred=$(awk '/\| Deferred \|/{c++} END{print c+0}' "$index_file" 2>/dev/null || echo 0)
+  archived=$(awk '/\| Archived \|/{c++} END{print c+0}' "$index_file" 2>/dev/null || echo 0)
+  rejected=$(awk '/\| Rejected \|/{c++} END{print c+0}' "$index_file" 2>/dev/null || echo 0)
 
   # Rewrite statistics section using awk (safe, no shell expansion issues)
   # Note: avoid awk variable names that clash with builtins (exp, log, etc.)


### PR DESCRIPTION
## Summary

Seven consecutive instances of the `grep -c || echo 0` anti-pattern (#531) in the vision registry statistics counter (`vision-lib.sh:705-711`). Under `set -o pipefail`, `grep -c` exits 1 on zero matches, producing `"0\n0"` instead of `"0"`.

Approved replacement: `awk '/pattern/{c++} END{print c+0}'`

## Changes

| File | Lines | Change |
|------|-------|--------|
| `.claude/scripts/vision-lib.sh` | 705-711 | `grep -c` → `awk` (7 sites) |

## Test plan

- [x] Mechanical replacement — same semantics, always exits 0
- [x] awk pattern matches the same strings as grep -c (pipe-delimited status values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)