### PR TITLE
fix(post-merge): broaden classifier to match cycle-NNN anywhere (#550)

### DIFF
--- a/.claude/scripts/classify-pr-type.sh
+++ b/.claude/scripts/classify-pr-type.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# =============================================================================
+# classify-pr-type.sh — shared classifier for post-merge pipeline routing
+# =============================================================================
+# Part of Issue #550 fix. Previously, two separate sites embedded the same
+# classifier logic and drifted:
+#   - .github/workflows/post-merge.yml  (narrow regex, missed feat(models):…)
+#   - .claude/scripts/post-merge-orchestrator.sh  (added `feat:` catch-all,
+#     false-positive on any feature PR)
+#
+# This helper is the single source of truth. Both sites now source it.
+#
+# Usage (sourced):
+#   source .claude/scripts/classify-pr-type.sh
+#   pr_type=$(classify_pr_type "$TITLE" "$LABELS")
+#
+# Usage (standalone, for scripts that can't source):
+#   .claude/scripts/classify-pr-type.sh --title "<title>" --labels "<labels>"
+#
+# Output: one of "cycle", "bugfix", "other" (on stdout).
+# =============================================================================
+
+# classify_pr_type — classify a PR by title and labels
+#
+# Returns one of:
+#   cycle  — PR represents a full cycle (CHANGELOG, GT, RTFM, Release run)
+#   bugfix — PR is a bugfix (tag + simple release only)
+#   other  — PR doesn't match either (tag only)
+#
+# Rules (in precedence order):
+#   1. Label contains "cycle" (case-insensitive) → cycle
+#   2. Title matches cycle-NNN anywhere → cycle
+#   3. Title starts with one of the cycle prefixes
+#      (Run Mode, Sprint Plan, feat(sprint, feat(cycle) → cycle
+#   4. Title starts with "fix" → bugfix
+#   5. Otherwise → other
+#
+# NOTE: `^feat:` (bare) is deliberately NOT treated as cycle — that was a
+# pre-existing false-positive in post-merge-orchestrator.sh that classified
+# every feat: PR (even small features) as a full cycle. Use `feat(cycle-NNN):`
+# or `feat(sprint-NNN):` for cycle-scoped PRs.
+classify_pr_type() {
+    local title="${1:-}"
+    local labels="${2:-}"
+
+    if echo "$labels" | grep -qi "cycle"; then
+        echo "cycle"
+        return 0
+    fi
+
+    if echo "$title" | grep -qE '\bcycle-[0-9]+\b'; then
+        echo "cycle"
+        return 0
+    fi
+
+    if echo "$title" | grep -qE "^(Run Mode|Sprint Plan|feat\(sprint|feat\(cycle)"; then
+        echo "cycle"
+        return 0
+    fi
+
+    if echo "$title" | grep -qE "^fix"; then
+        echo "bugfix"
+        return 0
+    fi
+
+    echo "other"
+}
+
+# When executed directly (not sourced), parse flags and invoke
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    TITLE=""
+    LABELS=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --title)
+                if [[ $# -lt 2 ]]; then echo "ERROR: --title requires a value" >&2; exit 2; fi
+                TITLE="$2"; shift 2 ;;
+            --labels)
+                if [[ $# -lt 2 ]]; then echo "ERROR: --labels requires a value" >&2; exit 2; fi
+                LABELS="$2"; shift 2 ;;
+            -h|--help)
+                echo "Usage: classify-pr-type.sh --title <title> [--labels <labels>]"
+                exit 0 ;;
+            *)
+                echo "Unknown arg: $1" >&2; exit 2 ;;
+        esac
+    done
+    classify_pr_type "$TITLE" "$LABELS"
+fi

--- a/.claude/scripts/post-merge-orchestrator.sh
+++ b/.claude/scripts/post-merge-orchestrator.sh
@@ -237,14 +237,25 @@ phase_classify() {
     title=$(echo "$pr_json" | jq -r '.title // ""')
     labels=$(echo "$pr_json" | jq -r '[.labels[]?.name] | join(",")' 2>/dev/null || echo "")
 
-    if echo "$labels" | grep -q "cycle"; then
-      PR_TYPE="cycle"
-    elif echo "$title" | grep -qE "^(Run Mode|Sprint Plan|feat\(sprint|feat\(cycle|feat:)"; then
-      PR_TYPE="cycle"
-    elif echo "$title" | grep -qE "^fix"; then
-      PR_TYPE="bugfix"
+    # Classify via shared helper — single source of truth (Issue #550).
+    # The pre-existing `|feat:` catch-all false-positived on every feat PR
+    # as a full cycle. New classifier uses `\bcycle-[0-9]+\b` instead.
+    local classifier="${SCRIPT_DIR}/classify-pr-type.sh"
+    if [[ -f "$classifier" ]]; then
+      # shellcheck source=classify-pr-type.sh
+      source "$classifier"
+      PR_TYPE=$(classify_pr_type "$title" "$labels")
     else
-      PR_TYPE="other"
+      # Defensive fallback
+      if echo "$labels" | grep -qi "cycle"; then
+        PR_TYPE="cycle"
+      elif echo "$title" | grep -qE '\bcycle-[0-9]+\b|^(Run Mode|Sprint Plan|feat\(sprint|feat\(cycle)'; then
+        PR_TYPE="cycle"
+      elif echo "$title" | grep -qE "^fix"; then
+        PR_TYPE="bugfix"
+      else
+        PR_TYPE="other"
+      fi
     fi
 
     local result

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -478,7 +478,7 @@
       ]
     }
   ],
-  "global_sprint_counter": 103,
+  "global_sprint_counter": 104,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -494,6 +494,21 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260418-i554-00a529/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260418-i554-00a529/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260418-i550-3512f6",
+      "label": "Bug Fix - post-merge classifier regex misses cycle PRs",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/550",
+      "meta_issue": "https://github.com/0xHoneyJar/loa/issues/557",
+      "parent_cycle": "cycle-083",
+      "created_at": "2026-04-18T04:30:00Z",
+      "sprints": [
+        "sprint-bug-104"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260418-i550-3512f6/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260418-i550-3512f6/sprint.md"
     }
   ]
 }

--- a/tests/unit/post-merge-classifier.bats
+++ b/tests/unit/post-merge-classifier.bats
@@ -1,0 +1,202 @@
+#!/usr/bin/env bats
+# =============================================================================
+# post-merge-classifier.bats — Tests for classify-pr-type.sh (Issue #550)
+# =============================================================================
+# Sprint-bug-104. Validates the shared PR-type classifier that routes merged
+# PRs into the Simple Release or Full Pipeline job in post-merge automation.
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export CLASSIFIER="$PROJECT_ROOT/.claude/scripts/classify-pr-type.sh"
+}
+
+# =========================================================================
+# PCT-T1..PCT-T4: label-based routing (highest precedence)
+# =========================================================================
+
+@test "label 'cycle' routes to cycle regardless of title" {
+    run "$CLASSIFIER" --title "random nonsense" --labels "cycle"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+@test "label 'Cycle' (case-insensitive) routes to cycle" {
+    run "$CLASSIFIER" --title "unrelated" --labels "Cycle,v2"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+# =========================================================================
+# PCT-T5..PCT-T10: title matching — the #550 defect class
+# =========================================================================
+
+@test "feat(models): with cycle-NNN suffix → cycle (#550 regression case)" {
+    run "$CLASSIFIER" --title "feat(models): promote Opus 4.7 to top-review default (cycle-082)"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+@test "feat(bridge): with cycle-NNN suffix → cycle" {
+    run "$CLASSIFIER" --title "feat(bridge): enrich kaironic review (cycle-053)"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+@test "feat(harness): with cycle-NNN → cycle" {
+    run "$CLASSIFIER" --title "feat(harness): spiral orchestrator (cycle-071)"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+@test "feat(sprint-3): legacy prefix still matches → cycle" {
+    run "$CLASSIFIER" --title "feat(sprint-3): task batch"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+@test "feat(cycle-042): explicit prefix matches → cycle" {
+    run "$CLASSIFIER" --title "feat(cycle-042): mining runtime routing"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+@test "Run Mode: full autonomous run → cycle" {
+    run "$CLASSIFIER" --title "Run Mode: autonomous sprint 3"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+# =========================================================================
+# PCT-T11..PCT-T13: anti-false-positive (the bug's mirror image)
+# =========================================================================
+
+@test "feat: (bare, no cycle-NNN) does NOT match cycle — regression guard" {
+    run "$CLASSIFIER" --title "feat: add login form"
+    [ "$status" -eq 0 ]
+    [ "$output" = "other" ]
+}
+
+@test "feat(auth): without cycle-NNN does NOT match cycle" {
+    run "$CLASSIFIER" --title "feat(auth): implement OAuth flow"
+    [ "$status" -eq 0 ]
+    [ "$output" = "other" ]
+}
+
+@test "cycle-related word in prose (not cycle-NNN) does NOT match" {
+    run "$CLASSIFIER" --title "refactor: break cycle dependency in auth module"
+    [ "$status" -eq 0 ]
+    [ "$output" = "other" ]
+}
+
+# =========================================================================
+# PCT-T14..PCT-T16: bugfix routing
+# =========================================================================
+
+@test "fix: routes to bugfix" {
+    run "$CLASSIFIER" --title "fix: null pointer in parser"
+    [ "$status" -eq 0 ]
+    [ "$output" = "bugfix" ]
+}
+
+@test "fix(auth): routes to bugfix" {
+    run "$CLASSIFIER" --title "fix(auth): OAuth state validation"
+    [ "$status" -eq 0 ]
+    [ "$output" = "bugfix" ]
+}
+
+@test "fix(skills): with cycle-NNN routes to cycle (label precedes fix)" {
+    run "$CLASSIFIER" --title "fix(skills): agent: Plan blocks Write (cycle-083)"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+# =========================================================================
+# PCT-T17: default fallback
+# =========================================================================
+
+@test "unclassifiable title routes to other" {
+    run "$CLASSIFIER" --title "random untyped PR"
+    [ "$status" -eq 0 ]
+    [ "$output" = "other" ]
+}
+
+@test "empty title routes to other" {
+    run "$CLASSIFIER" --title ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "other" ]
+}
+
+# =========================================================================
+# PCT-T18: arg validation
+# =========================================================================
+
+@test "--title without value exits 2" {
+    run "$CLASSIFIER" --title
+    [ "$status" -eq 2 ]
+}
+
+@test "--labels without value exits 2" {
+    run "$CLASSIFIER" --title "x" --labels
+    [ "$status" -eq 2 ]
+}
+
+# =========================================================================
+# PCT-T20: sourceable helper function
+# =========================================================================
+
+@test "function classify_pr_type is sourceable and callable" {
+    run bash -c "source '$CLASSIFIER'; classify_pr_type 'feat(models): cycle-099' ''"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+# =========================================================================
+# PCT-T21: historical backtest — last N merged cycle PRs should all classify as cycle
+# =========================================================================
+# From `git log --oneline main --grep='cycle-'`, representative PR titles:
+
+@test "backtest: representative cycle PR titles all classify as cycle" {
+    # Representative titles drawn from recent merged cycle PRs.
+    # Each carries a cycle-NNN, cycle prefix, or Run Mode / Sprint Plan marker.
+    titles=(
+      "feat(models): promote Opus 4.7 to top-review default (cycle-082)"
+      "fix(skills): drop restrictive agent: on write-capable skills + lint invariant (cycle-083)"
+      "fix(update-loa): refresh version markers post-merge (Phase 5.6) (cycle-083)"
+      "feat(bridge): multi-model Bridgebuilder pipeline (cycle-052)"
+      "feat(bridge): Amendment 1 post-PR loop + kaironic convergence (cycle-053)"
+      "feat(harness): spiral autopoietic orchestrator (cycle-071)"
+      "Run Mode: autonomous sprint implementation 1"
+      "Sprint Plan: cycle-060 platform hardening"
+      "feat(sprint-3): token budget enforcement"
+      "feat(cycle-042): mining runtime routing"
+      "feat(vision-registry): query API and lifecycle (cycle-069)"
+      "feat(simstim): HITL accelerated development workflow (cycle-048)"
+      "fix(harness): CLAUDE.md blocks, permission flags (cycle-071)"
+      "feat(flatline): 3-model tertiary support (cycle-040)"
+    )
+    for title in "${titles[@]}"; do
+        run "$CLASSIFIER" --title "$title"
+        if [[ "$output" != "cycle" ]]; then
+            echo "FAILED to classify as cycle: $title" >&2
+            echo "Got: $output" >&2
+            return 1
+        fi
+    done
+}
+
+@test "non-cycle feat PRs without cycle-NNN classify as other" {
+    # PRs that are legitimate feat work but not part of a cycle ship.
+    # They should get the simple tag-only release path, not Full Pipeline.
+    titles=(
+      "feat(adversarial-review): enforce Phase 2.5 at COMPLETED marker write"
+      "feat(auth): implement OAuth2 flow"
+      "feat(api): add user endpoint"
+    )
+    for title in "${titles[@]}"; do
+        run "$CLASSIFIER" --title "$title"
+        if [[ "$output" != "other" ]]; then
+            echo "Expected 'other', got '$output' for: $title" >&2
+            return 1
+        fi
+    done
+}

--- a/tests/unit/post-merge-classifier.bats
+++ b/tests/unit/post-merge-classifier.bats
@@ -89,6 +89,39 @@ setup() {
 }
 
 # =========================================================================
+# PCT-T-MID-1: cycle-NNN in middle of title (Bridgebuilder DISPUTED finding)
+# =========================================================================
+# Triangulates the "anywhere" regex claim — start/middle/end must all match.
+
+@test "cycle-NNN mid-title matches — triangulation" {
+    run "$CLASSIFIER" --title "feat: implement cycle-099 features"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+@test "cycle-NNN with content after also matches" {
+    run "$CLASSIFIER" --title "chore: cycle-042 release prep and final doc update"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+# =========================================================================
+# PCT-T-BOUNDARY: word-boundary negative cases
+# =========================================================================
+
+@test "precycle-082 (no word boundary before 'cycle') does NOT match" {
+    run "$CLASSIFIER" --title "feat: rebuild precycle-082 scaffold"
+    [ "$status" -eq 0 ]
+    [ "$output" = "other" ]
+}
+
+@test "cycle-abc (non-numeric suffix) does NOT match" {
+    run "$CLASSIFIER" --title "feat: cycle-abc branch protection"
+    [ "$status" -eq 0 ]
+    [ "$output" = "other" ]
+}
+
+# =========================================================================
 # PCT-T14..PCT-T16: bugfix routing
 # =========================================================================
 


### PR DESCRIPTION
## Summary

Fixes [#550](https://github.com/0xHoneyJar/loa/issues/550) — post-merge classifier regex misses cycle PRs with non-sprint prefixes (`feat(models):`, `feat(bridge):`, `feat(harness):`, etc.). PR #547 (cycle-082) was classified as "other" and the Full Pipeline job SKIPPED — CHANGELOG, GT, RTFM, Release all had to be done manually.

Root cause: two classifier sites drifted apart. Fix extracts to a shared helper with anti-drift BATS coverage.

## Changes

| File | Change |
|------|--------|
| `.claude/scripts/classify-pr-type.sh` | **New** — shared classifier. Function `classify_pr_type(title, labels)` → stdout one of `cycle`/`bugfix`/`other`. Also standalone with `--title`/`--labels`. |
| `.claude/scripts/post-merge-orchestrator.sh` | Sources helper. Defensive inline fallback if helper missing. **Drops** the `\|feat:` false-positive catch-all that incorrectly classified every `feat:` PR as cycle. |
| `tests/unit/post-merge-classifier.bats` | **New** — 21 BATS test cases (see below). |
| `grimoires/loa/ledger.json` | Sprint-bug-104 registration (counter bumped 103 → 104). |

## ⚠️ Workflow file update required separately

`.github/workflows/post-merge.yml` also contains the classifier regex but requires `workflow` OAuth scope to push, which this agent does not have. **@janitooor**: please apply the companion edit — the exact snippet is in the commit message body. The orchestrator fix lands regardless; the workflow fix is what makes the CI classification correct.

## Test Plan

- [x] `bats tests/unit/post-merge-classifier.bats` → 21/21 green
- [x] Label-based routing (`cycle`, case-insensitive)
- [x] #550 regression case: `feat(models): … cycle-082` → `cycle`
- [x] Variants: `feat(bridge)`, `feat(harness)`, `feat(sprint-N)`, `feat(cycle-N)`, `Run Mode`, `Sprint Plan` → all `cycle`
- [x] Anti-false-positive: bare `feat:`, `feat(auth):` without cycle-NNN, prose "cycle" without `-NNN` → all `other`
- [x] Bugfix routing: `fix:`, `fix(scope):` → `bugfix`
- [x] Bugfix with cycle-NNN: `fix(skills): ... (cycle-083)` → `cycle` (cycle label precedes fix prefix)
- [x] Arg validation: missing `--title`/`--labels` values exit 2
- [x] Sourceable: `source classify-pr-type.sh; classify_pr_type ...` works
- [x] Backtest: 14 representative historical cycle PR titles all classify as `cycle`
- [x] Anti-FP: 3 non-cycle feat titles all classify as `other`
- [x] Phase 2.5 adversarial review: 0 findings, clean
- [x] Phase 1C adversarial audit: 0 findings, clean
- [ ] Post-merge: next `feat(anything): cycle-NNN` PR triggers Full Pipeline automatically (requires workflow update)

## Links

- Source issue: [#550](https://github.com/0xHoneyJar/loa/issues/550)
- Meta tracker: [#557](https://github.com/0xHoneyJar/loa/issues/557) (Tier 1, cycle-083)
- Sister PRs: [#558](https://github.com/0xHoneyJar/loa/pull/558) (#553 merged), [#559](https://github.com/0xHoneyJar/loa/pull/559) (#554 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>