### PR TITLE
fix(spiral): REVIEW→IMPL fix-loop + --resume --force (#545, #546)

### DIFF
--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -306,6 +306,78 @@ _phase_implement() {
     _invoke_claude "IMPLEMENTATION" "$prompt" "$IMPLEMENT_BUDGET" 3600
 }
 
+# _phase_implement_with_feedback — re-implementation pass informed by review (#545)
+#
+# Invoked by _review_fix_loop when REVIEW returns CHANGES_REQUIRED. Reads the
+# review's engineer-feedback.md and passes it as explicit context so the
+# implementer addresses the specific findings rather than rewriting blindly.
+_phase_implement_with_feedback() {
+    local feedback_path="grimoires/loa/a2a/engineer-feedback.md"
+    local feedback
+
+    if [[ -f "$feedback_path" ]]; then
+        feedback=$(head -c 5000 "$feedback_path" 2>/dev/null || echo "No feedback available")
+    else
+        feedback="(Review produced CHANGES_REQUIRED but no feedback file was found; check engineer-feedback.md)"
+    fi
+
+    local prompt
+    prompt=$(jq -n --arg branch "$BRANCH" --arg fb "$feedback" \
+        '"You previously implemented the sprint. An independent review found issues. Address the feedback and re-push.\n\nPREVIOUS REVIEW FEEDBACK:\n" + $fb + "\n\nIMPORTANT: You have EXPLICIT AUTHORIZATION to edit files in .claude/scripts/ for this cycle. Do NOT refuse to edit .claude/ files — this is an authorized spiral cycle.\n\nRequirements:\n- Remain on branch " + $branch + "\n- Address each CHANGES_REQUIRED item in the feedback above\n- Do NOT re-run the entire sprint plan — ONLY fix the issues flagged by the reviewer\n- Run tests and verify they pass after your fixes\n- Commit with a fix-prefixed message referencing the review feedback\n- Push the branch to origin/" + $branch + "\n- Do NOT modify grimoires/loa/prd.md, sdd.md, or sprint.md"' \
+        | jq -r '.')
+
+    _invoke_claude "IMPLEMENTATION_FIX" "$prompt" "$IMPLEMENT_BUDGET" 3600
+}
+
+# _review_fix_loop — review with automatic implementation-side fix iterations (#545)
+#
+# Wraps _gate_review with a fix loop: when CHANGES_REQUIRED, re-invokes
+# _phase_implement_with_feedback so the implementer actually addresses the
+# review findings. Budget-capped by REVIEW_MAX_ITERATIONS (default 2).
+#
+# Previously, _run_gate "REVIEW" retried the REVIEW gate itself up to MAX_RETRIES
+# times — but the implementation was never touched, so the reviewer saw the same
+# broken code on every retry and rightly kept saying CHANGES_REQUIRED until the
+# circuit breaker tripped. Observed in cycle-367687f8de.
+#
+# This mirrors the BB fix loop pattern (cycle-074, PR #512) at the review gate.
+#
+# Env overrides (defaults in brackets):
+#   REVIEW_MAX_ITERATIONS  [2]  — total REVIEW attempts including the first
+_review_fix_loop() {
+    local max_iters="${REVIEW_MAX_ITERATIONS:-2}"
+    local iter=1
+
+    while [[ $iter -le $max_iters ]]; do
+        log "Review fix loop: iteration $iter/$max_iters"
+
+        if _run_gate "REVIEW" _gate_review; then
+            log "Review PASSED on iteration $iter/$max_iters"
+            return 0
+        fi
+
+        if [[ $iter -ge $max_iters ]]; then
+            log "Review FAILED: exhausted $max_iters fix iterations"
+            _record_action "REVIEW_FIX_LOOP_EXHAUSTED" "review-fix-loop" "changes_required" "" "" "" 0 0 0 \
+                "max_iterations=$max_iters" 2>/dev/null || true
+            return 1
+        fi
+
+        log "Review CHANGES_REQUIRED — dispatching implementation fix (iteration $((iter + 1))/$max_iters)"
+        _record_action "REVIEW_FIX_DISPATCH" "review-fix-loop" "fix_dispatched" "" "" "" 0 0 0 \
+            "iter=$iter" 2>/dev/null || true
+
+        if ! _phase_implement_with_feedback; then
+            log "Review fix loop: implementation-fix pass FAILED at iteration $iter"
+            return 1
+        fi
+
+        iter=$((iter + 1))
+    done
+
+    return 1
+}
+
 # =============================================================================
 # Gate Implementations
 # =============================================================================
@@ -1063,9 +1135,13 @@ main() {
         exit 1
     fi
 
-    # ── Gate 4: Independent Review (fresh session) ──────────────────────
-    _run_gate "REVIEW" _gate_review || {
-        log "Review CHANGES_REQUIRED — implementation needs work"
+    # ── Gate 4: Independent Review with IMPL fix-loop (#545) ────────────
+    # _review_fix_loop wraps _run_gate REVIEW with re-invocations of
+    # _phase_implement_with_feedback so the implementer actually addresses
+    # the reviewer's findings instead of the reviewer seeing the same
+    # broken code on every retry until circuit-breaker.
+    _review_fix_loop || {
+        log "Review CHANGES_REQUIRED — implementation needs work (fix loop exhausted)"
         exit 1
     }
 

--- a/.claude/scripts/spiral-orchestrator.sh
+++ b/.claude/scripts/spiral-orchestrator.sh
@@ -1330,6 +1330,28 @@ cmd_halt() {
     jq -n --arg reason "$reason" '{halted: true, reason: $reason}'
 }
 
+# _resume_terminal_decision — pure decision function for the COMPLETED/FAILED
+# case in cmd_resume. Extracted so tests can exercise it directly against the
+# shipped logic (not a simulation). Outputs one of:
+#   accept       — force-override applies; caller should treat as CRASHED
+#   refuse       — terminal state rejected (return 1)
+#   pass_through — non-terminal state; caller handles elsewhere
+# Exit codes: 0 for accept/pass_through, 1 for refuse.
+_resume_terminal_decision() {
+    local state="$1" stop_reason="$2" force="$3"
+    case "$state" in
+        COMPLETED|FAILED)
+            if [[ "$force" == "true" && "$stop_reason" == "quality_gate_failure" ]]; then
+                echo "accept"; return 0
+            fi
+            echo "refuse"; return 1
+            ;;
+        *)
+            echo "pass_through"; return 0
+            ;;
+    esac
+}
+
 cmd_resume() {
     if [[ ! -f "$STATE_FILE" ]]; then
         error "No spiral state to resume. Use --start."
@@ -1354,15 +1376,14 @@ cmd_resume() {
             current_state="CRASHED"
             ;;
         COMPLETED|FAILED)
-            # #546: allow narrow --force override when the stopping condition is
-            # `quality_gate_failure` (reviewer/auditor disagreement that the
-            # operator has judged recoverable). Refuses to override any other
-            # terminal state or any other stopping condition — those represent
-            # true end-of-spiral conditions.
-            local stop_reason force_flag
+            # #546: narrow --force override for quality_gate_failure only.
+            # Decision logic extracted to _resume_terminal_decision so tests
+            # call the shipped function, not a simulation.
+            local stop_reason force_flag decision
             stop_reason=$(jq -r '.stopping_condition // ""' "$STATE_FILE" 2>/dev/null || echo "")
             force_flag="${SPIRAL_RESUME_FORCE:-false}"
-            if [[ "$force_flag" == "true" && "$stop_reason" == "quality_gate_failure" ]]; then
+            decision=$(_resume_terminal_decision "$current_state" "$stop_reason" "$force_flag")
+            if [[ "$decision" == "accept" ]]; then
                 log "Resume --force: accepting terminal state $current_state with stopping_condition=quality_gate_failure"
                 current_state="CRASHED"
             else

--- a/.claude/scripts/spiral-orchestrator.sh
+++ b/.claude/scripts/spiral-orchestrator.sh
@@ -1354,8 +1354,21 @@ cmd_resume() {
             current_state="CRASHED"
             ;;
         COMPLETED|FAILED)
-            error "Cannot resume from terminal state: $current_state. Use --start for a new spiral."
-            return 1
+            # #546: allow narrow --force override when the stopping condition is
+            # `quality_gate_failure` (reviewer/auditor disagreement that the
+            # operator has judged recoverable). Refuses to override any other
+            # terminal state or any other stopping condition — those represent
+            # true end-of-spiral conditions.
+            local stop_reason force_flag
+            stop_reason=$(jq -r '.stopping_condition // ""' "$STATE_FILE" 2>/dev/null || echo "")
+            force_flag="${SPIRAL_RESUME_FORCE:-false}"
+            if [[ "$force_flag" == "true" && "$stop_reason" == "quality_gate_failure" ]]; then
+                log "Resume --force: accepting terminal state $current_state with stopping_condition=quality_gate_failure"
+                current_state="CRASHED"
+            else
+                error "Cannot resume from terminal state: $current_state. Use --start for a new spiral."
+                return 1
+            fi
             ;;
     esac
 
@@ -1434,7 +1447,18 @@ main() {
         --start) cmd_start "$@" ;;
         --status) cmd_status "$@" ;;
         --halt) cmd_halt "$@" ;;
-        --resume) cmd_resume ;;
+        --resume)
+            # #546: --resume accepts a narrow --force override for
+            # quality_gate_failure terminal states. Parsed here so
+            # cmd_resume can read SPIRAL_RESUME_FORCE without coupling
+            # to the main arg loop.
+            for arg in "$@"; do
+                if [[ "$arg" == "--force" ]]; then
+                    export SPIRAL_RESUME_FORCE=true
+                fi
+            done
+            cmd_resume
+            ;;
         --check-stop) cmd_check_stop ;;
         -h|--help|help|"")
             usage

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -515,9 +515,33 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260418-i555-5560f6/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260418-i555-5560f6/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260418-i545-e2c781",
+      "label": "Bug Fix — Spiral REVIEW gate fix-loop + quality_gate recovery (#545 + #546)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issues": [
+        "https://github.com/0xHoneyJar/loa/issues/545",
+        "https://github.com/0xHoneyJar/loa/issues/546"
+      ],
+      "meta_tracker": "https://github.com/0xHoneyJar/loa/issues/557",
+      "parent_cycle": "cycle-084",
+      "created_at": "2026-04-18T07:41:02Z",
+      "sprints": [
+        {
+          "local_id": 1,
+          "global_id": 107,
+          "sprint_id": "sprint-bug-107",
+          "label": "REVIEW fix-loop + quality_gate recovery",
+          "status": "active"
+        }
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260418-i545-e2c781/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260418-i545-e2c781/sprint.md"
     }
   ],
-  "global_sprint_counter": 106,
+  "global_sprint_counter": 107,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/spiral-resume-force.bats
+++ b/tests/unit/spiral-resume-force.bats
@@ -1,0 +1,186 @@
+#!/usr/bin/env bats
+# =============================================================================
+# spiral-resume-force.bats — Tests for cmd_resume --force (#546)
+# =============================================================================
+# Sprint-bug-107. Validates the narrow --force override for resuming a
+# spiral from COMPLETED/FAILED terminal state with stopping_condition =
+# quality_gate_failure. Refuses any other combination.
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export TEST_DIR="$BATS_TEST_TMPDIR/spiral-state"
+    mkdir -p "$TEST_DIR"
+    export SPIRAL_STATE_DIR="$TEST_DIR"
+}
+
+teardown() {
+    unset SPIRAL_RESUME_FORCE SPIRAL_STATE_DIR
+    rm -rf "$TEST_DIR" 2>/dev/null || true
+}
+
+# Extract just the first `case` block of cmd_resume that we're testing — we
+# don't want to wire up the full orchestrator machinery (coalesce, state
+# writes, PID tracking) for a narrow behavior test.
+make_isolated_cmd() {
+    local state="$1" stop_reason="$2"
+    local state_file="$TEST_DIR/state.json"
+    cat > "$state_file" <<EOF
+{
+  "state": "$state",
+  "stopping_condition": $(if [[ -n "$stop_reason" ]]; then echo "\"$stop_reason\""; else echo "null"; fi)
+}
+EOF
+    echo "$state_file"
+}
+
+resume_gate() {
+    # Simulate the exact case-block logic added in spiral-orchestrator.sh
+    # for --resume's handling of terminal states. Returns the outcome as
+    # stdout: "accept", "refuse", or "pass_through".
+    local state_file="$1"
+    local current_state stop_reason force_flag
+    current_state=$(jq -r '.state' "$state_file")
+    stop_reason=$(jq -r '.stopping_condition // ""' "$state_file")
+    force_flag="${SPIRAL_RESUME_FORCE:-false}"
+
+    case "$current_state" in
+        COMPLETED|FAILED)
+            if [[ "$force_flag" == "true" && "$stop_reason" == "quality_gate_failure" ]]; then
+                echo "accept"; return 0
+            else
+                echo "refuse"; return 1
+            fi
+            ;;
+        *)
+            echo "pass_through"; return 0
+            ;;
+    esac
+}
+
+# =========================================================================
+# RF-T1: COMPLETED + quality_gate_failure + --force → accept
+# =========================================================================
+
+@test "resume --force: COMPLETED + quality_gate_failure accepted" {
+    local state_file
+    state_file=$(make_isolated_cmd "COMPLETED" "quality_gate_failure")
+    export SPIRAL_RESUME_FORCE=true
+
+    run resume_gate "$state_file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "accept" ]
+}
+
+# =========================================================================
+# RF-T2: FAILED + quality_gate_failure + --force → accept
+# =========================================================================
+
+@test "resume --force: FAILED + quality_gate_failure accepted" {
+    local state_file
+    state_file=$(make_isolated_cmd "FAILED" "quality_gate_failure")
+    export SPIRAL_RESUME_FORCE=true
+
+    run resume_gate "$state_file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "accept" ]
+}
+
+# =========================================================================
+# RF-T3: COMPLETED + quality_gate_failure WITHOUT --force → refuse
+# =========================================================================
+
+@test "resume (no --force): COMPLETED + quality_gate_failure refused" {
+    local state_file
+    state_file=$(make_isolated_cmd "COMPLETED" "quality_gate_failure")
+    unset SPIRAL_RESUME_FORCE
+
+    run resume_gate "$state_file"
+    [ "$status" -eq 1 ]
+    [ "$output" = "refuse" ]
+}
+
+# =========================================================================
+# RF-T4: COMPLETED + cycle_budget_exhausted + --force → refuse (narrow gate)
+# =========================================================================
+
+@test "resume --force: COMPLETED + non-quality_gate_failure refused even with force" {
+    local state_file
+    state_file=$(make_isolated_cmd "COMPLETED" "cycle_budget_exhausted")
+    export SPIRAL_RESUME_FORCE=true
+
+    run resume_gate "$state_file"
+    [ "$status" -eq 1 ]
+    [ "$output" = "refuse" ]
+}
+
+# =========================================================================
+# RF-T5: COMPLETED + flatline_convergence + --force → refuse (narrow gate)
+# =========================================================================
+
+@test "resume --force: COMPLETED + flatline_convergence refused" {
+    local state_file
+    state_file=$(make_isolated_cmd "COMPLETED" "flatline_convergence")
+    export SPIRAL_RESUME_FORCE=true
+
+    run resume_gate "$state_file"
+    [ "$status" -eq 1 ]
+}
+
+# =========================================================================
+# RF-T6: HALTED + --force → pass through (normal resumable state)
+# =========================================================================
+
+@test "resume --force: HALTED passes through case-block (normal resume path)" {
+    local state_file
+    state_file=$(make_isolated_cmd "HALTED" "hitl_halt")
+    export SPIRAL_RESUME_FORCE=true
+
+    run resume_gate "$state_file"
+    [ "$status" -eq 0 ]
+    [ "$output" = "pass_through" ]
+}
+
+# =========================================================================
+# RF-T7: --force with null stopping_condition → refuse
+# =========================================================================
+
+@test "resume --force: COMPLETED + null stopping_condition refused" {
+    local state_file
+    state_file=$(make_isolated_cmd "COMPLETED" "")
+    export SPIRAL_RESUME_FORCE=true
+
+    run resume_gate "$state_file"
+    [ "$status" -eq 1 ]
+}
+
+# =========================================================================
+# RF-T8: CLI parsing — --force flag sets SPIRAL_RESUME_FORCE
+# =========================================================================
+
+@test "CLI parses --force arg for --resume subcommand" {
+    # Simulate the CLI arg-loop added to main()
+    local args=("--resume" "--force")
+    shift_args() {
+        for arg in "$@"; do
+            if [[ "$arg" == "--force" ]]; then
+                export SPIRAL_RESUME_FORCE=true
+            fi
+        done
+    }
+    shift_args "${args[@]:1}"  # drop "--resume"
+    [ "$SPIRAL_RESUME_FORCE" = "true" ]
+}
+
+@test "CLI parsing: --resume without --force leaves SPIRAL_RESUME_FORCE unset" {
+    local args=("--resume")
+    shift_args() {
+        for arg in "$@"; do
+            if [[ "$arg" == "--force" ]]; then
+                export SPIRAL_RESUME_FORCE=true
+            fi
+        done
+    }
+    unset SPIRAL_RESUME_FORCE
+    shift_args "${args[@]:1}"
+    [ "${SPIRAL_RESUME_FORCE:-unset}" = "unset" ]
+}

--- a/tests/unit/spiral-resume-force.bats
+++ b/tests/unit/spiral-resume-force.bats
@@ -18,9 +18,15 @@ teardown() {
     rm -rf "$TEST_DIR" 2>/dev/null || true
 }
 
-# Extract just the first `case` block of cmd_resume that we're testing — we
-# don't want to wire up the full orchestrator machinery (coalesce, state
-# writes, PID tracking) for a narrow behavior test.
+# Extract the shipped _resume_terminal_decision function from spiral-orchestrator.sh
+# so tests exercise the actual shipped code, not a re-implementation (addresses
+# Bridgebuilder F1 HIGH finding). The function is pure — no globals, no side
+# effects — so it sources cleanly without the rest of the orchestrator machinery.
+extract_decision_fn() {
+    local orch="$PROJECT_ROOT/.claude/scripts/spiral-orchestrator.sh"
+    awk '/^# _resume_terminal_decision — pure decision/,/^}$/' "$orch" > "$TEST_DIR/decision.sh"
+}
+
 make_isolated_cmd() {
     local state="$1" stop_reason="$2"
     local state_file="$TEST_DIR/state.json"
@@ -34,27 +40,17 @@ EOF
 }
 
 resume_gate() {
-    # Simulate the exact case-block logic added in spiral-orchestrator.sh
-    # for --resume's handling of terminal states. Returns the outcome as
-    # stdout: "accept", "refuse", or "pass_through".
+    # Calls the shipped _resume_terminal_decision via the extracted source.
+    # State file is read via jq (matching cmd_resume's own extraction).
     local state_file="$1"
+    extract_decision_fn
+    # shellcheck source=/dev/null
+    source "$TEST_DIR/decision.sh"
     local current_state stop_reason force_flag
     current_state=$(jq -r '.state' "$state_file")
     stop_reason=$(jq -r '.stopping_condition // ""' "$state_file")
     force_flag="${SPIRAL_RESUME_FORCE:-false}"
-
-    case "$current_state" in
-        COMPLETED|FAILED)
-            if [[ "$force_flag" == "true" && "$stop_reason" == "quality_gate_failure" ]]; then
-                echo "accept"; return 0
-            else
-                echo "refuse"; return 1
-            fi
-            ;;
-        *)
-            echo "pass_through"; return 0
-            ;;
-    esac
+    _resume_terminal_decision "$current_state" "$stop_reason" "$force_flag"
 }
 
 # =========================================================================

--- a/tests/unit/spiral-review-fix-loop.bats
+++ b/tests/unit/spiral-review-fix-loop.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# =============================================================================
+# spiral-review-fix-loop.bats — Tests for _review_fix_loop (#545)
+# =============================================================================
+# Sprint-bug-107 cycle-084. Validates that the review fix-loop re-invokes
+# _phase_implement_with_feedback when REVIEW returns CHANGES_REQUIRED,
+# rather than retrying the same reviewer against the same unchanged
+# implementation until circuit-breaker.
+#
+# Approach: isolate _review_fix_loop by extracting just the function
+# under test into a minimal test harness. Mock _run_gate,
+# _phase_implement_with_feedback, _record_action, log, _gate_review.
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export HARNESS_SCRIPT="$PROJECT_ROOT/.claude/scripts/spiral-harness.sh"
+    export TEST_DIR="$BATS_TEST_TMPDIR"
+
+    cat > "$TEST_DIR/test-harness.sh" <<'EOF'
+# Minimal mock harness — override the dependencies that _review_fix_loop
+# calls. Tests set the behavior of each mock via env vars.
+
+# Counters observed by tests
+export _MOCK_RUN_GATE_CALLS=0
+export _MOCK_IMPL_FIX_CALLS=0
+export _MOCK_RECORD_CALLS=0
+
+# Configurable: space-separated list of review verdicts (PASS or FAIL).
+# First token is consumed on the first _run_gate REVIEW call, etc.
+: "${_MOCK_REVIEW_VERDICTS:=PASS}"
+
+# Configurable: "PASS" (default) or "FAIL" for _phase_implement_with_feedback
+: "${_MOCK_IMPL_FIX_VERDICT:=PASS}"
+
+log() { :; }
+error() { echo "ERROR: $*" >&2; }
+_record_action() { _MOCK_RECORD_CALLS=$((_MOCK_RECORD_CALLS + 1)); }
+_record_failure() { :; }
+_gate_review() { :; }
+
+_run_gate() {
+    _MOCK_RUN_GATE_CALLS=$((_MOCK_RUN_GATE_CALLS + 1))
+    local gate_name="$1"
+    [[ "$gate_name" == "REVIEW" ]] || return 0
+    # Consume next verdict from the space-separated list
+    local first rest
+    first=$(echo "$_MOCK_REVIEW_VERDICTS" | awk '{print $1}')
+    rest=$(echo "$_MOCK_REVIEW_VERDICTS" | awk '{$1=""; print $0}' | sed 's/^ *//')
+    export _MOCK_REVIEW_VERDICTS="$rest"
+    if [[ "$first" == "PASS" ]]; then return 0; else return 1; fi
+}
+
+_phase_implement_with_feedback() {
+    _MOCK_IMPL_FIX_CALLS=$((_MOCK_IMPL_FIX_CALLS + 1))
+    if [[ "$_MOCK_IMPL_FIX_VERDICT" == "PASS" ]]; then return 0; else return 1; fi
+}
+EOF
+
+    # Extract _review_fix_loop from the real script into an isolated file
+    awk '/^# _review_fix_loop — review with automatic/,/^}$/' "$HARNESS_SCRIPT" \
+        > "$TEST_DIR/review-fix-loop.sh"
+}
+
+teardown() {
+    unset _MOCK_RUN_GATE_CALLS _MOCK_IMPL_FIX_CALLS _MOCK_RECORD_CALLS
+    unset _MOCK_REVIEW_VERDICTS _MOCK_IMPL_FIX_VERDICT
+    unset REVIEW_MAX_ITERATIONS
+}
+
+# =========================================================================
+# RFL-T1: REVIEW passes first attempt — no fix dispatched
+# =========================================================================
+
+@test "review_fix_loop: PASS on first attempt — no impl-fix dispatch" {
+    export _MOCK_REVIEW_VERDICTS="PASS"
+    export REVIEW_MAX_ITERATIONS=2
+
+    run env _MOCK_REVIEW_VERDICTS="$_MOCK_REVIEW_VERDICTS" _MOCK_IMPL_FIX_VERDICT="${_MOCK_IMPL_FIX_VERDICT:-PASS}" REVIEW_MAX_ITERATIONS="${REVIEW_MAX_ITERATIONS:-}" bash -c "source '$TEST_DIR/test-harness.sh'; source '$TEST_DIR/review-fix-loop.sh'; _review_fix_loop; rc=\$?; echo \"RUN_GATE=\$_MOCK_RUN_GATE_CALLS IMPL_FIX=\$_MOCK_IMPL_FIX_CALLS\"; exit \$rc"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RUN_GATE=1"* ]]
+    [[ "$output" == *"IMPL_FIX=0"* ]]
+}
+
+# =========================================================================
+# RFL-T2: REVIEW fails first, passes after fix — fix called once
+# =========================================================================
+
+@test "review_fix_loop: FAIL then PASS — impl-fix dispatched once" {
+    export _MOCK_REVIEW_VERDICTS="FAIL PASS"
+    export REVIEW_MAX_ITERATIONS=2
+
+    run env _MOCK_REVIEW_VERDICTS="$_MOCK_REVIEW_VERDICTS" _MOCK_IMPL_FIX_VERDICT="${_MOCK_IMPL_FIX_VERDICT:-PASS}" REVIEW_MAX_ITERATIONS="${REVIEW_MAX_ITERATIONS:-}" bash -c "source '$TEST_DIR/test-harness.sh'; source '$TEST_DIR/review-fix-loop.sh'; _review_fix_loop; rc=\$?; echo \"RUN_GATE=\$_MOCK_RUN_GATE_CALLS IMPL_FIX=\$_MOCK_IMPL_FIX_CALLS\"; exit \$rc"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RUN_GATE=2"* ]]
+    [[ "$output" == *"IMPL_FIX=1"* ]]
+}
+
+# =========================================================================
+# RFL-T3: REVIEW fails all iterations — exhausts budget, returns 1
+# =========================================================================
+
+@test "review_fix_loop: FAIL FAIL — exhausts iterations and returns 1" {
+    export _MOCK_REVIEW_VERDICTS="FAIL FAIL"
+    export REVIEW_MAX_ITERATIONS=2
+
+    run env _MOCK_REVIEW_VERDICTS="$_MOCK_REVIEW_VERDICTS" _MOCK_IMPL_FIX_VERDICT="${_MOCK_IMPL_FIX_VERDICT:-PASS}" REVIEW_MAX_ITERATIONS="${REVIEW_MAX_ITERATIONS:-}" bash -c "source '$TEST_DIR/test-harness.sh'; source '$TEST_DIR/review-fix-loop.sh'; _review_fix_loop; rc=\$?; echo \"RUN_GATE=\$_MOCK_RUN_GATE_CALLS IMPL_FIX=\$_MOCK_IMPL_FIX_CALLS\"; exit \$rc"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"RUN_GATE=2"* ]]
+    [[ "$output" == *"IMPL_FIX=1"* ]]
+}
+
+# =========================================================================
+# RFL-T4: REVIEW_MAX_ITERATIONS=3 with all FAIL — three reviews, two fixes
+# =========================================================================
+
+@test "review_fix_loop: honors REVIEW_MAX_ITERATIONS=3" {
+    export _MOCK_REVIEW_VERDICTS="FAIL FAIL FAIL"
+    export REVIEW_MAX_ITERATIONS=3
+
+    run env _MOCK_REVIEW_VERDICTS="$_MOCK_REVIEW_VERDICTS" _MOCK_IMPL_FIX_VERDICT="${_MOCK_IMPL_FIX_VERDICT:-PASS}" REVIEW_MAX_ITERATIONS="${REVIEW_MAX_ITERATIONS:-}" bash -c "source '$TEST_DIR/test-harness.sh'; source '$TEST_DIR/review-fix-loop.sh'; _review_fix_loop; rc=\$?; echo \"RUN_GATE=\$_MOCK_RUN_GATE_CALLS IMPL_FIX=\$_MOCK_IMPL_FIX_CALLS\"; exit \$rc"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"RUN_GATE=3"* ]]
+    [[ "$output" == *"IMPL_FIX=2"* ]]
+}
+
+# =========================================================================
+# RFL-T5: IMPLEMENTATION_FIX fails — returns 1 early
+# =========================================================================
+
+@test "review_fix_loop: implementation-fix failure returns 1 without further review" {
+    export _MOCK_REVIEW_VERDICTS="FAIL PASS PASS"
+    export _MOCK_IMPL_FIX_VERDICT="FAIL"
+    export REVIEW_MAX_ITERATIONS=3
+
+    run env _MOCK_REVIEW_VERDICTS="$_MOCK_REVIEW_VERDICTS" _MOCK_IMPL_FIX_VERDICT="${_MOCK_IMPL_FIX_VERDICT:-PASS}" REVIEW_MAX_ITERATIONS="${REVIEW_MAX_ITERATIONS:-}" bash -c "source '$TEST_DIR/test-harness.sh'; source '$TEST_DIR/review-fix-loop.sh'; _review_fix_loop; rc=\$?; echo \"RUN_GATE=\$_MOCK_RUN_GATE_CALLS IMPL_FIX=\$_MOCK_IMPL_FIX_CALLS\"; exit \$rc"
+    [ "$status" -eq 1 ]
+    # One review (FAIL) then one failed fix dispatch, no second review
+    [[ "$output" == *"RUN_GATE=1"* ]]
+    [[ "$output" == *"IMPL_FIX=1"* ]]
+}
+
+# =========================================================================
+# RFL-T6: default REVIEW_MAX_ITERATIONS is 2
+# =========================================================================
+
+@test "review_fix_loop: default max iterations is 2" {
+    export _MOCK_REVIEW_VERDICTS="FAIL FAIL FAIL"
+    unset REVIEW_MAX_ITERATIONS
+
+    run env _MOCK_REVIEW_VERDICTS="$_MOCK_REVIEW_VERDICTS" _MOCK_IMPL_FIX_VERDICT="${_MOCK_IMPL_FIX_VERDICT:-PASS}" REVIEW_MAX_ITERATIONS="${REVIEW_MAX_ITERATIONS:-}" bash -c "source '$TEST_DIR/test-harness.sh'; source '$TEST_DIR/review-fix-loop.sh'; _review_fix_loop; rc=\$?; echo \"RUN_GATE=\$_MOCK_RUN_GATE_CALLS IMPL_FIX=\$_MOCK_IMPL_FIX_CALLS\"; exit \$rc"
+    [ "$status" -eq 1 ]
+    # Default is 2: two reviews, one fix dispatch
+    [[ "$output" == *"RUN_GATE=2"* ]]
+    [[ "$output" == *"IMPL_FIX=1"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes [#545](https://github.com/0xHoneyJar/loa/issues/545) + partial [#546](https://github.com/0xHoneyJar/loa/issues/546) — two coupled defects in spiral-harness recovery that share the `_run_gate` / `evaluate_stopping_conditions` code path.

**#545**: Spiral REVIEW gate retried the reviewer against the same broken implementation until circuit-breaker. Observed in cycle-367687f8de (flight recorder: seq 13 → 19 REVIEW attempts on unchanged impl).

**#546**: Spiral cycle that fails on implementation budget can't be resumed; `--start` regenerates all planning artifacts (~25 min + $6 per cycle). MVP fix: narrow `--resume --force` override.

## Changes

| File | Change |
|------|--------|
| `.claude/scripts/spiral-harness.sh` | **New** `_phase_implement_with_feedback` — re-impl with engineer-feedback.md injected. **New** `_review_fix_loop` — mirror of cycle-074 BB fix-loop for internal REVIEW gate, budget-capped by `REVIEW_MAX_ITERATIONS` (default 2). Replaced `_run_gate "REVIEW"` call with `_review_fix_loop`. |
| `.claude/scripts/spiral-orchestrator.sh` | `cmd_resume` accepts `SPIRAL_RESUME_FORCE=true` with `stopping_condition=quality_gate_failure` (refuses other stop-reasons and non-force paths). `main()` `--resume` arm parses `--force` flag. |
| `tests/unit/spiral-review-fix-loop.bats` | **New** — 6 cases mocking `_run_gate`/`_phase_implement_with_feedback` |
| `tests/unit/spiral-resume-force.bats` | **New** — 9 cases covering the full decision table |

## Why these two together

Both are symptoms of the same assumption in the spiral-harness state machine: that gate retries are sufficient to recover from implementation defects, and that a failed cycle is terminal. Both symptoms show the harness can't recover from a recoverable situation (the reviewer was *right* about the bug, but had no way to signal "fix this and try again"; the budget was *temporarily* too small, but the planning work was perfectly valid).

Porting cycle-074's `_phase_bb_fix_loop` pattern onto the internal REVIEW gate was the cleanest answer for #545. The narrow `--resume --force` is an MVP for #546 that unblocks operators today; the fuller artifact-copy design (`spiral.seed.from_cycle_id`) remains valuable and is tracked as a follow-up.

## Test Plan

- [x] `bats tests/unit/spiral-review-fix-loop.bats` → 6/6 green
- [x] `bats tests/unit/spiral-resume-force.bats` → 9/9 green
- [x] Adversarial audit (Phase 1C): **0 findings, clean**
- [x] Adversarial review (Phase 2.5): 1 finding, provably false-positive hallucination ({{DOCUMENT_CONTENT}} template artifact — bash -n validates both files, grep confirms zero such tokens). Rejected with documentation.
- [ ] Post-merge: spiral invocation with a buggy impl triggers fix-loop and converges on second iteration

## Out of Scope (Follow-up)

Tracked for future sprint:
- `spiral.seed.from_cycle_id` config + artifact-copy preflight (#546 full scope)
- `consecutive_quality_gate_failures` counter + `PAUSED_QUALITY_GATE` soft-stop state

## Links

- Source issues: [#545](https://github.com/0xHoneyJar/loa/issues/545), [#546](https://github.com/0xHoneyJar/loa/issues/546)
- Meta tracker: [#557](https://github.com/0xHoneyJar/loa/issues/557) (Tier 2 cycle-084)
- Pattern source: cycle-074 `_phase_bb_fix_loop` (PR #512)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
