### PR TITLE
fix(tripwire): detect untracked-only changes in rollback precheck (#563)

### DIFF
--- a/.claude/scripts/tripwire-handler.sh
+++ b/.claude/scripts/tripwire-handler.sh
@@ -108,8 +108,14 @@ is_rollback_enabled() {
 perform_rollback() {
     local rollback_result="false"
 
-    # Check for uncommitted changes
-    if git diff --quiet 2>/dev/null && git diff --cached --quiet 2>/dev/null; then
+    # Check for uncommitted changes. `git diff` only sees tracked files —
+    # we also need to detect untracked-only cases (new files not yet added)
+    # so they get preserved via the backup stash below. Without the third
+    # clause, a worktree containing only untracked files would skip the
+    # backup entirely and the user could lose their content. Fixes #563.
+    if git diff --quiet 2>/dev/null \
+       && git diff --cached --quiet 2>/dev/null \
+       && [[ -z "$(git ls-files --others --exclude-standard 2>/dev/null)" ]]; then
         echo "no_changes"
         return
     fi
@@ -349,4 +355,9 @@ main() {
     fi
 }
 
-main "$@"
+# Only run main when executed as a script (not when sourced for testing).
+# Enables `source tripwire-handler.sh; perform_rollback` from BATS without
+# triggering the CLI arg parser. See tests/unit/tripwire-handler-rollback.bats.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -555,9 +555,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260418-i548-a2460c/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260418-i548-a2460c/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260418-i563-39dbdf",
+      "label": "Bug Fix — tripwire-handler rollback precheck misses untracked-only changes",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/563",
+      "created_at": "2026-04-18T09:32:56Z",
+      "sprints": [
+        "sprint-bug-109"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260418-i563-39dbdf/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260418-i563-39dbdf/sprint.md"
     }
   ],
-  "global_sprint_counter": 108,
+  "global_sprint_counter": 109,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/tripwire-handler-rollback.bats
+++ b/tests/unit/tripwire-handler-rollback.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tripwire-handler-rollback.bats — Tests for perform_rollback precheck (#563)
+# =============================================================================
+# Sprint-bug-109. Validates the untracked-only precheck fix so perform_rollback
+# does not return "no_changes" when the worktree has only untracked files.
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export SCRIPT="$PROJECT_ROOT/.claude/scripts/tripwire-handler.sh"
+    export REPO="$BATS_TEST_TMPDIR/repo"
+
+    mkdir -p "$REPO"
+    cd "$REPO"
+
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git config commit.gpgsign false 2>/dev/null || true
+
+    echo "v1" > tracked.txt
+    git add tracked.txt
+    git commit -qm "init"
+}
+
+teardown() {
+    cd /
+    rm -rf "$BATS_TEST_TMPDIR/repo" 2>/dev/null || true
+}
+
+# Invoke `perform_rollback` and return only the final stdout line (the verdict).
+invoke_rollback() {
+    # Source the script, call the function, emit only its verdict.
+    bash -c "cd '$REPO' && source '$SCRIPT' && perform_rollback" 2>/dev/null | tail -1
+}
+
+# =========================================================================
+# TH-T1: clean worktree → no_changes (unchanged behavior)
+# =========================================================================
+
+@test "perform_rollback: clean worktree returns no_changes" {
+    cd "$REPO"
+    run invoke_rollback
+    [ "$status" -eq 0 ]
+    [ "$output" = "no_changes" ]
+}
+
+# =========================================================================
+# TH-T2: untracked-only worktree — regression case from #563
+# =========================================================================
+
+@test "perform_rollback: untracked-only worktree does NOT return no_changes" {
+    cd "$REPO"
+    echo "new" > new-untracked.txt
+    run invoke_rollback
+    [ "$status" -eq 0 ]
+    [ "$output" != "no_changes" ]
+    # Accept true (stash succeeded) or false (stash failed; we just want
+    # the precheck to NOT short-circuit).
+    [[ "$output" == "true" || "$output" == "false" ]]
+}
+
+# =========================================================================
+# TH-T3: tracked-modified worktree — existing behavior preserved
+# =========================================================================
+
+@test "perform_rollback: tracked-modified worktree attempts backup" {
+    cd "$REPO"
+    echo "v2" > tracked.txt
+    run invoke_rollback
+    [ "$status" -eq 0 ]
+    [ "$output" != "no_changes" ]
+}
+
+# =========================================================================
+# TH-T4: mixed (tracked + untracked) — existing behavior preserved
+# =========================================================================
+
+@test "perform_rollback: mixed tracked + untracked attempts backup" {
+    cd "$REPO"
+    echo "v2" > tracked.txt
+    echo "new" > added-untracked.txt
+    run invoke_rollback
+    [ "$status" -eq 0 ]
+    [ "$output" != "no_changes" ]
+}
+
+# =========================================================================
+# TH-T5: ignored files do NOT trigger a rollback attempt
+# =========================================================================
+# `--exclude-standard` in ls-files should ignore .gitignore-matched files.
+# If a user has only gitignored files in the worktree, we should still
+# return no_changes (they're not meant to be rolled back).
+
+@test "perform_rollback: only gitignored files → no_changes" {
+    cd "$REPO"
+    echo "build/" > .gitignore
+    git add .gitignore
+    git commit -qm "add gitignore"
+    mkdir -p build
+    echo "binary" > build/artifact.bin
+    # The .gitignore change was committed; worktree only has gitignored
+    # build/ artifacts. Those should NOT count as changes worth preserving.
+    run invoke_rollback
+    [ "$status" -eq 0 ]
+    [ "$output" = "no_changes" ]
+}
+
+# =========================================================================
+# TH-T6: untracked inside a subdirectory also detected
+# =========================================================================
+
+@test "perform_rollback: untracked in subdirectory detected" {
+    cd "$REPO"
+    mkdir -p src
+    echo "content" > src/new-file.ts
+    run invoke_rollback
+    [ "$status" -eq 0 ]
+    [ "$output" != "no_changes" ]
+}


### PR DESCRIPTION
## Summary

Fixes [#563](https://github.com/0xHoneyJar/loa/issues/563) — `perform_rollback` precheck missed untracked-only changes. A worktree with only new files (not yet `git add`-ed) would return `no_changes` and skip the backup stash, risking loss of the user's untracked content on rollback.

Surfaced during Phase 2.5 adversarial review of PR #564 (stash safety).

## Changes

| File | Change |
|------|--------|
| `.claude/scripts/tripwire-handler.sh` | Precheck adds `git ls-files --others --exclude-standard` as a third clause. `--exclude-standard` respects `.gitignore` so build artifacts don't spuriously block `no_changes`. Added `if [[ BASH_SOURCE == 0 ]]; then main; fi` guard so BATS can source + call `perform_rollback` directly without tripping the CLI arg parser. |
| `tests/unit/tripwire-handler-rollback.bats` | New, 6 cases: clean, untracked-only (regression), tracked-modified, mixed, gitignored-only, untracked-in-subdirectory |

## Deferred (intentionally)

Defect 2 from #563 (the `git restore .` fallback not clearing untracked files) is **not** addressed here. That's conservative-by-design behavior — don't destroy unknown content. Documented inline; operators should prefer the stash backup path for full clean-slate rollback.

## Test Plan

- [x] `bats tests/unit/tripwire-handler-rollback.bats` → 6/6 green
- [x] Phase 2.5 adversarial review: 0 findings
- [x] Phase 1C adversarial audit: 0 findings

## Links

- Source issue: [#563](https://github.com/0xHoneyJar/loa/issues/563)
- Discovered during: PR #564 (#555 stash safety)
- Meta tracker: [#557](https://github.com/0xHoneyJar/loa/issues/557)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
