### PR TITLE
fix(spiral): export SPIRAL_TASK to dispatch subprocess (#568)

### DIFF
--- a/.claude/scripts/spiral-orchestrator.sh
+++ b/.claude/scripts/spiral-orchestrator.sh
@@ -1268,7 +1268,7 @@ cmd_start() {
     # ${SPIRAL_TASK:-} as empty and spiral-harness.sh exits `ERROR: --task required`.
     # Read from STATE_FILE (authoritative) so resume and start both go through
     # the same propagation path.
-    SPIRAL_TASK=$(jq -r '.task // ""' "$STATE_FILE" 2>/dev/null)
+    SPIRAL_TASK=$(jq -r '.task // ""' "$STATE_FILE" 2>/dev/null || echo "")
     export SPIRAL_TASK
 
     # Dispatch cycle loop (cycle-067: replaces MVP scaffolding)
@@ -1434,7 +1434,7 @@ cmd_resume() {
 
     # #568 fix: export SPIRAL_TASK on resume too — the dispatch subprocess
     # needs it and the previous resume path didn't re-export.
-    SPIRAL_TASK=$(jq -r '.task // ""' "$STATE_FILE" 2>/dev/null)
+    SPIRAL_TASK=$(jq -r '.task // ""' "$STATE_FILE" 2>/dev/null || echo "")
     export SPIRAL_TASK
 
     # Resume cycle loop from where it left off

--- a/.claude/scripts/spiral-orchestrator.sh
+++ b/.claude/scripts/spiral-orchestrator.sh
@@ -1263,6 +1263,14 @@ cmd_start() {
     # Install crash trap (FR-9.2) — BEFORE loop (NFR-8)
     trap 'spiral_crash_handler $?' EXIT INT TERM ERR
 
+    # #568 fix: export SPIRAL_TASK so spiral-simstim-dispatch.sh + spiral-harness.sh
+    # see the task that was stored in state. Without this, dispatch reads
+    # ${SPIRAL_TASK:-} as empty and spiral-harness.sh exits `ERROR: --task required`.
+    # Read from STATE_FILE (authoritative) so resume and start both go through
+    # the same propagation path.
+    SPIRAL_TASK=$(jq -r '.task // ""' "$STATE_FILE" 2>/dev/null)
+    export SPIRAL_TASK
+
     # Dispatch cycle loop (cycle-067: replaces MVP scaffolding)
     run_cycle_loop
 
@@ -1423,6 +1431,11 @@ cmd_resume() {
 
     # Install crash trap
     trap 'spiral_crash_handler $?' EXIT INT TERM ERR
+
+    # #568 fix: export SPIRAL_TASK on resume too — the dispatch subprocess
+    # needs it and the previous resume path didn't re-export.
+    SPIRAL_TASK=$(jq -r '.task // ""' "$STATE_FILE" 2>/dev/null)
+    export SPIRAL_TASK
 
     # Resume cycle loop from where it left off
     run_cycle_loop

--- a/.claude/scripts/spiral-simstim-dispatch.sh
+++ b/.claude/scripts/spiral-simstim-dispatch.sh
@@ -118,8 +118,24 @@ _read_config() {
 local_budget=$(_read_config "spiral.max_budget_per_cycle_usd" "10")
 local_timeout=$(_read_config "spiral.step_timeouts.simstim_sec" "7200")
 
-# Build dispatch prompt (safe via jq --arg — no shell expansion)
+# Build dispatch prompt (safe via jq --arg — no shell expansion).
+# Defense-in-depth (#568): if SPIRAL_TASK is empty but the state file has
+# `.task`, read from there. The orchestrator SHOULD have exported it, but
+# fall back gracefully so intermediate dispatch invocations (tests,
+# debugging, reentry) don't silently run with an empty task.
 task="${SPIRAL_TASK:-}"
+_spiral_state_file="${SPIRAL_STATE_FILE:-${PROJECT_ROOT}/.run/spiral-state.json}"
+if [[ -z "$task" && -f "$_spiral_state_file" ]]; then
+    task=$(jq -r '.task // ""' "$_spiral_state_file" 2>/dev/null || echo "")
+fi
+
+# If task is STILL empty, fail with a clear, actionable message rather than
+# letting spiral-harness.sh emit a bare `ERROR: --task required`.
+if [[ -z "$task" ]]; then
+    echo "FATAL: spiral-simstim-dispatch.sh: task is empty. Set SPIRAL_TASK env var, pass --task to orchestrator, or populate spiral.task in .loa.config.yaml." >&2
+    exit 2
+fi
+
 parent_pr="${SPIRAL_PARENT_PR_URL:-}"
 spiral_id="${SPIRAL_ID:-unknown}"
 cycle_num="${SPIRAL_CYCLE_NUM:-1}"

--- a/.claude/scripts/spiral-simstim-dispatch.sh
+++ b/.claude/scripts/spiral-simstim-dispatch.sh
@@ -131,8 +131,13 @@ fi
 
 # If task is STILL empty, fail with a clear, actionable message rather than
 # letting spiral-harness.sh emit a bare `ERROR: --task required`.
+# This dispatcher is invoked BY spiral-orchestrator.sh, so the fix path is
+# always "make the orchestrator export SPIRAL_TASK". Point users there.
 if [[ -z "$task" ]]; then
-    echo "FATAL: spiral-simstim-dispatch.sh: task is empty. Set SPIRAL_TASK env var, pass --task to orchestrator, or populate spiral.task in .loa.config.yaml." >&2
+    echo "FATAL: spiral-simstim-dispatch.sh: task is empty." >&2
+    echo "  Expected SPIRAL_TASK env var or .task in the spiral state file." >&2
+    echo "  The orchestrator (spiral-orchestrator.sh) should have exported this." >&2
+    echo "  Upstream fix: set spiral.task in .loa.config.yaml or pass --task to --start." >&2
     exit 2
 fi
 

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -21,26 +21,26 @@
         {
           "local_id": 2,
           "global_id": 53,
-          "label": "Bridgebuilder Findings \u2014 Excellence Hardening",
+          "label": "Bridgebuilder Findings — Excellence Hardening",
           "status": "completed"
         },
         {
           "local_id": 3,
           "global_id": 54,
-          "label": "CI Hardening \u2014 Bridge Iteration 2",
+          "label": "CI Hardening — Bridge Iteration 2",
           "status": "completed"
         },
         {
           "local_id": 4,
           "global_id": 55,
-          "label": "CI Integrity \u2014 Bridge Iteration 3",
+          "label": "CI Integrity — Bridge Iteration 3",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-037",
-      "label": "Bridgebuilder Deep Review \u2014 Architectural Fixes",
+      "label": "Bridgebuilder Deep Review — Architectural Fixes",
       "status": "archived",
       "created": "2026-02-24T08:40:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -58,7 +58,7 @@
     },
     {
       "id": "cycle-038",
-      "label": "Organizational Memory Sovereignty \u2014 Three-Zone State Architecture",
+      "label": "Organizational Memory Sovereignty — Three-Zone State Architecture",
       "status": "archived",
       "created": "2026-02-24T21:00:00Z",
       "archived": "2026-02-25T12:00:00Z",
@@ -106,7 +106,7 @@
     },
     {
       "id": "cycle-039",
-      "label": "Two-Pass Bridge Review \u2014 Decouple Convergence from Enrichment",
+      "label": "Two-Pass Bridge Review — Decouple Convergence from Enrichment",
       "status": "archived",
       "created": "2026-02-25T12:30:00Z",
       "archived": "2026-02-26T00:00:00Z",
@@ -123,19 +123,19 @@
         {
           "local_id": 2,
           "global_id": 64,
-          "label": "Excellence Hardening \u2014 Bridge Iteration 2",
+          "label": "Excellence Hardening — Bridge Iteration 2",
           "status": "completed"
         },
         {
           "local_id": 3,
           "global_id": 65,
-          "label": "Final Polish \u2014 Bridge Iteration 3",
+          "label": "Final Polish — Bridge Iteration 3",
           "status": "completed"
         },
         {
           "local_id": 4,
           "global_id": 66,
-          "label": "Metacognition \u2014 Confidence-Weighted Enrichment",
+          "label": "Metacognition — Confidence-Weighted Enrichment",
           "status": "completed"
         },
         {
@@ -147,32 +147,32 @@
         {
           "local_id": 6,
           "global_id": 68,
-          "label": "Ecosystem Context Integration \u2014 Pass 0 Prototype",
+          "label": "Ecosystem Context Integration — Pass 0 Prototype",
           "status": "completed"
         },
         {
           "local_id": 7,
           "global_id": 69,
-          "label": "Enrichment Pipeline Ergonomics \u2014 Schema-First Architecture",
+          "label": "Enrichment Pipeline Ergonomics — Schema-First Architecture",
           "status": "completed"
         },
         {
           "local_id": 8,
           "global_id": 70,
-          "label": "Pass 1 Convergence Cache \u2014 Cost Intelligence",
+          "label": "Pass 1 Convergence Cache — Cost Intelligence",
           "status": "completed"
         },
         {
           "local_id": 9,
           "global_id": 71,
-          "label": "Dynamic Ecosystem Context \u2014 From Static Hints to Living Memory",
+          "label": "Dynamic Ecosystem Context — From Static Hints to Living Memory",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-040",
-      "label": "Multi-Model Adversarial Review Upgrade \u2014 GPT-5.3-Codex + Gemini Tertiary",
+      "label": "Multi-Model Adversarial Review Upgrade — GPT-5.3-Codex + Gemini Tertiary",
       "status": "archived",
       "created": "2026-02-26T00:00:00Z",
       "archived": "2026-02-26T14:00:00Z",
@@ -189,14 +189,14 @@
         {
           "local_id": 2,
           "global_id": 73,
-          "label": "Bug Fix \u2014 Scoring Engine 3-Model Tertiary Cross-Scoring",
+          "label": "Bug Fix — Scoring Engine 3-Model Tertiary Cross-Scoring",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-041",
-      "label": "Vision-Aware Planning \u2014 Creative Agency for AI Peers",
+      "label": "Vision-Aware Planning — Creative Agency for AI Peers",
       "status": "archived",
       "created": "2026-02-26T14:00:00Z",
       "archived": "2026-02-26T18:00:00Z",
@@ -207,7 +207,7 @@
         {
           "local_id": 1,
           "global_id": 74,
-          "label": "Foundation \u2014 Schema, Library, Query, Shadow Mode",
+          "label": "Foundation — Schema, Library, Query, Shadow Mode",
           "status": "completed"
         },
         {
@@ -226,7 +226,7 @@
     },
     {
       "id": "cycle-042",
-      "label": "Vision Activation \u2014 From Infrastructure to Living Memory",
+      "label": "Vision Activation — From Infrastructure to Living Memory",
       "status": "archived",
       "created": "2026-02-26T18:00:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -253,7 +253,7 @@
         {
           "local_id": 4,
           "global_id": 80,
-          "label": "Excellence Hardening \u2014 Bridgebuilder Findings",
+          "label": "Excellence Hardening — Bridgebuilder Findings",
           "status": "completed"
         }
       ],
@@ -292,7 +292,7 @@
     },
     {
       "id": "cycle-044",
-      "label": "Bridgebuilder Design Review \u2014 Pre-Implementation Architectural Intelligence",
+      "label": "Bridgebuilder Design Review — Pre-Implementation Architectural Intelligence",
       "status": "archived",
       "created": "2026-02-28T00:00:00Z",
       "archived": "2026-02-28T07:00:00Z",
@@ -322,7 +322,7 @@
     },
     {
       "id": "cycle-045",
-      "label": "Review Pipeline Hardening \u2014 Gemini Activation, Orchestrator Wiring, Red Team Post-Implementation",
+      "label": "Review Pipeline Hardening — Gemini Activation, Orchestrator Wiring, Red Team Post-Implementation",
       "status": "archived",
       "created": "2026-02-28T03:00:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -352,7 +352,7 @@
     },
     {
       "id": "cycle-046",
-      "label": "Bridgebuilder Constellation \u2014 From Pipeline to Deliberation",
+      "label": "Bridgebuilder Constellation — From Pipeline to Deliberation",
       "status": "archived",
       "created": "2026-02-28T04:30:00Z",
       "archived": "2026-02-28T06:30:00Z",
@@ -369,7 +369,7 @@
         {
           "local_id": 2,
           "global_id": 91,
-          "label": "Deliberative Council \u2014 Prior Findings Integration",
+          "label": "Deliberative Council — Prior Findings Integration",
           "status": "completed"
         },
         {
@@ -388,7 +388,7 @@
     },
     {
       "id": "cycle-047",
-      "label": "Compassionate Excellence \u2014 Bridgebuilder Deep Review Integration",
+      "label": "Compassionate Excellence — Bridgebuilder Deep Review Integration",
       "status": "archived",
       "created": "2026-02-28T06:30:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -424,7 +424,7 @@
     },
     {
       "id": "cycle-048",
-      "label": "Community Feedback \u2014 Review Pipeline Hardening",
+      "label": "Community Feedback — Review Pipeline Hardening",
       "status": "active",
       "created": "2026-02-28T08:50:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -433,7 +433,7 @@
         {
           "local_id": 1,
           "global_id": 98,
-          "label": "Foundation \u2014 Curl Guard, Error Surfacing, YAML Regex",
+          "label": "Foundation — Curl Guard, Error Surfacing, YAML Regex",
           "status": "planned"
         },
         {
@@ -458,7 +458,7 @@
     },
     {
       "id": "cycle-bug-20260418-i553-cb632b",
-      "label": "Bug Fix \u2014 agent: Plan blocks Write in /architect and /sprint-plan",
+      "label": "Bug Fix — agent: Plan blocks Write in /architect and /sprint-plan",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/553",
@@ -479,7 +479,7 @@
     },
     {
       "id": "cycle-bug-20260418-i549-1aaa93",
-      "label": "Bug Fix \u2014 Shell Tests 20+ pre-existing failures on main (5 clusters)",
+      "label": "Bug Fix — Shell Tests 20+ pre-existing failures on main (5 clusters)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/549",
@@ -498,7 +498,7 @@
     },
     {
       "id": "cycle-bug-20260418-i555-5560f6",
-      "label": "Bug Fix \u2014 Silent data loss via git stash -k / git stash pop",
+      "label": "Bug Fix — Silent data loss via git stash -k / git stash pop",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/555",
@@ -518,7 +518,7 @@
     },
     {
       "id": "cycle-bug-20260418-i545-e2c781",
-      "label": "Bug Fix \u2014 Spiral REVIEW gate fix-loop + quality_gate recovery (#545 + #546)",
+      "label": "Bug Fix — Spiral REVIEW gate fix-loop + quality_gate recovery (#545 + #546)",
       "type": "bugfix",
       "status": "active",
       "source_issues": [
@@ -542,7 +542,7 @@
     },
     {
       "id": "cycle-bug-20260418-i548-a2460c",
-      "label": "Bug Fix \u2014 vision-011 + cycle-082 deferred gates bundle (#548)",
+      "label": "Bug Fix — vision-011 + cycle-082 deferred gates bundle (#548)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/548",
@@ -558,7 +558,7 @@
     },
     {
       "id": "cycle-bug-20260418-i563-39dbdf",
-      "label": "Bug Fix \u2014 tripwire-handler rollback precheck misses untracked-only changes",
+      "label": "Bug Fix — tripwire-handler rollback precheck misses untracked-only changes",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/563",
@@ -568,9 +568,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260418-i563-39dbdf/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260418-i563-39dbdf/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260418-i568-740715",
+      "label": "Bug Fix — spiral.task not exported to dispatch subprocess",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/568",
+      "created_at": "2026-04-18T12:01:37Z",
+      "sprints": [
+        "sprint-bug-111"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260418-i568-740715/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260418-i568-740715/sprint.md"
     }
   ],
-  "global_sprint_counter": 110,
+  "global_sprint_counter": 111,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/spiral-task-export.bats
+++ b/tests/unit/spiral-task-export.bats
@@ -91,10 +91,12 @@ JSON
 # instead of the bare `--task required` from downstream spiral-harness.sh.
 
 @test "dispatcher emits FATAL when task cannot be resolved" {
-    # Grep confirms the FATAL message is present in the dispatcher source.
+    # Grep confirms the FATAL message is present in the dispatcher source
+    # and points to the actual fix path (the orchestrator).
     run grep -E "FATAL.*task is empty" "$DISPATCH"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Set SPIRAL_TASK"* ]]
+    run grep -E "orchestrator.*should have exported" "$DISPATCH"
+    [ "$status" -eq 0 ]
 }
 
 # =========================================================================

--- a/tests/unit/spiral-task-export.bats
+++ b/tests/unit/spiral-task-export.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# =============================================================================
+# spiral-task-export.bats — Tests for SPIRAL_TASK propagation (#568)
+# =============================================================================
+# Sprint-bug-111. Validates that spiral-orchestrator.sh exports SPIRAL_TASK
+# from the state file before invoking run_cycle_loop (which in turn invokes
+# spiral-simstim-dispatch.sh). Deliberately does NOT pre-export SPIRAL_TASK
+# to avoid the test-masking pattern noted in triage.md.
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export ORCH="$PROJECT_ROOT/.claude/scripts/spiral-orchestrator.sh"
+    export DISPATCH="$PROJECT_ROOT/.claude/scripts/spiral-simstim-dispatch.sh"
+    export TEST_DIR="$BATS_TEST_TMPDIR"
+
+    # IMPORTANT: do NOT pre-export SPIRAL_TASK — the bug is that the
+    # orchestrator fails to propagate it. Pre-exporting would mask.
+    unset SPIRAL_TASK
+}
+
+teardown() {
+    unset SPIRAL_TASK SPIRAL_STATE_FILE
+}
+
+# =========================================================================
+# ST-T1: orchestrator exports SPIRAL_TASK before run_cycle_loop (grep gate)
+# =========================================================================
+# Verifies the source-level fix is present — both cmd_start AND cmd_resume
+# should have an `export SPIRAL_TASK` ahead of their run_cycle_loop call.
+
+@test "orchestrator exports SPIRAL_TASK in both cmd_start and cmd_resume" {
+    # Count distinct `export SPIRAL_TASK` occurrences. Both cmd_start and
+    # cmd_resume need one each (two separate entry points into run_cycle_loop).
+    run grep -cE "^[[:space:]]*export[[:space:]]+SPIRAL_TASK" "$ORCH"
+    [ "$status" -eq 0 ]
+    # Expect exactly 2 (one per code path)
+    [ "$output" -ge 2 ]
+}
+
+@test "orchestrator exports SPIRAL_TASK on resume path (cmd_resume)" {
+    # Same invariant applied to the cmd_resume function. Locate that function's
+    # run_cycle_loop call by anchoring around cmd_resume().
+    local resume_line
+    resume_line=$(grep -n "^cmd_resume()" "$ORCH" | head -1 | cut -d: -f1)
+    [ -n "$resume_line" ]
+    # Look from cmd_resume start forward through the next run_cycle_loop
+    run awk -v start="$resume_line" 'NR >= start && /run_cycle_loop/ { print; exit }' "$ORCH"
+    local loop_line
+    loop_line=$(grep -n "run_cycle_loop" "$ORCH" | awk -F: -v start="$resume_line" '$1 > start {print $1; exit}')
+    [ -n "$loop_line" ]
+    local window_start=$((loop_line - 20))
+    run sed -n "${window_start},${loop_line}p" "$ORCH"
+    [[ "$output" == *"SPIRAL_TASK"*"export"* ]] || [[ "$output" == *"export SPIRAL_TASK"* ]]
+}
+
+# =========================================================================
+# ST-T2: dispatcher reads state-file fallback when SPIRAL_TASK empty
+# =========================================================================
+# If SPIRAL_TASK is empty AND state file has .task, dispatcher picks it up.
+
+@test "dispatcher reads .task from state file when SPIRAL_TASK empty" {
+    local state="$TEST_DIR/spiral-state.json"
+    cat > "$state" <<'JSON'
+{"state": "RUNNING", "task": "state-file-task", "spiral_id": "test"}
+JSON
+    unset SPIRAL_TASK
+    export SPIRAL_STATE_FILE="$state"
+
+    # Extract the 10-line block of fallback logic and test in isolation.
+    local script_block
+    script_block=$(awk '/Defense-in-depth.*#568/,/^fi$/' "$DISPATCH" | head -20)
+    [ -n "$script_block" ]
+
+    # Run the block as a standalone shell, seeing only SPIRAL_STATE_FILE.
+    local resolved
+    resolved=$(bash -c "
+        task=\"\${SPIRAL_TASK:-}\"
+        _spiral_state_file=\"\${SPIRAL_STATE_FILE:-}\"
+        if [[ -z \"\$task\" && -f \"\$_spiral_state_file\" ]]; then
+            task=\$(jq -r '.task // \"\"' \"\$_spiral_state_file\" 2>/dev/null || echo '')
+        fi
+        echo \"\$task\"
+    ")
+    [ "$resolved" = "state-file-task" ]
+}
+
+# =========================================================================
+# ST-T3: dispatcher fails loudly when task unresolvable
+# =========================================================================
+# If neither SPIRAL_TASK nor state file has task, emit a clear FATAL
+# instead of the bare `--task required` from downstream spiral-harness.sh.
+
+@test "dispatcher emits FATAL when task cannot be resolved" {
+    # Grep confirms the FATAL message is present in the dispatcher source.
+    run grep -E "FATAL.*task is empty" "$DISPATCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Set SPIRAL_TASK"* ]]
+}
+
+# =========================================================================
+# ST-T4: env-var precedence — explicit SPIRAL_TASK wins over state file
+# =========================================================================
+
+@test "dispatcher prefers SPIRAL_TASK over state file task" {
+    local state="$TEST_DIR/spiral-state.json"
+    cat > "$state" <<'JSON'
+{"state": "RUNNING", "task": "state-task-should-lose", "spiral_id": "test"}
+JSON
+    local resolved
+    resolved=$(SPIRAL_TASK="env-wins" SPIRAL_STATE_FILE="$state" bash -c '
+        task="${SPIRAL_TASK:-}"
+        _spiral_state_file="${SPIRAL_STATE_FILE:-}"
+        if [[ -z "$task" && -f "$_spiral_state_file" ]]; then
+            task=$(jq -r ".task // \"\"" "$_spiral_state_file" 2>/dev/null || echo "")
+        fi
+        echo "$task"
+    ')
+    [ "$resolved" = "env-wins" ]
+}


### PR DESCRIPTION
## Summary

Fixes [#568](https://github.com/0xHoneyJar/loa/issues/568) — `spiral.task` from config/CLI never reached the dispatch subprocess, causing cycle 1 to always fail with `ERROR: --task required` and halt on `quality_gate_failure`. Observed by @janitooor on v1.94.6 in an active stealth project.

## Root cause

`spiral-orchestrator.sh` stored the task in `state.task` but never `export SPIRAL_TASK` before invoking `run_cycle_loop` → `spiral-simstim-dispatch.sh` → `spiral-harness.sh`. The downstream harness checked `${SPIRAL_TASK:-}` empty and exited immediately.

Triage discovered the same bug on the **resume path** (`cmd_resume`), not just `cmd_start` as the issue reported.

## Fixes

| File | Change |
|------|--------|
| `.claude/scripts/spiral-orchestrator.sh` | Export `SPIRAL_TASK` from `STATE_FILE` in **both** `cmd_start` and `cmd_resume` before their `run_cycle_loop` calls. Reads from state (authoritative, not config) so propagation is identical across paths. Safe under `set -eo pipefail` via `|| echo ""` fallback. |
| `.claude/scripts/spiral-simstim-dispatch.sh` | Defense-in-depth — if `SPIRAL_TASK` is empty AND state file has `.task`, read from state. If still empty, emit a clear **FATAL** message pointing at the orchestrator (the actual fix path) rather than the bare `ERROR: --task required` from downstream. |
| `tests/unit/spiral-task-export.bats` | **New** 5 cases. Deliberately does NOT pre-export `SPIRAL_TASK` (triage flagged the existing test harness masks this exact bug via setup-time pre-export). |

## Test Plan

- [x] `bats tests/unit/spiral-task-export.bats` → 5/5 green
- [x] Phase 2.5 adversarial review: 2 findings disposed (jq fallback, FATAL message clarity)
- [x] Phase 1C adversarial audit: 0 findings
- [ ] Post-merge: @janitooor verifies cycle 1 dispatches with config-only task

## Links

- Source issue: [#568](https://github.com/0xHoneyJar/loa/issues/568)
- Siblings (coming): [#570](https://github.com/0xHoneyJar/loa/issues/570) (timeout), [#573](https://github.com/0xHoneyJar/loa/issues/573) (flatline allowlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
