### PR TITLE
fix(spiral): configurable planning-phase timeouts (#570)

### DIFF
--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -74,9 +74,26 @@ ADVISOR_MODEL=$(_read_harness_config "spiral.harness.advisor_model" "opus")
 # for non-trivial specs (>15 KB seed → claude -p needed >5min, artifact
 # emerged 0 bytes, evidence gate failed). New defaults chosen to clear
 # observed-failure window while staying well under simstim_sec=7200 cap.
-DISCOVERY_TIMEOUT=$(_read_harness_config "spiral.harness.discovery_timeout_sec" "1200")
-ARCHITECTURE_TIMEOUT=$(_read_harness_config "spiral.harness.architecture_timeout_sec" "1200")
-PLANNING_TIMEOUT=$(_read_harness_config "spiral.harness.planning_timeout_sec" "600")
+# Validate values are positive integers; fall back to the safe default
+# otherwise (prevents garbage config from crashing `timeout` downstream).
+_validate_timeout_sec() {
+    local val="$1" fallback="$2" key="$3"
+    if [[ ! "$val" =~ ^[1-9][0-9]*$ ]]; then
+        echo "[spiral-harness] WARN: invalid $key='$val' (expected positive integer), using fallback $fallback" >&2
+        echo "$fallback"
+    else
+        echo "$val"
+    fi
+}
+DISCOVERY_TIMEOUT=$(_validate_timeout_sec \
+    "$(_read_harness_config "spiral.harness.discovery_timeout_sec" "1200")" \
+    "1200" "spiral.harness.discovery_timeout_sec")
+ARCHITECTURE_TIMEOUT=$(_validate_timeout_sec \
+    "$(_read_harness_config "spiral.harness.architecture_timeout_sec" "1200")" \
+    "1200" "spiral.harness.architecture_timeout_sec")
+PLANNING_TIMEOUT=$(_validate_timeout_sec \
+    "$(_read_harness_config "spiral.harness.planning_timeout_sec" "600")" \
+    "600" "spiral.harness.planning_timeout_sec")
 
 # Pipeline Profiles (cycle-072): match intensity to task complexity
 # full    = all 3 Flatline gates + Opus advisor ($15, architecture/security)

--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -70,6 +70,14 @@ BB_MAX_ITERATIONS=$(_read_harness_config "spiral.harness.bb_max_iterations" "3")
 EXECUTOR_MODEL=$(_read_harness_config "spiral.harness.executor_model" "sonnet")
 ADVISOR_MODEL=$(_read_harness_config "spiral.harness.advisor_model" "opus")
 
+# #570 — planning-phase timeouts. Previously hardcoded 300s was too tight
+# for non-trivial specs (>15 KB seed → claude -p needed >5min, artifact
+# emerged 0 bytes, evidence gate failed). New defaults chosen to clear
+# observed-failure window while staying well under simstim_sec=7200 cap.
+DISCOVERY_TIMEOUT=$(_read_harness_config "spiral.harness.discovery_timeout_sec" "1200")
+ARCHITECTURE_TIMEOUT=$(_read_harness_config "spiral.harness.architecture_timeout_sec" "1200")
+PLANNING_TIMEOUT=$(_read_harness_config "spiral.harness.planning_timeout_sec" "600")
+
 # Pipeline Profiles (cycle-072): match intensity to task complexity
 # full    = all 3 Flatline gates + Opus advisor ($15, architecture/security)
 # standard = Sprint Flatline only + Opus advisor ($12, most features) [DEFAULT]
@@ -262,7 +270,7 @@ _phase_discovery() {
          "\n\nRequirements:\n- Include ## Assumptions section listing what you assumed\n- Include ## Goals & Success Metrics with measurable criteria\n- Include ## Acceptance Criteria as checkboxes\n- Write ONLY to grimoires/loa/prd.md\n- Do NOT write code. Do NOT create an SDD or sprint plan. Only write the PRD."' \
         | jq -r '.')
 
-    _invoke_claude "DISCOVERY" "$prompt" "$PLANNING_BUDGET" 300
+    _invoke_claude "DISCOVERY" "$prompt" "$PLANNING_BUDGET" "$DISCOVERY_TIMEOUT"
 
     _verify_artifact "DISCOVERY" "grimoires/loa/prd.md" 500 >/dev/null
 }
@@ -277,7 +285,7 @@ _phase_architecture() {
          "Requirements:\n- Include system architecture, component design, data model\n- Include security design and error handling\n- Address each Flatline finding in the design\n- Write ONLY to grimoires/loa/sdd.md\n- Do NOT write code. Only write the SDD."' \
         | jq -r '.')
 
-    _invoke_claude "ARCHITECTURE" "$prompt" "$PLANNING_BUDGET" 300
+    _invoke_claude "ARCHITECTURE" "$prompt" "$PLANNING_BUDGET" "$ARCHITECTURE_TIMEOUT"
 
     _verify_artifact "ARCHITECTURE" "grimoires/loa/sdd.md" 500 >/dev/null
 }
@@ -292,7 +300,7 @@ _phase_planning() {
          "Requirements:\n- Break into tasks with acceptance criteria\n- Include test requirements per task\n- Write ONLY to grimoires/loa/sprint.md\n- Do NOT write code. Only write the sprint plan."' \
         | jq -r '.')
 
-    _invoke_claude "PLANNING" "$prompt" "$PLANNING_BUDGET" 300
+    _invoke_claude "PLANNING" "$prompt" "$PLANNING_BUDGET" "$PLANNING_TIMEOUT"
 
     _verify_artifact "PLANNING" "grimoires/loa/sprint.md" 300 >/dev/null
 }

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -581,9 +581,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260418-i568-740715/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260418-i568-740715/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260418-i570-83c0b5",
+      "label": "Bug Fix — spiral-harness hardcoded 300s planning timeouts",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/570",
+      "created_at": "2026-04-18T00:00:00Z",
+      "sprints": [
+        "sprint-bug-112"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260418-i570-83c0b5/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260418-i570-83c0b5/sprint.md"
     }
   ],
-  "global_sprint_counter": 111,
+  "global_sprint_counter": 112,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/spiral-phase-timeouts.bats
+++ b/tests/unit/spiral-phase-timeouts.bats
@@ -65,9 +65,51 @@ setup() {
 # =========================================================================
 
 @test "config keys under spiral.harness.{phase}_timeout_sec" {
+    # At least 3 references (one per key via _read_harness_config). Validation
+    # and error messages may add more — we just want the keys present.
     run grep -cE 'spiral\.harness\.(discovery|architecture|planning)_timeout_sec' "$HARNESS"
     [ "$status" -eq 0 ]
-    [ "$output" -eq 3 ]
+    [ "$output" -ge 3 ]
+}
+
+# =========================================================================
+# PT-T6: garbage config values fall back to safe defaults (DISS-001)
+# =========================================================================
+
+@test "_validate_timeout_sec rejects non-integer input" {
+    run bash -c "
+        source <(awk '/^_validate_timeout_sec\\(\\)/,/^}\$/' '$HARNESS')
+        _validate_timeout_sec 'not-a-number' '600' 'test.key'
+    "
+    [ "$status" -eq 0 ]
+    [ "$output" = "600" ]
+}
+
+@test "_validate_timeout_sec accepts positive integers" {
+    run bash -c "
+        source <(awk '/^_validate_timeout_sec\\(\\)/,/^}\$/' '$HARNESS')
+        _validate_timeout_sec '1800' '600' 'test.key'
+    "
+    [ "$status" -eq 0 ]
+    [ "$output" = "1800" ]
+}
+
+@test "_validate_timeout_sec rejects zero" {
+    run bash -c "
+        source <(awk '/^_validate_timeout_sec\\(\\)/,/^}\$/' '$HARNESS')
+        _validate_timeout_sec '0' '600' 'test.key'
+    "
+    [ "$status" -eq 0 ]
+    [ "$output" = "600" ]
+}
+
+@test "_validate_timeout_sec rejects negative values" {
+    run bash -c "
+        source <(awk '/^_validate_timeout_sec\\(\\)/,/^}\$/' '$HARNESS')
+        _validate_timeout_sec '-1' '600' 'test.key'
+    "
+    [ "$status" -eq 0 ]
+    [ "$output" = "600" ]
 }
 
 # =========================================================================

--- a/tests/unit/spiral-phase-timeouts.bats
+++ b/tests/unit/spiral-phase-timeouts.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# =============================================================================
+# spiral-phase-timeouts.bats — Tests for planning-phase timeout config (#570)
+# =============================================================================
+# Sprint-bug-112. Validates that spiral-harness.sh reads
+# spiral.harness.{discovery,architecture,planning}_timeout_sec from config
+# and propagates them to the _invoke_claude call, instead of the hardcoded
+# 300s that was too tight for non-trivial specs.
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export HARNESS="$PROJECT_ROOT/.claude/scripts/spiral-harness.sh"
+}
+
+# =========================================================================
+# PT-T1: source file no longer contains the hardcoded 300s on phase calls
+# =========================================================================
+
+@test "no hardcoded 300 on _invoke_claude DISCOVERY/ARCHITECTURE/PLANNING" {
+    run grep -E '_invoke_claude "(DISCOVERY|ARCHITECTURE|PLANNING)".*"\$PLANNING_BUDGET" 300' "$HARNESS"
+    [ "$status" -ne 0 ]
+}
+
+# =========================================================================
+# PT-T2: each planning phase now references a config-read timeout variable
+# =========================================================================
+
+@test "DISCOVERY phase uses DISCOVERY_TIMEOUT variable" {
+    run grep -E '_invoke_claude "DISCOVERY".*\$DISCOVERY_TIMEOUT' "$HARNESS"
+    [ "$status" -eq 0 ]
+}
+
+@test "ARCHITECTURE phase uses ARCHITECTURE_TIMEOUT variable" {
+    run grep -E '_invoke_claude "ARCHITECTURE".*\$ARCHITECTURE_TIMEOUT' "$HARNESS"
+    [ "$status" -eq 0 ]
+}
+
+@test "PLANNING phase uses PLANNING_TIMEOUT variable" {
+    run grep -E '_invoke_claude "PLANNING".*\$PLANNING_TIMEOUT' "$HARNESS"
+    [ "$status" -eq 0 ]
+}
+
+# =========================================================================
+# PT-T3: timeout variables are populated via _read_harness_config with
+# defaults that clear the observed 300s failure window
+# =========================================================================
+
+@test "DISCOVERY_TIMEOUT default is 1200s (was 300s, too tight per #570)" {
+    run grep -E 'DISCOVERY_TIMEOUT=.*_read_harness_config.*"1200"' "$HARNESS"
+    [ "$status" -eq 0 ]
+}
+
+@test "ARCHITECTURE_TIMEOUT default is 1200s" {
+    run grep -E 'ARCHITECTURE_TIMEOUT=.*_read_harness_config.*"1200"' "$HARNESS"
+    [ "$status" -eq 0 ]
+}
+
+@test "PLANNING_TIMEOUT default is 600s" {
+    run grep -E 'PLANNING_TIMEOUT=.*_read_harness_config.*"600"' "$HARNESS"
+    [ "$status" -eq 0 ]
+}
+
+# =========================================================================
+# PT-T4: config keys follow the existing naming convention
+# =========================================================================
+
+@test "config keys under spiral.harness.{phase}_timeout_sec" {
+    run grep -cE 'spiral\.harness\.(discovery|architecture|planning)_timeout_sec' "$HARNESS"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 3 ]
+}
+
+# =========================================================================
+# PT-T5: totals stay under simstim_sec cap (2h = 7200s)
+# =========================================================================
+
+@test "new default timeouts total well under simstim_sec cap of 7200s" {
+    # 1200 + 1200 + 600 = 3000s = 50 minutes. Leaves 4200s for impl+review+audit.
+    local total=$((1200 + 1200 + 600))
+    [ "$total" -lt 7200 ]
+}

--- a/tests/unit/spiral-phase-timeouts.bats
+++ b/tests/unit/spiral-phase-timeouts.bats
@@ -77,9 +77,10 @@ setup() {
 # =========================================================================
 
 @test "_validate_timeout_sec rejects non-integer input" {
+    # Suppress WARN (stderr) so we can check stdout-only against fallback
     run bash -c "
         source <(awk '/^_validate_timeout_sec\\(\\)/,/^}\$/' '$HARNESS')
-        _validate_timeout_sec 'not-a-number' '600' 'test.key'
+        _validate_timeout_sec 'not-a-number' '600' 'test.key' 2>/dev/null
     "
     [ "$status" -eq 0 ]
     [ "$output" = "600" ]
@@ -97,7 +98,7 @@ setup() {
 @test "_validate_timeout_sec rejects zero" {
     run bash -c "
         source <(awk '/^_validate_timeout_sec\\(\\)/,/^}\$/' '$HARNESS')
-        _validate_timeout_sec '0' '600' 'test.key'
+        _validate_timeout_sec '0' '600' 'test.key' 2>/dev/null
     "
     [ "$status" -eq 0 ]
     [ "$output" = "600" ]
@@ -106,7 +107,7 @@ setup() {
 @test "_validate_timeout_sec rejects negative values" {
     run bash -c "
         source <(awk '/^_validate_timeout_sec\\(\\)/,/^}\$/' '$HARNESS')
-        _validate_timeout_sec '-1' '600' 'test.key'
+        _validate_timeout_sec '-1' '600' 'test.key' 2>/dev/null
     "
     [ "$status" -eq 0 ]
     [ "$output" = "600" ]


### PR DESCRIPTION
## Summary

Fixes [#570](https://github.com/0xHoneyJar/loa/issues/570) — `spiral-harness.sh` hardcoded 300s timeout on DISCOVERY / ARCHITECTURE / PLANNING phases. For non-trivial specs (>15 KB seed), `claude -p` needs >5min and hits the timeout mid-generation; evidence gate rejects the empty file, spiral halts on `quality_gate_failure`.

Observed by @janitooor on v1.94.6. Reliably bites cycle 1 with non-trivial product specs per flight recorder evidence.

## Fix

Three new config keys with clearing defaults:

| Config key | Default | Previous hardcoded |
|------------|---------|---------------------|
| `spiral.harness.discovery_timeout_sec` | **1200** | 300 |
| `spiral.harness.architecture_timeout_sec` | **1200** | 300 |
| `spiral.harness.planning_timeout_sec` | **600** | 300 |

New total 3000s = 50min, well under `simstim_sec=7200` cap (2h). Operators with simpler specs can tune down; operators with very large specs can tune up.

Values validated as positive integers on load via `_validate_timeout_sec`; garbage input logs a WARN and falls back to the hardcoded default.

## Test Plan

- [x] `bats tests/unit/spiral-phase-timeouts.bats` → 13/13 green
- [x] Phase 2.5 adversarial review: DISS-001 BLOCKING (input validation) disposed
- [x] Phase 1C adversarial audit: 0 findings

## Links

- Source issue: [#570](https://github.com/0xHoneyJar/loa/issues/570)
- Sibling: [#568](https://github.com/0xHoneyJar/loa/issues/568) (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
