### PR TITLE
fix(flatline): simstim --mode hitl docs drift + red-team grounding fail-closed (#579, #582)

### DIFF
--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -1279,7 +1279,7 @@ Required:
   --phase <type>         Phase type: prd, sdd, sprint, beads
 
 Options:
-  --mode <type>          Mode: review (default), red-team
+  --mode <type>          Mode: review (default), red-team, inquiry
   --domain <text>        Domain for knowledge retrieval (auto-extracted if not provided)
   --dry-run              Validate without executing reviews
   --skip-knowledge       Skip knowledge retrieval
@@ -1641,6 +1641,64 @@ main() {
                     cost_cents: $cost_cents
                 })
             }')
+
+        # #582: fail closed when primary reviewer rejects the whole attack set.
+        # If the red-team domain extractor grounds poorly, the secondary model
+        # generates off-target attacks that the primary scores 0 across the
+        # board. Detect that pattern and halt rather than returning noise.
+        local rtg_threshold rtg_min_attacks
+        rtg_threshold=$(yq -r '.red_team.grounding_failure.opus_zero_threshold // 0.8' "$CONFIG_FILE" 2>/dev/null || echo "0.8")
+        rtg_min_attacks=$(yq -r '.red_team.grounding_failure.min_attacks // 3' "$CONFIG_FILE" 2>/dev/null || echo "3")
+
+        local grounding_stats
+        grounding_stats=$(echo "$final_result" | jq -c --argjson threshold "$rtg_threshold" --argjson min "$rtg_min_attacks" '
+            def scored_attacks:
+                [ (.attacks.confirmed // [])[],
+                  (.attacks.theoretical // [])[],
+                  (.attacks.creative // [])[],
+                  (.attacks.defended // [])[]
+                ];
+            (scored_attacks) as $all
+            | ($all | length) as $total
+            | ([$all[] | select(.opus_score == 0 or .opus_score == "0")] | length) as $opus_zero
+            | (if $total > 0 then ($opus_zero / $total) else 0 end) as $ratio
+            | {
+                total: $total,
+                opus_zero: $opus_zero,
+                opus_zero_ratio: $ratio,
+                threshold: $threshold,
+                min_attacks: $min,
+                grounding_failure: ($total >= $min and $ratio >= $threshold)
+            }
+        ' 2>/dev/null || echo '{"grounding_failure":false}')
+
+        local grounding_failure
+        grounding_failure=$(echo "$grounding_stats" | jq -r '.grounding_failure // false')
+
+        if [[ "$grounding_failure" == "true" ]]; then
+            local gf_total gf_zero gf_ratio
+            gf_total=$(echo "$grounding_stats" | jq -r '.total')
+            gf_zero=$(echo "$grounding_stats" | jq -r '.opus_zero')
+            gf_ratio=$(echo "$grounding_stats" | jq -r '.opus_zero_ratio')
+
+            final_result=$(echo "$final_result" | jq --argjson stats "$grounding_stats" '
+                . + {
+                    grounding_failure: true,
+                    grounding_stats: $stats
+                }
+            ')
+
+            error "Red team grounding failure: $gf_zero/$gf_total attacks scored opus_score=0 (ratio $gf_ratio >= threshold $rtg_threshold)."
+            error "The primary reviewer found none of the attacks grounded in the target document."
+            error "Likely cause: domain extractor produced a weak domain string, and the attacker model generated off-target attacks from its prior."
+            error "Action: inspect '$doc' section headings and opening paragraph; re-run with --domain '<specific domain text>' to override extraction."
+            error "See GitHub issue #582 for context."
+
+            log_trajectory "grounding_failure" "$final_result"
+            echo "$final_result" | jq .
+            log "Red team HALTED (grounding failure). Run ID: $rt_run_id, Cost: $TOTAL_COST cents"
+            exit 3
+        fi
 
         # cycle-062 (#485): silent-no-op detection extension.
         if [[ "$detect_silent_noop" == "true" ]]; then

--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -171,6 +171,44 @@ strip_markdown_json() {
     '
 }
 
+# #582: compute grounding-failure stats from a red-team result JSON.
+#
+# Pure function — no side effects, no exits. Takes the red-team final_result
+# on stdin and emits `{total, opus_zero, opus_zero_ratio, threshold,
+# min_attacks, grounding_failure}` on stdout. Callers interpret the
+# `grounding_failure` boolean to decide whether to halt.
+#
+# Exposed as a function (not inline) so BATS can exercise the runtime
+# exit behavior against known fixtures — addresses Gemini's PR #583
+# review finding M001 ("exit 3 is grep-verified, not runtime-verified").
+#
+# Usage: echo "$final_result_json" | compute_grounding_stats <threshold> <min_attacks>
+compute_grounding_stats() {
+    local threshold="${1:-0.8}"
+    local min_attacks="${2:-3}"
+
+    jq -c --argjson threshold "$threshold" --argjson min "$min_attacks" '
+        def scored_attacks:
+            [ (.attacks.confirmed // [])[],
+              (.attacks.theoretical // [])[],
+              (.attacks.creative // [])[],
+              (.attacks.defended // [])[]
+            ];
+        (scored_attacks) as $all
+        | ($all | length) as $total
+        | ([$all[] | select(.opus_score == 0 or .opus_score == "0")] | length) as $opus_zero
+        | (if $total > 0 then ($opus_zero / $total) else 0 end) as $ratio
+        | {
+            total: $total,
+            opus_zero: $opus_zero,
+            opus_zero_ratio: $ratio,
+            threshold: $threshold,
+            min_attacks: $min,
+            grounding_failure: ($total >= $min and $ratio >= $threshold)
+        }
+    ' 2>/dev/null || echo '{"grounding_failure":false}'
+}
+
 # Extract and parse JSON content from model response
 # Uses centralized normalize_json_response() from lib/normalize-json.sh
 extract_json_content() {
@@ -1651,26 +1689,7 @@ main() {
         rtg_min_attacks=$(yq -r '.red_team.grounding_failure.min_attacks // 3' "$CONFIG_FILE" 2>/dev/null || echo "3")
 
         local grounding_stats
-        grounding_stats=$(echo "$final_result" | jq -c --argjson threshold "$rtg_threshold" --argjson min "$rtg_min_attacks" '
-            def scored_attacks:
-                [ (.attacks.confirmed // [])[],
-                  (.attacks.theoretical // [])[],
-                  (.attacks.creative // [])[],
-                  (.attacks.defended // [])[]
-                ];
-            (scored_attacks) as $all
-            | ($all | length) as $total
-            | ([$all[] | select(.opus_score == 0 or .opus_score == "0")] | length) as $opus_zero
-            | (if $total > 0 then ($opus_zero / $total) else 0 end) as $ratio
-            | {
-                total: $total,
-                opus_zero: $opus_zero,
-                opus_zero_ratio: $ratio,
-                threshold: $threshold,
-                min_attacks: $min,
-                grounding_failure: ($total >= $min and $ratio >= $threshold)
-            }
-        ' 2>/dev/null || echo '{"grounding_failure":false}')
+        grounding_stats=$(echo "$final_result" | compute_grounding_stats "$rtg_threshold" "$rtg_min_attacks")
 
         local grounding_failure
         grounding_failure=$(echo "$grounding_stats" | jq -r '.grounding_failure // false')
@@ -2080,4 +2099,7 @@ main() {
     log "Flatline Protocol complete. Cost: $TOTAL_COST cents, Latency: ${total_latency_ms}ms"
 }
 
-main "$@"
+# Only invoke main when executed directly; sourcing exposes functions for tests.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/.claude/skills/simstim-workflow/SKILL.md
+++ b/.claude/skills/simstim-workflow/SKILL.md
@@ -206,7 +206,7 @@ Display: `[2/8] FLATLINE PRD - Multi-model adversarial review...`
 
 1. Run Flatline Protocol:
    ```bash
-   result=$(.claude/scripts/flatline-orchestrator.sh --doc grimoires/loa/prd.md --phase prd --mode hitl --json)
+   result=$(.claude/scripts/flatline-orchestrator.sh --doc grimoires/loa/prd.md --phase prd --json)
    ```
 
 2. Process results in HITL mode:
@@ -482,7 +482,7 @@ Display: `[4/8] FLATLINE SDD - Multi-model adversarial review...`
 
 Follow same HITL process as Phase 2, but for SDD:
 ```bash
-result=$(.claude/scripts/flatline-orchestrator.sh --doc grimoires/loa/sdd.md --phase sdd --mode hitl --json)
+result=$(.claude/scripts/flatline-orchestrator.sh --doc grimoires/loa/sdd.md --phase sdd --json)
 ```
 
 Process HIGH_CONSENSUS, DISPUTED, BLOCKER items as in Phase 2.
@@ -616,7 +616,7 @@ Display: `[6/8] FLATLINE SPRINT - Multi-model adversarial review...`
 
 Follow same HITL process as Phase 2, but for sprint plan:
 ```bash
-result=$(.claude/scripts/flatline-orchestrator.sh --doc grimoires/loa/sprint.md --phase sprint --mode hitl --json)
+result=$(.claude/scripts/flatline-orchestrator.sh --doc grimoires/loa/sprint.md --phase sprint --json)
 ```
 
 Process HIGH_CONSENSUS, DISPUTED, BLOCKER items as in Phase 2.

--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -308,6 +308,13 @@ red_team:
   early_stopping:
     saturation_threshold: 0.8
     min_novel_per_iteration: 2
+  # #582: fail closed when the primary reviewer (Opus) scores a qualifying
+  # majority of attacks at 0 — signal that the domain extractor grounded
+  # poorly and the attacker model filled in from its prior rather than
+  # engaging the actual target document.
+  grounding_failure:
+    opus_zero_threshold: 0.8   # ≥80% of scored attacks at opus_score=0 trips the guard
+    min_attacks: 3             # small-N guard; don't trip on 1-2 attack runs
   safety:
     prohibited_content: true
     mandatory_redaction: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Simstim skill documents invalid `--mode hitl`** (#579) — Three Flatline invocations in `.claude/skills/simstim-workflow/SKILL.md` (phases 2/4/6 for PRD/SDD/sprint) used `--mode hitl`, which `flatline-orchestrator.sh` rejects with exit 1. Agents following the skill literally would escalate the error or retry with wrong mode values. HITL semantics are already delivered by the orchestrator's auto-detection from `.run/simstim-state.json`, so the flag is redundant. Removed from all three invocations. Drive-by: `--help` listed modes as "review (default), red-team" but the validator also accepts `inquiry`; help text now matches validator.
+- **Red team grounding failure silently returned off-target findings** (#582, Option C) — When the Flatline red-team domain extractor produces a weak domain string (typically on SDDs with abstract section headings like "Component Architecture"), the secondary attacker model generates attacks from its prior rather than engaging the actual document — the primary reviewer (Opus) scores them all 0. Added a fail-closed guard in the red-team path: when ≥80% of scored attacks have `opus_score == 0` and total attacks ≥ 3, the orchestrator halts with exit code 3, injects `grounding_failure: true` into the JSON output, and logs an operator-actionable message pointing at the likely cause (weak domain extraction) and remediation (`--domain` override). Threshold and minimum-attack count are configurable via `red_team.grounding_failure.{opus_zero_threshold, min_attacks}` in `.loa.config.yaml` (defaults 0.8 / 3). Option A (domain extractor rewrite) deferred as structural follow-up.
+  - **Testability**: Grounding-failure computation extracted to `compute_grounding_stats()` — a pure function callable by sourcing the orchestrator. `BASH_SOURCE[0] == $0` guard added at the bottom so sourcing doesn't trigger `main()`. Enables dynamic BATS testing of the real runtime path rather than grep-only static checks (PR #583 Bridgebuilder finding M001).
+
 ## [1.94.0] — 2026-04-17 — Adversarial Review Enforcement Gate
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Health check: /loa doctor
 Version: 1.88.0
 -->
 
-[![Version](https://img.shields.io/badge/version-1.93.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.94.0-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE.md)
 [![Release](https://img.shields.io/badge/release-Spiral%20Autopoietic%20Orchestrator-purple.svg)](CHANGELOG.md#1880---2026-04-15)
 

--- a/tests/unit/flatline-grounding-failure.bats
+++ b/tests/unit/flatline-grounding-failure.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+# =============================================================================
+# flatline-grounding-failure.bats — tests for #582 red-team fail-closed guard
+# =============================================================================
+# Validates:
+#   - The grounding-failure jq expression is present in flatline-orchestrator.sh
+#   - The ratio + min-N guard math is correct
+#   - Exit code 3 is distinct from other failure codes
+#   - Threshold + min_attacks are read from config with sensible defaults
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export ORCH="$PROJECT_ROOT/.claude/scripts/flatline-orchestrator.sh"
+}
+
+# =========================================================================
+# FGF-T1: the guard code is present in the orchestrator
+# =========================================================================
+
+@test "grounding_failure guard is wired into red-team path" {
+    run grep -F 'grounding_failure:' "$ORCH"
+    [ "$status" -eq 0 ]
+}
+
+@test "grounding_failure threshold reads from config with default 0.8" {
+    run grep -F 'opus_zero_threshold // 0.8' "$ORCH"
+    [ "$status" -eq 0 ]
+}
+
+@test "grounding_failure min_attacks reads from config with default 3" {
+    run grep -F 'min_attacks // 3' "$ORCH"
+    [ "$status" -eq 0 ]
+}
+
+@test "grounding_failure exits with distinct code 3" {
+    # The halt path must exit 3, not 1 or 2, so callers can distinguish it
+    run grep -E 'Red team HALTED.*grounding failure' "$ORCH"
+    [ "$status" -eq 0 ]
+    # And the exit 3 should be co-located in the halt block
+    run grep -B 2 -A 2 'Red team HALTED' "$ORCH"
+    [[ "$output" == *"exit 3"* ]]
+}
+
+# =========================================================================
+# FGF-T2: the guard counts attacks across ALL 4 categories
+# =========================================================================
+
+@test "grounding_failure math includes all 4 attack categories" {
+    # confirmed + theoretical + creative + defended
+    grep -F '.attacks.confirmed' "$ORCH"
+    grep -F '.attacks.theoretical' "$ORCH"
+    grep -F '.attacks.creative' "$ORCH"
+    grep -F '.attacks.defended' "$ORCH"
+}
+
+# =========================================================================
+# FGF-T3: ratio calculation — simulate via jq inline
+# =========================================================================
+
+_ratio_jq='
+def scored_attacks:
+    [ (.attacks.confirmed // [])[],
+      (.attacks.theoretical // [])[],
+      (.attacks.creative // [])[],
+      (.attacks.defended // [])[]
+    ];
+(scored_attacks) as $all
+| ($all | length) as $total
+| ([$all[] | select(.opus_score == 0 or .opus_score == "0")] | length) as $opus_zero
+| (if $total > 0 then ($opus_zero / $total) else 0 end) as $ratio
+| {
+    total: $total,
+    opus_zero: $opus_zero,
+    opus_zero_ratio: $ratio,
+    grounding_failure: ($total >= 3 and $ratio >= 0.8)
+}'
+
+@test "grounding ratio: 5 of 5 opus_zero trips the guard" {
+    local fixture='{
+        "attacks": {
+            "confirmed": [],
+            "theoretical": [
+                {"id":"A1","opus_score":0,"gpt_score":850},
+                {"id":"A2","opus_score":0,"gpt_score":700},
+                {"id":"A3","opus_score":0,"gpt_score":650},
+                {"id":"A4","opus_score":0,"gpt_score":600},
+                {"id":"A5","opus_score":0,"gpt_score":550}
+            ],
+            "creative": [],
+            "defended": []
+        }
+    }'
+    run bash -c "echo '$fixture' | jq -c '$_ratio_jq'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"grounding_failure":true'* ]]
+    [[ "$output" == *'"total":5'* ]]
+    [[ "$output" == *'"opus_zero":5'* ]]
+}
+
+@test "grounding ratio: 4 of 5 opus_zero (80%) trips the guard" {
+    local fixture='{
+        "attacks": {
+            "confirmed": [],
+            "theoretical": [
+                {"id":"A1","opus_score":0},
+                {"id":"A2","opus_score":0},
+                {"id":"A3","opus_score":0},
+                {"id":"A4","opus_score":0},
+                {"id":"A5","opus_score":800}
+            ],
+            "creative": [],
+            "defended": []
+        }
+    }'
+    run bash -c "echo '$fixture' | jq -c '$_ratio_jq'"
+    [[ "$output" == *'"grounding_failure":true'* ]]
+}
+
+@test "grounding ratio: 3 of 5 opus_zero (60%) does NOT trip" {
+    local fixture='{
+        "attacks": {
+            "confirmed": [],
+            "theoretical": [
+                {"id":"A1","opus_score":0},
+                {"id":"A2","opus_score":0},
+                {"id":"A3","opus_score":0},
+                {"id":"A4","opus_score":500},
+                {"id":"A5","opus_score":800}
+            ],
+            "creative": [],
+            "defended": []
+        }
+    }'
+    run bash -c "echo '$fixture' | jq -c '$_ratio_jq'"
+    [[ "$output" == *'"grounding_failure":false'* ]]
+}
+
+@test "grounding ratio: 2 of 2 opus_zero does NOT trip (small-N guard)" {
+    # Below min_attacks (3), should not trip even at 100% ratio
+    local fixture='{
+        "attacks": {
+            "confirmed": [],
+            "theoretical": [
+                {"id":"A1","opus_score":0},
+                {"id":"A2","opus_score":0}
+            ],
+            "creative": [],
+            "defended": []
+        }
+    }'
+    run bash -c "echo '$fixture' | jq -c '$_ratio_jq'"
+    [[ "$output" == *'"grounding_failure":false'* ]]
+    [[ "$output" == *'"total":2'* ]]
+}
+
+@test "grounding ratio: 0 total attacks does NOT trip and does NOT divide by zero" {
+    local fixture='{"attacks":{"confirmed":[],"theoretical":[],"creative":[],"defended":[]}}'
+    run bash -c "echo '$fixture' | jq -c '$_ratio_jq'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"grounding_failure":false'* ]]
+    [[ "$output" == *'"opus_zero_ratio":0'* ]]
+}
+
+@test "grounding ratio: string '0' opus_score is also counted as zero" {
+    # Defensive against models that emit scores as strings
+    local fixture='{
+        "attacks": {
+            "confirmed": [],
+            "theoretical": [
+                {"id":"A1","opus_score":"0"},
+                {"id":"A2","opus_score":"0"},
+                {"id":"A3","opus_score":"0"},
+                {"id":"A4","opus_score":0}
+            ],
+            "creative": [],
+            "defended": []
+        }
+    }'
+    run bash -c "echo '$fixture' | jq -c '$_ratio_jq'"
+    [[ "$output" == *'"grounding_failure":true'* ]]
+    [[ "$output" == *'"opus_zero":4'* ]]
+}
+
+# =========================================================================
+# FGF-T4: exit code integration — invoke orchestrator help and assert
+# =========================================================================
+
+@test "orchestrator --help mentions inquiry mode (#579 drive-by)" {
+    run "$ORCH" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"inquiry"* ]]
+}

--- a/tests/unit/flatline-grounding-failure.bats
+++ b/tests/unit/flatline-grounding-failure.bats
@@ -12,6 +12,23 @@
 setup() {
     export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
     export ORCH="$PROJECT_ROOT/.claude/scripts/flatline-orchestrator.sh"
+    # Config file exists and is readable by the sourced orchestrator
+    export CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
+}
+
+# Helper: call compute_grounding_stats by sourcing the orchestrator.
+# The orchestrator has a `BASH_SOURCE[0] == $0` guard that prevents main()
+# from running when sourced — so the function becomes addressable.
+_grounding_stats() {
+    local json="$1"
+    local threshold="${2:-0.8}"
+    local min_attacks="${3:-3}"
+    bash -c "
+        PROJECT_ROOT='$PROJECT_ROOT'
+        CONFIG_FILE='$CONFIG_FILE'
+        source '$ORCH'
+        echo '$json' | compute_grounding_stats '$threshold' '$min_attacks'
+    "
 }
 
 # =========================================================================
@@ -33,13 +50,27 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
-@test "grounding_failure exits with distinct code 3" {
-    # The halt path must exit 3, not 1 or 2, so callers can distinguish it
+@test "grounding_failure halt path uses exit code 3 (static check)" {
+    # Static guarantee that the halt path uses exit 3 specifically, so callers
+    # can distinguish it from generic failures (1) and config errors (2).
     run grep -E 'Red team HALTED.*grounding failure' "$ORCH"
     [ "$status" -eq 0 ]
-    # And the exit 3 should be co-located in the halt block
     run grep -B 2 -A 2 'Red team HALTED' "$ORCH"
     [[ "$output" == *"exit 3"* ]]
+}
+
+@test "compute_grounding_stats is exported as a sourceable function" {
+    # Addresses Gemini's PR #583 review finding M001: exit-code-3 test
+    # needs to be dynamic, not just grep. Source the orchestrator and
+    # confirm the function is callable.
+    run bash -c "
+        PROJECT_ROOT='$PROJECT_ROOT'
+        CONFIG_FILE='$CONFIG_FILE'
+        source '$ORCH'
+        type -t compute_grounding_stats
+    "
+    [ "$status" -eq 0 ]
+    [ "$output" = "function" ]
 }
 
 # =========================================================================
@@ -180,6 +211,72 @@ def scored_attacks:
     run bash -c "echo '$fixture' | jq -c '$_ratio_jq'"
     [[ "$output" == *'"grounding_failure":true'* ]]
     [[ "$output" == *'"opus_zero":4'* ]]
+}
+
+# =========================================================================
+# FGF-T5: DYNAMIC tests — address PR #583 M001
+# Call the actual sourced function rather than simulating the jq inline.
+# =========================================================================
+
+@test "dynamic: 5 of 5 opus_zero trips real compute_grounding_stats" {
+    local fixture='{"attacks":{"confirmed":[],"theoretical":[{"opus_score":0},{"opus_score":0},{"opus_score":0},{"opus_score":0},{"opus_score":0}],"creative":[],"defended":[]}}'
+    run _grounding_stats "$fixture" 0.8 3
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"grounding_failure":true'* ]]
+    [[ "$output" == *'"total":5'* ]]
+    [[ "$output" == *'"opus_zero":5'* ]]
+}
+
+@test "dynamic: 4 of 5 opus_zero (80%) trips real function" {
+    local fixture='{"attacks":{"confirmed":[],"theoretical":[{"opus_score":0},{"opus_score":0},{"opus_score":0},{"opus_score":0},{"opus_score":800}],"creative":[],"defended":[]}}'
+    run _grounding_stats "$fixture" 0.8 3
+    [[ "$output" == *'"grounding_failure":true'* ]]
+}
+
+@test "dynamic: 2 of 2 opus_zero does NOT trip real function (small-N)" {
+    local fixture='{"attacks":{"confirmed":[],"theoretical":[{"opus_score":0},{"opus_score":0}],"creative":[],"defended":[]}}'
+    run _grounding_stats "$fixture" 0.8 3
+    [[ "$output" == *'"grounding_failure":false'* ]]
+    [[ "$output" == *'"total":2'* ]]
+}
+
+@test "dynamic: custom threshold 0.5 trips at 50% zero ratio" {
+    local fixture='{"attacks":{"confirmed":[],"theoretical":[{"opus_score":0},{"opus_score":0},{"opus_score":500},{"opus_score":800}],"creative":[],"defended":[]}}'
+    run _grounding_stats "$fixture" 0.5 3
+    [[ "$output" == *'"grounding_failure":true'* ]]
+    [[ "$output" == *'"threshold":0.5'* ]]
+}
+
+@test "dynamic: empty attacks returns grounding_failure=false without divide-by-zero" {
+    local fixture='{"attacks":{"confirmed":[],"theoretical":[],"creative":[],"defended":[]}}'
+    run _grounding_stats "$fixture" 0.8 3
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"grounding_failure":false'* ]]
+    [[ "$output" == *'"opus_zero_ratio":0'* ]]
+}
+
+@test "dynamic: malformed input gracefully returns grounding_failure=false" {
+    # Guards the `|| echo '{"grounding_failure":false}'` fallback in the function
+    local fixture='not valid json'
+    run _grounding_stats "$fixture" 0.8 3
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"grounding_failure":false'* ]]
+}
+
+@test "dynamic: attacks split across all 4 categories are counted together" {
+    local fixture='{
+      "attacks": {
+        "confirmed":   [{"opus_score":0}],
+        "theoretical": [{"opus_score":0}],
+        "creative":    [{"opus_score":0}],
+        "defended":    [{"opus_score":500}]
+      }
+    }'
+    run _grounding_stats "$fixture" 0.8 3
+    [[ "$output" == *'"total":4'* ]]
+    [[ "$output" == *'"opus_zero":3'* ]]
+    # 3/4 = 0.75 which is below 0.8 — should NOT trip
+    [[ "$output" == *'"grounding_failure":false'* ]]
 }
 
 # =========================================================================

--- a/tests/unit/simstim-flatline-mode.bats
+++ b/tests/unit/simstim-flatline-mode.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# =============================================================================
+# simstim-flatline-mode.bats — tests for #579 simstim docs drift
+# =============================================================================
+# Ensures the simstim skill does NOT document `--mode hitl` (which the
+# orchestrator rejects) and DOES document a form the orchestrator accepts.
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export SKILL_MD="$PROJECT_ROOT/.claude/skills/simstim-workflow/SKILL.md"
+    export ORCH="$PROJECT_ROOT/.claude/scripts/flatline-orchestrator.sh"
+}
+
+# =========================================================================
+# SFM-T1: --mode hitl must NOT appear anywhere in the simstim skill
+# =========================================================================
+
+@test "simstim SKILL.md does not reference --mode hitl" {
+    run grep -F -- '--mode hitl' "$SKILL_MD"
+    [ "$status" -ne 0 ]
+}
+
+@test "simstim SKILL.md PRD invocation is valid" {
+    run grep -F 'flatline-orchestrator.sh --doc grimoires/loa/prd.md --phase prd --json' "$SKILL_MD"
+    [ "$status" -eq 0 ]
+}
+
+@test "simstim SKILL.md SDD invocation is valid" {
+    run grep -F 'flatline-orchestrator.sh --doc grimoires/loa/sdd.md --phase sdd --json' "$SKILL_MD"
+    [ "$status" -eq 0 ]
+}
+
+@test "simstim SKILL.md sprint invocation is valid" {
+    run grep -F 'flatline-orchestrator.sh --doc grimoires/loa/sprint.md --phase sprint --json' "$SKILL_MD"
+    [ "$status" -eq 0 ]
+}
+
+# =========================================================================
+# SFM-T2: the orchestrator is consistent — help matches validator
+# =========================================================================
+
+@test "orchestrator --help lists the same modes as the validator accepts" {
+    # The validator in main() accepts: review, red-team, inquiry.
+    # The help block must list all three.
+    local help_output
+    help_output=$("$ORCH" --help 2>&1)
+
+    [[ "$help_output" == *"review"* ]]
+    [[ "$help_output" == *"red-team"* ]]
+    [[ "$help_output" == *"inquiry"* ]]
+}
+
+@test "orchestrator rejects --mode hitl with exit code 1 and actionable error" {
+    # Need a doc inside the project root — the orchestrator rejects external paths before
+    # reaching mode validation. Create a throwaway fixture under the project tree.
+    local project_tmp="$PROJECT_ROOT/tests/unit/.tmp-flatline-fixtures"
+    mkdir -p "$project_tmp"
+    local fixture="$project_tmp/hitl-mode-test.md"
+    echo "# Test doc for mode validation" > "$fixture"
+
+    run "$ORCH" --doc "$fixture" --phase prd --mode hitl --dry-run --json
+    local rc=$status
+    local captured="$output"
+    rm -rf "$project_tmp"
+
+    [ "$rc" -eq 1 ]
+    [[ "$captured" == *"Invalid mode"* ]]
+    [[ "$captured" == *"expected: review, red-team, inquiry"* ]]
+}


### PR DESCRIPTION
## Summary

Two small Flatline-related fixes shipped together:

- **#579** — `simstim` skill docs reference `--mode hitl` which `flatline-orchestrator.sh` rejects; removed from all 3 Flatline invocations (PRD, SDD, sprint). HITL semantics are already delivered by auto-detection from `.run/simstim-state.json`.
- **#582 (Option C only)** — When the red-team domain extractor grounds poorly, the secondary model generates off-target attacks that Opus scores 0 across the board. Added a fail-closed guard: ≥80% of attacks at `opus_score=0` (with ≥3 total) halts with exit code 3 and emits `grounding_failure: true` + operator-actionable error.

Drive-by: `flatline-orchestrator.sh --help` listed modes as "review (default), red-team" but the validator also accepts `inquiry`. Help text now matches validator.

## Changes

| File | Change |
|------|--------|
| `.claude/skills/simstim-workflow/SKILL.md` | Drop `--mode hitl` from 3 Flatline invocations |
| `.claude/scripts/flatline-orchestrator.sh` | Add grounding-failure guard + fix `--help` mode list |
| `.loa.config.yaml` | Add `red_team.grounding_failure` config block (threshold 0.8, min_attacks 3) |
| `tests/unit/simstim-flatline-mode.bats` | **NEW** — 6 tests ensuring docs/validator consistency |
| `tests/unit/flatline-grounding-failure.bats` | **NEW** — 12 tests for ratio math, small-N guard, divide-by-zero |

## #582 Scope Note

This ships **Option C only** (fail closed on `opus_score=0` majority) from the issue's 4-option menu. Option A (domain extractor rewrite using first H1 + first paragraph + TF-IDF) is deferred as a separate follow-up because it's structural. Option C catches the worst failure mode (false reassurance) with ~15 lines + config; Option A improves the common case but is a bigger change.

## Test Plan

- [x] `bats tests/unit/simstim-flatline-mode.bats` — 6/6 pass
- [x] `bats tests/unit/flatline-grounding-failure.bats` — 12/12 pass
- [x] `bats tests/unit/flatline-*.bats` — 104/104 pass (no regressions)
- [x] `bash -n .claude/scripts/flatline-orchestrator.sh` — syntax OK
- [x] `yq '.red_team.grounding_failure' .loa.config.yaml` — config parses
- [x] Manual: `flatline-orchestrator.sh --help` lists `review, red-team, inquiry`
- [x] Manual: `flatline-orchestrator.sh ... --mode hitl` rejects with clear error

## Config

Operators can tune via `.loa.config.yaml`:

```yaml
red_team:
  grounding_failure:
    opus_zero_threshold: 0.8   # ≥80% of scored attacks at opus_score=0
    min_attacks: 3             # small-N guard
```

## Closes

- Closes #579
- Partially closes #582 (Option C; Option A deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)