### PR TITLE
feat(spiral): observability dashboard — default-on metrics emission (#569)

### DIFF
--- a/.claude/scripts/spiral-evidence.sh
+++ b/.claude/scripts/spiral-evidence.sh
@@ -371,4 +371,120 @@ _finalize_flight_recorder() {
 
     _record_action "SUMMARY" "spiral-harness" "finalize" "" "" "" 0 0 "$total_cost" \
         "actions=${total_actions} failures=${failures} cost=${total_cost}"
+
+    # Final dashboard snapshot so external consumers see the complete picture
+    # without needing a live harness process.
+    _emit_dashboard_snapshot "FINALIZED" "$cycle_dir"
+}
+
+# =============================================================================
+# Observability Dashboard (#569)
+# =============================================================================
+#
+# Aggregates the raw flight-recorder.jsonl event stream into an operator-
+# friendly dashboard snapshot. Appends one JSON line per call to
+# dashboard.jsonl (append-only audit trail of observations) and overwrites
+# dashboard-latest.json (cheap read for /spiral --status consumers).
+#
+# Usage:
+#   _emit_dashboard_snapshot <current_phase> [cycle_dir]
+#
+# - current_phase is a string like "IMPLEMENT" or "FLATLINE_PRD". Appears in
+#   the snapshot so readers know what was active when the snapshot was taken.
+# - cycle_dir defaults to the dirname of $_FLIGHT_RECORDER.
+#
+# Environment:
+#   SPIRAL_TOTAL_BUDGET — if exported by the caller (spiral-harness main()
+#     exports this), the snapshot includes budget_cap_usd and remaining budget.
+#
+# Fail-safe: any jq/shell error is swallowed so instrumentation cannot
+# break the pipeline. Dashboard is best-effort observability.
+
+_emit_dashboard_snapshot() {
+    local current_phase="${1:-}"
+    local cycle_dir="${2:-}"
+
+    [[ -z "$_FLIGHT_RECORDER" || ! -f "$_FLIGHT_RECORDER" ]] && return 0
+
+    if [[ -z "$cycle_dir" ]]; then
+        cycle_dir="$(dirname "$_FLIGHT_RECORDER")"
+    fi
+
+    [[ ! -d "$cycle_dir" ]] && return 0
+
+    local dashboard_jsonl="$cycle_dir/dashboard.jsonl"
+    local dashboard_latest="$cycle_dir/dashboard-latest.json"
+
+    # Budget cap from env (set by spiral-harness main()). Fall back to 0 if unset.
+    local budget_cap="${SPIRAL_TOTAL_BUDGET:-0}"
+    # Guard against non-numeric values
+    [[ "$budget_cap" =~ ^[0-9]+(\.[0-9]+)?$ ]] || budget_cap=0
+
+    # Compute snapshot from flight-recorder. All numeric aggregation happens
+    # inside jq so we don't round-trip floats through shell arithmetic.
+    # -c emits compact JSON (one line per snapshot for dashboard.jsonl).
+    local snapshot
+    snapshot=$(jq -s -c \
+        --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg current_phase "$current_phase" \
+        --argjson budget_cap "$budget_cap" \
+        '
+        def safe_sum(path): [.[] | path // 0] | add // 0;
+        def safe_num(v): if (v | type) == "number" then v else 0 end;
+
+        . as $all
+        | (
+            # Per-phase rollup — group by .phase, sum metrics
+            group_by(.phase) | map({
+                phase: .[0].phase,
+                actions: length,
+                duration_ms: (map(safe_num(.duration_ms)) | add // 0),
+                bytes: (map(safe_num(.output_bytes)) | add // 0),
+                cost_usd: (map(safe_num(.cost_usd)) | add // 0),
+                failures: (map(select(.verdict | tostring | startswith("FAIL"))) | length),
+                first_ts: ([.[] | .ts] | min),
+                last_ts: ([.[] | .ts] | max)
+            })
+          ) as $per_phase
+        | (safe_sum(.cost_usd)) as $total_cost
+        | (safe_sum(.duration_ms)) as $total_duration_ms
+        | ($all | length) as $total_actions
+        | ([$all[] | select(.verdict | tostring | startswith("FAIL"))] | length) as $total_failures
+        | (if $budget_cap > 0 then ($budget_cap - $total_cost) else null end) as $remaining
+        | ([$all[] | select(.action == "REVIEW_FIX_DISPATCH" or .phase == "REVIEW_FIX_LOOP_EXHAUSTED")] | length) as $fix_loop_events
+        | ([$all[] | select(.phase | tostring | startswith("BB_FIX_CYCLE"))] | length) as $bb_fix_cycles
+        | ([$all[] | select(.action == "CIRCUIT_BREAKER")] | length) as $circuit_breaks
+        | ([$all[0].ts]) as $start_ts
+        | ([$all | last | .ts]) as $last_ts
+        | {
+            schema: "spiral.dashboard.v1",
+            ts: $ts,
+            current_phase: (if $current_phase == "" then null else $current_phase end),
+            totals: {
+                actions: $total_actions,
+                failures: $total_failures,
+                cost_usd: $total_cost,
+                duration_ms: $total_duration_ms,
+                budget_cap_usd: (if $budget_cap > 0 then $budget_cap else null end),
+                budget_remaining_usd: $remaining,
+                fix_loop_events: $fix_loop_events,
+                bb_fix_cycles: $bb_fix_cycles,
+                circuit_breaks: $circuit_breaks,
+                first_action_ts: ($start_ts[0] // null),
+                last_action_ts: ($last_ts[0] // null)
+            },
+            per_phase: $per_phase
+          }
+        ' "$_FLIGHT_RECORDER" 2>/dev/null) || snapshot=""
+
+    [[ -z "$snapshot" ]] && return 0
+
+    # Append to rolling journal + overwrite latest pointer. Both writes are
+    # atomic per call (jq produces complete JSON; >> and > are atomic for
+    # small writes on POSIX).
+    echo "$snapshot" >> "$dashboard_jsonl" 2>/dev/null || true
+    echo "$snapshot" > "${dashboard_latest}.tmp" 2>/dev/null && \
+        mv "${dashboard_latest}.tmp" "$dashboard_latest" 2>/dev/null || true
+
+    return 0
 }

--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -217,6 +217,10 @@ _parse_args() {
     mkdir -p "$EVIDENCE_DIR"
     _init_flight_recorder "$CYCLE_DIR"
 
+    # Export budget cap so _emit_dashboard_snapshot can compute remaining
+    # budget without re-reading config (#569 observability).
+    export SPIRAL_TOTAL_BUDGET="$TOTAL_BUDGET"
+
     _auto_escalate_profile "$TASK"
 
     # Signal to dispatch guard hook that harness is running (mechanical enforcement)
@@ -1093,13 +1097,16 @@ main() {
 
     _record_action "CONFIG" "spiral-harness" "profile" "" "" "" 0 0 0 \
         "profile=$PIPELINE_PROFILE gates=${FLATLINE_GATES:-none} advisor=$ADVISOR_MODEL"
+    _emit_dashboard_snapshot "START"
 
     # ── Phase 1: Discovery ──────────────────────────────────────────────
     log "Phase 1: DISCOVERY"
+    _emit_dashboard_snapshot "DISCOVERY"
     _phase_discovery || { error "Discovery failed"; exit 1; }
 
     # ── Gate 1: Flatline PRD (conditional) ──────────────────────────────
     if _should_run_flatline "prd"; then
+        _emit_dashboard_snapshot "FLATLINE_PRD"
         _run_gate "FLATLINE_PRD" _gate_flatline "prd" "grimoires/loa/prd.md" || exit 1
         prd_findings=$(_summarize_flatline "$EVIDENCE_DIR/flatline-prd.json")
     else
@@ -1109,10 +1116,12 @@ main() {
 
     # ── Phase 2: Architecture ───────────────────────────────────────────
     log "Phase 2: ARCHITECTURE"
+    _emit_dashboard_snapshot "ARCHITECTURE"
     _phase_architecture "$prd_findings" || { error "Architecture failed"; exit 1; }
 
     # ── Gate 2: Flatline SDD (conditional) ──────────────────────────────
     if _should_run_flatline "sdd"; then
+        _emit_dashboard_snapshot "FLATLINE_SDD"
         _run_gate "FLATLINE_SDD" _gate_flatline "sdd" "grimoires/loa/sdd.md" || exit 1
         sdd_findings=$(_summarize_flatline "$EVIDENCE_DIR/flatline-sdd.json")
     else
@@ -1122,6 +1131,7 @@ main() {
 
     # ── Phase 3: Planning ───────────────────────────────────────────────
     log "Phase 3: PLANNING"
+    _emit_dashboard_snapshot "PLANNING"
     _phase_planning "$sdd_findings" || { error "Planning failed"; exit 1; }
 
     # ── Gate 3: Flatline Sprint (conditional) ───────────────────────────
@@ -1141,6 +1151,7 @@ main() {
 
     # ── Phase 4: Implementation ─────────────────────────────────────────
     log "Phase 4: IMPLEMENTATION"
+    _emit_dashboard_snapshot "IMPLEMENT"
     _phase_implement || { error "Implementation failed"; exit 1; }
 
     # ── Post-implementation auto-escalation check ───────────────────────

--- a/.claude/scripts/spiral-orchestrator.sh
+++ b/.claude/scripts/spiral-orchestrator.sh
@@ -1299,20 +1299,117 @@ cmd_status() {
     fi
 
     if [[ "$json_mode" == "true" ]]; then
-        cat "$STATE_FILE"
-    else
-        local state phase cycle_index max_cycles spiral_id
-        state=$(jq -r '.state' "$STATE_FILE")
-        phase=$(jq -r '.phase' "$STATE_FILE")
-        cycle_index=$(jq -r '.cycle_index' "$STATE_FILE")
-        max_cycles=$(jq -r '.max_cycles' "$STATE_FILE")
-        spiral_id=$(jq -r '.spiral_id' "$STATE_FILE")
-        cat <<EOF
+        # JSON mode: merge spiral state with dashboard snapshot (if present)
+        # so downstream consumers get one blob with everything.
+        local state_json dashboard_json combined
+        state_json=$(cat "$STATE_FILE")
+        dashboard_json=$(_find_latest_dashboard)
+        if [[ -n "$dashboard_json" ]]; then
+            combined=$(jq -n \
+                --argjson state "$state_json" \
+                --argjson dashboard "$dashboard_json" \
+                '$state + {dashboard: $dashboard}' 2>/dev/null || echo "$state_json")
+            echo "$combined"
+        else
+            echo "$state_json"
+        fi
+        return 0
+    fi
+
+    # Pretty mode: spiral state + observability metrics from dashboard (#569)
+    local state phase cycle_index max_cycles spiral_id
+    state=$(jq -r '.state' "$STATE_FILE")
+    phase=$(jq -r '.phase' "$STATE_FILE")
+    cycle_index=$(jq -r '.cycle_index' "$STATE_FILE")
+    max_cycles=$(jq -r '.max_cycles' "$STATE_FILE")
+    spiral_id=$(jq -r '.spiral_id' "$STATE_FILE")
+    cat <<EOF
 Spiral: $spiral_id
 State:  $state
 Phase:  $phase
 Cycle:  $cycle_index / $max_cycles
 EOF
+
+    local dashboard_json
+    dashboard_json=$(_find_latest_dashboard)
+    if [[ -n "$dashboard_json" ]]; then
+        _format_dashboard_pretty "$dashboard_json"
+    fi
+}
+
+# _find_latest_dashboard — walks the most recent cycle dir(s) and returns the
+# contents of dashboard-latest.json, or empty string if none exists.
+# Handles both .run/cycles/cycle-NNN/ and ad-hoc cycle paths recorded in
+# state. Failures are silent — dashboard is best-effort.
+_find_latest_dashboard() {
+    # First try cycle_dir from state file (most accurate)
+    local cycle_dir=""
+    if [[ -f "$STATE_FILE" ]]; then
+        cycle_dir=$(jq -r '.cycle_dir // empty' "$STATE_FILE" 2>/dev/null || true)
+    fi
+
+    # Fallback: find the most recent cycle under .run/cycles/
+    if [[ -z "$cycle_dir" ]]; then
+        if [[ -d ".run/cycles" ]]; then
+            cycle_dir=$(ls -td .run/cycles/*/ 2>/dev/null | head -1 | sed 's:/*$::')
+        fi
+    fi
+
+    [[ -z "$cycle_dir" || ! -d "$cycle_dir" ]] && return 0
+
+    local dashboard="$cycle_dir/dashboard-latest.json"
+    if [[ -f "$dashboard" ]]; then
+        cat "$dashboard" 2>/dev/null || true
+    fi
+}
+
+# _format_dashboard_pretty — render a dashboard-latest.json payload as
+# terminal-friendly text. Handles missing fields gracefully so partial
+# snapshots still print useful information.
+_format_dashboard_pretty() {
+    local dashboard="$1"
+
+    [[ -z "$dashboard" ]] && return 0
+    echo "$dashboard" | jq -e . >/dev/null 2>&1 || return 0
+
+    local totals current_phase snap_ts
+    snap_ts=$(echo "$dashboard" | jq -r '.ts // "—"')
+    current_phase=$(echo "$dashboard" | jq -r '.current_phase // "—"')
+
+    local actions failures cost dur budget_cap budget_rem fix_loops bb_cycles circuit
+    actions=$(echo "$dashboard" | jq -r '.totals.actions // 0')
+    failures=$(echo "$dashboard" | jq -r '.totals.failures // 0')
+    cost=$(echo "$dashboard" | jq -r '.totals.cost_usd // 0')
+    dur=$(echo "$dashboard" | jq -r '.totals.duration_ms // 0')
+    budget_cap=$(echo "$dashboard" | jq -r '.totals.budget_cap_usd // "—"')
+    budget_rem=$(echo "$dashboard" | jq -r '.totals.budget_remaining_usd // "—"')
+    fix_loops=$(echo "$dashboard" | jq -r '.totals.fix_loop_events // 0')
+    bb_cycles=$(echo "$dashboard" | jq -r '.totals.bb_fix_cycles // 0')
+    circuit=$(echo "$dashboard" | jq -r '.totals.circuit_breaks // 0')
+
+    # Duration in seconds (1 decimal) for human reading
+    local dur_s
+    dur_s=$(awk "BEGIN { printf \"%.1f\", ${dur} / 1000 }" 2>/dev/null || echo "0")
+
+    cat <<EOF
+
+Metrics (as of $snap_ts, dashboard current: $current_phase):
+  Actions:         $actions  (failures: $failures)
+  Cost (USD):      $cost     (cap: $budget_cap, remaining: $budget_rem)
+  Duration:        ${dur_s}s
+  Fix-loops:       $fix_loops  (BB cycles: $bb_cycles, circuit-breaks: $circuit)
+EOF
+
+    # Per-phase breakdown, sorted by first_ts so the table reads top-to-bottom
+    # in the order phases ran.
+    local per_phase_count
+    per_phase_count=$(echo "$dashboard" | jq '.per_phase | length // 0')
+    if [[ "$per_phase_count" -gt 0 ]]; then
+        echo ""
+        echo "Per-phase (phase / actions / duration / cost):"
+        echo "$dashboard" | jq -r '.per_phase | sort_by(.first_ts // "") | .[] |
+            "  \(.phase | tostring)\t\(.actions)\t\((.duration_ms / 1000) | . * 10 | round / 10)s\t$\(.cost_usd)"' 2>/dev/null | \
+            column -t -s $'\t' 2>/dev/null || true
     fi
 }
 

--- a/tests/unit/spiral-dashboard.bats
+++ b/tests/unit/spiral-dashboard.bats
@@ -1,0 +1,391 @@
+#!/usr/bin/env bats
+# =============================================================================
+# spiral-dashboard.bats — tests for #569 spiral observability dashboard
+# =============================================================================
+# Validates:
+# - _emit_dashboard_snapshot aggregates flight-recorder.jsonl correctly
+# - dashboard.jsonl (append-only) and dashboard-latest.json (pointer) both
+#   receive the snapshot
+# - Failures are detected (verdict startswith "FAIL")
+# - Budget remaining is computed when SPIRAL_TOTAL_BUDGET is exported
+# - Per-phase rollup groups by .phase and sums metrics
+# - cmd_status --json merges dashboard into state output
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export EVIDENCE_SH="$PROJECT_ROOT/.claude/scripts/spiral-evidence.sh"
+    export ORCH_SH="$PROJECT_ROOT/.claude/scripts/spiral-orchestrator.sh"
+    export TEST_DIR="$BATS_TEST_TMPDIR/spiral-dashboard-test"
+    mkdir -p "$TEST_DIR"
+}
+
+teardown() {
+    [[ -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+# Helper: source the evidence script + init flight recorder at a test path.
+_setup_flight_recorder() {
+    local fr_path="$TEST_DIR/flight-recorder.jsonl"
+    touch "$fr_path"
+    export _FLIGHT_RECORDER="$fr_path"
+    export _FLIGHT_RECORDER_SEQ=0
+}
+
+# Helper: append a synthetic flight-recorder entry.
+_append_event() {
+    local phase="$1" actor="$2" action="$3" cost="${4:-0}" duration="${5:-0}" verdict="${6:-}"
+    local bytes="${7:-0}"
+    jq -n -c \
+        --argjson seq "$((++_FLIGHT_RECORDER_SEQ))" \
+        --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg phase "$phase" \
+        --arg actor "$actor" \
+        --arg action "$action" \
+        --argjson cost "$cost" \
+        --argjson duration_ms "$duration" \
+        --argjson bytes "$bytes" \
+        --arg verdict "$verdict" \
+        '{seq: $seq, ts: $ts, phase: $phase, actor: $actor, action: $action,
+          input_checksum: null, output_checksum: null, output_path: null,
+          output_bytes: $bytes, duration_ms: $duration_ms, cost_usd: $cost,
+          verdict: (if $verdict == "" then null else $verdict end)}' \
+        >> "$_FLIGHT_RECORDER"
+}
+
+# =========================================================================
+# SPD-T1: basic snapshot structure
+# =========================================================================
+
+@test "snapshot emits dashboard.jsonl + dashboard-latest.json" {
+    _setup_flight_recorder
+    _append_event "DISCOVERY" "claude" "invoke" "0.10" "1500" "" "200"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'DISCOVERY' '$TEST_DIR'
+    "
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_DIR/dashboard.jsonl" ]
+    [ -f "$TEST_DIR/dashboard-latest.json" ]
+}
+
+@test "snapshot payload has schema version" {
+    _setup_flight_recorder
+    _append_event "DISCOVERY" "claude" "invoke" "0.10" "1500"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'DISCOVERY' '$TEST_DIR'
+    "
+    run jq -r '.schema' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "spiral.dashboard.v1" ]
+}
+
+@test "snapshot records current_phase" {
+    _setup_flight_recorder
+    _append_event "DISCOVERY" "claude" "invoke" "0.10" "1500"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'ARCHITECTURE' '$TEST_DIR'
+    "
+    run jq -r '.current_phase' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "ARCHITECTURE" ]
+}
+
+# =========================================================================
+# SPD-T2: totals rollup math
+# =========================================================================
+
+@test "totals.cost_usd sums across all events" {
+    _setup_flight_recorder
+    _append_event "DISCOVERY" "claude" "invoke" "0.10" "1000"
+    _append_event "ARCHITECTURE" "claude" "invoke" "0.25" "2000"
+    _append_event "IMPLEMENT" "claude" "invoke" "0.50" "3000"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'IMPLEMENT' '$TEST_DIR'
+    "
+    run jq -r '.totals.cost_usd' "$TEST_DIR/dashboard-latest.json"
+    # 0.1 + 0.25 + 0.5 = 0.85
+    [[ "$output" == "0.85" ]]
+}
+
+@test "totals.actions counts all events" {
+    _setup_flight_recorder
+    for i in 1 2 3 4 5; do
+        _append_event "PHASE$i" "actor" "action" "0.01" "100"
+    done
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'x' '$TEST_DIR'
+    "
+    run jq -r '.totals.actions' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "5" ]
+}
+
+@test "totals.failures counts verdicts starting with FAIL" {
+    _setup_flight_recorder
+    _append_event "DISCOVERY" "claude" "invoke" "0.10" "1000" ""
+    _append_event "IMPL" "gate" "FAILED" "0" "0" "FAIL:MISSING:foo.md"
+    _append_event "REVIEW" "gate" "FAILED" "0" "0" "FAIL:CIRCUIT_BREAKER:attempts=3"
+    _append_event "AUDIT" "gate" "verified" "0" "0" "OK"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'AUDIT' '$TEST_DIR'
+    "
+    run jq -r '.totals.failures' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "2" ]
+}
+
+# =========================================================================
+# SPD-T3: budget math
+# =========================================================================
+
+@test "totals.budget_remaining_usd = cap - cost when SPIRAL_TOTAL_BUDGET set" {
+    _setup_flight_recorder
+    _append_event "A" "x" "y" "3.00" "100"
+    _append_event "B" "x" "y" "4.50" "100"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        export SPIRAL_TOTAL_BUDGET=12
+        _emit_dashboard_snapshot 'IMPL' '$TEST_DIR'
+    "
+    run jq -r '.totals.budget_remaining_usd' "$TEST_DIR/dashboard-latest.json"
+    # 12 - 7.5 = 4.5
+    [[ "$output" == "4.5" ]]
+}
+
+@test "totals.budget_cap_usd is null when SPIRAL_TOTAL_BUDGET unset" {
+    _setup_flight_recorder
+    _append_event "A" "x" "y" "1.00" "100"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        unset SPIRAL_TOTAL_BUDGET
+        _emit_dashboard_snapshot 'x' '$TEST_DIR'
+    "
+    run jq -r '.totals.budget_cap_usd' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "null" ]
+}
+
+# =========================================================================
+# SPD-T4: per-phase rollup groups by .phase
+# =========================================================================
+
+@test "per_phase groups events by phase + sums durations" {
+    _setup_flight_recorder
+    _append_event "DISCOVERY" "claude" "invoke" "0.1" "1000"
+    _append_event "DISCOVERY" "claude" "invoke" "0.2" "2000"
+    _append_event "ARCHITECTURE" "claude" "invoke" "0.3" "3000"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'ARCHITECTURE' '$TEST_DIR'
+    "
+    run jq -r '.per_phase | length' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "2" ]
+
+    run jq -r '.per_phase[] | select(.phase == "DISCOVERY") | .duration_ms' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "3000" ]
+
+    run jq -r '.per_phase[] | select(.phase == "DISCOVERY") | .actions' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "2" ]
+}
+
+# =========================================================================
+# SPD-T5: fix-loop + BB cycle counters
+# =========================================================================
+
+@test "totals.fix_loop_events counts REVIEW_FIX_DISPATCH actions" {
+    _setup_flight_recorder
+    _append_event "REVIEW_FIX_DISPATCH" "review-fix-loop" "REVIEW_FIX_DISPATCH" "0" "0"
+    _append_event "REVIEW_FIX_DISPATCH" "review-fix-loop" "REVIEW_FIX_DISPATCH" "0" "0"
+    _append_event "IMPL" "claude" "invoke" "1" "100"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'REVIEW' '$TEST_DIR'
+    "
+    run jq -r '.totals.fix_loop_events' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "2" ]
+}
+
+@test "totals.bb_fix_cycles counts BB_FIX_CYCLE_* phases" {
+    _setup_flight_recorder
+    _append_event "BB_FIX_CYCLE_START" "bb" "fix_cycle_start" "0" "0"
+    _append_event "BB_FIX_CYCLE_COMPLETE" "bb" "fix_cycle" "0" "0"
+    _append_event "REVIEW" "claude" "invoke" "0" "0"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'x' '$TEST_DIR'
+    "
+    run jq -r '.totals.bb_fix_cycles' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "2" ]
+}
+
+# =========================================================================
+# SPD-T6: append-only journal + pointer pattern
+# =========================================================================
+
+@test "multiple snapshots append to dashboard.jsonl" {
+    _setup_flight_recorder
+    _append_event "A" "x" "y" "1" "100"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'A' '$TEST_DIR'
+        _emit_dashboard_snapshot 'B' '$TEST_DIR'
+        _emit_dashboard_snapshot 'C' '$TEST_DIR'
+    "
+    run bash -c "wc -l < '$TEST_DIR/dashboard.jsonl' | tr -d ' '"
+    [ "$output" = "3" ]
+}
+
+@test "dashboard-latest.json is overwritten (not appended)" {
+    _setup_flight_recorder
+    _append_event "A" "x" "y" "1" "100"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'A' '$TEST_DIR'
+        _emit_dashboard_snapshot 'B' '$TEST_DIR'
+    "
+    # dashboard-latest.json should contain one JSON doc, not two concatenated
+    run jq -r '.current_phase' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "B" ]
+}
+
+# =========================================================================
+# SPD-T7: fail-safe — swallows errors, doesn't break pipeline
+# =========================================================================
+
+@test "emit is a no-op when flight recorder unset" {
+    run bash -c "
+        source '$EVIDENCE_SH'
+        unset _FLIGHT_RECORDER
+        _emit_dashboard_snapshot 'x' '$TEST_DIR'
+    "
+    # Should return 0 (no-op) without creating dashboard files
+    [ "$status" -eq 0 ]
+    [ ! -f "$TEST_DIR/dashboard.jsonl" ]
+    [ ! -f "$TEST_DIR/dashboard-latest.json" ]
+}
+
+@test "emit is a no-op when cycle_dir does not exist" {
+    _setup_flight_recorder
+    _append_event "A" "x" "y" "1" "100"
+    run bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'x' '/nonexistent/cycle/path'
+    "
+    [ "$status" -eq 0 ]
+}
+
+@test "emit handles empty flight-recorder gracefully" {
+    _setup_flight_recorder
+    # No events appended — empty file
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        _emit_dashboard_snapshot 'x' '$TEST_DIR'
+    "
+    # Should still produce a valid snapshot with 0 actions
+    run jq -r '.totals.actions' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "0" ]
+}
+
+@test "non-numeric SPIRAL_TOTAL_BUDGET defaults to 0 (no budget)" {
+    _setup_flight_recorder
+    _append_event "A" "x" "y" "1" "100"
+
+    bash -c "
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$_FLIGHT_RECORDER'
+        export _FLIGHT_RECORDER_SEQ=$_FLIGHT_RECORDER_SEQ
+        export SPIRAL_TOTAL_BUDGET='not-a-number'
+        _emit_dashboard_snapshot 'x' '$TEST_DIR'
+    "
+    run jq -r '.totals.budget_cap_usd' "$TEST_DIR/dashboard-latest.json"
+    [ "$output" = "null" ]
+}
+
+# =========================================================================
+# SPD-T8: cmd_status integration
+# =========================================================================
+
+@test "cmd_status --json merges dashboard into state output" {
+    # Build a fake spiral state + dashboard combo
+    local run_dir="$TEST_DIR/run-state"
+    local cycle_dir="$TEST_DIR/cycles/cycle-001"
+    mkdir -p "$run_dir" "$cycle_dir"
+
+    # Fake state
+    local state_file="$run_dir/state.json"
+    jq -n --arg cycle "$cycle_dir" '{
+        spiral_id: "spiral-test",
+        state: "RUNNING",
+        phase: "IMPLEMENT",
+        cycle_index: 1,
+        max_cycles: 3,
+        cycle_dir: $cycle
+    }' > "$state_file"
+
+    # Fake dashboard
+    jq -n '{
+        schema: "spiral.dashboard.v1",
+        ts: "2026-04-19T02:00:00Z",
+        current_phase: "IMPLEMENT",
+        totals: {actions: 10, cost_usd: 1.5, failures: 0},
+        per_phase: []
+    }' > "$cycle_dir/dashboard-latest.json"
+
+    # Source orchestrator (main guard prevents auto-execution). Override the
+    # STATE_FILE variable AFTER source so cmd_status sees the test fixture.
+    run bash -c "
+        source '$ORCH_SH' >/dev/null 2>&1
+        STATE_FILE='$state_file'
+        cmd_status --json 2>/dev/null
+    "
+
+    # Output should contain both state + dashboard
+    [[ "$output" == *'"spiral_id"'* ]] || { echo "Missing spiral_id in: $output"; false; }
+    [[ "$output" == *'"dashboard"'* ]] || { echo "Missing dashboard in: $output"; false; }
+    [[ "$output" == *'"spiral.dashboard.v1"'* ]] || { echo "Missing schema in: $output"; false; }
+}


### PR DESCRIPTION
## Summary

Closes @zkSoju's observability gap (#569). Until now, operators had to stand up ad-hoc Monitor wrappers mid-cycle to watch phase transitions, cost, and budget pressure — the flight-recorder exposed raw events but no aggregated view.

Default-on instrumentation at each phase boundary, plus pretty-printed metrics in `/spiral --status`.

## What ships

1. **`_emit_dashboard_snapshot(current_phase, cycle_dir)`** in `spiral-evidence.sh` — aggregates `flight-recorder.jsonl` into an operator-friendly snapshot:
   - Append-only journal: `<cycle-dir>/dashboard.jsonl`
   - Latest pointer:      `<cycle-dir>/dashboard-latest.json`

2. **Automatic emission at each phase boundary** in `spiral-harness.sh`: START, DISCOVERY, FLATLINE_PRD, ARCHITECTURE, FLATLINE_SDD, PLANNING, IMPLEMENT, FINALIZED. No flag — default-on per issue request.

3. **`SPIRAL_TOTAL_BUDGET`** exported from harness `main()` so snapshots compute budget remaining without re-reading config.

4. **`cmd_status` enhanced** in `spiral-orchestrator.sh`:
   - `--json`: merges dashboard into state output as `.dashboard` key
   - Pretty mode: renders "Metrics" block + "Per-phase" table

## Snapshot schema (`spiral.dashboard.v1`)

```jsonc
{
  "schema": "spiral.dashboard.v1",
  "ts": "2026-04-19T02:00:00Z",
  "current_phase": "IMPLEMENT",
  "totals": {
    "actions": 47,
    "failures": 2,            // verdicts startswith "FAIL"
    "cost_usd": 3.21,
    "duration_ms": 185400,
    "budget_cap_usd": 12,
    "budget_remaining_usd": 8.79,
    "fix_loop_events": 3,     // REVIEW_FIX_DISPATCH count
    "bb_fix_cycles": 2,       // BB_FIX_CYCLE_* phase count
    "circuit_breaks": 0,
    "first_action_ts": "...",
    "last_action_ts": "..."
  },
  "per_phase": [
    { "phase": "DISCOVERY", "actions": 5, "duration_ms": 42000, "cost_usd": 0.4, ... },
    { "phase": "ARCHITECTURE", ... }
  ]
}
```

## Why phase-boundary emission (not background timer)

The issue suggested "per N seconds" emission. Phase-boundary emission is:
- **Simpler** — no background process, no reaper on crash
- **Information-dense** — transitions are when metrics actually change
- **Extensible** — easy to add a timer-based sidecar later for finer resolution

Operators who want live streaming: `tail -f dashboard.jsonl` → updates at each phase boundary. Sufficient for the "is this spiral stuck?" diagnostic.

## Sample `/spiral --status` output

```
Spiral: spiral-20260419-xxx
State:  RUNNING
Phase:  IMPLEMENT
Cycle:  1 / 3

Metrics (as of 2026-04-19T02:00:00Z, dashboard current: IMPLEMENT):
  Actions:         47  (failures: 2)
  Cost (USD):      3.21  (cap: 12, remaining: 8.79)
  Duration:        185.4s
  Fix-loops:       3  (BB cycles: 2, circuit-breaks: 0)

Per-phase (phase / actions / duration / cost):
  DISCOVERY      5   42.0s   $0.4
  ARCHITECTURE   7   58.2s   $0.85
  PLANNING       3   30.0s   $0.36
  IMPLEMENT      32  55.2s   $1.6
```

## Test Plan

- [x] `bats tests/unit/spiral-dashboard.bats` — 18/18 pass
- [x] `bats tests/unit/spiral-*.bats` — 189/192 (3 pre-existing failures in `spiral-phase-timeouts.bats` unrelated to this PR; multi-line regex issue from #577 refactor)
- [x] `bash -n` on all three touched scripts — clean
- [x] Fail-safe paths covered (unset flight recorder, missing cycle_dir, empty flight recorder, non-numeric budget)

## Not addressed in this PR (noted in #569, scope for follow-ups)

- Context size loaded per phase (requires claude -p instrumentation)
- Regression fixtures (known SEED → known cycle outcome, CI-enforced)
- External sinks (Grafana, Honeycomb, OTEL) — hook points exist via `dashboard.jsonl` consumption; concrete sinks belong in their own PRs
- Background per-N-seconds emission (rationale: phase-boundary covers the observable moments)

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)