### PR TITLE
docs(spiral): name kaironic termination publicly (#575 item 5)

### DIFF
--- a/.claude/skills/spiraling/SKILL.md
+++ b/.claude/skills/spiraling/SKILL.md
@@ -93,18 +93,25 @@ SEED → SIMSTIM → HARVEST → EVALUATE → (next cycle OR terminate)
 
 ## Stopping Conditions
 
-A spiral terminates when ANY of:
+A spiral terminates when ANY of the conditions below fire. Stopping conditions come in two kinds — **chronos-coded** (wall-clock caps set in advance: max cycles, budget ceiling, runtime limit) and **kaironic** (the loop observes its own output rate and decides to terminate when signal exhausts).
 
-| Condition | Default | Floor | Status | Rationale |
-|-----------|---------|-------|--------|-----------|
-| `cycle_budget_exhausted` | 3 cycles | 50 | ✅ implemented | Primary runaway backstop |
-| `flatline_convergence` | 2 consecutive cycles < 3 findings | — | ✅ implemented | Kaironic signal: plateau reached |
-| `cost_budget_exhausted` | $20 | $100 | ✅ implemented | Credit exhaustion guard |
-| `wall_clock_exhausted` | 8h | 24h | ✅ implemented | Second backstop for plateau-at-N |
-| `hitl_halt` | sentinel file | — | ✅ implemented | Operator escape hatch |
-| `quality_gate_failure` | review AND audit fail | — | ⏳ deferred to cycle-067 | Prevent error compounding (requires embedded `/simstim` dispatch to observe review+audit outcomes) |
+**Kaironic termination is rare in agentic pipelines** — most only have chronos caps ("retry until budget runs out"). Second-order cybernetic convergence, where the loop is measuring its own findings-rate and opting to halt when the rate plateaus, is architecturally distinctive:
 
-**Safety floor note**: the floors (50 cycles / $100 / 24h) are hardcoded. Operators can relax values within those floors but cannot disable stopping conditions entirely.
+> Cycle N produces 8 findings. Cycle N+1 produces 2. Cycle N+2 produces 1.
+> The spiral does not continue to cycle N+3 even if budget remains — the work itself has said "we have reached a plateau."
+
+`flatline_convergence` in the table below is the kaironic condition. The rest are chronos backstops that prevent runaway.
+
+| Condition | Kind | Default | Floor | Status | Rationale |
+|-----------|------|---------|-------|--------|-----------|
+| `flatline_convergence` | **kaironic** | 2 consecutive cycles < 3 findings | — | ✅ implemented | Loop observes its own output-rate and halts when signal exhausts |
+| `cycle_budget_exhausted` | chronos | 3 cycles | 50 | ✅ implemented | Primary runaway backstop |
+| `cost_budget_exhausted` | chronos | $20 | $100 | ✅ implemented | Credit exhaustion guard |
+| `wall_clock_exhausted` | chronos | 8h | 24h | ✅ implemented | Second backstop for plateau-at-N |
+| `hitl_halt` | operator | sentinel file | — | ✅ implemented | Operator escape hatch |
+| `quality_gate_failure` | chronos | review AND audit fail | — | ⏳ deferred to cycle-067 | Prevent error compounding (requires embedded `/simstim` dispatch to observe review+audit outcomes) |
+
+**Safety floor note**: the chronos floors (50 cycles / $100 / 24h) are hardcoded. Operators can relax values within those floors but cannot disable stopping conditions entirely. The kaironic condition has no floor — if the system observes convergence, it trusts that signal.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Quality gates are **evidence-gated**: a bash orchestrator sequences phases as se
 
 **Cost optimization**: Sonnet handles planning and implementation (~5x cheaper tokens), Opus handles review and audit (judgment quality). [Benchmarked](grimoires/loa/reports/spiral-harness-benchmark-report.md) at equivalent output quality across both models. Default budget: $15/cycle.
 
+**Kaironic termination**: unlike most agentic pipelines that only stop when wall-clock caps fire (budget / max iterations / timeout), the spiral observes its own findings-rate and halts on `flatline_convergence` — 2 consecutive cycles producing < 3 new findings each. The loop decides "we've reached a plateau" and terminates *before* exhausting budget. Second-order cybernetic convergence; see `.claude/skills/spiraling/SKILL.md` for the distinction between chronos (wall-clock) and kairos (signal-exhaustion) stopping conditions.
+
 ```yaml
 # .loa.config.yaml — enable the spiral
 spiral:


### PR DESCRIPTION
## Summary

Item 5 from #575 (@zksoju's three-lens audit). Makes the kaironic / chronos distinction in spiral termination conditions discoverable and explicit in both operator-facing and framework-internal docs.

## Context

The `flatline_convergence` stopping condition was already implemented (cycle-066) and correctly noted as "Kaironic signal: plateau reached" in a single table cell of the spiraling skill. But the architectural rarity — that most agentic pipelines have ONLY chronos caps, and that second-order cybernetic convergence is distinctive — wasn't called out. @zksoju's recommendation was to lean into this publicly.

## Changes

| File | Change |
|------|--------|
| `.claude/skills/spiraling/SKILL.md` | Add chronos/kairos preamble to Stopping Conditions; add "Kind" column distinguishing `kaironic` / `chronos` / `operator`; note no safety floor for kaironic condition (system trusts the signal) |
| `README.md` | Add one-paragraph "Kaironic termination" callout below Cost optimization note under Spiral Autopoietic Orchestrator section |

No behavior change. Docs-only.

## Why this matters

The chronos/kaironic distinction is the architectural signature that differentiates `/spiral` from "agentic pipeline that retries until budget runs out." Naming it publicly closes one of the 6 gaps @zksoju's audit identified.

## Related

- #575 — parent issue, 6-primitive RFC
- PR #577 — item #6 (config-ify phase timeouts) already shipped
- Next in sequence: item #2 (flight-recorder ingestion into SEED context) — substantive follow-up

Partially closes #575 (item 5 only; tracked separately from items 1-4 which need their own PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)