### PR TITLE
feat(spiral): fold prior-cycle failure events into SEED context (#575 item 2)

### DIFF
--- a/.claude/scripts/spiral-evidence.sh
+++ b/.claude/scripts/spiral-evidence.sh
@@ -378,6 +378,158 @@ _finalize_flight_recorder() {
 }
 
 # =============================================================================
+# Prior Cycle Failure Summary (#575 item 2)
+# =============================================================================
+#
+# When a new spiral cycle starts, the previous cycle's flight-recorder.jsonl
+# contains load-bearing failure events (circuit breakers, stuck findings,
+# auto-escalations, exhausted fix-loops) that currently no downstream phase
+# reads. The operator would have to hand-curate these into the SEED. These
+# helpers extract and summarize them so the discovery phase can learn from
+# prior failure modes automatically.
+#
+# Feature flag: spiral.seed.include_flight_recorder (default false — safe
+# rollout; operators who want learning-across-cycles enable it explicitly).
+
+# _find_prior_cycle — locate the most recent cycle directory that ran before
+# the current one. Looks under .run/cycles/ and returns the lexicographically
+# previous entry. Returns empty if no prior cycle exists or the layout is
+# unexpected.
+_find_prior_cycle() {
+    local current_cycle_dir="$1"
+    local cycles_root
+    cycles_root="$(dirname "$current_cycle_dir")"
+
+    [[ ! -d "$cycles_root" ]] && { echo ""; return 0; }
+
+    local current_name
+    current_name="$(basename "$current_cycle_dir")"
+
+    # List sibling cycle dirs, sort lexicographically, pick the one before.
+    # Guard against directories that aren't actual cycles (no flight-recorder).
+    local prior=""
+    local prior_candidate
+    while IFS= read -r candidate; do
+        [[ -z "$candidate" ]] && continue
+        local cand_name
+        cand_name="$(basename "$candidate")"
+
+        # Skip the current cycle itself
+        [[ "$cand_name" == "$current_name" ]] && continue
+
+        # Only consider directories that have a flight-recorder (real cycles)
+        [[ ! -f "$candidate/flight-recorder.jsonl" ]] && continue
+
+        # Must sort before current_name (we want the predecessor)
+        [[ "$cand_name" < "$current_name" ]] || continue
+
+        prior_candidate="$candidate"
+        # Keep iterating — the last `prior_candidate` that's < current wins
+        # (dirs sorted ascending, so the last one before current is the
+        # immediate predecessor).
+        prior="$prior_candidate"
+    done < <(find "$cycles_root" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort)
+
+    echo "$prior"
+}
+
+# _summarize_prior_cycle_failures — scan a prior cycle's flight-recorder for
+# load-bearing failure events and emit a markdown summary suitable for
+# injection into discovery phase prompts.
+#
+# Events surfaced (load-bearing per #575):
+#   - CIRCUIT_BREAKER: gate tripped after MAX_RETRIES
+#   - BB_FINDING_STUCK: Bridgebuilder finding that can't be fixed
+#   - AUTO_ESCALATION: profile escalated mid-cycle (signals coverage gap)
+#   - REVIEW_FIX_LOOP_EXHAUSTED: fix-loop ran out of iterations
+#   - BUDGET (FAILED): budget exceeded
+#   - Any phase with verdict starting with "FAIL"
+#
+# Usage:
+#   _summarize_prior_cycle_failures <prior_cycle_dir>
+#
+# Emits markdown to stdout, or empty string if the prior cycle ran cleanly
+# (no load-bearing events found). Truncates output at ~2000 chars to avoid
+# inflating the discovery prompt.
+_summarize_prior_cycle_failures() {
+    local prior_cycle_dir="$1"
+
+    [[ -z "$prior_cycle_dir" || ! -d "$prior_cycle_dir" ]] && { echo ""; return 0; }
+
+    local fr="$prior_cycle_dir/flight-recorder.jsonl"
+    [[ ! -f "$fr" ]] && { echo ""; return 0; }
+
+    # Extract load-bearing events with verdict/action filtering.
+    # Using jq -s for streaming + array ops.
+    local events
+    events=$(jq -s -r '
+        def is_load_bearing:
+            (.phase // "") as $p
+            | (.action // "") as $a
+            | (.verdict // "") as $v
+            | ($p == "CIRCUIT_BREAKER")
+              or ($p | tostring | startswith("BB_FINDING_STUCK"))
+              or ($p | tostring | startswith("AUTO_ESCALATION"))
+              or ($p == "REVIEW_FIX_LOOP_EXHAUSTED")
+              or ($a == "CIRCUIT_BREAKER")
+              or ($p == "BUDGET" and ($v | tostring | startswith("FAIL")))
+              or (($v | tostring | startswith("FAIL")) and ($p != "BUDGET"));
+
+        [.[] | select(is_load_bearing)]
+        | if length == 0 then empty
+          else
+            "**Load-bearing events from prior cycle:**",
+            "",
+            (.[] | "- [\(.phase // "?")] \(.action // "?")\(if .verdict and (.verdict | tostring | length > 0) then " → \(.verdict)" else "" end)")
+          end
+    ' "$fr" 2>/dev/null || echo "")
+
+    # Truncate to avoid bloating discovery prompts
+    if [[ -n "$events" ]]; then
+        echo "$events" | head -c 2000
+    fi
+}
+
+# _build_seed_failure_prelude — if the feature is enabled and a prior cycle
+# exists, emits a full prelude block suitable for prepending to the SEED
+# context. Returns empty string when disabled or no prior data.
+#
+# Usage:
+#   _build_seed_failure_prelude <current_cycle_dir>
+_build_seed_failure_prelude() {
+    local current_cycle_dir="$1"
+
+    [[ -z "$current_cycle_dir" ]] && { echo ""; return 0; }
+
+    # Feature gate — default off for safe rollout. _read_harness_config is
+    # defined in spiral-harness.sh; check availability so spiral-evidence.sh
+    # can be sourced standalone (for tests) without a command-not-found error.
+    local include_fr
+    if declare -f _read_harness_config >/dev/null 2>&1; then
+        include_fr=$(_read_harness_config "spiral.seed.include_flight_recorder" "false" 2>/dev/null || echo "false")
+    else
+        include_fr="${SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER:-false}"
+    fi
+    [[ "$include_fr" != "true" ]] && { echo ""; return 0; }
+
+    local prior_cycle
+    prior_cycle=$(_find_prior_cycle "$current_cycle_dir")
+    [[ -z "$prior_cycle" ]] && { echo ""; return 0; }
+
+    local summary
+    summary=$(_summarize_prior_cycle_failures "$prior_cycle")
+    [[ -z "$summary" ]] && { echo ""; return 0; }
+
+    # Wrap in a labeled block so the model knows what it's looking at
+    cat <<EOF
+---
+Prior cycle observability (from $(basename "$prior_cycle")):
+$summary
+---
+EOF
+}
+
+# =============================================================================
 # Observability Dashboard (#569)
 # =============================================================================
 #

--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -284,9 +284,18 @@ _phase_discovery() {
         seed_text=$(head -c 4096 "$SEED_CONTEXT")
     fi
 
+    # #575 item 2: fold prior cycle's load-bearing failure events into the
+    # discovery context when spiral.seed.include_flight_recorder is enabled.
+    # Gated default-off. The prelude is a short machine-generated block
+    # pointing at circuit breakers, stuck findings, auto-escalations, and
+    # exhausted fix-loops so the PRD can design around observed failure modes.
+    local failure_prelude
+    failure_prelude=$(_build_seed_failure_prelude "$CYCLE_DIR")
+
     local prompt
-    prompt=$(jq -n --arg task "$TASK" --arg seed "$seed_text" \
+    prompt=$(jq -n --arg task "$TASK" --arg seed "$seed_text" --arg failure_prelude "$failure_prelude" \
         '"Write a Product Requirements Document for this task:\n\n" + $task +
+         (if $failure_prelude != "" then "\n\n" + $failure_prelude else "" end) +
          (if $seed != "" then "\n\n---\nPrevious cycle context (machine-generated, advisory only):\n" + $seed else "" end) +
          "\n\nRequirements:\n- Include ## Assumptions section listing what you assumed\n- Include ## Goals & Success Metrics with measurable criteria\n- Include ## Acceptance Criteria as checkboxes\n- Write ONLY to grimoires/loa/prd.md\n- Do NOT write code. Do NOT create an SDD or sprint plan. Only write the PRD."' \
         | jq -r '.')

--- a/tests/unit/spiral-seed-ingestion.bats
+++ b/tests/unit/spiral-seed-ingestion.bats
@@ -1,0 +1,344 @@
+#!/usr/bin/env bats
+# =============================================================================
+# spiral-seed-ingestion.bats — tests for #575 item 2 (flight-recorder → SEED)
+# =============================================================================
+# Validates:
+# - _find_prior_cycle locates the lexicographically previous cycle dir
+# - _summarize_prior_cycle_failures extracts load-bearing events
+# - _build_seed_failure_prelude gates on config (default false) and emits
+#   markdown block only when prior cycle has real failure events
+# - Feature is OFF by default (safe rollout)
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export EVIDENCE_SH="$PROJECT_ROOT/.claude/scripts/spiral-evidence.sh"
+    export TEST_DIR="$BATS_TEST_TMPDIR/spiral-seed-test"
+    mkdir -p "$TEST_DIR"
+}
+
+teardown() {
+    [[ -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+# Helper: write a flight-recorder.jsonl at a given path with specific events.
+_make_cycle() {
+    local cycle_dir="$1"
+    mkdir -p "$cycle_dir"
+    touch "$cycle_dir/flight-recorder.jsonl"
+}
+
+_append_to_cycle() {
+    local cycle_dir="$1"
+    local phase="$2" actor="$3" action="$4" verdict="${5:-}"
+    jq -n -c \
+        --arg phase "$phase" \
+        --arg actor "$actor" \
+        --arg action "$action" \
+        --arg verdict "$verdict" \
+        '{seq: 0, ts: "2026-04-19T00:00:00Z", phase: $phase, actor: $actor, action: $action,
+          input_checksum: null, output_checksum: null, output_path: null,
+          output_bytes: 0, duration_ms: 0, cost_usd: 0,
+          verdict: (if $verdict == "" then null else $verdict end)}' \
+        >> "$cycle_dir/flight-recorder.jsonl"
+}
+
+# =========================================================================
+# SSI-T1: _find_prior_cycle locates the predecessor
+# =========================================================================
+
+@test "_find_prior_cycle returns empty when no siblings exist" {
+    local cycles_root="$TEST_DIR/cycles"
+    local current="$cycles_root/cycle-002"
+    _make_cycle "$current"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _find_prior_cycle '$current'
+    "
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "_find_prior_cycle picks lexicographically previous sibling" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+    _make_cycle "$cycles_root/cycle-002"
+    _make_cycle "$cycles_root/cycle-003"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _find_prior_cycle '$cycles_root/cycle-003'
+    "
+    [[ "$output" == *"/cycle-002" ]]
+}
+
+@test "_find_prior_cycle skips dirs without flight-recorder" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+    # cycle-002 has no flight recorder — should be skipped
+    mkdir -p "$cycles_root/cycle-002"
+    _make_cycle "$cycles_root/cycle-003"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _find_prior_cycle '$cycles_root/cycle-003'
+    "
+    [[ "$output" == *"/cycle-001" ]]
+}
+
+@test "_find_prior_cycle returns empty when current cycle is first" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _find_prior_cycle '$cycles_root/cycle-001'
+    "
+    [ -z "$output" ]
+}
+
+# =========================================================================
+# SSI-T2: _summarize_prior_cycle_failures extracts load-bearing events
+# =========================================================================
+
+@test "summary extracts CIRCUIT_BREAKER events" {
+    local prior="$TEST_DIR/cycles/cycle-001"
+    _make_cycle "$prior"
+    _append_to_cycle "$prior" "CIRCUIT_BREAKER" "spiral-harness" "gate_trip" "FAIL:REVIEW:max_retries"
+    _append_to_cycle "$prior" "DISCOVERY" "claude" "invoke" "OK"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures '$prior'
+    "
+    [[ "$output" == *"CIRCUIT_BREAKER"* ]]
+    [[ "$output" == *"max_retries"* ]]
+}
+
+@test "summary extracts BB_FINDING_STUCK events" {
+    local prior="$TEST_DIR/cycles/cycle-001"
+    _make_cycle "$prior"
+    _append_to_cycle "$prior" "BB_FINDING_STUCK" "bb-fix-loop" "stuck_detected"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures '$prior'
+    "
+    [[ "$output" == *"BB_FINDING_STUCK"* ]]
+}
+
+@test "summary extracts AUTO_ESCALATION events" {
+    local prior="$TEST_DIR/cycles/cycle-001"
+    _make_cycle "$prior"
+    _append_to_cycle "$prior" "AUTO_ESCALATION" "spiral-harness" "profile_escalated" "profile_escalated"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures '$prior'
+    "
+    [[ "$output" == *"AUTO_ESCALATION"* ]]
+}
+
+@test "summary extracts REVIEW_FIX_LOOP_EXHAUSTED events" {
+    local prior="$TEST_DIR/cycles/cycle-001"
+    _make_cycle "$prior"
+    _append_to_cycle "$prior" "REVIEW_FIX_LOOP_EXHAUSTED" "review-fix-loop" "changes_required"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures '$prior'
+    "
+    [[ "$output" == *"REVIEW_FIX_LOOP_EXHAUSTED"* ]]
+}
+
+@test "summary extracts BUDGET FAIL events" {
+    local prior="$TEST_DIR/cycles/cycle-001"
+    _make_cycle "$prior"
+    _append_to_cycle "$prior" "BUDGET" "evidence-gate" "check" "FAIL:EXCEEDED:spent=15 max=12"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures '$prior'
+    "
+    [[ "$output" == *"BUDGET"* ]]
+    [[ "$output" == *"EXCEEDED"* ]]
+}
+
+@test "summary returns empty when cycle had no failures" {
+    local prior="$TEST_DIR/cycles/cycle-001"
+    _make_cycle "$prior"
+    _append_to_cycle "$prior" "DISCOVERY" "claude" "invoke" "OK"
+    _append_to_cycle "$prior" "ARCHITECTURE" "claude" "invoke" "OK"
+    _append_to_cycle "$prior" "IMPLEMENT" "claude" "invoke" "OK"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures '$prior'
+    "
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "summary returns empty when flight-recorder missing" {
+    local prior="$TEST_DIR/cycles/cycle-001"
+    mkdir -p "$prior"
+    # No flight-recorder.jsonl
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures '$prior'
+    "
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "summary returns empty for missing prior cycle dir" {
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures ''
+    "
+    [ -z "$output" ]
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures '/nonexistent/path'
+    "
+    [ -z "$output" ]
+}
+
+@test "summary truncates at 2000 chars to avoid bloating prompts" {
+    local prior="$TEST_DIR/cycles/cycle-001"
+    _make_cycle "$prior"
+    # Generate many failure events (50 × ~60 bytes each = 3000+ bytes)
+    for i in $(seq 1 50); do
+        _append_to_cycle "$prior" "CIRCUIT_BREAKER" "actor" "trip_$i" "FAIL:REASON_$i:detail_$i"
+    done
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        _summarize_prior_cycle_failures '$prior'
+    "
+    # Length of captured output should be <= 2000 chars
+    [ "${#output}" -le 2000 ]
+}
+
+# =========================================================================
+# SSI-T3: _build_seed_failure_prelude feature gate
+# =========================================================================
+
+@test "prelude is empty by default (feature off)" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+    _append_to_cycle "$cycles_root/cycle-001" "CIRCUIT_BREAKER" "x" "y" "FAIL:z:w"
+    _make_cycle "$cycles_root/cycle-002"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        # Explicit: feature flag NOT set
+        unset SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER
+        _build_seed_failure_prelude '$cycles_root/cycle-002'
+    "
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "prelude emits when feature flag set + prior cycle has failures" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+    _append_to_cycle "$cycles_root/cycle-001" "CIRCUIT_BREAKER" "x" "trip" "FAIL:REASON:detail"
+    _make_cycle "$cycles_root/cycle-002"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        export SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER=true
+        _build_seed_failure_prelude '$cycles_root/cycle-002'
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Prior cycle observability"* ]]
+    [[ "$output" == *"cycle-001"* ]]
+    [[ "$output" == *"CIRCUIT_BREAKER"* ]]
+}
+
+@test "prelude is empty when feature on but prior cycle had no failures" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+    _append_to_cycle "$cycles_root/cycle-001" "DISCOVERY" "x" "invoke" "OK"
+    _make_cycle "$cycles_root/cycle-002"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        export SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER=true
+        _build_seed_failure_prelude '$cycles_root/cycle-002'
+    "
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "prelude is empty when feature on but no prior cycle exists" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        export SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER=true
+        _build_seed_failure_prelude '$cycles_root/cycle-001'
+    "
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "prelude wraps content with labeled delimiter block" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+    _append_to_cycle "$cycles_root/cycle-001" "BUDGET" "x" "check" "FAIL:EXCEEDED:over"
+    _make_cycle "$cycles_root/cycle-002"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        export SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER=true
+        _build_seed_failure_prelude '$cycles_root/cycle-002'
+    "
+    # Must include the ---...--- wrapper (so the model knows the boundary)
+    run bash -c "
+        source '$EVIDENCE_SH'
+        export SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER=true
+        _build_seed_failure_prelude '$cycles_root/cycle-002'
+    "
+    local dashes
+    dashes=$(echo "$output" | grep -c "^---$")
+    [ "$dashes" -ge 2 ]
+}
+
+# =========================================================================
+# SSI-T4: default-off invariant across configurations
+# =========================================================================
+
+@test "prelude is OFF when SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER=false" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+    _append_to_cycle "$cycles_root/cycle-001" "CIRCUIT_BREAKER" "x" "y" "FAIL:z:w"
+    _make_cycle "$cycles_root/cycle-002"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        export SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER=false
+        _build_seed_failure_prelude '$cycles_root/cycle-002'
+    "
+    [ -z "$output" ]
+}
+
+@test "prelude is OFF when SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER is garbage" {
+    local cycles_root="$TEST_DIR/cycles"
+    _make_cycle "$cycles_root/cycle-001"
+    _append_to_cycle "$cycles_root/cycle-001" "CIRCUIT_BREAKER" "x" "y" "FAIL:z:w"
+    _make_cycle "$cycles_root/cycle-002"
+
+    run bash -c "
+        source '$EVIDENCE_SH'
+        export SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER=yes
+        _build_seed_failure_prelude '$cycles_root/cycle-002'
+    "
+    # Only the literal string 'true' enables (strict comparison)
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

Item 2 from #575. Closes one of the autopoietic-loop gaps @zksoju identified in the three-lens audit: prior cycles produce observability (flight-recorder.jsonl) but the next cycle's discovery phase never reads it. Operators had to hand-curate failure modes into the SEED — or, more commonly, not bother, and the same failure patterns recur.

Builds on the #569 dashboard infrastructure — both read flight-recorder.jsonl, but where the dashboard is **forward-looking** (operator sees now), this is **backward-looking** (next cycle's SEED sees prior).

## Shape

```
cycle-N runs → writes flight-recorder.jsonl
  │
  │ (operator starts cycle-(N+1))
  ↓
cycle-(N+1) _phase_discovery
  └─ _build_seed_failure_prelude(CYCLE_DIR)
        └─ _find_prior_cycle(CYCLE_DIR)  → .run/cycles/cycle-N
        └─ _summarize_prior_cycle_failures(cycle-N)
              └─ scans for CIRCUIT_BREAKER, BB_FINDING_STUCK,
                 AUTO_ESCALATION, REVIEW_FIX_LOOP_EXHAUSTED,
                 BUDGET FAIL, generic FAIL verdicts
        └─ emits markdown block delimited by `---`
  └─ block prepended to PRD prompt between task + SEED context
```

## Load-bearing events surfaced

Per the RFC's "what are the signals next cycle needs to know about?" analysis:

| Event | Why it matters |
|-------|---------------|
| `CIRCUIT_BREAKER` | Gate tripped after MAX_RETRIES — design defect or scope mismatch |
| `BB_FINDING_STUCK` | Bridgebuilder found something that can't be fixed in the loop |
| `AUTO_ESCALATION` | Profile escalated mid-cycle — signal that default coverage was insufficient |
| `REVIEW_FIX_LOOP_EXHAUSTED` | Reviewer right, implementer couldn't close the gap in N iterations |
| `BUDGET FAIL` | Cost estimation was off, next cycle should plan more conservatively |
| Any phase with `FAIL:` verdict | Deterministic gate failure |

Output truncated to 2000 chars — keeps the discovery prompt small even on pathological cycles.

## Feature flag

```yaml
spiral:
  seed:
    include_flight_recorder: true   # default false — safe rollout
```

Also honours `SPIRAL_SEED_INCLUDE_FLIGHT_RECORDER=true` env var for tests and scripts that can't touch config.

**Why default off**: bounded blast radius; operators opt-in when they want the learning loop; lets us observe real-world prompt-quality impact before enabling by default.

## Changes

| File | Change |
|------|--------|
| `.claude/scripts/spiral-evidence.sh` | Three new functions: `_find_prior_cycle`, `_summarize_prior_cycle_failures`, `_build_seed_failure_prelude` |
| `.claude/scripts/spiral-harness.sh` | `_phase_discovery` calls `_build_seed_failure_prelude` and weaves the output into the PRD prompt |
| `tests/unit/spiral-seed-ingestion.bats` | **NEW** — 20 tests across 4 suites |

## Test Plan

- [x] `bats tests/unit/spiral-seed-ingestion.bats` → 20/20 pass
- [x] `bats tests/unit/spiral-*.bats` → 209/212 (3 pre-existing phase-timeout regex failures on main, unrelated)
- [x] `bash -n` on both scripts — syntax clean
- [x] Fail-safe paths: empty cycle dir, missing flight-recorder, no prior cycle, feature-off — all return empty string without error
- [ ] Post-merge: enable in a live spiral run to observe prompt quality (follow-up after initial merge)

## Not addressed (separate follow-ups per #575)

- **Item 1** — auto-SEED-from-HARVEST (the big architectural move; needs own design RFC)
- **Item 3** — `_pre_check_seed` environment-invariant gate
- **Item 4** — failure-typed bead escalation as SEED hard-dependency

Items 5 + 6 already shipped (docs + config-ify timeouts respectively).

Partially closes #575 (item 2 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)