### PR TITLE
feat(spiral): _pre_check_seed environment-invariant gate (#575 item 3)

### DIFF
--- a/.claude/scripts/spiral-evidence.sh
+++ b/.claude/scripts/spiral-evidence.sh
@@ -353,6 +353,104 @@ _pre_check_review() {
     [[ "$issues" -eq 0 ]]
 }
 
+
+
+# =============================================================================
+# SEED Pre-Check (#575 item 3)
+# =============================================================================
+#
+# Validates environment invariants BEFORE the discovery phase dispatches,
+# mirroring _pre_check_implementation / _pre_check_review which validate
+# post-conditions for later phases. Catches classes of failure that are
+# visible pre-dispatch but currently only surface as confusing mid-cycle
+# errors.
+#
+# Empirical justification: cycle-084 CWD-mismatch (reviewer subprocess
+# running in .loa/ submodule CWD vs main repo) was catchable pre-dispatch
+# but currently surfaces as "grimoires/loa/prd.md not found" after discovery
+# runs and writes to the wrong location.
+#
+# Checks (in order):
+#   1. CWD is a git repository AND has grimoires/loa/ directory (hard-fail —
+#      this is the cycle-084 class of defect)
+#   2. Cycle dir is writable or creatable (hard-fail)
+#   3. SEED_CONTEXT file exists when path provided (warn, not block — the
+#      operator may have intended a standalone run)
+#
+# Returns 0 on pass (possibly with warnings), 1 on hard-fail.
+#
+# Usage:
+#   _pre_check_seed <cycle_dir>
+#
+# Env:
+#   SPIRAL_PRE_CHECK_SEED_STRICT=true — promote warnings to errors
+_pre_check_seed() {
+    local cycle_dir="${1:-}"
+    local issues=0
+    local warnings=0
+    local strict="${SPIRAL_PRE_CHECK_SEED_STRICT:-false}"
+
+    # 1. CWD must be a git repository root with grimoires/loa/ present.
+    #    This is the cycle-084 failure: CWD was .loa/ (a submodule) not the
+    #    main repo, so any grimoires/loa/prd.md write went to the wrong path.
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "PRE-CHECK-SEED FAIL: CWD $(pwd) is not inside a git work tree" >&2
+        issues=$((issues + 1))
+    fi
+
+    if [[ ! -d "grimoires/loa" ]]; then
+        echo "PRE-CHECK-SEED FAIL: grimoires/loa/ not found from CWD $(pwd) — likely wrong CWD (cycle-084 class)" >&2
+        issues=$((issues + 1))
+    fi
+
+    # 2. Cycle dir must exist or be creatable (check parent writable).
+    if [[ -n "$cycle_dir" ]]; then
+        if [[ ! -d "$cycle_dir" ]]; then
+            local parent
+            parent="$(dirname "$cycle_dir")"
+            if [[ ! -d "$parent" ]]; then
+                # Try to create it; if that fails, hard-fail
+                if ! mkdir -p "$parent" 2>/dev/null; then
+                    echo "PRE-CHECK-SEED FAIL: cannot create cycle parent: $parent" >&2
+                    issues=$((issues + 1))
+                fi
+            elif [[ ! -w "$parent" ]]; then
+                echo "PRE-CHECK-SEED FAIL: cycle parent not writable: $parent" >&2
+                issues=$((issues + 1))
+            fi
+        elif [[ ! -w "$cycle_dir" ]]; then
+            echo "PRE-CHECK-SEED FAIL: cycle dir not writable: $cycle_dir" >&2
+            issues=$((issues + 1))
+        fi
+    fi
+
+    # 3. SEED_CONTEXT file existence — warn if operator specified a path that's missing
+    if [[ -n "${SEED_CONTEXT:-}" ]]; then
+        if [[ ! -f "$SEED_CONTEXT" ]]; then
+            echo "PRE-CHECK-SEED WARN: SEED_CONTEXT path does not resolve: $SEED_CONTEXT" >&2
+            warnings=$((warnings + 1))
+        elif [[ ! -r "$SEED_CONTEXT" ]]; then
+            echo "PRE-CHECK-SEED WARN: SEED_CONTEXT file not readable: $SEED_CONTEXT" >&2
+            warnings=$((warnings + 1))
+        elif [[ ! -s "$SEED_CONTEXT" ]]; then
+            echo "PRE-CHECK-SEED WARN: SEED_CONTEXT file is empty: $SEED_CONTEXT" >&2
+            warnings=$((warnings + 1))
+        fi
+    fi
+
+    # Strict mode: promote warnings to errors
+    if [[ "$strict" == "true" ]]; then
+        issues=$((issues + warnings))
+    fi
+
+    # Record trajectory (if flight recorder is active)
+    [[ -n "${_FLIGHT_RECORDER:-}" ]] && \
+        _record_action "PRE_CHECK_SEED" "evidence-gate" "seed_ready" "" "" "" 0 0 0 \
+            "$([ "$issues" -eq 0 ] && echo "PASS:warnings=$warnings" || echo "FAIL:${issues}_issues_warnings=${warnings}")"
+
+    [[ "$issues" -eq 0 ]]
+}
+
 # =============================================================================
 # Finalization
 # =============================================================================

--- a/.claude/scripts/spiral-harness.sh
+++ b/.claude/scripts/spiral-harness.sh
@@ -1108,6 +1108,16 @@ main() {
         "profile=$PIPELINE_PROFILE gates=${FLATLINE_GATES:-none} advisor=$ADVISOR_MODEL"
     _emit_dashboard_snapshot "START"
 
+    # ── Pre-check: SEED environment invariants (#575 item 3) ────────────
+    # Catches cycle-084 class defects (wrong CWD, unwritable cycle dir,
+    # missing SEED_CONTEXT file) BEFORE discovery dispatches an expensive
+    # LLM call that writes artefacts to the wrong location.
+    log "Pre-check: validating SEED environment"
+    if ! _pre_check_seed "$CYCLE_DIR"; then
+        error "SEED pre-check failed: environment invariants violated"
+        exit 1
+    fi
+
     # ── Phase 1: Discovery ──────────────────────────────────────────────
     log "Phase 1: DISCOVERY"
     _emit_dashboard_snapshot "DISCOVERY"

--- a/tests/unit/spiral-pre-check-seed.bats
+++ b/tests/unit/spiral-pre-check-seed.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+# =============================================================================
+# spiral-pre-check-seed.bats — tests for #575 item 3 (SEED environment gate)
+# =============================================================================
+# Validates:
+# - Hard-fail when CWD is not a git work tree (cycle-084 class)
+# - Hard-fail when grimoires/loa/ missing from CWD
+# - Hard-fail when cycle dir / parent not writable
+# - Warn (not fail) when SEED_CONTEXT path doesn't resolve
+# - Strict mode promotes warnings to errors
+# - Records PRE_CHECK_SEED trajectory entry
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export EVIDENCE_SH="$PROJECT_ROOT/.claude/scripts/spiral-evidence.sh"
+    export TEST_DIR="$BATS_TEST_TMPDIR/spiral-pre-seed-test"
+    mkdir -p "$TEST_DIR"
+}
+
+teardown() {
+    [[ -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+# Helper: initialize a fake git repo with grimoires/loa layout
+_make_git_project() {
+    local dir="$1"
+    mkdir -p "$dir/grimoires/loa"
+    mkdir -p "$dir/.run/cycles"
+    (cd "$dir" && git init -q 2>&1 | head -0; git config user.email test@test; git config user.name test)
+}
+
+# =========================================================================
+# PCS-T1: happy path
+# =========================================================================
+
+@test "pre_check passes in a valid git project with grimoires/loa and writable cycle dir" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/.run/cycles/cycle-001"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        unset SEED_CONTEXT
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-001'
+    "
+    [ "$status" -eq 0 ]
+}
+
+@test "pre_check passes when cycle dir doesn't exist but parent is writable" {
+    _make_git_project "$TEST_DIR/proj"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        unset SEED_CONTEXT
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-002'
+    "
+    [ "$status" -eq 0 ]
+}
+
+# =========================================================================
+# PCS-T2: CWD checks (cycle-084 class)
+# =========================================================================
+
+@test "pre_check fails when CWD is not a git work tree" {
+    # No git init — CWD is just a plain directory
+    mkdir -p "$TEST_DIR/not-a-git-repo/grimoires/loa"
+
+    run bash -c "
+        cd '$TEST_DIR/not-a-git-repo'
+        source '$EVIDENCE_SH'
+        unset SEED_CONTEXT
+        _pre_check_seed '$TEST_DIR/not-a-git-repo/.run/cycles/cycle-001'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not inside a git work tree"* ]]
+}
+
+@test "pre_check fails when grimoires/loa/ is missing from CWD" {
+    mkdir -p "$TEST_DIR/no-grimoires"
+    (cd "$TEST_DIR/no-grimoires" && git init -q)
+
+    run bash -c "
+        cd '$TEST_DIR/no-grimoires'
+        source '$EVIDENCE_SH'
+        unset SEED_CONTEXT
+        _pre_check_seed '$TEST_DIR/no-grimoires/.run/cycles/cycle-001'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"grimoires/loa/ not found"* ]]
+    [[ "$output" == *"cycle-084 class"* ]]
+}
+
+# =========================================================================
+# PCS-T3: cycle dir writability
+# =========================================================================
+
+@test "pre_check fails when cycle dir parent is not writable" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/readonly-parent"
+    chmod 555 "$TEST_DIR/proj/readonly-parent"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        unset SEED_CONTEXT
+        _pre_check_seed '$TEST_DIR/proj/readonly-parent/cycle-001'
+    "
+    # Restore permissions for cleanup
+    chmod 755 "$TEST_DIR/proj/readonly-parent"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not writable"* ]]
+}
+
+# =========================================================================
+# PCS-T4: SEED_CONTEXT warnings (non-blocking by default)
+# =========================================================================
+
+@test "pre_check warns (but passes) when SEED_CONTEXT path missing" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/.run/cycles/cycle-001"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        export SEED_CONTEXT='/nonexistent/seed.md'
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-001'
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN"* ]]
+    [[ "$output" == *"does not resolve"* ]]
+}
+
+@test "pre_check warns when SEED_CONTEXT file is empty" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/.run/cycles/cycle-001"
+    touch "$TEST_DIR/proj/empty-seed.md"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        export SEED_CONTEXT='$TEST_DIR/proj/empty-seed.md'
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-001'
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN"* ]]
+    [[ "$output" == *"empty"* ]]
+}
+
+@test "pre_check passes cleanly when SEED_CONTEXT is unset" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/.run/cycles/cycle-001"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        unset SEED_CONTEXT
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-001'
+    "
+    [ "$status" -eq 0 ]
+    # No WARN because nothing to warn about
+    [[ "$output" != *"WARN"* ]]
+}
+
+@test "pre_check passes with populated SEED_CONTEXT file" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/.run/cycles/cycle-001"
+    echo "# Real seed content" > "$TEST_DIR/proj/valid-seed.md"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        export SEED_CONTEXT='$TEST_DIR/proj/valid-seed.md'
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-001'
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WARN"* ]]
+    [[ "$output" != *"FAIL"* ]]
+}
+
+# =========================================================================
+# PCS-T5: strict mode promotes warnings to errors
+# =========================================================================
+
+@test "strict mode promotes missing SEED_CONTEXT to error" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/.run/cycles/cycle-001"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        export SEED_CONTEXT='/nonexistent/seed.md'
+        export SPIRAL_PRE_CHECK_SEED_STRICT=true
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-001'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"WARN"* ]]
+}
+
+@test "strict=false (default) keeps warnings non-blocking" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/.run/cycles/cycle-001"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        export SEED_CONTEXT='/nonexistent/seed.md'
+        export SPIRAL_PRE_CHECK_SEED_STRICT=false
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-001'
+    "
+    [ "$status" -eq 0 ]
+}
+
+# =========================================================================
+# PCS-T6: trajectory recording
+# =========================================================================
+
+@test "pre_check emits PRE_CHECK_SEED trajectory action when flight recorder active" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/.run/cycles/cycle-001"
+    touch "$TEST_DIR/proj/.run/cycles/cycle-001/flight-recorder.jsonl"
+
+    bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$TEST_DIR/proj/.run/cycles/cycle-001/flight-recorder.jsonl'
+        export _FLIGHT_RECORDER_SEQ=0
+        unset SEED_CONTEXT
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-001'
+    "
+    run jq -r '.phase' "$TEST_DIR/proj/.run/cycles/cycle-001/flight-recorder.jsonl"
+    [ "$output" = "PRE_CHECK_SEED" ]
+
+    run jq -r '.action' "$TEST_DIR/proj/.run/cycles/cycle-001/flight-recorder.jsonl"
+    [ "$output" = "seed_ready" ]
+}
+
+@test "pre_check records PASS verdict when all checks pass" {
+    _make_git_project "$TEST_DIR/proj"
+    mkdir -p "$TEST_DIR/proj/.run/cycles/cycle-001"
+    touch "$TEST_DIR/proj/.run/cycles/cycle-001/flight-recorder.jsonl"
+
+    bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        export _FLIGHT_RECORDER='$TEST_DIR/proj/.run/cycles/cycle-001/flight-recorder.jsonl'
+        export _FLIGHT_RECORDER_SEQ=0
+        unset SEED_CONTEXT
+        _pre_check_seed '$TEST_DIR/proj/.run/cycles/cycle-001'
+    "
+    run jq -r '.verdict' "$TEST_DIR/proj/.run/cycles/cycle-001/flight-recorder.jsonl"
+    [[ "$output" == PASS:* ]]
+}
+
+# =========================================================================
+# PCS-T7: missing cycle_dir argument
+# =========================================================================
+
+@test "pre_check tolerates empty cycle_dir argument (checks CWD only)" {
+    _make_git_project "$TEST_DIR/proj"
+
+    run bash -c "
+        cd '$TEST_DIR/proj'
+        source '$EVIDENCE_SH'
+        unset SEED_CONTEXT
+        _pre_check_seed ''
+    "
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Item 3 from #575. Mirrors existing `_pre_check_implementation` / `_pre_check_review` which validate post-conditions for later phases — the SEED seam had no counterpart, so environment invariants (wrong CWD, unwritable cycle dir, missing SEED_CONTEXT file) only surfaced mid-cycle as confusing `"grimoires/loa/prd.md not found"` errors AFTER the LLM had already written artefacts to the wrong location.

**Empirical justification**: cycle-084 CWD-mismatch (mentioned in RFC) — reviewer subprocess ran in `.loa/` submodule CWD instead of main repo. Catchable pre-dispatch.

## Checks (in order)

| # | Severity | Check | Catches |
|---|----------|-------|---------|
| 1 | hard-fail | `git rev-parse --is-inside-work-tree` succeeds from CWD | "running from /tmp" |
| 2 | hard-fail | `grimoires/loa/` directory present from CWD | cycle-084 class |
| 3 | hard-fail | cycle dir (or parent if dir missing) is writable | permission errors |
| 4 | warn | `$SEED_CONTEXT` exists + readable + non-empty when set | operator typos |

Warnings are non-blocking by default. Env var `SPIRAL_PRE_CHECK_SEED_STRICT=true` promotes warnings to errors — useful for CI.

## Wire-up

`spiral-harness.sh main()` calls `_pre_check_seed "$CYCLE_DIR"` before Phase 1 Discovery. Failures `exit 1` with the specific FAIL reason on stderr — no silent fallthrough.

## Changes

| File | Change |
|------|--------|
| `.claude/scripts/spiral-evidence.sh` | New `_pre_check_seed(cycle_dir)` function; records `PRE_CHECK_SEED` action to flight recorder when active |
| `.claude/scripts/spiral-harness.sh` | `main()` invokes `_pre_check_seed` before dispatching Phase 1 Discovery |
| `tests/unit/spiral-pre-check-seed.bats` | **NEW** — 14 tests across 7 suites |

## Test Plan

- [x] `bats tests/unit/spiral-pre-check-seed.bats` → 14/14 pass
- [x] `bats tests/unit/spiral-*.bats` → 223/226 (3 pre-existing phase-timeout regex failures, unrelated)
- [x] `bash -n` on both scripts — clean
- [x] Cycle-084 reproduction: test 4 confirms "grimoires/loa/ not found" message includes "cycle-084 class"

## Not addressed (follow-ups per #575)

- **Item 1** — Auto-SEED-from-HARVEST (needs own design RFC — largest move in the #575 set)
- **Item 4** — Failure-typed bead escalation as SEED hard-dep (pairs with item 1 — "membrane-repair primitive" framing)

Items 2, 5, 6 already shipped in v1.99.2, v1.99.1, v1.96.2 respectively.

Partially closes #575 (item 3 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)