### PR TITLE
feat(cycle-006): migrate construct tooling (compose + validate + schemas) from loa-constructs

### DIFF
--- a/.claude/schemas/artifact.schema.json
+++ b/.claude/schemas/artifact.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/artifact.schema.json",
+  "title": "Artifact",
+  "description": "Produced material stream row. Doctrine §3.3. File-at-path with content-hash + metadata. Content-addressable — multiple constructs may read the same artifact; writers commit to versioned paths.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp", "path"],
+  "properties": {
+    "stream_type": {
+      "const": "Artifact"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "path": {
+      "type": "string",
+      "description": "Filesystem or URI path to the material."
+    },
+    "content_hash": {
+      "type": "string",
+      "description": "Optional content hash (sha256 hex preferred) for content-addressable lookup."
+    },
+    "media_type": {
+      "type": "string",
+      "description": "MIME type or informal type tag (e.g. text/markdown, application/yaml, image/png)."
+    },
+    "producer": {
+      "type": "string",
+      "description": "Construct slug or pack-scoped skill handle that produced this artifact."
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "derived_from": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional list of upstream artifact paths or content-hashes this artifact was derived from."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Free-form producer metadata — descriptions, tags, version labels.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/.claude/schemas/intent.schema.json
+++ b/.claude/schemas/intent.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/intent.schema.json",
+  "title": "Intent",
+  "description": "Operator routing signal. Doctrine §3.4 + §14.4 (structured-slot amendment). The entry point — every pipe chain begins with an Intent. Producers: operator (the only source). Consumers: orchestration layer.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp", "intent"],
+  "properties": {
+    "stream_type": {
+      "const": "Intent"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "intent": {
+      "type": "string",
+      "description": "Operator utterance — free-form prose framing the ask."
+    },
+    "intent_class": {
+      "type": "string",
+      "description": "Optional classification enum (e.g. audit, implement, review, plan, dispatch). Orchestrator may use it for composition selection."
+    },
+    "context": {
+      "type": "object",
+      "description": "Inline typed slots — artifact refs, entity handles, mode hints. Doctrine §14.4 multi-modal slot pattern.",
+      "additionalProperties": true
+    },
+    "constraints": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Hard guardrails from the operator (e.g. 'no admin-merge', 'shell-first only')."
+    },
+    "feedback_on": {
+      "type": "string",
+      "description": "Optional reference — prior artifact, verdict, or run_id — this intent reacts to. Feedback-as-pipe-input per doctrine §6."
+    },
+    "operator": {
+      "type": "string",
+      "description": "Optional operator identifier for multi-operator contexts."
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "read_mode": {
+      "type": "string",
+      "enum": ["glance", "orient", "intervene"]
+    }
+  }
+}

--- a/.claude/schemas/operator-model.schema.json
+++ b/.claude/schemas/operator-model.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/operator-model.schema.json",
+  "title": "Operator-Model",
+  "description": "Operator knowledge/expertise map. Doctrine §14.2 (5th stream primitive). Sourced from ~/hivemind/ + session context + explicit operator utterances. Every pipe stage reads this alongside its domain input so output register calibrates to operator expertise.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp"],
+  "properties": {
+    "stream_type": {
+      "const": "Operator-Model"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "operator": {
+      "type": "string",
+      "description": "Operator identifier. Default implicit when single-operator context."
+    },
+    "expertise": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Declared or inferred domains of expertise (e.g. design-engineering, solidity, convex)."
+    },
+    "mode": {
+      "type": "string",
+      "description": "Current Operator-OS mode if any (e.g. FEEL, ARCH, DIG, SHIP, FRAME, TEND). Orientation hint, not dispatch requirement."
+    },
+    "lenses": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Active lenses layered over mode (e.g. craft, keeper, canon, weaver)."
+    },
+    "references": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Things the operator has named this session — projects, people, code refs. Consumers may avoid re-explaining these."
+    },
+    "register": {
+      "type": "string",
+      "enum": ["novice", "intermediate", "expert", "mixed"],
+      "description": "Optional calibration tier for output depth. Consumers may expand on novice, shortcut on expert."
+    },
+    "hivemind_sources": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Paths to hivemind entries loaded into context (personal + organizational). Provenance for any operator-facing claim."
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "read_mode": {
+      "type": "string",
+      "enum": ["glance", "orient", "intervene"]
+    }
+  }
+}

--- a/.claude/schemas/signal.schema.json
+++ b/.claude/schemas/signal.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/signal.schema.json",
+  "title": "Signal",
+  "description": "Raw observation stream row. Doctrine §3.1. Append-only JSONL. Producers: observer, beehive, dig-search, feedback-widget. Consumers: archivists, analyzers, scoring constructs.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp", "source", "observation"],
+  "properties": {
+    "stream_type": {
+      "const": "Signal"
+    },
+    "schema_version": {
+      "type": "string",
+      "description": "Semver of the row shape. Rows with forward-compatible minor bumps MUST continue to validate; breaking shape changes require a major bump.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp (e.g. 2026-04-22T12:34:56Z)."
+    },
+    "source": {
+      "type": "string",
+      "description": "Producer identity — usually construct slug or pack-scoped skill handle (e.g. observer/observing-users)."
+    },
+    "observation": {
+      "type": "string",
+      "description": "Free-form observation text. Glance/orient consumers read this directly."
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional tag set for filtering."
+    },
+    "session_id": {
+      "type": "string",
+      "description": "Optional paired trajectory session_id if this Signal originated inside a construct invocation."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Optional composition run_id if this Signal was emitted inside a composition chain."
+    },
+    "read_mode": {
+      "type": "string",
+      "enum": ["glance", "orient", "intervene"],
+      "description": "Tiered output level per doctrine §14.3. Consumers at glance-latency read only rows tagged glance; intervene-level rows carry full detail."
+    }
+  }
+}

--- a/.claude/schemas/verdict.schema.json
+++ b/.claude/schemas/verdict.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://constructs.network/schemas/verdict.schema.json",
+  "title": "Verdict",
+  "description": "Evaluated judgment stream row. Doctrine §3.2. Per-invocation (one invocation → one verdict row). Composes with feedback-v3.schema.json — a Verdict row at this level is equivalent to a feedback-v3 entry with an explicit stream_type.",
+  "type": "object",
+  "schema_version": "1.0.0",
+  "additionalProperties": true,
+  "required": ["stream_type", "schema_version", "timestamp", "source", "verdict"],
+  "properties": {
+    "stream_type": {
+      "const": "Verdict"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "string",
+      "description": "Emitting persona or construct slug (e.g. ALEXANDER, observer)."
+    },
+    "verdict": {
+      "type": "string",
+      "description": "Core evaluated judgment — actionable, operator-legible."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["info", "low", "medium", "high", "critical"],
+      "description": "Operator-facing severity tag. Consumers may filter by severity tier."
+    },
+    "evidence": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Supporting signals or file:line references. Should cite observable reality, not speculation."
+    },
+    "subject": {
+      "type": "string",
+      "description": "Optional target of the verdict — file path, component name, entity id."
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "read_mode": {
+      "type": "string",
+      "enum": ["glance", "orient", "intervene"]
+    },
+    "glance": {
+      "type": "string",
+      "description": "Single-line variant of this verdict (≤ 120 chars). Satisfies glance-latency consumers."
+    },
+    "orient": {
+      "type": "string",
+      "description": "3-5 line variant of this verdict. Satisfies orient-latency consumers."
+    }
+  }
+}

--- a/.claude/scripts/butterfreezone-construct-gen.sh
+++ b/.claude/scripts/butterfreezone-construct-gen.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# =============================================================================
+# butterfreezone-construct-gen.sh — per-pack CONSTRUCT-README.md generator (cycle-005 L6)
+# =============================================================================
+# Reads a construct pack directory (construct.yaml + skills/ + commands/ +
+# identity/ + CLAUDE.md) and emits CONSTRUCT-README.md summarising:
+#
+#   - description + short_description
+#   - persona handles (with identity file paths)
+#   - skill inventory (slug → SKILL.md title + description)
+#   - command inventory (name → description)
+#   - composability (composes_with + symmetric compositions)
+#   - streams reads/writes (doctrine §3 pipe compatibility)
+#   - grimoires read/write paths (SEED §12 — "grimoire path IS the interface")
+#   - install instructions
+#   - author + provenance
+#
+# Idempotent: output byte-identical across re-runs modulo a single timestamp
+# line in the footer (stripped by default; pass --timestamp to include).
+#
+# Usage:
+#   butterfreezone-construct-gen.sh <pack-path> [-o OUTPUT_FILE] [--stdout]
+#                                    [--dry-run] [--timestamp]
+#
+# Exit codes:
+#   0 = success
+#   1 = pack path missing / construct.yaml missing
+#   2 = required tooling missing (yq, jq)
+# =============================================================================
+set -euo pipefail
+
+export LC_ALL=C
+export TZ=UTC
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PACK_PATH=""
+OUTPUT=""
+TO_STDOUT=0
+DRY_RUN=0
+WITH_TIMESTAMP=0
+
+usage() { sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)    usage; exit 0 ;;
+    -o|--output)  OUTPUT="$2"; shift 2 ;;
+    --stdout)     TO_STDOUT=1; shift ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    --timestamp)  WITH_TIMESTAMP=1; shift ;;
+    -*)           echo "[bfz-construct-gen] ERROR: unknown flag $1" >&2; exit 2 ;;
+    *) if [[ -z "$PACK_PATH" ]]; then PACK_PATH="$1"; else echo "[bfz-construct-gen] ERROR: unexpected arg: $1" >&2; exit 2; fi; shift ;;
+  esac
+done
+
+[[ -n "$PACK_PATH" ]] || { usage >&2; exit 1; }
+PACK_PATH=$(cd "$PACK_PATH" 2>/dev/null && pwd) || { echo "[bfz-construct-gen] ERROR: pack path missing: $PACK_PATH" >&2; exit 1; }
+YAML="$PACK_PATH/construct.yaml"
+[[ -f "$YAML" ]] || { echo "[bfz-construct-gen] ERROR: construct.yaml not found at $YAML" >&2; exit 1; }
+
+command -v yq >/dev/null 2>&1 || { echo "[bfz-construct-gen] ERROR: yq v4+ required" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "[bfz-construct-gen] ERROR: jq required" >&2; exit 2; }
+
+PACK_JSON=$(yq -o=json '.' "$YAML")
+
+get() { echo "$PACK_JSON" | jq -r "$1 // empty"; }
+
+SLUG=$(get '.slug')
+NAME=$(get '.name')
+VERSION=$(get '.version')
+DESCRIPTION=$(get '.description')
+SHORT_DESCRIPTION=$(get '.short_description')
+AUTHOR=$(get '.author')
+LICENSE=$(get '.license')
+SCHEMA_VERSION=$(get '.schema_version')
+
+# --------------------------------------------------------------------------
+# Personas — merge construct.yaml `personas:` list + identity/<HANDLE>.md
+# --------------------------------------------------------------------------
+mapfile -t yaml_personas < <(echo "$PACK_JSON" | jq -r '(.personas // [])[] | select(. != "")')
+declare -a identity_files=()
+if [[ -d "$PACK_PATH/identity" ]]; then
+  while IFS= read -r f; do
+    base=$(basename "$f" .md)
+    # Persona handles are uppercase_letters / digits / underscores (e.g. ALEXANDER, OSTROM, KEEPER, BARTH).
+    [[ "$base" =~ ^[A-Z][A-Z0-9_]+$ ]] || continue
+    identity_files+=("$f")
+  done < <(find "$PACK_PATH/identity" -maxdepth 1 -name '*.md' -print | LC_ALL=C sort)
+fi
+
+# --------------------------------------------------------------------------
+# Skills — pull description from SKILL.md frontmatter `description:` or first H1
+# --------------------------------------------------------------------------
+frontmatter_desc() {
+  local md="$1"
+  [[ -f "$md" ]] || { echo ""; return; }
+  # Inline form: "description: foo bar"
+  local desc
+  desc=$(awk '/^---/{f=!f; next} f && /^description:/{sub(/^description:[[:space:]]*/,""); print; exit}' "$md")
+  # Block scalar indicators (| or >) with no value after — pull first non-empty continuation line.
+  if [[ "$desc" == "|" || "$desc" == ">" || "$desc" == "|-" || "$desc" == ">-" || "$desc" == "|+" || "$desc" == ">+" ]]; then
+    desc=$(awk '
+      /^---/{f=!f; next}
+      f && /^description:[[:space:]]*[|>]/{ in_block=1; next }
+      in_block && /^[A-Za-z_][A-Za-z0-9_]*:/{ exit }
+      in_block && NF{ sub(/^[[:space:]]+/,""); print; exit }
+    ' "$md")
+  fi
+  # Fall back to first markdown H1.
+  if [[ -z "$desc" ]]; then
+    desc=$(awk '!/^---/ && /^#[[:space:]]/{sub(/^#+[[:space:]]*/,""); print; exit}' "$md")
+  fi
+  echo "$desc"
+}
+
+skill_line() {
+  local skill_dir="$1" slug="$2"
+  local desc
+  desc=$(frontmatter_desc "$skill_dir/SKILL.md")
+  [[ -z "$desc" ]] && desc="(no description)"
+  printf -- "- \`%s\` — %s\n" "$slug" "$desc"
+}
+
+skills_block=""
+while IFS= read -r slug; do
+  [[ -z "$slug" ]] && continue
+  path=$(echo "$PACK_JSON" | jq -r --arg s "$slug" '(.skills // [])[] | select(.slug == $s) | .path // empty' | head -1)
+  [[ -z "$path" ]] && path="skills/$slug"
+  line=$(skill_line "$PACK_PATH/$path" "$slug")
+  skills_block+="$line"$'\n'
+done < <(echo "$PACK_JSON" | jq -r '(.skills // [])[] | .slug // empty' | LC_ALL=C sort)
+
+# --------------------------------------------------------------------------
+# Commands — name → description (from command markdown frontmatter / H1)
+# --------------------------------------------------------------------------
+command_line() {
+  local name="$1" path="$2"
+  local desc
+  desc=$(frontmatter_desc "$PACK_PATH/$path")
+  [[ -z "$desc" ]] && desc="(no description)"
+  printf -- "- \`/%s\` — %s\n" "$name" "$desc"
+}
+
+commands_block=""
+while IFS= read -r row; do
+  [[ -z "$row" ]] && continue
+  name=$(echo "$row" | jq -r '.name // empty')
+  path=$(echo "$row" | jq -r '.path // empty')
+  [[ -z "$name" ]] && continue
+  line=$(command_line "$name" "$path")
+  commands_block+="$line"$'\n'
+done < <(echo "$PACK_JSON" | jq -c '(.commands // [])[]' | LC_ALL=C sort)
+
+# --------------------------------------------------------------------------
+# Composes with
+# --------------------------------------------------------------------------
+composes_block=""
+while IFS= read -r x; do
+  [[ -z "$x" ]] && continue
+  composes_block+="- $x"$'\n'
+done < <(echo "$PACK_JSON" | jq -r '(.composes_with // [])[]' | LC_ALL=C sort -u)
+[[ -z "$composes_block" ]] && composes_block="_None declared._"$'\n'
+
+# --------------------------------------------------------------------------
+# Streams — reads/writes
+# --------------------------------------------------------------------------
+reads_list=$(echo "$PACK_JSON" | jq -r '(.reads // .streams.reads // [])[] // empty' | LC_ALL=C sort -u)
+writes_list=$(echo "$PACK_JSON" | jq -r '(.writes // .streams.writes // [])[] // empty' | LC_ALL=C sort -u)
+
+fmt_list() {
+  local l="$1"
+  if [[ -z "$l" ]]; then
+    echo "_not declared_"
+    return
+  fi
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    echo "- $t"
+  done <<< "$l"
+}
+
+# --------------------------------------------------------------------------
+# Grimoires read/write paths (construct.yaml declarations)
+# SEED §12 — "grimoire path IS the interface"
+# --------------------------------------------------------------------------
+grimoires_reads=$(echo "$PACK_JSON"  | jq -r '((.composition_paths.reads // .grimoires.reads // []))[] // empty'  | LC_ALL=C sort -u)
+grimoires_writes=$(echo "$PACK_JSON" | jq -r '((.composition_paths.writes // .grimoires.writes // []))[] // empty' | LC_ALL=C sort -u)
+
+# Fallback scan: if neither list is declared, grep construct.yaml for grimoires/ paths
+if [[ -z "$grimoires_reads$grimoires_writes" ]]; then
+  mapfile -t fallback_paths < <(grep -oE 'grimoires/[A-Za-z0-9._-]+[/A-Za-z0-9._-]*' "$YAML" 2>/dev/null | LC_ALL=C sort -u)
+  if (( ${#fallback_paths[@]} > 0 )); then
+    grimoires_writes=$(printf '%s\n' "${fallback_paths[@]}")
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# Drift detection — CLAUDE.md missing explicit grimoires section
+# --------------------------------------------------------------------------
+drift_notice=""
+if [[ -f "$PACK_PATH/CLAUDE.md" ]]; then
+  if ! grep -qiE 'grimoires?/' "$PACK_PATH/CLAUDE.md"; then
+    drift_notice="> ⚠ SEED §12 drift — pack \`CLAUDE.md\` does not reference \`grimoires/\`. The canonical declaration lives in \`construct.yaml\`; regenerate CLAUDE.md or add the section manually."$'\n\n'
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# Compose document
+# --------------------------------------------------------------------------
+HEADER_TITLE="${NAME:-$SLUG}"
+SHORT="${SHORT_DESCRIPTION:-$DESCRIPTION}"
+
+doc=""
+doc+="<!-- Generated by .claude/scripts/butterfreezone-construct-gen.sh -->"$'\n'
+doc+="<!-- Canonical source: construct.yaml · do not edit by hand -->"$'\n\n'
+doc+="# $HEADER_TITLE"$'\n\n'
+if [[ -n "$SHORT" ]]; then
+  doc+="> $SHORT"$'\n\n'
+fi
+
+if [[ -n "$drift_notice" ]]; then
+  doc+="$drift_notice"
+fi
+
+doc+="## About"$'\n\n'
+doc+="| field | value |"$'\n'
+doc+="|---|---|"$'\n'
+doc+="| slug | \`$SLUG\` |"$'\n'
+doc+="| version | \`${VERSION:-?}\` |"$'\n'
+doc+="| schema_version | \`${SCHEMA_VERSION:-?}\` |"$'\n'
+doc+="| author | ${AUTHOR:-?} |"$'\n'
+doc+="| license | ${LICENSE:-?} |"$'\n\n'
+
+if [[ -n "$DESCRIPTION" && "$DESCRIPTION" != "$SHORT" ]]; then
+  doc+="$DESCRIPTION"$'\n\n'
+fi
+
+# Personas
+if (( ${#yaml_personas[@]} > 0 )) || (( ${#identity_files[@]} > 0 )); then
+  doc+="## Personas"$'\n\n'
+  declare -a seen=()
+  for p in "${yaml_personas[@]}" "${identity_files[@]}"; do
+    if [[ "$p" == *.md ]]; then
+      handle=$(basename "$p" .md)
+      rel=${p#$PACK_PATH/}
+      line="- \`@$handle\` → [\`$rel\`]($rel)"
+    else
+      handle="$p"
+      if [[ -f "$PACK_PATH/identity/$handle.md" ]]; then
+        rel="identity/$handle.md"
+        line="- \`@$handle\` → [\`$rel\`]($rel)"
+      else
+        line="- \`@$handle\`"
+      fi
+    fi
+    case " ${seen[*]} " in *" $handle "*) continue ;; esac
+    seen+=("$handle")
+    doc+="$line"$'\n'
+  done
+  doc+=$'\n'
+fi
+
+# Skills
+if [[ -n "$skills_block" ]]; then
+  doc+="## Skills"$'\n\n'
+  doc+="$skills_block"
+  doc+=$'\n'
+fi
+
+# Commands
+if [[ -n "$commands_block" ]]; then
+  doc+="## Commands"$'\n\n'
+  doc+="$commands_block"
+  doc+=$'\n'
+fi
+
+# Composes with
+doc+="## Composes with"$'\n\n'
+doc+="$composes_block"
+doc+=$'\n'
+
+# Streams
+doc+="## Streams"$'\n\n'
+doc+="**Reads**:"$'\n\n'
+doc+=$(fmt_list "$reads_list")
+doc+=$'\n\n'
+doc+="**Writes**:"$'\n\n'
+doc+=$(fmt_list "$writes_list")
+doc+=$'\n\n'
+if [[ -z "$reads_list$writes_list" ]]; then
+  doc+="> Declare \`reads:\` and \`writes:\` in \`construct.yaml\` to enable doctrine §3 pipe compatibility checks."$'\n\n'
+fi
+
+# Grimoires
+doc+="## Grimoires read/write (SEED §12)"$'\n\n'
+if [[ -z "$grimoires_reads$grimoires_writes" ]]; then
+  doc+="_No grimoires paths declared. Without a declaration this construct cannot participate in path-based composition — see SEED §12 for the convention._"$'\n\n'
+else
+  if [[ -n "$grimoires_reads" ]]; then
+    doc+="**Reads from**:"$'\n\n'
+    while IFS= read -r p; do [[ -z "$p" ]] && continue; doc+="- \`$p\`"$'\n'; done <<< "$grimoires_reads"
+    doc+=$'\n'
+  fi
+  if [[ -n "$grimoires_writes" ]]; then
+    doc+="**Writes to**:"$'\n\n'
+    while IFS= read -r p; do [[ -z "$p" ]] && continue; doc+="- \`$p\`"$'\n'; done <<< "$grimoires_writes"
+    doc+=$'\n'
+  fi
+  doc+="> The grimoire path IS the interface — constructs writing to the same path compose automatically."$'\n\n'
+fi
+
+# Install
+doc+="## Install"$'\n\n'
+doc+='```bash'$'\n'
+doc+="/constructs install $SLUG"$'\n'
+doc+='```'$'\n\n'
+
+doc+="## Provenance"$'\n\n'
+doc+="- Canonical spec: \`construct.yaml\`"$'\n'
+doc+="- Generator: \`.claude/scripts/butterfreezone-construct-gen.sh\`"$'\n'
+doc+="- Doctrine: \`bonfire-construct-pipe-doctrine.md\` §3 typed streams · §4 composition · §14.2 Operator-Model"$'\n'
+if (( WITH_TIMESTAMP )); then
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  doc+="- Generated at: $ts"$'\n'
+fi
+
+# --------------------------------------------------------------------------
+# Emit
+# --------------------------------------------------------------------------
+if (( TO_STDOUT )); then
+  printf '%s' "$doc"
+  exit 0
+fi
+
+OUTPUT="${OUTPUT:-$PACK_PATH/CONSTRUCT-README.md}"
+if (( DRY_RUN )); then
+  echo "[bfz-construct-gen] would write → $OUTPUT (${#doc} bytes)"
+  printf '%s' "$doc" | head -10
+  echo "..."
+  exit 0
+fi
+
+printf '%s' "$doc" > "$OUTPUT"
+echo "[bfz-construct-gen] wrote $OUTPUT"

--- a/.claude/scripts/construct-compose.sh
+++ b/.claude/scripts/construct-compose.sh
@@ -1,0 +1,470 @@
+#!/usr/bin/env bash
+# =============================================================================
+# construct-compose.sh — composition runner (cycle-005 L1)
+# =============================================================================
+# Reads a composition YAML from grimoires/compositions/<name>.yaml and
+# executes its pipe chain: validates type compatibility at chain-build time,
+# sequences stages via construct-invoke.sh entry/exit, pipes stdin/stdout
+# between stages, emits a final summary at the requested read-mode.
+#
+# Doctrine:
+#   §3  — typed streams (Signal/Verdict/Artifact/Intent/Operator-Model)
+#   §4  — composition = pipe chain spec
+#   §5  — runner is the shell-equivalent layer (layer 4 in §5.1)
+#   §13.1 — shell-first, no TypeScript
+#   §14.3 — three read-modes (glance / orient / intervene)
+#   §16.4 — agent-transparency invariant: active set + trajectory on every stage
+#
+# Usage:
+#   construct-compose.sh <composition-name> [options]
+#   construct-compose.sh feel-audit --target src/app/ui/Button.tsx
+#
+# Options:
+#   --target PATH           Input artifact path (binds composition.inputs[type=Artifact])
+#   --input JSON            Raw JSON value for the first-stage stdin (overrides --target)
+#   --dry-run               Validate + print plan; no trajectory emitted, no stages run
+#   --run-id ID             Override generated run_id (useful in tests)
+#   --executor PATH         Override stage executor (env LOA_COMPOSE_STAGE_EXECUTOR)
+#   --compositions-dir DIR  Override compositions search dir (default: grimoires/compositions)
+#   --glance                Summary: 1 line (default)
+#   --orient                Summary: 3-6 lines, per-stage durations
+#   --intervene             Summary: full JSON blob on stderr
+#   -h, --help              Print this help
+#
+# Exit codes:
+#   0 = success
+#   1 = composition missing or malformed
+#   2 = type-compatibility failure (reported with stage + expected vs produced)
+#   3 = stage execution failure
+#   4 = final-output schema validation failure
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+DEFAULT_COMPOSITIONS_DIR="${LOA_COMPOSITIONS_DIR:-$PROJECT_ROOT/grimoires/compositions}"
+TRAJECTORY_FILE="${LOA_TRAJECTORY_FILE:-$PROJECT_ROOT/.run/construct-trajectory.jsonl}"
+FEEDBACK_FILE="${LOA_FEEDBACK_FILE:-$PROJECT_ROOT/.run/feedback-v3.jsonl}"
+SCHEMA_VERSION="1.0.0"
+
+# --------------------------------------------------------------------------
+# Args
+# --------------------------------------------------------------------------
+COMPOSITION_NAME=""
+TARGET_PATH=""
+RAW_INPUT=""
+DRY_RUN=0
+RUN_ID=""
+STAGE_EXECUTOR="${LOA_COMPOSE_STAGE_EXECUTOR:-}"
+COMPOSITIONS_DIR="$DEFAULT_COMPOSITIONS_DIR"
+READ_MODE="glance"
+
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+die() {
+  local code="${1:-1}"
+  shift || true
+  echo "[construct-compose] ERROR: $*" >&2
+  exit "$code"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)           usage; exit 0 ;;
+    --target)            TARGET_PATH="$2"; shift 2 ;;
+    --input)             RAW_INPUT="$2"; shift 2 ;;
+    --dry-run)           DRY_RUN=1; shift ;;
+    --run-id)            RUN_ID="$2"; shift 2 ;;
+    --executor)          STAGE_EXECUTOR="$2"; shift 2 ;;
+    --compositions-dir)  COMPOSITIONS_DIR="$2"; shift 2 ;;
+    --glance)            READ_MODE="glance"; shift ;;
+    --orient)            READ_MODE="orient"; shift ;;
+    --intervene)         READ_MODE="intervene"; shift ;;
+    --) shift; break ;;
+    -*) die 1 "unknown flag: $1" ;;
+    *)  if [[ -z "$COMPOSITION_NAME" ]]; then COMPOSITION_NAME="$1"; else die 1 "unexpected positional: $1"; fi; shift ;;
+  esac
+done
+
+[[ -n "$COMPOSITION_NAME" ]] || { usage >&2; die 1 "composition name required"; }
+
+# --------------------------------------------------------------------------
+# Tool dependencies
+# --------------------------------------------------------------------------
+command -v yq >/dev/null 2>&1 || die 1 "yq (v4+) required — install via 'brew install yq' or equivalent"
+command -v jq >/dev/null 2>&1 || die 1 "jq required"
+
+# --------------------------------------------------------------------------
+# Composition load
+# --------------------------------------------------------------------------
+COMPOSITION_FILE="$COMPOSITIONS_DIR/$COMPOSITION_NAME.yaml"
+[[ -f "$COMPOSITION_FILE" ]] || die 1 "composition not found: $COMPOSITION_FILE"
+
+COMPOSITION_JSON=$(yq -o=json '.' "$COMPOSITION_FILE" 2>/dev/null) \
+  || die 1 "failed to parse YAML: $COMPOSITION_FILE"
+
+STAGE_COUNT=$(echo "$COMPOSITION_JSON" | jq -r '.chain | length')
+(( STAGE_COUNT > 0 )) || die 1 "composition '$COMPOSITION_NAME' has empty chain"
+
+# --------------------------------------------------------------------------
+# run_id
+# --------------------------------------------------------------------------
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID=$(uuidgen 2>/dev/null \
+           || python3 -c "import uuid; print(uuid.uuid4())" 2>/dev/null \
+           || echo "compose-$(date +%s)-$$")
+fi
+
+# --------------------------------------------------------------------------
+# Persona resolution — first persona of the stage's construct
+# --------------------------------------------------------------------------
+resolve_persona() {
+  local slug="$1"
+  local resolver="$SCRIPT_DIR/construct-resolve.sh"
+  local persona=""
+  if [[ -x "$resolver" ]]; then
+    persona=$("$resolver" resolve "$slug" --json 2>/dev/null \
+              | jq -r '.construct.personas[0] // empty' 2>/dev/null || echo "")
+  fi
+  if [[ -z "$persona" ]]; then
+    # Fallback: uppercase slug prefix
+    persona=$(echo "$slug" | tr '[:lower:]' '[:upper:]')
+  fi
+  echo "$persona"
+}
+
+# --------------------------------------------------------------------------
+# Type-compatibility check (chain-build-time)
+# --------------------------------------------------------------------------
+# Per doctrine §4: every pipe edge's types must align. A stage's `reads` must
+# be satisfiable by the union of composition inputs + all prior stages' writes.
+# --------------------------------------------------------------------------
+produced_types=()
+inputs_types=$(echo "$COMPOSITION_JSON" | jq -r '.inputs[]?.type // empty')
+while IFS= read -r t; do
+  [[ -z "$t" ]] && continue
+  produced_types+=("$t")
+done <<< "$inputs_types"
+
+set_contains() {
+  local needle="$1"; shift
+  for x in "$@"; do
+    [[ "$x" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# Pre-flight: verify every stage's reads ⊆ produced-so-far
+for (( i=0; i<STAGE_COUNT; i++ )); do
+  stage_json=$(echo "$COMPOSITION_JSON" | jq -c ".chain[$i]")
+  stage_label=$(echo "$stage_json" | jq -r '.stage // (. | tostring)')
+  reads=$(echo "$stage_json" | jq -r '(.reads // [])[]')
+  while IFS= read -r r; do
+    [[ -z "$r" ]] && continue
+    if ! set_contains "$r" "${produced_types[@]}"; then
+      produced_csv=$(IFS=, ; echo "${produced_types[*]}")
+      die 2 "type mismatch at stage $stage_label: reads '$r' but upstream has produced only [$produced_csv]"
+    fi
+  done <<< "$reads"
+  writes=$(echo "$stage_json" | jq -r '(.writes // [])[]')
+  while IFS= read -r w; do
+    [[ -z "$w" ]] && continue
+    set_contains "$w" "${produced_types[@]}" || produced_types+=("$w")
+  done <<< "$writes"
+done
+
+# --------------------------------------------------------------------------
+# Plan output
+# --------------------------------------------------------------------------
+print_plan() {
+  echo "[construct-compose] composition=$COMPOSITION_NAME run_id=$RUN_ID stages=$STAGE_COUNT" >&2
+  for (( i=0; i<STAGE_COUNT; i++ )); do
+    local s construct skill reads writes stage_label
+    s=$(echo "$COMPOSITION_JSON" | jq -c ".chain[$i]")
+    stage_label=$(echo "$s" | jq -r '.stage // empty')
+    construct=$(echo "$s" | jq -r '.construct')
+    skill=$(echo "$s" | jq -r '.skill // "<none>"')
+    reads=$(echo "$s" | jq -r '(.reads // []) | join(",")')
+    writes=$(echo "$s" | jq -r '(.writes // []) | join(",")')
+    printf "[construct-compose] stage %s: %s::%s reads=[%s] writes=[%s]\n" \
+      "${stage_label:-$((i+1))}" "$construct" "$skill" "$reads" "$writes" >&2
+  done
+}
+
+if (( DRY_RUN )); then
+  print_plan
+  echo "[construct-compose] dry-run OK — type compatibility verified, no stages executed" >&2
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Initial stdin payload for stage 1
+# --------------------------------------------------------------------------
+emit_initial_payload() {
+  if [[ -n "$RAW_INPUT" ]]; then
+    printf '%s' "$RAW_INPUT"
+    return
+  fi
+  # Build a seed payload that carries composition inputs to stage 1 via stdin.
+  # Stage 1's reads determine which typed fields we populate.
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local target_path="$TARGET_PATH"
+  [[ -z "$target_path" ]] && target_path="<unspecified>"
+  jq -n \
+    --arg run_id "$RUN_ID" \
+    --arg composition "$COMPOSITION_NAME" \
+    --arg ts "$ts" \
+    --arg target "$target_path" \
+    --arg schema_version "$SCHEMA_VERSION" \
+    '{
+      _compose_meta: {
+        run_id: $run_id,
+        composition: $composition,
+        timestamp: $ts,
+        schema_version: $schema_version
+      },
+      inputs: {
+        target: $target
+      }
+    }'
+}
+
+# --------------------------------------------------------------------------
+# Default stage executor (stub)
+#
+# Produces a schema-valid placeholder row for the primary type in `writes`.
+# Designed to be swapped via --executor / $LOA_COMPOSE_STAGE_EXECUTOR when
+# real LLM-driven skill dispatch ships (cycle-006+ orchestrator).
+#
+# Stdin: previous stage output (JSON, may be empty on stage 1 if no inputs)
+# Args: construct_slug skill persona stage_label writes_csv run_id session_id
+# Stdout: JSON row conforming to the PRIMARY write type's schema
+# --------------------------------------------------------------------------
+default_stage_executor() {
+  local construct="$1" skill="$2" persona="$3" stage_label="$4" writes_csv="$5" run_id="$6" session_id="$7"
+  local primary_type
+  primary_type=$(echo "$writes_csv" | awk -F',' '{print $1}')
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Carry forward prior stage output for transparency.
+  local prior=""
+  if [[ ! -t 0 ]]; then
+    prior=$(cat -)
+  fi
+
+  case "$primary_type" in
+    Signal)
+      jq -n \
+        --arg ts "$ts" --arg source "$construct/$skill" --arg persona "$persona" \
+        --arg observation "[stub] stage $stage_label · $construct/$skill executed over upstream payload" \
+        --arg schema_version "$SCHEMA_VERSION" --arg run_id "$run_id" --arg session_id "$session_id" \
+        --argjson prior "${prior:-null}" \
+        '{
+          stream_type: "Signal",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          source: $source,
+          observation: $observation,
+          tags: ["stub", "composition", $persona],
+          session_id: $session_id,
+          run_id: $run_id,
+          _prior: $prior
+        }'
+      ;;
+    Verdict)
+      jq -n \
+        --arg ts "$ts" --arg source "$persona" --arg schema_version "$SCHEMA_VERSION" \
+        --arg run_id "$run_id" --arg session_id "$session_id" \
+        --arg verdict "[stub] stage $stage_label · $construct/$skill judgment placeholder — swap executor for real skill dispatch" \
+        --arg glance "[stub $persona] stage $stage_label verdict" \
+        --argjson prior "${prior:-null}" \
+        '{
+          stream_type: "Verdict",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          source: $source,
+          verdict: $verdict,
+          severity: "info",
+          evidence: [],
+          glance: $glance,
+          session_id: $session_id,
+          run_id: $run_id,
+          _prior: $prior
+        }'
+      ;;
+    Artifact)
+      jq -n \
+        --arg ts "$ts" --arg producer "$construct/$skill" --arg schema_version "$SCHEMA_VERSION" \
+        --arg run_id "$run_id" --arg session_id "$session_id" \
+        --arg path "${TARGET_PATH:-/tmp/stub-artifact}" \
+        '{
+          stream_type: "Artifact",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          path: $path,
+          producer: $producer,
+          media_type: "application/x-stub",
+          session_id: $session_id,
+          run_id: $run_id
+        }'
+      ;;
+    Intent)
+      jq -n \
+        --arg ts "$ts" --arg schema_version "$SCHEMA_VERSION" --arg run_id "$run_id" \
+        --arg intent "[stub] stage $stage_label · $construct/$skill intent placeholder" \
+        '{
+          stream_type: "Intent",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          intent: $intent,
+          run_id: $run_id
+        }'
+      ;;
+    Operator-Model)
+      jq -n \
+        --arg ts "$ts" --arg schema_version "$SCHEMA_VERSION" --arg run_id "$run_id" \
+        '{
+          stream_type: "Operator-Model",
+          schema_version: $schema_version,
+          timestamp: $ts,
+          expertise: [],
+          run_id: $run_id
+        }'
+      ;;
+    *)
+      die 3 "stage $stage_label declares unknown primary write type '$primary_type'"
+      ;;
+  esac
+}
+
+# --------------------------------------------------------------------------
+# Execute chain
+# --------------------------------------------------------------------------
+now_ms() {
+  python3 -c "import time; print(int(time.time()*1000))" 2>/dev/null \
+    || echo "$(($(date +%s) * 1000))"
+}
+
+start_ms=$(now_ms)
+print_plan
+
+declare -a STAGE_DURATIONS=()
+declare -a STAGE_OUTCOMES=()
+declare -a STAGE_LABELS=()
+declare -a STAGE_SESSIONS=()
+
+current_payload=$(emit_initial_payload)
+
+for (( i=0; i<STAGE_COUNT; i++ )); do
+  stage_json=$(echo "$COMPOSITION_JSON" | jq -c ".chain[$i]")
+  stage_label=$(echo "$stage_json" | jq -r '.stage // empty')
+  [[ -z "$stage_label" ]] && stage_label="$((i+1))"
+  construct=$(echo "$stage_json" | jq -r '.construct')
+  skill=$(echo "$stage_json" | jq -r '.skill // "<none>"')
+  writes_csv=$(echo "$stage_json" | jq -r '(.writes // []) | join(",")')
+  persona=$(resolve_persona "$construct")
+
+  # Entry row — construct-invoke prints session_id on stdout, trajectory on disk.
+  session_id=$("$SCRIPT_DIR/construct-invoke.sh" entry "$persona" "$construct" "/compose:$COMPOSITION_NAME#$stage_label" 2>/dev/null || echo "")
+  [[ -z "$session_id" ]] && session_id="compose-${RUN_ID}-stage-${stage_label}"
+
+  t0_ms=$(now_ms)
+
+  # Execute stage — default stub or operator-supplied executor.
+  stage_output=""
+  exec_rc=0
+  if [[ -n "$STAGE_EXECUTOR" && -x "$STAGE_EXECUTOR" ]]; then
+    stage_output=$(printf '%s' "$current_payload" | "$STAGE_EXECUTOR" \
+      "$construct" "$skill" "$persona" "$stage_label" "$writes_csv" "$RUN_ID" "$session_id") || exec_rc=$?
+  else
+    stage_output=$(printf '%s' "$current_payload" | default_stage_executor \
+      "$construct" "$skill" "$persona" "$stage_label" "$writes_csv" "$RUN_ID" "$session_id") || exec_rc=$?
+  fi
+
+  t1_ms=$(now_ms)
+  dur_ms=$(( t1_ms - t0_ms ))
+  (( dur_ms >= 0 )) || dur_ms=0
+
+  outcome="completed"
+  if (( exec_rc != 0 )); then
+    outcome="failed"
+    "$SCRIPT_DIR/construct-invoke.sh" exit "$persona" "$construct" "$dur_ms" "$outcome" "/compose:$COMPOSITION_NAME#$stage_label" >/dev/null 2>&1 || true
+    die 3 "stage $stage_label ($construct/$skill) executor exited $exec_rc"
+  fi
+
+  # Exit row
+  "$SCRIPT_DIR/construct-invoke.sh" exit "$persona" "$construct" "$dur_ms" "$outcome" "/compose:$COMPOSITION_NAME#$stage_label" >/dev/null 2>&1 || true
+
+  STAGE_DURATIONS+=("$dur_ms")
+  STAGE_OUTCOMES+=("$outcome")
+  STAGE_LABELS+=("$stage_label:$construct/$skill")
+  STAGE_SESSIONS+=("$session_id")
+
+  current_payload="$stage_output"
+done
+
+end_ms=$(now_ms)
+total_ms=$(( end_ms - start_ms ))
+(( total_ms >= 0 )) || total_ms=0
+
+# --------------------------------------------------------------------------
+# Final output validation — if last stage writes a known stream type,
+# validate against its schema. Failure routes to exit 4.
+# --------------------------------------------------------------------------
+last_writes=$(echo "$COMPOSITION_JSON" | jq -r '(.chain[-1].writes // [])[0] // empty')
+if [[ -n "$last_writes" ]]; then
+  if ! "$SCRIPT_DIR/stream-validate.sh" "$last_writes" "$current_payload" 2>/dev/null; then
+    echo "[construct-compose] final output failed $last_writes schema validation:" >&2
+    "$SCRIPT_DIR/stream-validate.sh" "$last_writes" "$current_payload" || true
+    echo "[construct-compose] raw final output follows on stdout; exit 4" >&2
+    printf '%s\n' "$current_payload"
+    exit 4
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# Final payload to stdout (the chain's last output)
+# --------------------------------------------------------------------------
+printf '%s\n' "$current_payload"
+
+# --------------------------------------------------------------------------
+# Summary per read-mode (to stderr so stdout stays pipe-clean)
+# --------------------------------------------------------------------------
+case "$READ_MODE" in
+  glance)
+    local_stages=${#STAGE_DURATIONS[@]}
+    echo "✓ compose $COMPOSITION_NAME · stages=$local_stages · ${total_ms}ms · run=${RUN_ID:0:8}" >&2
+    ;;
+  orient)
+    echo "compose $COMPOSITION_NAME · run_id=$RUN_ID · total=${total_ms}ms" >&2
+    for (( i=0; i<${#STAGE_LABELS[@]}; i++ )); do
+      echo "  stage ${STAGE_LABELS[$i]} · ${STAGE_DURATIONS[$i]}ms · ${STAGE_OUTCOMES[$i]}" >&2
+    done
+    echo "  final writes: ${last_writes:-<untyped>}" >&2
+    ;;
+  intervene)
+    jq -n \
+      --arg composition "$COMPOSITION_NAME" \
+      --arg run_id "$RUN_ID" \
+      --argjson total_ms "$total_ms" \
+      --arg final_type "$last_writes" \
+      --argjson stages "$(printf '%s\n' "${STAGE_LABELS[@]}" | jq -R . | jq -s .)" \
+      --argjson durations "$(printf '%s\n' "${STAGE_DURATIONS[@]}" | jq -s .)" \
+      --argjson outcomes "$(printf '%s\n' "${STAGE_OUTCOMES[@]}" | jq -R . | jq -s .)" \
+      --argjson sessions "$(printf '%s\n' "${STAGE_SESSIONS[@]}" | jq -R . | jq -s .)" \
+      '{
+        composition: $composition,
+        run_id: $run_id,
+        total_ms: $total_ms,
+        final_type: $final_type,
+        stages: $stages,
+        durations_ms: $durations,
+        outcomes: $outcomes,
+        session_ids: $sessions
+      }' >&2
+    ;;
+esac

--- a/.claude/scripts/construct-invoke.sh
+++ b/.claude/scripts/construct-invoke.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# =============================================================================
+# construct-invoke.sh — Trajectory emission wrapper for construct invocations
+# =============================================================================
+# Emits JSONL rows to .run/construct-trajectory.jsonl for persona session
+# observability. Supports paired entry/exit rows matched by session_id.
+#
+# Usage:
+#   construct-invoke.sh entry <persona> <construct_slug>
+#   construct-invoke.sh exit  <persona> <construct_slug> <duration_ms> <outcome>
+#
+# Exit Codes:
+#   0 = success (JSONL write failure is non-fatal — logs warning)
+#   1 = invalid subcommand
+#
+# SEED: grimoires/loa-constructs-seed-2026-04-21/SEED-loa-constructs-infrastructure-cycle.md
+# Leg D: Construct Trajectory Emission
+# Cycle: loa-constructs-cycle-001
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+TRAJECTORY_FILE="${LOA_TRAJECTORY_FILE:-$PROJECT_ROOT/.run/construct-trajectory.jsonl}"
+TEMP_DIR="${TMPDIR:-/tmp}/construct-invoke"
+
+# =============================================================================
+# Log rotation — 30-day retention, runs before each emit
+# =============================================================================
+
+rotate_trajectory() {
+  if [[ ! -f "$TRAJECTORY_FILE" ]]; then
+    return 0
+  fi
+
+  # BSD/GNU compatible date arithmetic
+  local cutoff
+  cutoff=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+           || date -u -v-30d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+           || echo "")
+
+  if [[ -z "$cutoff" ]]; then
+    # Cannot compute cutoff — skip rotation
+    return 0
+  fi
+
+  local tmp
+  tmp=$(mktemp) || return 0
+
+  if jq -c "select(.timestamp >= \"$cutoff\")" "$TRAJECTORY_FILE" > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$TRAJECTORY_FILE"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+# =============================================================================
+# Session ID management
+# =============================================================================
+
+session_key() {
+  local persona="$1"
+  local construct="$2"
+  echo "${persona}__${construct}" | tr '[:upper:]' '[:lower:]' | tr ' /' '__'
+}
+
+session_temp_path() {
+  local key="$1"
+  echo "$TEMP_DIR/session_${key}.id"
+}
+
+# =============================================================================
+# JSONL emit
+# =============================================================================
+
+emit_row() {
+  local row="$1"
+
+  mkdir -p "$(dirname "$TRAJECTORY_FILE")" 2>/dev/null || true
+
+  if ! echo "$row" >> "$TRAJECTORY_FILE" 2>/dev/null; then
+    echo "[construct-invoke] WARNING: failed to write to $TRAJECTORY_FILE" >&2
+  fi
+}
+
+# =============================================================================
+# Subcommand: entry
+# =============================================================================
+
+do_entry() {
+  local persona="$1"
+  local construct_slug="$2"
+  local trigger="${3:-}"
+
+  # Derive trigger from persona name if not supplied
+  if [[ -z "$trigger" ]]; then
+    case "$persona" in
+      ALEXANDER) trigger="/feel" ;;
+      STAMETS)   trigger="/dig" ;;
+      OSTROM)    trigger="/systems" ;;
+      *)         trigger="/${persona,,}" ;;
+    esac
+  fi
+
+  # Generate session_id
+  local session_id
+  session_id=$(uuidgen 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())" 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "$(date +%s)-$$")
+
+  # Store session_id keyed by persona+construct
+  local key
+  key=$(session_key "$persona" "$construct_slug")
+  mkdir -p "$TEMP_DIR" 2>/dev/null || true
+  echo "$session_id" > "$(session_temp_path "$key")" 2>/dev/null || true
+
+  # Rotate before emit
+  rotate_trajectory
+
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Doctrine §13.3 L3: declare stream_type on trajectory rows.
+  # Default to "Signal" (an observation-type emission) for invocation events;
+  # persona-specific downstream rows may declare "Verdict" explicitly.
+  local stream_type="${LOA_STREAM_TYPE:-Signal}"
+  local read_mode="${LOA_READ_MODE:-orient}"
+
+  local row
+  row=$(jq -cn \
+    --arg event "entry" \
+    --arg session_id "$session_id" \
+    --arg persona "$persona" \
+    --arg trigger "$trigger" \
+    --arg construct_slug "$construct_slug" \
+    --arg timestamp "$ts" \
+    --arg stream_type "$stream_type" \
+    --arg read_mode "$read_mode" \
+    '{event: $event, session_id: $session_id, persona: $persona, trigger: $trigger, construct_slug: $construct_slug, stream_type: $stream_type, read_mode: $read_mode, timestamp: $timestamp}')
+
+  emit_row "$row"
+  echo "$session_id"
+}
+
+# =============================================================================
+# Subcommand: exit
+# =============================================================================
+
+do_exit() {
+  local persona="$1"
+  local construct_slug="$2"
+  local duration_ms="${3:-}"
+  local outcome="${4:-completed}"
+  local trigger="${5:-}"
+
+  # Derive trigger from persona name if not supplied
+  if [[ -z "$trigger" ]]; then
+    case "$persona" in
+      ALEXANDER) trigger="/feel" ;;
+      STAMETS)   trigger="/dig" ;;
+      OSTROM)    trigger="/systems" ;;
+      *)         trigger="/${persona,,}" ;;
+    esac
+  fi
+
+  # Read session_id from temp file
+  local key
+  key=$(session_key "$persona" "$construct_slug")
+  local temp_path
+  temp_path=$(session_temp_path "$key")
+
+  local session_id=""
+  if [[ -f "$temp_path" ]]; then
+    session_id=$(cat "$temp_path" 2>/dev/null || echo "")
+    rm -f "$temp_path" 2>/dev/null || true
+  fi
+
+  if [[ -z "$session_id" ]]; then
+    echo "[construct-invoke] WARNING: no session_id found for $persona/$construct_slug — exit row will have null session_id" >&2
+    session_id="null"
+  fi
+
+  # Validate/normalize duration_ms
+  local dur_json
+  if [[ -n "$duration_ms" ]] && [[ "$duration_ms" =~ ^[0-9]+$ ]]; then
+    dur_json="$duration_ms"
+  else
+    dur_json="null"
+  fi
+
+  # Rotate before emit
+  rotate_trajectory
+
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Doctrine §13.3 L3: declare stream_type on trajectory rows.
+  local stream_type="${LOA_STREAM_TYPE:-Signal}"
+  local read_mode="${LOA_READ_MODE:-orient}"
+
+  local row
+  if [[ "$session_id" == "null" ]]; then
+    row=$(jq -cn \
+      --arg event "exit" \
+      --arg persona "$persona" \
+      --arg trigger "$trigger" \
+      --arg construct_slug "$construct_slug" \
+      --arg timestamp "$ts" \
+      --argjson duration_ms "$dur_json" \
+      --arg outcome "$outcome" \
+      --arg stream_type "$stream_type" \
+      --arg read_mode "$read_mode" \
+      '{event: $event, session_id: null, persona: $persona, trigger: $trigger, construct_slug: $construct_slug, stream_type: $stream_type, read_mode: $read_mode, timestamp: $timestamp, duration_ms: $duration_ms, outcome: $outcome}')
+  else
+    row=$(jq -cn \
+      --arg event "exit" \
+      --arg session_id "$session_id" \
+      --arg persona "$persona" \
+      --arg trigger "$trigger" \
+      --arg construct_slug "$construct_slug" \
+      --arg timestamp "$ts" \
+      --argjson duration_ms "$dur_json" \
+      --arg outcome "$outcome" \
+      --arg stream_type "$stream_type" \
+      --arg read_mode "$read_mode" \
+      '{event: $event, session_id: $session_id, persona: $persona, trigger: $trigger, construct_slug: $construct_slug, stream_type: $stream_type, read_mode: $read_mode, timestamp: $timestamp, duration_ms: $duration_ms, outcome: $outcome}')
+  fi
+
+  emit_row "$row"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+  local subcommand="${1:-}"
+
+  case "$subcommand" in
+    entry)
+      [[ $# -ge 3 ]] || { echo "Usage: construct-invoke.sh entry <persona> <construct_slug> [trigger]" >&2; exit 1; }
+      do_entry "$2" "$3" "${4:-}"
+      ;;
+    exit)
+      [[ $# -ge 3 ]] || { echo "Usage: construct-invoke.sh exit <persona> <construct_slug> [duration_ms] [outcome] [trigger]" >&2; exit 1; }
+      do_exit "$2" "$3" "${4:-}" "${5:-completed}" "${6:-}"
+      ;;
+    -h|--help)
+      echo "Usage: construct-invoke.sh entry|exit <persona> <construct_slug> [args...]"
+      echo "  entry <persona> <slug> [trigger]"
+      echo "  exit  <persona> <slug> [duration_ms] [outcome] [trigger]"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown subcommand: $subcommand" >&2
+      echo "Usage: construct-invoke.sh entry|exit <persona> <construct_slug>" >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.claude/scripts/construct-validate.sh
+++ b/.claude/scripts/construct-validate.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# =============================================================================
+# construct-validate.sh — pre-install / pre-publish manifest validator (cycle-005 L4)
+# =============================================================================
+# Validates a construct pack directory against the cycle-005 checks surfaced
+# by F28 (missing commands declarations) and SEED §12 (grimoires read/write
+# convention on CLAUDE.md). Emits Verdict stream rows per doctrine §3 on
+# failure; each finding carries severity and evidence.
+#
+# Usage:
+#   construct-validate.sh <pack-path> [--json] [--strict]
+#
+# Checks:
+#   1. construct.yaml present + parseable
+#   2. required fields: schema_version, slug, name, version, description
+#   3. skills[].path resolves to a filesystem directory
+#   4. persona routes declared: identity/<HANDLE>.md file OR personas: list
+#   5. /-commands OR persona handles exist (F28 closure gate)
+#   6. streams declared: reads / writes not empty (warn only)
+#   7. CLAUDE.md contains an explicit grimoires read/write declaration (SEED §12)
+#
+# Severity tiers:
+#   critical — missing construct.yaml / unparseable
+#   high     — missing required field, broken skill path
+#   medium   — no routes (F28), missing grimoires section (§12)
+#   low      — empty stream declarations (advisory)
+#   info     — pack passes all hard checks
+#
+# Exit codes:
+#   0 = no high or critical findings
+#   1 = at least one high/critical (or medium if --strict)
+#   2 = pack path does not exist
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+SCHEMA_VERSION="1.0.0"
+
+OUTPUT_JSON=0
+STRICT=0
+PACK_PATH=""
+
+usage() { sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --json)    OUTPUT_JSON=1; shift ;;
+    --strict)  STRICT=1; shift ;;
+    -*) echo "[construct-validate] ERROR: unknown flag $1" >&2; exit 2 ;;
+    *) if [[ -z "$PACK_PATH" ]]; then PACK_PATH="$1"; else echo "[construct-validate] ERROR: unexpected positional: $1" >&2; exit 2; fi; shift ;;
+  esac
+done
+
+[[ -n "$PACK_PATH" ]] || { usage >&2; exit 2; }
+PACK_PATH="$(cd "$PACK_PATH" 2>/dev/null && pwd)" || { echo "[construct-validate] ERROR: pack path does not exist: $PACK_PATH" >&2; exit 2; }
+
+command -v yq >/dev/null 2>&1 || { echo "[construct-validate] ERROR: yq v4+ required" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "[construct-validate] ERROR: jq required" >&2; exit 2; }
+
+declare -a FINDINGS=()
+
+emit_finding() {
+  local severity="$1" check="$2" message="$3" evidence="${4:-}"
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local row
+  row=$(jq -n \
+    --arg sv "$severity" --arg ck "$check" --arg msg "$message" \
+    --arg ev "$evidence" --arg ts "$ts" \
+    --arg schema_version "$SCHEMA_VERSION" --arg pack "$PACK_PATH" \
+    '{
+      stream_type: "Verdict",
+      schema_version: $schema_version,
+      timestamp: $ts,
+      source: "construct-validate",
+      verdict: ("[" + $ck + "] " + $msg),
+      severity: $sv,
+      evidence: ([$ev] | map(select(. != ""))),
+      subject: $pack,
+      tags: [$ck]
+    }')
+  FINDINGS+=("$row")
+}
+
+PACK_YAML="$PACK_PATH/construct.yaml"
+if [[ ! -f "$PACK_YAML" ]]; then
+  emit_finding critical construct_yaml "construct.yaml not found in pack root" "$PACK_PATH"
+else
+  PACK_JSON=$(yq -o=json '.' "$PACK_YAML" 2>/dev/null) || PACK_JSON=""
+  if [[ -z "$PACK_JSON" ]]; then
+    emit_finding critical construct_yaml "construct.yaml failed to parse" "$PACK_YAML"
+  else
+    # Required fields
+    for field in schema_version slug name version description; do
+      val=$(echo "$PACK_JSON" | jq -r --arg f "$field" '.[$f] // empty')
+      [[ -z "$val" ]] && emit_finding high required_field "construct.yaml missing required field '$field'" "$PACK_YAML"
+    done
+
+    # skills[].path resolution
+    mapfile -t skills < <(echo "$PACK_JSON" | jq -r '(.skills // [])[] | .path // empty')
+    for s in "${skills[@]}"; do
+      [[ -z "$s" ]] && continue
+      if [[ ! -d "$PACK_PATH/$s" && ! -L "$PACK_PATH/$s" ]]; then
+        emit_finding high skill_path "skills[].path does not resolve: $s" "$PACK_YAML"
+      fi
+    done
+
+    # Commands consistency (if declared) — every commands[].path must exist
+    mapfile -t cmd_paths < <(echo "$PACK_JSON" | jq -r '(.commands // [])[] | .path // empty')
+    for c in "${cmd_paths[@]}"; do
+      [[ -z "$c" ]] && continue
+      if [[ ! -f "$PACK_PATH/$c" ]]; then
+        emit_finding high command_path "commands[].path does not resolve: $c" "$PACK_YAML"
+      fi
+    done
+
+    # F28 gate — pack must declare at least one route: commands OR persona handles
+    cmd_count=$(echo "$PACK_JSON" | jq '(.commands // []) | length')
+    persona_count=0
+    if [[ -d "$PACK_PATH/identity" ]]; then
+      persona_count=$(find "$PACK_PATH/identity" -maxdepth 1 -name '*.md' -print | while read -r f; do base=$(basename "$f" .md); [[ "$base" =~ ^[A-Z][A-Z0-9_]+$ ]] && echo 1; done | wc -l | tr -d ' ')
+    fi
+    listed_personas=$(echo "$PACK_JSON" | jq '(.personas // []) | length')
+    if (( cmd_count == 0 && persona_count == 0 && listed_personas == 0 )); then
+      emit_finding medium route_declared "F28: pack declares neither commands: nor personas — operator can only route by slug/name" "$PACK_YAML"
+    fi
+
+    # Stream declarations — warn if empty
+    reads_count=$(echo "$PACK_JSON" | jq '(.reads // .streams.reads // []) | length')
+    writes_count=$(echo "$PACK_JSON" | jq '(.writes // .streams.writes // []) | length')
+    if (( reads_count == 0 )); then
+      emit_finding low streams "construct declares no 'reads:' stream types — pipe composition will be ambiguous" "$PACK_YAML"
+    fi
+    if (( writes_count == 0 )); then
+      emit_finding low streams "construct declares no 'writes:' stream types — pipe composition will be ambiguous" "$PACK_YAML"
+    fi
+  fi
+fi
+
+# SEED §12 — CLAUDE.md must carry explicit grimoires read/write declaration
+CLAUDE_MD="$PACK_PATH/CLAUDE.md"
+if [[ -f "$CLAUDE_MD" ]]; then
+  if ! grep -qiE 'grimoires?/' "$CLAUDE_MD"; then
+    emit_finding medium grimoires_section \
+      "CLAUDE.md contains no grimoires/ path reference — SEED §12 convention: 'grimoire path IS the interface'" \
+      "$CLAUDE_MD"
+  else
+    # Must reference at least one of: 'Writes to', 'Reads from', 'writes:' or 'reads:'
+    if ! grep -qiE '(writes to|reads from|writes:|reads:)' "$CLAUDE_MD"; then
+      emit_finding medium grimoires_section \
+        "CLAUDE.md mentions grimoires/ but lacks explicit read/write declaration — SEED §12" \
+        "$CLAUDE_MD"
+    fi
+  fi
+else
+  emit_finding medium claude_md "pack is missing CLAUDE.md — operator-facing description not declared" "$PACK_PATH"
+fi
+
+# Exit-code calculation
+worst="info"
+for row in "${FINDINGS[@]}"; do
+  sev=$(echo "$row" | jq -r '.severity')
+  case "$sev" in
+    critical) worst="critical" ;;
+    high) [[ "$worst" != "critical" ]] && worst="high" ;;
+    medium) [[ "$worst" != "critical" && "$worst" != "high" ]] && worst="medium" ;;
+    low) [[ "$worst" == "info" ]] && worst="low" ;;
+  esac
+done
+
+# Output
+if (( OUTPUT_JSON == 1 )); then
+  # Emit JSON array of Verdict rows
+  if (( ${#FINDINGS[@]} == 0 )); then
+    echo "[]"
+  else
+    printf '%s\n' "${FINDINGS[@]}" | jq -s '.'
+  fi
+else
+  echo "# construct-validate · $PACK_PATH"
+  if (( ${#FINDINGS[@]} == 0 )); then
+    echo "  ✓ all checks passed"
+  else
+    for row in "${FINDINGS[@]}"; do
+      sev=$(echo "$row" | jq -r '.severity')
+      msg=$(echo "$row" | jq -r '.verdict')
+      ev=$(echo "$row" | jq -r '.evidence[0] // "-"')
+      printf "  [%s] %s\n    → %s\n" "$sev" "$msg" "$ev"
+    done
+  fi
+  echo "# worst: $worst · total: ${#FINDINGS[@]}"
+fi
+
+case "$worst" in
+  critical|high) exit 1 ;;
+  medium)        (( STRICT )) && exit 1 || exit 0 ;;
+  *) exit 0 ;;
+esac

--- a/.claude/scripts/stream-validate.sh
+++ b/.claude/scripts/stream-validate.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# =============================================================================
+# stream-validate.sh — JSON Schema validator for construct stream rows (cycle-005 L2)
+# =============================================================================
+# Validates a Signal / Verdict / Artifact / Intent / Operator-Model JSON payload
+# against its schema at .claude/schemas/<type-slug>.schema.json.
+#
+# Usage:
+#   stream-validate.sh <stream_type> <json-string>
+#   stream-validate.sh <stream_type> --file <path>
+#   stream-validate.sh <stream_type> -           # read JSON from stdin
+#
+# Stream types: Signal | Verdict | Artifact | Intent | Operator-Model
+#
+# Exit codes:
+#   0 = valid
+#   1 = schema validation failed (message on stderr)
+#   2 = unknown stream type or schema file missing
+#   3 = validator engine unavailable (python3+jsonschema required)
+#
+# Doctrine §3 + §14.2 — stream typing enforced at pipe edges.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+SCHEMA_DIR="${LOA_SCHEMA_DIR:-$PROJECT_ROOT/.claude/schemas}"
+
+usage() {
+  sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Map Stream-Type name → slug used in schema filename.
+schema_slug() {
+  case "$1" in
+    Signal)         echo "signal" ;;
+    Verdict)        echo "verdict" ;;
+    Artifact)       echo "artifact" ;;
+    Intent)         echo "intent" ;;
+    Operator-Model) echo "operator-model" ;;
+    *)              return 1 ;;
+  esac
+}
+
+main() {
+  if [[ $# -lt 2 ]]; then
+    usage >&2
+    exit 2
+  fi
+
+  local stream_type="$1"
+  local arg2="$2"
+  local payload
+
+  local slug
+  if ! slug=$(schema_slug "$stream_type"); then
+    echo "[stream-validate] ERROR: unknown stream_type '$stream_type'. Expected one of: Signal, Verdict, Artifact, Intent, Operator-Model." >&2
+    exit 2
+  fi
+
+  local schema_file="$SCHEMA_DIR/${slug}.schema.json"
+  if [[ ! -f "$schema_file" ]]; then
+    echo "[stream-validate] ERROR: schema file missing: $schema_file" >&2
+    exit 2
+  fi
+
+  if [[ "$arg2" == "--file" ]]; then
+    [[ $# -ge 3 ]] || { echo "[stream-validate] ERROR: --file requires a path argument." >&2; exit 2; }
+    payload=$(cat "$3")
+  elif [[ "$arg2" == "-" ]]; then
+    payload=$(cat -)
+  else
+    payload="$arg2"
+  fi
+
+  # Sanity-check: payload is valid JSON.
+  if ! echo "$payload" | jq -e . >/dev/null 2>&1; then
+    echo "[stream-validate] ERROR: payload is not valid JSON." >&2
+    exit 1
+  fi
+
+  # Sanity-check: declared stream_type matches.
+  local declared
+  declared=$(echo "$payload" | jq -r '.stream_type // empty')
+  if [[ -n "$declared" && "$declared" != "$stream_type" ]]; then
+    echo "[stream-validate] ERROR: payload declares stream_type='$declared' but validator invoked with '$stream_type'." >&2
+    exit 1
+  fi
+
+  # Prefer python3+jsonschema (full draft-07). Fall back to jq required-field check.
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import jsonschema" >/dev/null 2>&1; then
+    local payload_tmp
+    payload_tmp=$(mktemp -t stream-validate-payload.XXXXXX.json)
+    # shellcheck disable=SC2064  # expand trap path now
+    trap "rm -f '$payload_tmp'" EXIT
+    printf '%s' "$payload" > "$payload_tmp"
+    python3 - "$schema_file" "$stream_type" "$payload_tmp" <<'PY'
+import json
+import sys
+
+schema_path, stream_type, payload_path = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    with open(payload_path) as fh:
+        payload = json.load(fh)
+except json.JSONDecodeError as exc:
+    print(f"[stream-validate] ERROR: JSON decode failed: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+with open(schema_path) as fh:
+    schema = json.load(fh)
+
+from jsonschema import Draft7Validator  # type: ignore
+
+validator = Draft7Validator(schema)
+errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path))
+if errors:
+    print(f"[stream-validate] {stream_type} INVALID:", file=sys.stderr)
+    for err in errors[:20]:
+        loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        print(f"  - {loc}: {err.message}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+    exit $?
+  fi
+
+  # Fallback validator — required-field presence only, no full schema semantics.
+  echo "[stream-validate] WARNING: python3/jsonschema missing — running degraded required-field-only validation." >&2
+  local required
+  required=$(jq -r '.required // [] | .[]' "$schema_file")
+  local missing=()
+  while IFS= read -r field; do
+    [[ -z "$field" ]] && continue
+    if ! echo "$payload" | jq -e --arg f "$field" '.[$f] != null' >/dev/null 2>&1; then
+      missing+=("$field")
+    fi
+  done <<< "$required"
+
+  if (( ${#missing[@]} > 0 )); then
+    echo "[stream-validate] $stream_type INVALID: missing required field(s): ${missing[*]}" >&2
+    exit 1
+  fi
+  exit 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.claude/skills/validating-construct-manifest/SKILL.md
+++ b/.claude/skills/validating-construct-manifest/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: validating-construct-manifest
+description: Pre-install / pre-publish manifest linter for construct packs. Emits Verdict stream rows on findings. Gates `constructs install` and `constructs publish` against F28-class breakage and SEED §12 grimoires-convention drift.
+---
+
+# Validating Construct Manifest
+
+> Caught at install-time is cheap. Caught at publish-time still cheap. Caught by an operator at `/feel` not resolving is expensive.
+
+## Purpose
+
+Validate a construct pack directory before it lands in a registry or a local install. Surfaces:
+
+1. **Required-field gates** — missing `schema_version`, `slug`, `name`, `version`, `description` in `construct.yaml`
+2. **Path resolution** — `skills[].path` and `commands[].path` entries that don't resolve
+3. **F28 closure** — pack declares neither `commands:` nor persona handles (operator can only route by slug/name)
+4. **Stream declarations** — empty `reads:` / `writes:` arrays (doctrine §3 pipe compatibility is ambiguous)
+5. **SEED §12 grimoires convention** — `CLAUDE.md` must contain an explicit `grimoires/<path>` read/write declaration; known drift surfaces here
+
+Each finding is a **Verdict stream row** (doctrine §3.2) — severity-tagged, evidence-cited, pipeable downstream.
+
+## Invocation
+
+```bash
+# Run directly (shell-first, no agent needed)
+.claude/scripts/construct-validate.sh <pack-path>
+.claude/scripts/construct-validate.sh <pack-path> --json     # Verdict[] on stdout
+.claude/scripts/construct-validate.sh <pack-path> --strict   # MEDIUM → exit 1
+```
+
+Install / publish integration:
+
+- `constructs-install.sh` calls the validator after license check. Findings print to the console. Set `LOA_STRICT_VALIDATION=1` to abort install on HIGH/CRITICAL.
+- `constructs-publish.sh` adds a `manifest_validate` check to the 10-point pre-publish report.
+
+## Severity tiers
+
+| Tier | Meaning | Install behavior | Publish behavior |
+|------|---------|------------------|------------------|
+| `critical` | `construct.yaml` missing or unparseable | Always blocks | Always blocks |
+| `high`     | Required field missing / broken path | Warn by default, block with `LOA_STRICT_VALIDATION=1` | Blocks |
+| `medium`   | F28 route gap, §12 grimoires drift | Advisory | Advisory (unless `--strict`) |
+| `low`      | Empty stream declarations | Advisory | Advisory |
+| `info`     | All checks passed | — | — |
+
+## Checks in detail
+
+### 1 · construct.yaml presence + parseability (`critical`)
+
+The manifest must exist and yq must parse it. This is the only unrecoverable failure.
+
+### 2 · Required fields (`high`)
+
+`schema_version`, `slug`, `name`, `version`, `description` must all be non-empty. These power the registry listing + resolver tiers.
+
+### 3 · Skill path resolution (`high`)
+
+Every entry in `skills: [{path}]` must resolve to a directory (or symlink) under the pack root.
+
+### 4 · Command path resolution (`high`)
+
+Every entry in `commands: [{path}]` must resolve to a file. Rosenzu-class breakage (commands pointing at skill directories) surfaces here.
+
+### 5 · F28 route declaration (`medium`)
+
+If the pack declares no `commands:` AND no persona handles (either via `personas:` in yaml or `identity/<HANDLE>.md` filenames), the operator can only route by slug/name. This surfaces the gap that made `/feel` un-resolvable in cycle-004.
+
+### 6 · Stream declarations (`low`)
+
+Per doctrine §3, packs should declare `reads:` and `writes:` stream types so the composition runner can verify pipe compatibility. Empty arrays are advisory-level.
+
+### 7 · SEED §12 grimoires convention (`medium`)
+
+`CLAUDE.md` must reference `grimoires/<path>` AND include at least one of: `Writes to`, `Reads from`, `writes:`, `reads:`. This is the convention the `construct-base` template already enforces; installed packs that pre-date the template drifted.
+
+The canary here is `artisan` — its `construct.yaml` declares grimoire paths, but its `CLAUDE.md` does not mirror them. L6 butterfreezone adapter regenerates the missing section.
+
+## Output shape
+
+Default (human-readable):
+
+```
+# construct-validate · /Users/.../packs/artisan
+  [low] [streams] construct declares no 'reads:' stream types — pipe composition will be ambiguous
+    → /Users/.../packs/artisan/construct.yaml
+  [medium] [grimoires_section] CLAUDE.md contains no grimoires/ path reference — SEED §12
+    → /Users/.../packs/artisan/CLAUDE.md
+# worst: medium · total: 2
+```
+
+`--json` emits a JSON array of Verdict rows conforming to `.claude/schemas/verdict.schema.json`. Each row carries:
+
+- `stream_type: "Verdict"`
+- `severity`: critical | high | medium | low
+- `verdict`: `[<check>] <message>`
+- `evidence`: `[<file path>]`
+- `subject`: pack path
+- `tags`: `[<check name>]`
+
+Downstream tools (e.g. `constructs-publish.sh`, dashboard surfaces, CI lint jobs) can consume this array directly.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No HIGH or CRITICAL findings (MEDIUM passes unless `--strict`) |
+| 1 | At least one HIGH/CRITICAL finding, or MEDIUM with `--strict` |
+| 2 | Pack path does not exist / required tooling missing |
+
+## Relationship to other validators
+
+- `constructs-loader.sh validate-pack` — license validation, retained alongside
+- `validate-pack-manifests.mjs` — Zod-based manifest schema check (sandbox packs)
+- `construct-validate.sh` (this) — ecosystem-wide cycle-005 checks, Verdict-emitting
+
+## Related
+
+- Script: `.claude/scripts/construct-validate.sh`
+- Schema: `.claude/schemas/verdict.schema.json`
+- Doctrine: `grimoires/loa-constructs-seed-2026-04-21/bonfire-construct-pipe-doctrine.md` §3.2, §14.2
+- SEED: `grimoires/loa-constructs-seed-2026-04-21/cycle-005-SEED-runtime-integration.md` L4 + §12
+- Sibling skills: `publishing-constructs`, `browsing-constructs`

--- a/.claude/skills/validating-construct-manifest/index.yaml
+++ b/.claude/skills/validating-construct-manifest/index.yaml
@@ -1,0 +1,80 @@
+name: validating-construct-manifest
+version: "1.0.0"
+description: |
+  Pre-install and pre-publish manifest linter for construct packs. Runs
+  F28-class checks (commands / personas declaration), SEED §12 grimoires
+  read/write convention check on CLAUDE.md, and required-field gates on
+  construct.yaml. Emits Verdict stream rows (doctrine §3.2) per finding.
+
+model: haiku
+color: yellow
+
+triggers:
+  - pattern: "/validate-construct"
+    description: "Run manifest checks against a construct pack path"
+
+capabilities:
+  model_tier: haiku
+  danger_level: safe
+  effort_hint: small
+  downgrade_allowed: true
+  execution_hint: sequential
+  requires:
+    native_runtime: false
+    tool_calling: true
+    thinking_traces: false
+    vision: false
+
+dependencies:
+  - tool: yq
+    min_version: "4.0.0"
+    rationale: "Parses construct.yaml"
+  - tool: jq
+    rationale: "Emits Verdict rows + JSON report mode"
+
+inputs:
+  - name: path
+    type: string
+    description: "Path to construct pack directory (contains construct.yaml)"
+    required: true
+  - name: strict
+    type: boolean
+    description: "Treat MEDIUM findings as blocking (exit 1)"
+    required: false
+    default: false
+  - name: json
+    type: boolean
+    description: "Emit findings as a JSON array of Verdict rows on stdout"
+    required: false
+    default: false
+
+outputs:
+  - name: findings
+    type: array
+    description: "List of Verdict stream rows, one per finding"
+  - name: worst_severity
+    type: string
+    description: "Highest severity seen (critical|high|medium|low|info)"
+  - name: exit_code
+    type: integer
+    description: "0 = clean, 1 = has HIGH/CRITICAL (or MEDIUM with --strict), 2 = pack missing"
+
+zones:
+  system: read
+  state: read
+  app: none
+
+streams:
+  reads:
+    - Artifact
+  writes:
+    - Verdict
+
+composes_with:
+  - publishing-constructs
+  - browsing-constructs
+
+related:
+  - script: .claude/scripts/construct-validate.sh
+  - doctrine: grimoires/loa-constructs-seed-2026-04-21/bonfire-construct-pipe-doctrine.md §3.2 §14.2
+  - seed: grimoires/loa-constructs-seed-2026-04-21/cycle-005-SEED-runtime-integration.md L4 + §12


### PR DESCRIPTION
## Summary

Cycle-006 L-migrate — relocates cycle-005-shipped construct connectivity tooling from `loa-constructs` into `loa` proper. Additive only; zero breaking changes. Per [[constructs-as-packages]] §"Four-axis ownership boundary": connectivity tooling (compose, validate, stream-validate, generate) belongs on the computer (Loa); the network (loa-constructs / constructs.network) owns servicing + distribution + installation rules.

## What this PR adds

**Scripts (5):**
- `.claude/scripts/construct-compose.sh` — pipe runner + chain-build-time type compatibility
- `.claude/scripts/construct-invoke.sh` — entry/exit trajectory emission
- `.claude/scripts/construct-validate.sh` — manifest linter (pre-install + pre-publish gate)
- `.claude/scripts/stream-validate.sh` — JSON Schema validator for typed stream rows
- `.claude/scripts/butterfreezone-construct-gen.sh` — CONSTRUCT-README.md auto-generator

**Schemas (5 typed-stream primitives):**
- `signal.schema.json`, `verdict.schema.json`, `artifact.schema.json`, `intent.schema.json`, `operator-model.schema.json`

**Skills (1):**
- `.claude/skills/validating-construct-manifest/` — v3 schema + §12 grimoires convention enforcement

## Why

- **Ownership boundary**: per [[constructs-as-packages]] four-axis split (connectivity / servicing / distribution / installation), these scripts are connectivity. The registry doesn't need to ship the client; the computer should.
- **Cycle-006 builds on these**: loa-constructs cycle-006 L-backend ships `compose-run.sh` + `stage-executor-tmux.sh` on top of `construct-compose.sh` — consumes the cycle-005 `--executor` seam without modification. Operators installing Loa get the full composition runtime without needing loa-constructs as a dependency.
- **Validator + generator are the ecosystem's lint/autofix pair**. They need to be reachable from Loa-default skills, not gated on registry clone.

## Risk

- **Zero breaking changes**: these are net-new additions to Loa. Nothing existing is touched.
- **loa-constructs retains the same scripts** during the transition period — anyone referencing them at their current path continues to work. A future cycle will add a deprecation shim in loa-constructs pointing to the Loa-installed copies.
- **Smoke tested in the fresh loa checkout**:
  - `construct-compose.sh --help` runs clean
  - `stream-validate.sh Signal <valid_row>` exits 0
- Typed-stream schemas are additive to `.claude/schemas/`; no existing schemas modified.
- `validating-construct-manifest` skill is a sibling of the existing `browsing-constructs` skill — consistent with Loa's construct-skill convention.

## Downstream benefits (from cycle-005 findings)

- **F31** (symlink integrity drift in global sync): mechanically addressable via `construct-validate.sh` running on any operator's install.
- **F32** (27 packs §12-drifted): `butterfreezone-construct-gen.sh` as the autofix path. Once this ships, batch regeneration becomes one-command for any operator.

## Request

Review requested. Cycle-006 does NOT gate on merge (per cycle-006 SEED §11 Jani-PR discipline). If changes are requested, I'll iterate in-place. If this PR is rejected or takes longer than the cycle window, L-migrate becomes an in-flight item carried to cycle-007.

**No admin-merge.** This repo is yours; this PR is an opinion, not an imposition.

## Test plan

- [ ] `construct-compose.sh --help` displays usage and exit codes
- [ ] `construct-compose.sh feel-audit --dry-run` (requires a composition YAML at `grimoires/compositions/feel-audit.yaml` — will fail loudly with "composition not found" if not present in this repo, which is expected)
- [ ] `stream-validate.sh Signal '{"stream_type":"Signal",...}'` validates
- [ ] `construct-validate.sh <any installed pack path>` runs
- [ ] `butterfreezone-construct-gen.sh <any installed pack path>` generates a `CONSTRUCT-README.md`

## Provenance

- **Cycle-006 SEED**: `grimoires/loa-constructs-seed-2026-04-21/cycle-006-SEED-agentic-fullstack-runtime.md` §3 AC-migrate.1-6
- **Cycle-005 origin of scripts**: cycle-005 L1 (compose), L2 (schemas), L4 (validator skill), L6 (butterfreezone adapter)
- **Doctrine**: `bonfire-construct-pipe-doctrine.md` v5 + v6 (§18 three-layer architecture)
- **Companion cycle-006 commits in loa-constructs**:
  - `feat(cycle-006 L-backend + L-composition): agentic full-stack runtime + first composition`
  - `feat(cycle-006 L-frontend + L-threadpipe): vibe-coding UI + API contract`
  - `test(cycle-006 L-e2e): website-scaffold trajectory invariants`

## Doctrine references

- [[constructs-as-packages]] §"Four-axis ownership boundary"
- Pipe doctrine v5 §17.4 (grimoires-as-interface)
- Pipe doctrine v6 §18.4 (backend-choice rationale — Unix-native substrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)