### PR TITLE
fix(sprint-3A): add anthropic-version header to /v1/messages probes

### DIFF
--- a/.claude/scripts/model-health-probe.sh
+++ b/.claude/scripts/model-health-probe.sh
@@ -536,10 +536,22 @@ _curl_json() {
     source "$SCRIPT_DIR/lib-security.sh"
     local cfg
     case "$auth_type" in
-        bearer)          cfg=$(write_curl_auth_config "Authorization" "Bearer $api_key") || return 1 ;;
-        x-api-key)       cfg=$(write_curl_auth_config "x-api-key" "$api_key") || return 1 ;;
-        x-goog-api-key)  cfg=$(write_curl_auth_config "x-goog-api-key" "$api_key") || return 1 ;;
-        *)               log_error "unknown auth_type: $auth_type"; return 1 ;;
+        bearer)
+            cfg=$(write_curl_auth_config "Authorization" "Bearer $api_key") || return 1
+            ;;
+        x-api-key)
+            cfg=$(write_curl_auth_config "x-api-key" "$api_key") || return 1
+            # Anthropic /v1/messages requires anthropic-version on every call.
+            # Audit L-1 / Bridgebuilder iter-3 BLOCKING fix; tempfile is 0600.
+            printf 'header = "anthropic-version: 2023-06-01"\n' >> "$cfg"
+            ;;
+        x-goog-api-key)
+            cfg=$(write_curl_auth_config "x-goog-api-key" "$api_key") || return 1
+            ;;
+        *)
+            log_error "unknown auth_type: $auth_type"
+            return 1
+            ;;
     esac
 
     local out_body
@@ -785,20 +797,14 @@ _probe_anthropic() {
 
     local t0 t1
     t0=$(date +%s%3N 2>/dev/null || date +%s000)
+    # _curl_json adds the anthropic-version: 2023-06-01 header automatically
+    # for the x-api-key auth_type (closes Audit L-1 / Bridgebuilder iter-3 BLOCKING).
     _curl_json "https://api.anthropic.com/v1/messages" "x-api-key" "$ANTHROPIC_API_KEY" POST "$body_file"
-    # NOTE: Anthropic also requires an anthropic-version header (Audit L-1, review Concern).
-    # Tracked for sprint-3B before live-API CI gate engages.
     local resp="$RESPONSE_BODY"
     t1=$(date +%s%3N 2>/dev/null || date +%s000)
     PROBE_LATENCY_MS=$((t1 - t0))
     PROBE_HTTP="$HTTP_STATUS"
     rm -f "$body_file"
-
-    # Anthropic also requires anthropic-version header; add via body_file approach:
-    # NOTE: above _curl_json passes content-type but not anthropic-version. In real operation,
-    # anthropic requires "anthropic-version: 2023-06-01". For this script, we use x-api-key
-    # auth + content-type and expect the API to accept a default version. If not, body parse
-    # below will yield schema_mismatch → UNKNOWN (safe default).
 
     case "$HTTP_STATUS" in
         200)

--- a/tests/unit/model-health-probe.bats
+++ b/tests/unit/model-health-probe.bats
@@ -317,6 +317,13 @@ teardown() {
     [ "$PROBE_ERROR_CLASS" = "transient" ]
 }
 
+@test "anthropic auth: x-api-key path appends anthropic-version header (Audit L-1 / iter-3 fix)" {
+    # Static guard: verify _curl_json's x-api-key branch appends the
+    # anthropic-version header. Catches accidental removal of the iter-3
+    # BLOCKING fix that closed the spec-compliance gap with /v1/messages.
+    grep -A 6 'x-api-key)$' "$PROBE" | grep -q 'anthropic-version: 2023-06-01'
+}
+
 # -----------------------------------------------------------------------------
 # --canary non-blocking smoke mode (Flatline SKP-002)
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the Bridgebuilder kaironic iter-3 BLOCKING finding (DISS-001 / Audit L-1) on the cycle-093 sprint-3A merge.

The Anthropic Messages API requires `anthropic-version: 2023-06-01` on every call. The probe was sending only `x-api-key` + `content-type`, so a strict-compliance gateway returns 400 regardless of model — every Anthropic probe degraded to UNKNOWN, leaving zero AVAILABLE signal for one of three providers.

Fix: when `_curl_json` builds a curl config for `auth_type=x-api-key`, append `header = "anthropic-version: 2023-06-01"` to the same 0600 tempfile that holds the `x-api-key` line.

## Scope

- 1 file changed, ~13 lines net (a 4-line append + comment cleanup in `_probe_anthropic`)
- Tightly scoped: only `x-api-key` auth gets the extra header; OpenAI bearer and Google `x-goog-api-key` unchanged.
- New test (54th in `model-health-probe.bats`): static-grep regression guard that asserts the version-header append exists.

## Test plan

- [x] `bats tests/unit/model-health-probe.bats tests/unit/model-health-probe-hardstop.bats` → 54/54 + 8/8
- [x] `bash -n .claude/scripts/model-health-probe.sh`
- [ ] CI on main (Cross-Platform Compatibility, Shell Tests subset, etc.)
- [ ] Confirm no regression in adversarial-review or hallucination-filter suites

## Provenance

- Bridgebuilder iter-1 (12 findings, 0 BLOCKER, 1 HIGH consensus): closed sprint-3A MEDIUM hermetic test isolation
- Bridgebuilder iter-2 (22 findings, 0 BLOCKER, 3 HIGH consensus): closed sprint-2 hardcoded path
- **Bridgebuilder iter-3 (1 finding, BLOCKING)**: this PR. Cost ~$0.02. Hallucination filter: 0 downgrades (real issue).

Provenance file: `grimoires/loa/a2a/sprint-3A/adversarial-review-iter3.json` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)