### PR TITLE
docs(changelog): backfill v1.102.0 entry — cycle-093 sprints 1-3A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.102.0] — 2026-04-25 — Cycle-093 stabilization (sprints 1–3A)
+
+Three Tier-1 silent-failure issues closed plus the keystone health-probe foundation. The probe is implemented and tested but not yet wired into runtime — sprint-3B (resilience + CI workflows + runtime integration) and sprint-4 (registry currency + E2E gate) follow.
+
+### Added
+
+- **Provider health-probe foundation** (T2.2 part 1, sprint-3A) — `.claude/scripts/model-health-probe.sh` (1146+ lines) classifies each registered model as `AVAILABLE | UNAVAILABLE | UNKNOWN` against live provider APIs. Three per-provider adapters (OpenAI `/v1/models`, Google `/v1beta/models`, Anthropic `POST /v1/messages` with `max_tokens:1`), explicit state machine, atomic-write JSON cache (`temp + fsync + mv` under `flock`), lock-free reader retry, per-provider PID sentinel for background-probe dedup, hard-stop budget enforcement (10 probes/run, $0.05 cost cap, 120s total / 30s per call — each emits a `budget_hardstop` trajectory event before exit 5), `--canary` non-blocking smoke mode, `LOA_PROBE_LEGACY_BEHAVIOR=1` emergency fallback with mandatory `probe_legacy_bypass` audit-log entry, env-overridable cache/trajectory/audit paths for hermetic testing. 54 BATS tests (45 main + 8 hardstop + 1 iter-3 regression guard).
+- **Spiral harness adversarial wiring** (T1.1, sprint-1, [#605](https://github.com/0xHoneyJar/loa/issues/605)) — `_run_adversarial_dissent` post-hoc dispatch in `spiral-harness.sh::_gate_review`/`_gate_audit`. Closes the silent no-op gap where `flatline_protocol.code_review.enabled: true` was set but no adversarial pass actually ran.
+- **Bridgebuilder dist artifacts now committed** (T1.2, sprint-2, [#607](https://github.com/0xHoneyJar/loa/issues/607)) — un-ignored `.claude/skills/bridgebuilder-review/dist/` and force-added 36 compiled JS/d.ts/map files. Closes the `ERR_MODULE_NOT_FOUND` failure on first invocation in fresh clones.
+- **Dissenter hallucination filter** (T1.3, sprint-2, [#618](https://github.com/0xHoneyJar/loa/issues/618)) — bidirectional token-match semantics in `adversarial-review.sh` that downgrade dissenter findings claiming `{{DOCUMENT_CONTENT}}` tokens absent from the diff. 6 normalization variants + 15 BATS tests. Earns its keep immediately: caught 2 false-positive hallucinations during sprint-3A's own kaironic Bridgebuilder review.
+
+### Fixed
+
+- **SKP-001 — Anthropic ambiguous-4xx → UNKNOWN** (sprint-3A) — `_probe_anthropic` now rejects any `4xx` lacking explicit `model`-field reference instead of misclassifying as `AVAILABLE`. Two paired regression tests enforce the discriminator.
+- **Anthropic `anthropic-version` header on `/v1/messages`** (sprint-3A iter-3, Audit L-1, [PR #624](https://github.com/0xHoneyJar/loa/pull/624)) — `_curl_json` now appends `header = "anthropic-version: 2023-06-01"` to the secure tempfile when `auth_type=x-api-key`. Without this, every live Anthropic probe degraded to `UNKNOWN`. Static-grep BATS regression guard prevents accidental removal.
+- **Google API key no longer in URL query string** (sprint-3A audit M-1) — `_probe_google` switched to header-only auth (`x-goog-api-key`). The previous `?key=` query parameter leaked via `ps aux`, proxy logs, and CDN access logs.
+- **Hermetic test isolation** (sprint-3A Bridgebuilder iter-1 F8/F-002/F-003) — `LOA_TRAJECTORY_DIR` and `LOA_AUDIT_LOG` env-var overrides on the probe; tests point them at `$TEST_DIR`. Prior tests asserted against `$PROJECT_ROOT/.run/` and could false-pass on stale entries.
+- **`adversarial-review-hallucination-filter.bats` portability** (sprint-2 Bridgebuilder iter-2 HIGH) — replaced hard-coded `/home/merlin/Documents/thj/code/loa/...` path with `$BATS_TEST_FILENAME`-relative resolution. Test now portable for other contributors and CI.
+
+### Quality gates
+
+- **53 + 1 new BATS tests** for sprint-3A; 84 existing adversarial-review and hallucination-filter tests pass with no regression.
+- **Bridgebuilder kaironic review**: 4 iterations, ~$0.05 total. Iter-1 found 3 sprint-3A `MEDIUM` (closed). Iter-2 surfaced 1 sprint-2 `HIGH` (hardcoded path, closed). Iter-3 surfaced 1 `BLOCKING` (anthropic-version header, closed). Iter-4 clean (0 findings).
+- **Adversarial cross-model review** (GPT-5.3-codex via `adversarial-review.sh`) on sprint-3A produced 2 findings, both correctly downgraded by the new sprint-2 hallucination filter — meta-validation of T1.3 within the same release.
+
+### Notes
+
+- Probe is **dead code on `main`** until sprint-3B wires it into `model-adapter.sh` runtime. No production behavior change for operators on this release except for closing #605/#607/#618. Operators currently relying on the hand-allowlist behavior remain unaffected.
+- Tracked follow-ups for sprint-3B: bash error UX on unwritable `--cache-path` (audit L-2), dead `_redact_secrets` cleanup (L-3), sed-based BATS test sourcing pattern (structural, project-wide).
+
 ## [1.101.0] — 2026-04-19 — Spiral SEED environment gate
 
 ### Added


### PR DESCRIPTION
## Summary

`v1.102.0` was auto-tagged at `6d86cff` by the post-merge pipeline when [#624](https://github.com/0xHoneyJar/loa/pull/624) merged. The Simple Release path created the tag but didn't generate a CHANGELOG entry (Full Pipeline Cycle path was skipped due to classifier routing on the bugfix-titled iter-3 fix).

This backfills the `v1.102.0` entry retroactively, matching the pattern used by [PR #595](https://github.com/0xHoneyJar/loa/pull/595) (v1.101.0 backfill) and [PR #593](https://github.com/0xHoneyJar/loa/pull/593) (v1.99.x backfill).

## Test plan

- [ ] CI green (docs-only change)
- [ ] CHANGELOG renders correctly on GitHub releases page

🤖 Generated with [Claude Code](https://claude.com/claude-code)