### PR TITLE
fix(ci): npm ci before bridgebuilder dist smoke import test (#637)

### DIFF
--- a/.github/workflows/bridgebuilder-dist-smoke.yml
+++ b/.github/workflows/bridgebuilder-dist-smoke.yml
@@ -65,6 +65,11 @@ jobs:
             try {
               await import('./dist/main.js');
               console.log('import OK');
+              // dist/main.js is a CLI: top-level imports succeed, then the
+              // CLI's deferred main() runs (env checks, process.exit on
+              // missing API keys). We only care about resolution — exit
+              // before the CLI's deferred main() can run with rc != 0.
+              process.exit(0);
             } catch (e) {
               if (e && e.code === 'ERR_MODULE_NOT_FOUND') {
                 console.error('REGRESSION: ' + e.message);
@@ -72,6 +77,7 @@ jobs:
               }
               // Any other error is acceptable — imports resolved
               console.log('imports resolved (post-import error tolerated in CI)');
+              process.exit(0);
             }
           " || {
             rc=$?

--- a/.github/workflows/bridgebuilder-dist-smoke.yml
+++ b/.github/workflows/bridgebuilder-dist-smoke.yml
@@ -34,6 +34,12 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: .claude/skills/bridgebuilder-review/package-lock.json
+
+      - name: Install bridgebuilder deps
+        run: npm ci
+        working-directory: .claude/skills/bridgebuilder-review
 
       - name: Verify dist/core/multi-model-pipeline.js is tracked
         run: |

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -682,9 +682,22 @@
           "status": "planned"
         }
       ]
+    },
+    {
+      "id": "cycle-bug-20260428-i637-20ddd6",
+      "label": "Bug Fix — bridgebuilder-dist-smoke CI lane fails because workflow does not run npm ci (#637)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/637",
+      "created_at": "2026-04-28T10:24:06Z",
+      "sprints": [
+        "sprint-bug-121"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260428-i637-20ddd6/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260428-i637-20ddd6/sprint.md"
     }
   ],
-  "global_sprint_counter": 120,
+  "global_sprint_counter": 121,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",


### PR DESCRIPTION
## Summary
- Restore signal in the `bridgebuilder-dist-smoke` CI lane by installing the bridgebuilder skill's npm deps before the import smoke test runs.
- Without this, every push since 2026-04-25 produced `REGRESSION: Cannot find package 'zod'` — masking real ERR_MODULE_NOT_FOUND regressions behind a persistent zod false positive.
- Mirrors the existing `.github/workflows/secret-scanning.yml:181-188` `setup-node` + `npm ci` pattern. No System Zone (`.claude/`) files modified.

## Failing-state evidence

5 consecutive failures on `main` cited from `gh run list --workflow bridgebuilder-dist-smoke --limit 5`:

| Run | SHA | Date |
|-----|-----|------|
| [24954037488](https://github.com/0xHoneyJar/loa/actions/runs/24954037488) | 3970e61 | 2026-04-26T10:07Z |
| 24952112682 | 5015c58 | 2026-04-26T08:21Z |
| 24950228414 | 7d151df | 2026-04-26T06:33Z |
| 24947950025 | 7ae3a12 | 2026-04-26T04:11Z |
| 24946649403 | 43b9fe1 | 2026-04-26T02:50Z |

All five fail on the `Import smoke test (no ERR_MODULE_NOT_FOUND)` step with annotation `Import smoke test failed — likely ERR_MODULE_NOT_FOUND regression` — the wrapper's own `::error::` line emitted on `rc != 0`.

## Why `npm ci` (not `npm install`)

The workflow is a regression detector. Lockfile drift would itself be a regression — `npm ci` honors the lockfile and fails fast on drift; `npm install` would silently mutate `package-lock.json`.

## Test plan
- [ ] `bridgebuilder-dist-smoke` workflow on this PR exits 0 on the `Import smoke test` step. Step output contains `import OK` or `imports resolved (post-import error tolerated in CI)` — NOT `REGRESSION:`.
- [ ] No regressions in other lanes: `bats-tests`, `ci`, `lib-tests`, `secret-scanning` remain green on this PR (`gh pr checks`).
- [ ] After merge, the next push to `main` shows the smoke lane green (closes the regression, restores the guard).

Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)