### PR TITLE
fix(mount): structural version resolver — kill /mount stale-stamp regression class (#640)

### DIFF
--- a/.claude/skills/mounting-framework/SKILL.md
+++ b/.claude/skills/mounting-framework/SKILL.md
@@ -168,7 +168,23 @@ cat > .loa-version.json << EOF
 EOF
 
 # Replace placeholder via the SAME resolver /update-loa uses (single source of truth).
-.claude/scripts/update-loa-bump-version.sh --target "$TARGET_VERSION"
+# Fail-loud: if the resolver fails, the manifest is left at __PENDING__ and would
+# poison the trajectory log + NOTES.md. Delete the manifest and exit so the user
+# gets a clear failure instead of a silent stale-stamp.
+if ! .claude/scripts/update-loa-bump-version.sh --target "$TARGET_VERSION"; then
+  echo "❌ Failed to resolve framework_version via update-loa-bump-version.sh"
+  rm -f .loa-version.json
+  exit 1
+fi
+
+# Defense-in-depth: verify the placeholder was actually replaced. Guards against
+# a resolver that exits 0 without patching (e.g., target-validation rejects the
+# value silently, or bump_version_json no-ops on an unexpected match).
+if [[ "$(jq -r '.framework_version' .loa-version.json 2>/dev/null)" == "__PENDING__" ]]; then
+  echo "❌ Resolver returned 0 but framework_version is still __PENDING__"
+  rm -f .loa-version.json
+  exit 1
+fi
 echo "✓ Version manifest created (resolved: $TARGET_VERSION)"
 ```
 
@@ -328,7 +344,12 @@ TRAJECTORY_FILE="grimoires/loa/a2a/trajectory/mounting-$(date +%Y%m%d).jsonl"
 # Never re-template a literal here — this is how prior recurrences (#56, #123, #640) regressed.
 RESOLVED_VERSION=$(jq -r '.framework_version' .loa-version.json)
 
-echo '{"timestamp":"'$MOUNT_DATE'","agent":"mounting-framework","action":"mount","status":"complete","version":"'"$RESOLVED_VERSION"'"}' >> "$TRAJECTORY_FILE"
+# Use jq to construct the JSON line. String concatenation breaks on unusual
+# chars in $RESOLVED_VERSION (quote, newline, backslash) and could produce a
+# malformed JSONL row that breaks downstream parsers. jq handles encoding.
+jq -nc --arg ts "$MOUNT_DATE" --arg v "$RESOLVED_VERSION" \
+  '{timestamp:$ts, agent:"mounting-framework", action:"mount", status:"complete", version:$v}' \
+  >> "$TRAJECTORY_FILE"
 ```
 
 ---

--- a/.claude/skills/mounting-framework/SKILL.md
+++ b/.claude/skills/mounting-framework/SKILL.md
@@ -130,10 +130,28 @@ fi
 
 ### Step 4: Create Version Manifest
 
+The manifest's `framework_version` is resolved from the upstream HEAD that is being mounted. The skill writes a `__PENDING__` placeholder and then delegates to `.claude/scripts/update-loa-bump-version.sh` — the same resolver `/update-loa` uses (Phase 5.6). This makes `/mount` and `/update-loa` share a single source of truth so the version stamp can never go stale relative to the framework files just checked out.
+
 ```bash
+# Resolve target version from the upstream HEAD the user just checked out.
+# Source priority: upstream's .loa-version.json → upstream tag → short SHA fallback.
+# Uses the remote/branch already configured by Step 1 (LOA_REMOTE_NAME=loa-upstream,
+# LOA_BRANCH defaults to main). NOT the same as $LOA_UPSTREAM env var which Step 1
+# overloads as the remote URL — name collision avoided here by composing the ref
+# from the remote name + branch directly.
+LOA_UPSTREAM_REF="loa-upstream/${LOA_BRANCH:-main}"
+TARGET_VERSION=""
+if git show "${LOA_UPSTREAM_REF}":.loa-version.json 2>/dev/null | jq -er '.framework_version' >/dev/null 2>&1; then
+  TARGET_VERSION=$(git show "${LOA_UPSTREAM_REF}":.loa-version.json | jq -r '.framework_version')
+elif git tag --points-at "${LOA_UPSTREAM_REF}" 2>/dev/null | grep -qE '^v[0-9]+\.'; then
+  TARGET_VERSION=$(git tag --points-at "${LOA_UPSTREAM_REF}" | grep -E '^v[0-9]+\.' | head -1 | sed 's/^v//')
+else
+  TARGET_VERSION="0.0.0-unknown-$(git rev-parse --short "${LOA_UPSTREAM_REF}" 2>/dev/null || echo 'nosha')"
+fi
+
 cat > .loa-version.json << EOF
 {
-  "framework_version": "0.6.0",
+  "framework_version": "__PENDING__",
   "schema_version": 2,
   "last_sync": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "zones": {
@@ -148,7 +166,10 @@ cat > .loa-version.json << EOF
   }
 }
 EOF
-echo "✓ Version manifest created"
+
+# Replace placeholder via the SAME resolver /update-loa uses (single source of truth).
+.claude/scripts/update-loa-bump-version.sh --target "$TARGET_VERSION"
+echo "✓ Version manifest created (resolved: $TARGET_VERSION)"
 ```
 
 ### Step 5: Generate Checksums (Anti-Tamper)
@@ -303,19 +324,28 @@ Log mount action to trajectory:
 ```bash
 MOUNT_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TRAJECTORY_FILE="grimoires/loa/a2a/trajectory/mounting-$(date +%Y%m%d).jsonl"
+# Read the resolved version BACK from the manifest written in Step 4.
+# Never re-template a literal here — this is how prior recurrences (#56, #123, #640) regressed.
+RESOLVED_VERSION=$(jq -r '.framework_version' .loa-version.json)
 
-echo '{"timestamp":"'$MOUNT_DATE'","agent":"mounting-framework","action":"mount","status":"complete","version":"0.6.0"}' >> "$TRAJECTORY_FILE"
+echo '{"timestamp":"'$MOUNT_DATE'","agent":"mounting-framework","action":"mount","status":"complete","version":"'"$RESOLVED_VERSION"'"}' >> "$TRAJECTORY_FILE"
 ```
 
 ---
 
 ## NOTES.md Update
 
-After successful mount, add entry to NOTES.md:
+After successful mount, add an entry to NOTES.md. The version field MUST be read from `.loa-version.json` (NOT templated as a literal — that is how prior recurrences #56, #123, and #640 regressed). The agent that runs this step should resolve `${RESOLVED_VERSION}` via:
+
+```bash
+RESOLVED_VERSION=$(jq -r '.framework_version' .loa-version.json)
+```
+
+…and then append the row, substituting the variable into the markdown:
 
 ```markdown
 ## Session Continuity
 | Timestamp | Agent | Summary |
 |-----------|-------|---------|
-| [now] | mounting-framework | Mounted Loa v0.6.0 on repository |
+| [now] | mounting-framework | Mounted Loa v${RESOLVED_VERSION} on repository |
 ```

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -697,7 +697,7 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260428-i637-20ddd6/sprint.md"
     }
   ],
-  "global_sprint_counter": 121,
+  "global_sprint_counter": 122,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -744,6 +744,21 @@
       "triage": "grimoires/loa/a2a/bug-20260418-c05b25/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260418-c05b25/sprint.md",
       "predecessor_pr": "https://github.com/0xHoneyJar/loa/pull/566"
+    }
+  ],
+  "bugfixes": [
+    {
+      "id": "cycle-bug-20260428-i640-1cc190",
+      "label": "Bug Fix — /mount writes stale framework_version: 0.6.0 (THIRD recurrence #640)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/640",
+      "created_at": "2026-04-28T00:00:00Z",
+      "sprints": [
+        "sprint-bug-122"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260428-i640-1cc190/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260428-i640-1cc190/sprint.md"
     }
   ]
 }

--- a/tests/unit/mount-version-resolver.bats
+++ b/tests/unit/mount-version-resolver.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# =============================================================================
+# mount-version-resolver.bats — Regression test for #640 / sprint-bug-122
+# =============================================================================
+# Static-grep regression suite for `.claude/skills/mounting-framework/SKILL.md`.
+#
+# Purpose: prevent recurrence-class #4 of the "/mount writes stale
+# framework_version" defect. Prior recurrences:
+#   #56  (Jan 2026) — original
+#   #123 (Feb 2026) — bumped literal, returned at next release
+#   #640 (Apr 2026) — same literal back at "0.6.0" again
+#
+# The structural fix routes /mount through update-loa-bump-version.sh
+# (single source of truth shared with /update-loa) and reads the version
+# back from .loa-version.json via jq. These tests fail the moment any
+# hardcoded version literal reappears in the SKILL.md template.
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export SKILL_FILE="$PROJECT_ROOT/.claude/skills/mounting-framework/SKILL.md"
+    [[ -f "$SKILL_FILE" ]] || skip "SKILL.md not found at $SKILL_FILE"
+}
+
+@test "SKILL.md must not contain framework_version JSON literal (e.g., \"framework_version\": \"0.6.0\")" {
+    run grep -nE '"framework_version"[[:space:]]*:[[:space:]]*"[0-9]' "$SKILL_FILE"
+    if [[ "$status" -eq 0 ]]; then
+        echo "Found stale framework_version literal(s) — see #640:"
+        echo "$output"
+        return 1
+    fi
+}
+
+@test "SKILL.md must not contain version-string literal in trajectory line (e.g., \"version\":\"0.6.0\")" {
+    run grep -nE '"version"[[:space:]]*:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$SKILL_FILE"
+    if [[ "$status" -eq 0 ]]; then
+        echo "Found stale trajectory version literal(s) — see #640:"
+        echo "$output"
+        return 1
+    fi
+}
+
+@test "SKILL.md must not contain v0.X.Y NOTES.md template literal (e.g., 'Mounted Loa v0.6.0')" {
+    run grep -nE 'Mounted Loa v[0-9]+\.[0-9]+\.[0-9]+' "$SKILL_FILE"
+    if [[ "$status" -eq 0 ]]; then
+        echo "Found stale NOTES.md template literal(s) — see #640:"
+        echo "$output"
+        return 1
+    fi
+}
+
+@test "SKILL.md invokes update-loa-bump-version.sh resolver (single source of truth)" {
+    grep -qF 'update-loa-bump-version.sh' "$SKILL_FILE"
+}
+
+@test "SKILL.md reads version BACK via jq from .loa-version.json (trajectory + NOTES read-back, not just idempotency check)" {
+    # SKILL.md already reads .loa-version.json for the "Loa already mounted"
+    # idempotency check at the top of the skill (~line 49). Post-fix MUST
+    # read it back at LEAST one more time — for the trajectory log + NOTES.md
+    # row that no longer use templated literals. Threshold: >= 2 occurrences.
+    local count
+    count=$(grep -cE 'jq.*-r.*framework_version.*\.loa-version\.json' "$SKILL_FILE" || true)
+    if [[ "$count" -lt 2 ]]; then
+        echo "Expected >= 2 jq read-backs of .loa-version.json (idempotency + trajectory/NOTES); found $count"
+        return 1
+    fi
+}


### PR DESCRIPTION
## Summary
- THIRD recurrence of the `/mount writes stale framework_version` defect (#56 → #123 → #640). This fix eliminates the recurrence class structurally instead of bumping the literal again.
- `/mount` and `/update-loa` now share a single version-resolution source — `.claude/scripts/update-loa-bump-version.sh`. The trajectory log + NOTES.md template read the version BACK from `.loa-version.json` via `jq` instead of re-templating literals.
- New `tests/unit/mount-version-resolver.bats` (5 tests, 3 negative-greps + 2 positive structural assertions) is the regression-class defense — fails on ANY future reintroduction of a hardcoded version literal in the skill template.

## What changed in `.claude/skills/mounting-framework/SKILL.md`

| Line | Before | After |
|------|--------|-------|
| 136 (Step 4 heredoc) | `"framework_version": "0.6.0"` | `"framework_version": "__PENDING__"` (placeholder; resolver overwrites) |
| ~314 (trajectory log) | `"version":"0.6.0"` literal | `RESOLVED_VERSION=$(jq -r .framework_version .loa-version.json)` then `"version":"'"$RESOLVED_VERSION"'"` |
| ~333 (NOTES.md row) | `Mounted Loa v0.6.0` literal | `Mounted Loa v${RESOLVED_VERSION}` with prose telling the agent to populate via `jq` |

A new ~12-line resolution block before the heredoc derives `$TARGET_VERSION` from the upstream HEAD (priority: upstream's `.loa-version.json` → tag with `v` stripped → `0.0.0-unknown-{shortsha}` fallback) and passes it to `update-loa-bump-version.sh --target`.

## Catch during implementation

The triage proposed reusing `LOA_UPSTREAM` as the git ref, but Step 1 of SKILL.md already uses `LOA_UPSTREAM` as the **remote URL** override. A user setting `LOA_UPSTREAM=https://github.com/.../loa.git` would have made `git show https://...:.loa-version.json` fail silently. Renamed to `LOA_UPSTREAM_REF` and computed locally as `loa-upstream/${LOA_BRANCH:-main}`. Documented inline.

## Tests

64/64 pass across all affected suites:

- `tests/unit/mount-version-resolver.bats` (NEW, 5 tests) — 5/5 fail on pre-fix HEAD (verified), 5/5 pass on this branch
- `tests/unit/mount-clean.bats` (13 tests) — no regressions
- `tests/unit/mount-conflicts.bats` (5 tests) — no regressions
- `tests/unit/update-loa-bump.bats` (41 tests) — resolver dependency unchanged; no regressions

```bash
$ bats tests/unit/mount-version-resolver.bats
1..5
ok 1 SKILL.md must not contain framework_version JSON literal
ok 2 SKILL.md must not contain version-string literal in trajectory line
ok 3 SKILL.md must not contain v0.X.Y NOTES.md template literal
ok 4 SKILL.md invokes update-loa-bump-version.sh resolver
ok 5 SKILL.md reads version BACK via jq from .loa-version.json
```

## System Zone authorization

This PR edits `.claude/skills/mounting-framework/SKILL.md` — the System Zone file that IS the bug. Authorized by issue #640 (third recurrence of the same regression class) and by the `/bug` triage flow. The fix necessarily modifies the framework template; there is no override path that could fix this from `.claude/overrides/`.

## Test plan
- [ ] PR CI: `bats-tests` lane green (covers all four affected suites)
- [ ] Manual smoke-test on a fresh repo: `git clone` something, add `loa-upstream` remote, `git fetch`, `git checkout loa-upstream/main -- .claude`, run `/mount`, verify `jq -r .framework_version .loa-version.json` shows the upstream HEAD's version (NOT `__PENDING__` and NOT `0.6.0`)
- [ ] Confirm `/update-loa` still works (resolver dependency — should be unaffected; `update-loa-bump.bats` 41/41 covers this)

Closes #640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)