### PR TITLE
fix(tests): flatline-model-validation array extraction (was 7/15 fail on main)

### DIFF
--- a/tests/unit/flatline-model-validation.bats
+++ b/tests/unit/flatline-model-validation.bats
@@ -2,17 +2,46 @@
 # Unit tests for flatline-orchestrator.sh model validation (issue #305)
 # Tests validate_model(), DEFAULT_MODEL_TIMEOUT, stderr capture, and stagger logic
 
+# Bats quirk: each `@test` runs in a subshell that does not inherit non-exported
+# state from setup() or file-top-level. Bash arrays cannot be exported, so the
+# strategy below is to redefine validate_model as a wrapper that sources
+# generated-model-maps.sh inside its OWN body. That way every `run validate_model`
+# call sees the populated VALID_FLATLINE_MODELS regardless of subshell scoping.
+
 setup() {
     BATS_TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     PROJECT_ROOT="$(cd "$BATS_TEST_DIR/../.." && pwd)"
-    ORCHESTRATOR="$PROJECT_ROOT/.claude/scripts/flatline-orchestrator.sh"
+    export ORCHESTRATOR="$PROJECT_ROOT/.claude/scripts/flatline-orchestrator.sh"
+    export GENERATED_MAPS="$PROJECT_ROOT/.claude/scripts/generated-model-maps.sh"
 
-    # Load validation function and model list from orchestrator (once per test).
-    # Uses awk for robust multi-line extraction instead of fragile sed patterns.
-    eval "$(awk '/^VALID_FLATLINE_MODELS=/{found=1} found{print} found && /^\)/{exit}' "$ORCHESTRATOR")"
-    eval "$(awk '/^validate_model\(\)/{found=1} found{print; if(/^}/)exit}' "$ORCHESTRATOR")"
-    # Stub the error() function (defined elsewhere in the orchestrator)
+    # Stubs for functions defined elsewhere in the orchestrator.
     error() { echo "ERROR: $*" >&2; }
+    log() { echo "$*" >&2; }
+    export -f error log
+
+    # Extract the orchestrator's validate_model() definition and rename it so
+    # we can wrap it with a fresh-source-each-call wrapper (see below).
+    local fn_src
+    fn_src=$(awk '/^validate_model\(\)/{found=1} found{print; if(/^}/)exit}' "$ORCHESTRATOR")
+    # Rename the extracted function to _real_validate_model.
+    fn_src="${fn_src/validate_model()/_real_validate_model()}"
+    eval "$fn_src"
+
+    # Extract VALID_MODEL_PATTERNS (top-level definition).
+    eval "$(awk '/^VALID_MODEL_PATTERNS=/{found=1} found{print} found && /^\)/{exit}' "$ORCHESTRATOR")"
+
+    # Wrapper: sources VALID_FLATLINE_MODELS fresh into the call's local scope
+    # (combined with `declare -ga`-style re-export below) before delegating.
+    # This avoids the bats-subshell-vs-bash-array visibility issue: arrays
+    # cannot be exported across subshell boundaries, but a freshly-sourced
+    # generated-model-maps.sh inside the function body brings the array into
+    # validate_model's own scope so the for-loop sees it.
+    validate_model() {
+        # shellcheck source=/dev/null
+        [[ -f "$GENERATED_MAPS" ]] && source "$GENERATED_MAPS"
+        _real_validate_model "$@"
+    }
+    export -f validate_model _real_validate_model
 }
 
 # =============================================================================
@@ -49,11 +78,16 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
-@test "validate_model rejects 'reviewer' with actionable error" {
-    run validate_model "reviewer" "secondary"
+@test "validate_model rejects an unknown name with actionable error" {
+    # Note: this test originally used 'reviewer' as the rejection example.
+    # cycle-093 sprint-4 (T4.2) added 'reviewer' (and other aliases) to the
+    # SSOT-derived VALID_FLATLINE_MODELS array — aliases are now valid
+    # flatline model names by design. Use a name that's neither in the array
+    # nor matches any forward-compat pattern to exercise the rejection path.
+    run validate_model "agent-style-bogus-name" "secondary"
     [ "$status" -eq 1 ]
     [[ "$output" == *"Unknown flatline model"* ]]
-    [[ "$output" == *"reviewer"* ]]
+    [[ "$output" == *"agent-style-bogus-name"* ]]
     [[ "$output" == *".loa.config.yaml"* ]]
     [[ "$output" == *"agent alias"* ]]
 }
@@ -77,7 +111,13 @@ setup() {
 }
 
 @test "error message includes valid model list" {
-    run validate_model "reviewer" "secondary"
+    # Use a model name that's definitively NOT in the array AND doesn't match
+    # any forward-compat pattern, so validate_model falls through to the
+    # error-path which prints `Known-good models: ${VALID_FLATLINE_MODELS[*]}`.
+    run validate_model "definitely-not-a-real-model-zzz" "secondary"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown flatline model"* ]]
+    # Two well-known sentinels from the SSOT-derived list.
     [[ "$output" == *"opus"* ]]
     [[ "$output" == *"gpt-5.2"* ]]
 }


### PR DESCRIPTION
## Summary
- Fixes 7 of the long-standing Shell Tests failures on main: the validate_model accept/reject test cluster in `tests/unit/flatline-model-validation.bats`.
- Root cause: bats setup() awk-extracted `VALID_FLATLINE_MODELS` via `^VALID_FLATLINE_MODELS=` anchor, but the orchestrator defines the array as `    declare -a VALID_FLATLINE_MODELS=(...)` (indented inside an `else`, prefixed with `declare -a`). Anchor never matched → array empty → most validation tests failed.
- Also addresses array-not-inherited-by-bats-subshell issue with a wrapper that sources the SSOT maps fresh inside each `validate_model` call.

## What changed

`tests/unit/flatline-model-validation.bats:5-46`:

1. **Source the SSOT generator output** (`generated-model-maps.sh`) instead of trying to awk-extract from the orchestrator's indented declaration. This is the same file the orchestrator sources at runtime — single source of truth for the array contents.

2. **Add VALID_MODEL_PATTERNS extraction** (was missing entirely from the original setup; the forward-compat regex patterns weren't loaded so no fallback path either).

3. **Wrap `validate_model` with a fresh-source-each-call helper.** Bash arrays cannot cross subshell boundaries (no `export -a`), and bats `@test` runs in a subshell that doesn't inherit non-exported state. The wrapper sources `generated-model-maps.sh` inside its own body, putting the array in the call's scope, then delegates to a renamed `_real_validate_model`.

`tests/unit/flatline-model-validation.bats:69, 96`:

4. **Test-data drift cleanup.** Two tests had stale expectations: cycle-093 sprint-4 added `reviewer` (and other aliases) to `VALID_FLATLINE_MODELS`, so the previously-broken array masked the fact that those tests no longer exercise the rejection path. Replaced `reviewer` test inputs with clearly-bogus names that still hit the rejection error-path.

## Verification

```bash
$ bats tests/unit/flatline-model-validation.bats
1..15
ok 1 validate_model accepts 'opus'
ok 2 validate_model accepts 'gpt-5.2'
ok 3 validate_model accepts 'claude-opus-4.6'
ok 4 validate_model accepts 'claude-opus-4.7' (cycle-082)
ok 5 validate_model accepts 'claude-opus-4-7' (cycle-082 canonical)
ok 6 validate_model accepts 'gemini-2.0'
ok 7 validate_model rejects an unknown name with actionable error
ok 8 validate_model rejects 'skeptic'
ok 9 validate_model rejects empty string
ok 10 validate_model rejects 'nonexistent'
ok 11 error message includes valid model list
ok 12 DEFAULT_MODEL_TIMEOUT is at least 120 seconds
ok 13 Phase 1 call_model lines do not redirect stderr to /dev/null
ok 14 Phase 1 uses stderr capture files for all 4 calls
ok 15 Phase 1 includes stagger sleep between review and skeptic waves
```

15/15 pass. Pre-fix: 8/15 (verified by checking out main and running the same suite).

## Why these tests passed at all on main

Tests 7-10 (the "rejects" tests) passed on main only because the bogus inputs (`skeptic`, `nonexistent`, empty string) don't match the forward-compat regex patterns either. They got rejected as the test expected — but for the wrong reason (not because of the array, but because nothing was being checked).

## Test plan
- [ ] PR CI bats lane: `tests/unit/flatline-model-validation.bats` 15/15
- [ ] No regressions in other bats suites

This is the FIRST cluster of pre-existing Shell Tests failures on main. Five more clusters remain (`release-notes:`, `search-orchestrator`, self-heal-state's `check-only`/NOTES.md, `DISCOVERY_TIMEOUT` spiral) — each will land as a separate small fix PR when triaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)