### PR TITLE
fix(post-merge): scaffold workflow on mount + submodules:recursive (#669)

### DIFF
--- a/.claude/scripts/lib/scaffold-post-merge-workflow.sh
+++ b/.claude/scripts/lib/scaffold-post-merge-workflow.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scaffold-post-merge-workflow.sh — single source of truth for #669 scaffold
+# =============================================================================
+# Bridgebuilder F2 + F6 (PR #671): the scaffold helper used to live in three
+# places (mount-loa.sh, mount-submodule.sh, and an inline copy in
+# tests/unit/mount-workflow-scaffold.bats), held together by a "keep in sync"
+# comment. Three-way duplication is exactly the maintenance hazard the
+# Bridgebuilder flagged — drift between test fixture and production passes
+# tests while breaking users.
+#
+# This lib is the canonical implementation. Sourced by both installer
+# scripts AND the test file so the test exercises the same code that runs
+# in production. Pattern mirrors lib/portable-realpath.sh and
+# lib/flatline-exit-classifier.sh.
+#
+# Usage (sourced):
+#   source scaffold-post-merge-workflow.sh
+#   scaffold_post_merge_workflow [source_path]
+#
+# Args:
+#   $1 — optional absolute path to a workflow file. When empty/absent,
+#        the helper falls through to `git checkout
+#        $LOA_REMOTE_NAME/$LOA_BRANCH -- .github/workflows/post-merge.yml`.
+#
+# Behavior:
+#   - Idempotent: if `.github/workflows/post-merge.yml` already exists,
+#     preserves it (matches sync_optional_file semantics)
+#   - Mode-agnostic: direct mode passes empty (uses git checkout fallback);
+#     submodule mode passes the in-tree submodule path
+#   - Always returns 0 (best-effort scaffold; never aborts the installer)
+# =============================================================================
+
+scaffold_post_merge_workflow() {
+    local source_path="${1:-}"
+    local target=".github/workflows/post-merge.yml"
+
+    if [[ -f "$target" ]]; then
+        # Idempotency: preserve user-customized workflow on re-mount
+        return 0
+    fi
+
+    mkdir -p .github/workflows
+
+    if [[ -n "$source_path" && -f "$source_path" ]]; then
+        cp "$source_path" "$target"
+        return 0
+    fi
+
+    # Fallback: git checkout from configured upstream (direct-install mode)
+    if [[ -n "${LOA_REMOTE_NAME:-}" && -n "${LOA_BRANCH:-}" ]]; then
+        git checkout "$LOA_REMOTE_NAME/$LOA_BRANCH" -- "$target" 2>/dev/null || true
+    fi
+
+    return 0
+}

--- a/.claude/scripts/mount-loa.sh
+++ b/.claude/scripts/mount-loa.sh
@@ -616,6 +616,10 @@ sync_zones() {
   # Create .reviewignore template for review scope filtering (FR-4, #303)
   create_reviewignore
 
+  # Scaffold post-merge automation workflow (#669). Idempotent: preserves a
+  # user-customized .github/workflows/post-merge.yml on re-mount.
+  scaffold_post_merge_workflow ""
+
   mkdir -p .beads
   touch .beads/.gitkeep
 
@@ -877,6 +881,35 @@ sync_optional_file() {
   git checkout "$LOA_REMOTE_NAME/$LOA_BRANCH" -- "$file" 2>/dev/null || {
     warn "No $file in upstream, skipping..."
   }
+}
+
+# Issue #669: scaffold post-merge automation workflow on first mount.
+# Idempotent (preserves user-customized workflow). Mode-agnostic helper:
+# direct-mode callers omit $1 to fall through to the upstream git checkout;
+# submodule-mode callers pass the in-tree submodule path.
+scaffold_post_merge_workflow() {
+  local source_path="${1:-}"
+  local target=".github/workflows/post-merge.yml"
+
+  if [[ -f "$target" ]]; then
+    log "$target already exists, preserving..."
+    return 0
+  fi
+
+  mkdir -p .github/workflows
+
+  if [[ -n "$source_path" && -f "$source_path" ]]; then
+    cp "$source_path" "$target"
+    log "Scaffolded $target from $source_path"
+    return 0
+  fi
+
+  log "Scaffolding $target from upstream..."
+  if git checkout "$LOA_REMOTE_NAME/$LOA_BRANCH" -- "$target" 2>/dev/null; then
+    log "Scaffolded $target"
+  else
+    warn "post-merge.yml not in upstream, skipping (post-merge automation will be inert)"
+  fi
 }
 
 # Orchestrate root file synchronization

--- a/.claude/scripts/mount-loa.sh
+++ b/.claude/scripts/mount-loa.sh
@@ -883,34 +883,11 @@ sync_optional_file() {
   }
 }
 
-# Issue #669: scaffold post-merge automation workflow on first mount.
-# Idempotent (preserves user-customized workflow). Mode-agnostic helper:
-# direct-mode callers omit $1 to fall through to the upstream git checkout;
-# submodule-mode callers pass the in-tree submodule path.
-scaffold_post_merge_workflow() {
-  local source_path="${1:-}"
-  local target=".github/workflows/post-merge.yml"
-
-  if [[ -f "$target" ]]; then
-    log "$target already exists, preserving..."
-    return 0
-  fi
-
-  mkdir -p .github/workflows
-
-  if [[ -n "$source_path" && -f "$source_path" ]]; then
-    cp "$source_path" "$target"
-    log "Scaffolded $target from $source_path"
-    return 0
-  fi
-
-  log "Scaffolding $target from upstream..."
-  if git checkout "$LOA_REMOTE_NAME/$LOA_BRANCH" -- "$target" 2>/dev/null; then
-    log "Scaffolded $target"
-  else
-    warn "post-merge.yml not in upstream, skipping (post-merge automation will be inert)"
-  fi
-}
+# Issue #669 / Bridgebuilder F6 (PR #671): scaffold helper extracted to
+# .claude/scripts/lib/scaffold-post-merge-workflow.sh as single source of
+# truth (sourced by both installers AND the bats test).
+# shellcheck source=lib/scaffold-post-merge-workflow.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/scaffold-post-merge-workflow.sh"
 
 # Orchestrate root file synchronization
 sync_root_files() {

--- a/.claude/scripts/mount-submodule.sh
+++ b/.claude/scripts/mount-submodule.sh
@@ -253,30 +253,18 @@ relocate_memory_stack() {
   log "Memory Stack relocated: .loa/ -> .loa-state/ ($source_count files)"
 }
 
-# Issue #669: scaffold post-merge automation workflow from the submodule's
-# in-tree copy. Submodule mode copies (not symlinks) the workflow file into
-# the consumer repo's .github/workflows/ — GitHub Actions ignores symlinked
-# workflow files, and consumer-side customization should be possible. The
-# scaffolded workflow's actions/checkout MUST set `submodules: recursive`
-# (baked into the upstream workflow file) so the .claude/scripts/* symlinks
-# resolve at runtime. Idempotent (preserves user-customized workflow).
-scaffold_post_merge_workflow() {
-  local source_path="${1:-$SUBMODULE_PATH/.github/workflows/post-merge.yml}"
-  local target=".github/workflows/post-merge.yml"
+# Issue #669 / Bridgebuilder F6 (PR #671): scaffold helper sourced from the
+# canonical lib. Submodule mode passes the in-tree submodule path as
+# default source. Submodule installs copy (not symlink) the workflow file
+# into the consumer's .github/workflows/ — GH Actions ignores symlinked
+# workflow files, and consumer-side customization should be possible.
+# shellcheck source=lib/scaffold-post-merge-workflow.sh
+SCRIPT_DIR_FOR_SCAFFOLD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR_FOR_SCAFFOLD}/lib/scaffold-post-merge-workflow.sh"
 
-  if [[ -f "$target" ]]; then
-    log "$target already exists, preserving..."
-    return 0
-  fi
-
-  if [[ ! -f "$source_path" ]]; then
-    warn "post-merge.yml not in submodule ($source_path), skipping (post-merge automation will be inert)"
-    return 0
-  fi
-
-  mkdir -p .github/workflows
-  cp "$source_path" "$target"
-  log "Scaffolded $target from $source_path"
+# Submodule mode wrapper — defaults source path to the in-tree submodule copy
+scaffold_post_merge_workflow_submodule() {
+    scaffold_post_merge_workflow "${1:-$SUBMODULE_PATH/.github/workflows/post-merge.yml}"
 }
 
 # === Auto-Init Submodule (post-clone recovery) ===
@@ -957,7 +945,7 @@ main() {
   create_config
   create_manifest
   init_state_zone
-  scaffold_post_merge_workflow
+  scaffold_post_merge_workflow_submodule
   create_commit
 
   echo ""

--- a/.claude/scripts/mount-submodule.sh
+++ b/.claude/scripts/mount-submodule.sh
@@ -253,6 +253,32 @@ relocate_memory_stack() {
   log "Memory Stack relocated: .loa/ -> .loa-state/ ($source_count files)"
 }
 
+# Issue #669: scaffold post-merge automation workflow from the submodule's
+# in-tree copy. Submodule mode copies (not symlinks) the workflow file into
+# the consumer repo's .github/workflows/ — GitHub Actions ignores symlinked
+# workflow files, and consumer-side customization should be possible. The
+# scaffolded workflow's actions/checkout MUST set `submodules: recursive`
+# (baked into the upstream workflow file) so the .claude/scripts/* symlinks
+# resolve at runtime. Idempotent (preserves user-customized workflow).
+scaffold_post_merge_workflow() {
+  local source_path="${1:-$SUBMODULE_PATH/.github/workflows/post-merge.yml}"
+  local target=".github/workflows/post-merge.yml"
+
+  if [[ -f "$target" ]]; then
+    log "$target already exists, preserving..."
+    return 0
+  fi
+
+  if [[ ! -f "$source_path" ]]; then
+    warn "post-merge.yml not in submodule ($source_path), skipping (post-merge automation will be inert)"
+    return 0
+  fi
+
+  mkdir -p .github/workflows
+  cp "$source_path" "$target"
+  log "Scaffolded $target from $source_path"
+}
+
 # === Auto-Init Submodule (post-clone recovery) ===
 auto_init_submodule() {
   if [[ -f ".gitmodules" ]] && grep -q "$SUBMODULE_PATH" .gitmodules 2>/dev/null; then
@@ -931,6 +957,7 @@ main() {
   create_config
   create_manifest
   init_state_zone
+  scaffold_post_merge_workflow
   create_commit
 
   echo ""

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -5,6 +5,29 @@ on:
   push:
     branches: [main]
 
+# =============================================================================
+# Issue #669 / Bridgebuilder F-001 (PR #671): submodule recursion decision trail
+# =============================================================================
+# All `actions/checkout` steps below set `submodules: recursive`. Required for
+# Loa's submodule install mode where `.claude/scripts/*` are symlinks into the
+# `.loa/` submodule — without recursion, runtime hits `exit-127: No such file
+# or directory: .claude/scripts/classify-pr-type.sh`.
+#
+# Trade-off (security): consumers with their own (non-Loa) submodules will now
+# also fetch them on every post-merge run. Mitigations:
+#   1. GH Actions runner does NOT execute submodule post-checkout hooks; the
+#      recursive fetch only places source files on the runner disk.
+#   2. The workflow token's permissions (`contents: write, pull-requests:
+#      write, actions: read`) bound the blast radius of any malicious
+#      submodule content.
+#   3. Consumers should review their `.gitmodules` before adding new entries
+#      to avoid pinning untrusted sources.
+#
+# If a future job demonstrably does not need submodules, downgrade to
+# `submodules: false` for that job specifically — but keep the default at
+# `recursive` so the symlink-resolution failure mode does not return.
+# =============================================================================
+
 # Permissions required for tag creation, release, PR comments
 permissions:
   contents: write

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -32,6 +32,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          # Issue #669: submodule installs symlink .claude/scripts/* into the
+          # submodule. Without `submodules: recursive`, runtime invocation
+          # fails with `exit-127: No such file or directory`. No-op on
+          # non-submodule consumer repos.
+          submodules: recursive
 
       - name: Classify PR type
         id: classify
@@ -67,6 +72,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          # Issue #669: submodule installs symlink .claude/scripts/* into the
+          # submodule. Without `submodules: recursive`, runtime invocation
+          # fails with `exit-127: No such file or directory`. No-op on
+          # non-submodule consumer repos.
+          submodules: recursive
 
       - name: Install jq
         run: sudo apt-get install -y jq
@@ -136,6 +146,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          # Issue #669: submodule installs symlink .claude/scripts/* into the
+          # submodule. Without `submodules: recursive`, runtime invocation
+          # fails with `exit-127: No such file or directory`. No-op on
+          # non-submodule consumer repos.
+          submodules: recursive
 
       - name: Configure git identity
         run: |

--- a/.loa.config.yaml.example
+++ b/.loa.config.yaml.example
@@ -1916,6 +1916,12 @@ agent_teams:
 # =============================================================================
 # Automated post-merge pipeline triggered on push to main.
 # 3-layer architecture: GH Actions → claude-code-action → shell orchestrator.
+#
+# Workflow file `.github/workflows/post-merge.yml` is scaffolded automatically
+# by `mount-loa.sh` / `mount-submodule.sh` on first install (Issue #669) and
+# preserved on re-mount. Submodule installs require `submodules: recursive`
+# on actions/checkout (baked into the upstream template) so symlinked
+# `.claude/scripts/*` paths resolve at runtime.
 post_merge:
   # Master toggle — must be true for GH Actions workflow to process merges
   enabled: false

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -757,9 +757,30 @@
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/652",
       "archived": "2026-05-02T06:11:32Z",
       "archive_path": "grimoires/loa/archive/2026-05-02-cycle-096-aws-bedrock"
+    },
+    {
+      "id": "cycle-bug-20260502-i669-55150d",
+      "label": "Bug Fix — post-merge automation: orchestrator scripts ship without an invoking workflow template",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/669",
+      "created_at": "2026-05-02T08:46:16Z",
+      "prd": null,
+      "sdd": null,
+      "sprints": [
+        {
+          "local_id": 1,
+          "global_id": 130,
+          "label": "post-merge workflow scaffold gap on downstream installs",
+          "status": "planned",
+          "bug_id": "20260502-i669-55150d",
+          "triage": "grimoires/loa/a2a/bug-20260502-i669-55150d/triage.md",
+          "sprint_plan": "grimoires/loa/a2a/bug-20260502-i669-55150d/sprint.md"
+        }
+      ]
     }
   ],
-  "global_sprint_counter": 129,
+  "global_sprint_counter": 130,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/mount-workflow-scaffold.bats
+++ b/tests/unit/mount-workflow-scaffold.bats
@@ -1,0 +1,169 @@
+#!/usr/bin/env bats
+# =============================================================================
+# mount-workflow-scaffold.bats — Tests for scaffold_post_merge_workflow (#669)
+# =============================================================================
+# sprint-bug-130. Validates that mount installs a runnable
+# .github/workflows/post-merge.yml in the consumer repo and that the
+# scaffolded file includes `submodules: recursive` on actions/checkout
+# (required for the submodule-install mode where .claude/scripts/* are
+# symlinks into the submodule).
+#
+# Pattern mirrors tests/unit/mount-clean.bats: function under test is
+# defined inline in setup so the bats can run in isolation without
+# sourcing mount-loa.sh / mount-submodule.sh (which have main "$@"
+# guards that side-effect on source).
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export TARGET_DIR="$TEST_DIR"
+
+    # Fixture upstream workflow file — represents what `git checkout
+    # $REMOTE/$BRANCH -- .github/workflows/post-merge.yml` would produce
+    # OR what a submodule mode mount would copy from $SUBMODULE_PATH.
+    FIXTURE_DIR="$TEST_DIR/_upstream"
+    mkdir -p "$FIXTURE_DIR/.github/workflows"
+    cat > "$FIXTURE_DIR/.github/workflows/post-merge.yml" <<'YAML'
+name: Post-Merge Pipeline
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Classify
+        run: .claude/scripts/classify-merge-pr.sh --merge-sha "$MERGE_SHA"
+YAML
+
+    cd "$TEST_DIR"
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+# =============================================================================
+# Function under test — keep in sync with mount-loa.sh / mount-submodule.sh
+# implementations. The shape is intentionally minimal: one source-aware
+# helper, idempotent, mode-agnostic.
+# =============================================================================
+scaffold_post_merge_workflow() {
+    local source_path="${1:-}"
+    local target=".github/workflows/post-merge.yml"
+
+    if [[ -f "$target" ]]; then
+        return 0
+    fi
+
+    mkdir -p .github/workflows
+
+    if [[ -n "$source_path" && -f "$source_path" ]]; then
+        cp "$source_path" "$target"
+        return 0
+    fi
+
+    # Fallback: not provided + no git remote → graceful no-op (caller logs)
+    return 0
+}
+
+# =========================================================================
+# MWS-T1..T2: idempotency (preserve user customization)
+# =========================================================================
+
+@test "MWS-T1: writes target when absent + valid source" {
+    scaffold_post_merge_workflow "$FIXTURE_DIR/.github/workflows/post-merge.yml"
+    [ -f "$TEST_DIR/.github/workflows/post-merge.yml" ]
+}
+
+@test "MWS-T2: preserves existing target (idempotency)" {
+    mkdir -p .github/workflows
+    echo "# user-customized workflow" > .github/workflows/post-merge.yml
+    scaffold_post_merge_workflow "$FIXTURE_DIR/.github/workflows/post-merge.yml"
+    run cat .github/workflows/post-merge.yml
+    [ "$output" = "# user-customized workflow" ]
+}
+
+# =========================================================================
+# MWS-T3..T5: structural validity of the scaffolded YAML
+# =========================================================================
+
+@test "MWS-T3: scaffolded workflow names a workflow and triggers on push to main" {
+    scaffold_post_merge_workflow "$FIXTURE_DIR/.github/workflows/post-merge.yml"
+    run grep -E "^name:" "$TEST_DIR/.github/workflows/post-merge.yml"
+    [ "$status" -eq 0 ]
+    run grep -E "branches:.*\[main\]|branches: \[ main \]" "$TEST_DIR/.github/workflows/post-merge.yml"
+    [ "$status" -eq 0 ]
+}
+
+@test "MWS-T4: scaffolded workflow references classify-merge-pr.sh OR post-merge-orchestrator.sh" {
+    scaffold_post_merge_workflow "$FIXTURE_DIR/.github/workflows/post-merge.yml"
+    grep -qE "(classify-merge-pr|post-merge-orchestrator)\.sh" "$TEST_DIR/.github/workflows/post-merge.yml"
+}
+
+@test "MWS-T5: scaffolded workflow includes submodules: recursive on actions/checkout (#669 symlink fix)" {
+    scaffold_post_merge_workflow "$FIXTURE_DIR/.github/workflows/post-merge.yml"
+    grep -qE "submodules:\s*recursive" "$TEST_DIR/.github/workflows/post-merge.yml"
+}
+
+# =========================================================================
+# MWS-T6: empty source path → graceful no-op (mount-loa.sh git fallback path)
+# =========================================================================
+
+@test "MWS-T6: empty source path → no file written, no error" {
+    scaffold_post_merge_workflow ""
+    [ ! -f "$TEST_DIR/.github/workflows/post-merge.yml" ]
+}
+
+# =========================================================================
+# MWS-T7: nonexistent source path → graceful no-op
+# =========================================================================
+
+@test "MWS-T7: nonexistent source path → no file written, no error" {
+    scaffold_post_merge_workflow "$TEST_DIR/_does_not_exist/post-merge.yml"
+    [ ! -f "$TEST_DIR/.github/workflows/post-merge.yml" ]
+}
+
+# =========================================================================
+# MWS-T8: live source-of-truth — repo's actual upstream workflow
+# (validates the submodules: recursive change to post-merge.yml landed)
+# =========================================================================
+
+@test "MWS-T8: repo's .github/workflows/post-merge.yml has submodules: recursive on every actions/checkout" {
+    local upstream_workflow="$BATS_TEST_DIRNAME/../../.github/workflows/post-merge.yml"
+    [ -f "$upstream_workflow" ]
+    # Count actions/checkout invocations and submodules: recursive entries
+    local checkout_count submodules_count
+    checkout_count=$(grep -cE "uses:\s*actions/checkout" "$upstream_workflow" || echo 0)
+    submodules_count=$(grep -cE "submodules:\s*recursive" "$upstream_workflow" || echo 0)
+    # Every checkout must have a matching submodules: recursive
+    [ "$checkout_count" -gt 0 ]
+    [ "$submodules_count" -ge "$checkout_count" ]
+}
+
+# =========================================================================
+# MWS-T9: mount-loa.sh defines scaffold_post_merge_workflow
+# =========================================================================
+
+@test "MWS-T9: mount-loa.sh defines scaffold_post_merge_workflow" {
+    local script="$BATS_TEST_DIRNAME/../../.claude/scripts/mount-loa.sh"
+    grep -qE "^scaffold_post_merge_workflow\(\)" "$script"
+}
+
+# =========================================================================
+# MWS-T10: mount-submodule.sh defines scaffold_post_merge_workflow
+# =========================================================================
+
+@test "MWS-T10: mount-submodule.sh defines scaffold_post_merge_workflow" {
+    local script="$BATS_TEST_DIRNAME/../../.claude/scripts/mount-submodule.sh"
+    grep -qE "^scaffold_post_merge_workflow\(\)" "$script"
+}

--- a/tests/unit/mount-workflow-scaffold.bats
+++ b/tests/unit/mount-workflow-scaffold.bats
@@ -17,6 +17,14 @@ setup() {
     TEST_DIR="$(mktemp -d)"
     export TARGET_DIR="$TEST_DIR"
 
+    # Bridgebuilder F2/F6 (PR #671): test exercises the REAL production
+    # function via lib/scaffold-post-merge-workflow.sh. No more inline
+    # fixture copy — drift between test and production is impossible
+    # because they are now the same code.
+    PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    # shellcheck source=../../.claude/scripts/lib/scaffold-post-merge-workflow.sh
+    source "$PROJECT_ROOT/.claude/scripts/lib/scaffold-post-merge-workflow.sh"
+
     # Fixture upstream workflow file — represents what `git checkout
     # $REMOTE/$BRANCH -- .github/workflows/post-merge.yml` would produce
     # OR what a submodule mode mount would copy from $SUBMODULE_PATH.
@@ -43,6 +51,9 @@ jobs:
         run: .claude/scripts/classify-merge-pr.sh --merge-sha "$MERGE_SHA"
 YAML
 
+    # Ensure the lib's git-checkout fallback is inert in the test environment
+    unset LOA_REMOTE_NAME LOA_BRANCH
+
     cd "$TEST_DIR"
 }
 
@@ -50,30 +61,6 @@ teardown() {
     if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
         rm -rf "$TEST_DIR"
     fi
-}
-
-# =============================================================================
-# Function under test — keep in sync with mount-loa.sh / mount-submodule.sh
-# implementations. The shape is intentionally minimal: one source-aware
-# helper, idempotent, mode-agnostic.
-# =============================================================================
-scaffold_post_merge_workflow() {
-    local source_path="${1:-}"
-    local target=".github/workflows/post-merge.yml"
-
-    if [[ -f "$target" ]]; then
-        return 0
-    fi
-
-    mkdir -p .github/workflows
-
-    if [[ -n "$source_path" && -f "$source_path" ]]; then
-        cp "$source_path" "$target"
-        return 0
-    fi
-
-    # Fallback: not provided + no git remote → graceful no-op (caller logs)
-    return 0
 }
 
 # =========================================================================
@@ -141,29 +128,50 @@ scaffold_post_merge_workflow() {
 @test "MWS-T8: repo's .github/workflows/post-merge.yml has submodules: recursive on every actions/checkout" {
     local upstream_workflow="$BATS_TEST_DIRNAME/../../.github/workflows/post-merge.yml"
     [ -f "$upstream_workflow" ]
-    # Count actions/checkout invocations and submodules: recursive entries
+    # Bridgebuilder F4 (PR #671): drop the redundant `|| echo 0` from grep -c.
+    # `grep -cE` already prints 0 when no matches; the `|| true` keeps
+    # bash strict-mode pipefail from aborting on empty results.
     local checkout_count submodules_count
-    checkout_count=$(grep -cE "uses:\s*actions/checkout" "$upstream_workflow" || echo 0)
-    submodules_count=$(grep -cE "submodules:\s*recursive" "$upstream_workflow" || echo 0)
-    # Every checkout must have a matching submodules: recursive
+    checkout_count=$(grep -cE "uses:\s*actions/checkout" "$upstream_workflow" || true)
+    submodules_count=$(grep -cE "submodules:\s*recursive" "$upstream_workflow" || true)
+    # Every checkout must have a matching submodules: recursive (3 of each
+    # in the live workflow as of #669)
     [ "$checkout_count" -gt 0 ]
     [ "$submodules_count" -ge "$checkout_count" ]
 }
 
 # =========================================================================
-# MWS-T9: mount-loa.sh defines scaffold_post_merge_workflow
+# MWS-T9: mount-loa.sh sources the canonical scaffold lib
 # =========================================================================
 
-@test "MWS-T9: mount-loa.sh defines scaffold_post_merge_workflow" {
+@test "MWS-T9: mount-loa.sh sources scaffold-post-merge-workflow lib" {
     local script="$BATS_TEST_DIRNAME/../../.claude/scripts/mount-loa.sh"
-    grep -qE "^scaffold_post_merge_workflow\(\)" "$script"
+    grep -qE "scaffold-post-merge-workflow\.sh" "$script"
 }
 
 # =========================================================================
-# MWS-T10: mount-submodule.sh defines scaffold_post_merge_workflow
+# MWS-T10: mount-submodule.sh sources the canonical scaffold lib
 # =========================================================================
 
-@test "MWS-T10: mount-submodule.sh defines scaffold_post_merge_workflow" {
+@test "MWS-T10: mount-submodule.sh sources scaffold-post-merge-workflow lib" {
     local script="$BATS_TEST_DIRNAME/../../.claude/scripts/mount-submodule.sh"
-    grep -qE "^scaffold_post_merge_workflow\(\)" "$script"
+    grep -qE "scaffold-post-merge-workflow\.sh" "$script"
+}
+
+# =========================================================================
+# MWS-T11: lib is the single source of truth (no inline defs in installers)
+# Bridgebuilder F2/F6 (PR #671): drift between test and prod is impossible
+# when both source the same lib. Verify no inline scaffold_post_merge_workflow()
+# function definition remains in either installer (would shadow the lib).
+# =========================================================================
+
+@test "MWS-T11: no inline scaffold_post_merge_workflow body in mount-loa.sh" {
+    local script="$BATS_TEST_DIRNAME/../../.claude/scripts/mount-loa.sh"
+    # Allow comment references to the function name; reject standalone definitions
+    ! grep -qE "^scaffold_post_merge_workflow\(\)\s*\{" "$script"
+}
+
+@test "MWS-T12: no inline scaffold_post_merge_workflow body in mount-submodule.sh" {
+    local script="$BATS_TEST_DIRNAME/../../.claude/scripts/mount-submodule.sh"
+    ! grep -qE "^scaffold_post_merge_workflow\(\)\s*\{" "$script"
 }


### PR DESCRIPTION
## Summary

The post-merge automation pipeline shipped in PR #670 with **zero install-time scaffolding** into downstream consumer repos. This PR closes that gap by:

1. Adding `submodules: recursive` to all 3 `actions/checkout` steps in `.github/workflows/post-merge.yml` (single source of truth — no-op for direct-mode consumers, required for submodule-mode consumers).
2. Adding idempotent `scaffold_post_merge_workflow()` helpers to both `mount-loa.sh` and `mount-submodule.sh` that copy/pull the workflow on first install and preserve user customization on re-mount.

## Issue Resolved

#669 — post-merge automation: orchestrator scripts ship without an invoking workflow template

## Quality Gate Evidence

**Implementation**:
- 10 new bats tests in `tests/unit/mount-workflow-scaffold.bats` (all green)
- 85 adjacent regression tests pass (mount-clean, post-merge-classifier, classify-merge-pr, post-merge-orchestrator)

**Review** (`/review-sprint sprint-bug-130`):
- Adversarial cross-model review: 1 finding, hallucinated (downgraded by filter)
- 0 real findings; 3 documented non-blocking concerns + 1 assumption challenge in `engineer-feedback.md`

**Audit** (`/audit-sprint sprint-bug-130`):
- Adversarial cross-model audit: 0 findings, status `clean`
- 2 LOW non-blocking from my review: input-validation defense-in-depth (AUD-130-1) and `submodules: recursive` supply-chain-surface tradeoff acceptance (AUD-130-2)

## What Changed

- `.github/workflows/post-merge.yml`: 3 checkout steps → +`submodules: recursive` with #669 comment block
- `.claude/scripts/mount-loa.sh`: +`scaffold_post_merge_workflow()` helper, wired into `sync_zones`
- `.claude/scripts/mount-submodule.sh`: +`scaffold_post_merge_workflow()` helper, wired into `main` between `init_state_zone` and `create_commit`
- `.loa.config.yaml.example`: +4-line auto-install note in the `post_merge:` block header
- `tests/unit/mount-workflow-scaffold.bats`: new (10 tests)
- `grimoires/loa/ledger.json`: sprint-bug-130 registration

## Notable Tradeoff

`submodules: recursive` expands the supply-chain surface for consumers with their own (non-Loa) submodules — the workflow's recursive checkout will fetch them. **Mitigation**: GH Actions runner does not execute submodule post-checkout hooks; `submodules: recursive` only fetches sources, doesn't execute them. The alternative (broken symlinks for submodule-mode Loa consumers, with `exit-127` failures) is much worse than the marginal supply-chain expansion. Documented in `auditor-sprint-feedback.md` AUD-130-2.

## Classifier Routing

This PR titled `fix(post-merge): ...` (no `cycle-NNN` prefix) routes as `bugfix` per the new classifier (#668), correctly producing a patch-bump tag without running the full cycle pipeline. Single-defect fix; appropriate scope.

## Test Plan

- [x] `bats tests/unit/mount-workflow-scaffold.bats` — 10/10 pass
- [x] `bats tests/unit/mount-clean.bats` — regression guard
- [x] `bats tests/unit/post-merge-classifier.bats` — regression guard
- [x] `bats tests/unit/classify-merge-pr.bats` — regression guard
- [x] `bats tests/unit/post-merge-orchestrator.bats` — regression guard
- [ ] **Live verification (deferred)**: next downstream consumer mount produces `.github/workflows/post-merge.yml` automatically. Same deferral pattern as sprint-bug-124 AC-5.

## Bug Artifacts

```
grimoires/loa/a2a/bug-20260502-i669-55150d/
├── triage.md
├── sprint.md
├── reviewer.md
├── engineer-feedback.md
├── auditor-sprint-feedback.md
├── adversarial-review.json
├── adversarial-audit.json
└── COMPLETED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)