### PR TITLE
chore: bump README + .loa-version.json to v1.110.1 (drift catch-up)

### DIFF
--- a/.loa-version.json
+++ b/.loa-version.json
@@ -1,7 +1,7 @@
 {
-  "framework_version": "1.109.4",
+  "framework_version": "1.110.1",
   "schema_version": 2,
-  "last_sync": "2026-05-02T09:13:00Z",
+  "last_sync": "2026-05-03T03:04:00Z",
   "zones": {
     "system": ".claude",
     "state": [

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Power user interface: 48 slash commands (truenames).
 Architecture: Three-zone model (System: .claude/, State: grimoires/ + .beads/, App: src/).
 Configuration: .loa.config.yaml (user-owned, never modified by framework).
 Health check: /loa doctor
-Version: 1.88.0
+Version: 1.110.1
 -->
 
-[![Version](https://img.shields.io/badge/version-1.102.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.110.1-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE.md)
 [![Release](https://img.shields.io/badge/release-Spiral%20Autopoietic%20Orchestrator-purple.svg)](CHANGELOG.md#1880---2026-04-15)
 


### PR DESCRIPTION
Closes the documented version drift flagged by bridgebuilder on PR #677.

| File | Before | After |
|------|--------|-------|
| README.md (header) | 1.88.0 | 1.110.1 |
| README.md (badge) | 1.102.0 | 1.110.1 |
| .loa-version.json | 1.109.4 | 1.110.1 |

Latest GitHub release: v1.110.1 (cycle-098 ledger activation, today). Per memory `reference_release_process.md`: bugfix/cycle PRs auto-tag + auto-release but don't update README or version file — drift requires manual bumps. This is the catch-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>