### PR TITLE
chore(cycle-098-sprint-1.5): hardening — close #689 + #690 + #695

### DIFF
--- a/.claude/adapters/loa_cheval/audit_envelope.py
+++ b/.claude/adapters/loa_cheval/audit_envelope.py
@@ -373,9 +373,27 @@ def audit_emit(
 
 # -----------------------------------------------------------------------------
 # Issue #690 (Sprint 1.5): trust-store auto-verify cache. Per-process,
-# mtime-keyed.
+# (mtime, size, sha256)-keyed.
+#
+# Bridgebuilder F4 hardening: mtime-only is racy on second-granularity
+# filesystems (ext4 without nsec, FAT, some NFS configs) — Linus's "racy
+# git" 2014 problem. Same-second tampering bypasses mtime invalidation.
+# Adding size + content-hash to the key closes the TOCTOU window.
 # -----------------------------------------------------------------------------
-_TRUST_STORE_CACHE: dict = {"path": None, "mtime": None, "status": None}
+_TRUST_STORE_CACHE: dict = {"path": None, "key": None, "status": None}
+
+
+def _trust_store_cache_key(ts_path: Path) -> tuple:
+    """Return (mtime_ns, size, sha256-hex) for the trust-store path."""
+    try:
+        st = ts_path.stat()
+    except OSError:
+        return (None, None, None)
+    try:
+        sha = hashlib.sha256(ts_path.read_bytes()).hexdigest()
+    except OSError:
+        sha = None
+    return (st.st_mtime_ns, st.st_size, sha)
 
 
 def _trust_store_status() -> str:
@@ -395,7 +413,8 @@ def _trust_store_status() -> str:
     INVALID: trust-store has populated keys/revocations but the
     root_signature does not verify (or is missing).
 
-    Cached per-process by (path, mtime); recomputed when mtime changes.
+    Cached per-process by (path, mtime, size, sha256); recomputed when ANY
+    component of the key changes (F4 bridgebuilder hardening).
     """
     ts_path = _trust_store_path()
 
@@ -403,15 +422,12 @@ def _trust_store_status() -> str:
     if not ts_path.is_file():
         return "BOOTSTRAP-PENDING"
 
-    try:
-        mtime = ts_path.stat().st_mtime_ns
-    except OSError:
-        mtime = None
+    cache_key = _trust_store_cache_key(ts_path)
 
     cache = _TRUST_STORE_CACHE
     if (
         cache["path"] == str(ts_path)
-        and cache["mtime"] == mtime
+        and cache["key"] == cache_key
         and cache["status"] is not None
     ):
         return cache["status"]
@@ -438,7 +454,7 @@ def _trust_store_status() -> str:
         status = "VERIFIED" if ok else "INVALID"
 
     cache["path"] = str(ts_path)
-    cache["mtime"] = mtime
+    cache["key"] = cache_key
     cache["status"] = status
     return status
 

--- a/.claude/adapters/loa_cheval/audit_envelope.py
+++ b/.claude/adapters/loa_cheval/audit_envelope.py
@@ -24,16 +24,24 @@ tests/integration/audit-envelope-signing.bats).
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import json
 import os
 import stat
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, Tuple, Union
 
 from loa_cheval.jcs import canonicalize as jcs_canonicalize
+
+try:
+    import fcntl  # POSIX-only; matches bash adapter's flock requirement (CC-3)
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover — Windows fallback
+    _HAS_FCNTL = False
 
 PathLike = Union[str, Path]
 
@@ -212,6 +220,56 @@ def _compute_prev_hash(log_path: Path) -> str:
     return _sha256_hex(_chain_input_bytes(last_env))
 
 
+@contextlib.contextmanager
+def _acquire_log_lock(log_path: Path, timeout: float = 10.0):
+    """
+    Acquire an exclusive flock on `<log_path>.lock` for the entire
+    compute-prev-hash → sign → validate → append sequence.
+
+    Mirrors bash `audit_emit` flock-on-emit pattern (issue #689 / CC-3) so
+    concurrent bash + Python writers serialize on the same file lock. Without
+    this, racing tail-reads + appends produce missing entries or a broken
+    chain — issue surfaced by Sprint 1 audit MED-1.
+
+    Raises TimeoutError after `timeout` seconds of contention.
+    Non-blocking + sleep-loop is portable across kernels with deterministic
+    bounds; matches bash's `flock -w 10` semantics.
+    """
+    if not _HAS_FCNTL:
+        raise RuntimeError(
+            "audit_emit requires fcntl for atomic chain writes (CC-3). "
+            "Python on this platform lacks fcntl support."
+        )
+    lock_path = Path(f"{log_path}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    if not lock_path.exists():
+        lock_path.touch()
+
+    deadline = time.monotonic() + timeout
+    fd = open(lock_path, "w")
+    try:
+        while True:
+            try:
+                fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"audit_emit: failed to acquire lock on {lock_path} "
+                        f"(timeout {timeout}s)"
+                    )
+                time.sleep(0.01)
+        try:
+            yield
+        finally:
+            try:
+                fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+            except OSError:  # pragma: no cover — defensive
+                pass
+    finally:
+        fd.close()
+
+
 def _validate_envelope(envelope: dict) -> None:
     """
     Validate envelope against the JSON schema. Raises ValueError on failure.
@@ -271,36 +329,132 @@ def audit_emit(
     if not isinstance(payload, dict):
         raise TypeError("payload must be a dict")
 
+    # Issue #690 (Sprint 1.5): auto-verify trust-store before any write.
+    # BOOTSTRAP-PENDING + VERIFIED permit; INVALID raises [TRUST-STORE-INVALID].
+    _check_trust_store()
+
     log_path = Path(log_path)
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
-    envelope = {
-        "schema_version": schema_version,
-        "primitive_id": primitive_id,
-        "event_type": event_type,
-        "ts_utc": _now_iso8601(),
-        "prev_hash": _compute_prev_hash(log_path),
-        "payload": payload,
-        "redaction_applied": None,
-    }
+    # Issue #689 (Sprint 1.5): acquire flock on <log_path>.lock for the entire
+    # compute-prev-hash → sign → validate → append sequence. Bash adapter does
+    # this post-Sprint-1 F3 (CC-3); without parity, mixed bash + Python writers
+    # race. Sprint 2's L2 reconciliation cron is the first cross-adapter
+    # writer of the audit envelope.
+    with _acquire_log_lock(log_path):
+        envelope = {
+            "schema_version": schema_version,
+            "primitive_id": primitive_id,
+            "event_type": event_type,
+            "ts_utc": _now_iso8601(),
+            "prev_hash": _compute_prev_hash(log_path),
+            "payload": payload,
+            "redaction_applied": None,
+        }
 
-    # Sprint 1B: sign chain-input when signing key configured.
-    kid = signing_key_id or os.environ.get("LOA_AUDIT_SIGNING_KEY_ID")
-    if kid:
-        priv = _load_private_key(kid, password=password)
-        canonical = _chain_input_bytes(envelope)
-        sig = priv.sign(canonical)
-        envelope["signing_key_id"] = kid
-        envelope["signature"] = base64.b64encode(sig).decode()
+        # Sprint 1B: sign chain-input when signing key configured.
+        kid = signing_key_id or os.environ.get("LOA_AUDIT_SIGNING_KEY_ID")
+        if kid:
+            priv = _load_private_key(kid, password=password)
+            canonical = _chain_input_bytes(envelope)
+            sig = priv.sign(canonical)
+            envelope["signing_key_id"] = kid
+            envelope["signature"] = base64.b64encode(sig).decode()
 
-    _validate_envelope(envelope)
+        _validate_envelope(envelope)
 
-    # Append a single JSON line (no internal whitespace, terminated \n).
-    line = json.dumps(envelope, separators=(",", ":"), ensure_ascii=False)
-    with log_path.open("a", encoding="utf-8") as f:
-        f.write(line)
-        f.write("\n")
-    return envelope
+        # Append a single JSON line (no internal whitespace, terminated \n).
+        line = json.dumps(envelope, separators=(",", ":"), ensure_ascii=False)
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(line)
+            f.write("\n")
+        return envelope
+
+
+# -----------------------------------------------------------------------------
+# Issue #690 (Sprint 1.5): trust-store auto-verify cache. Per-process,
+# mtime-keyed.
+# -----------------------------------------------------------------------------
+_TRUST_STORE_CACHE: dict = {"path": None, "mtime": None, "status": None}
+
+
+def _trust_store_status() -> str:
+    """
+    Auto-verify the active trust-store, returning one of:
+    BOOTSTRAP-PENDING | VERIFIED | INVALID.
+
+    BOOTSTRAP-PENDING graceful fallback: empty signature + empty keys[] +
+    empty revocations[] = the operator has not yet bootstrapped a signed
+    trust-store; reads/writes are permitted so cycle-098 can install
+    incrementally without requiring the maintainer-offline-root-key ceremony.
+
+    VERIFIED: trust-store has a populated signature OR populated keys/
+    revocations AND the root_signature verifies against the pinned root
+    pubkey.
+
+    INVALID: trust-store has populated keys/revocations but the
+    root_signature does not verify (or is missing).
+
+    Cached per-process by (path, mtime); recomputed when mtime changes.
+    """
+    ts_path = _trust_store_path()
+
+    # No trust-store file → BOOTSTRAP-PENDING (cycle-098 install-time default).
+    if not ts_path.is_file():
+        return "BOOTSTRAP-PENDING"
+
+    try:
+        mtime = ts_path.stat().st_mtime_ns
+    except OSError:
+        mtime = None
+
+    cache = _TRUST_STORE_CACHE
+    if (
+        cache["path"] == str(ts_path)
+        and cache["mtime"] == mtime
+        and cache["status"] is not None
+    ):
+        return cache["status"]
+
+    # Detect BOOTSTRAP-PENDING.
+    bootstrap_pending = False
+    try:
+        import yaml  # noqa: PLC0415
+        with ts_path.open("r", encoding="utf-8") as f:
+            doc = yaml.safe_load(f) or {}
+        sig = ((doc.get("root_signature") or {}).get("signature") or "").strip()
+        keys = doc.get("keys") or []
+        revs = doc.get("revocations") or []
+        if not sig and not keys and not revs:
+            bootstrap_pending = True
+    except Exception:
+        # Unreadable trust-store: treat as BOOTSTRAP-PENDING (graceful).
+        bootstrap_pending = True
+
+    if bootstrap_pending:
+        status = "BOOTSTRAP-PENDING"
+    else:
+        ok, _msg = audit_trust_store_verify(ts_path)
+        status = "VERIFIED" if ok else "INVALID"
+
+    cache["path"] = str(ts_path)
+    cache["mtime"] = mtime
+    cache["status"] = status
+    return status
+
+
+def _check_trust_store() -> None:
+    """
+    Gate function called at top of audit_emit + audit_verify_chain.
+    Raises RuntimeError with [TRUST-STORE-INVALID] on tampered trust-stores.
+    """
+    status = _trust_store_status()
+    if status in ("BOOTSTRAP-PENDING", "VERIFIED"):
+        return
+    raise RuntimeError(
+        "[TRUST-STORE-INVALID] trust-store root_signature does NOT verify "
+        "against pinned root pubkey; refusing all writes/reads (issue #690)"
+    )
 
 
 def _read_trust_cutoff() -> Optional[str]:
@@ -357,6 +511,12 @@ def audit_verify_chain(log_path: PathLike) -> Tuple[bool, str]:
     log_path = Path(log_path)
     if not log_path.exists():
         return False, f"file not found: {log_path}"
+
+    # Issue #690 (Sprint 1.5): auto-verify trust-store before chain walk.
+    try:
+        _check_trust_store()
+    except RuntimeError as exc:
+        return False, str(exc)
 
     verify_sigs = os.environ.get("LOA_AUDIT_VERIFY_SIGS", "1") != "0"
     cutoff = _read_trust_cutoff()

--- a/.claude/scripts/audit-envelope.sh
+++ b/.claude/scripts/audit-envelope.sh
@@ -313,6 +313,126 @@ _audit_pubkey_for_key_id() {
 }
 
 # -----------------------------------------------------------------------------
+# Issue #690 auto-verify cache: per-process, mtime-keyed.
+# When LOA_TRUST_STORE_FILE (or default) is unchanged + mtime matches, reuse
+# last computed status without re-running the helper.
+# -----------------------------------------------------------------------------
+_LOA_AUDIT_TS_CACHE_PATH=""
+_LOA_AUDIT_TS_CACHE_MTIME=""
+_LOA_AUDIT_TS_CACHE_STATUS=""
+
+# -----------------------------------------------------------------------------
+# _audit_file_mtime <path> — cross-platform mtime (seconds since epoch).
+# -----------------------------------------------------------------------------
+_audit_file_mtime() {
+    local f="$1"
+    [[ -f "$f" ]] || return 1
+    if stat -c %Y "$f" 2>/dev/null; then return 0; fi
+    if stat -f %m "$f" 2>/dev/null; then return 0; fi
+    python3 -c "import os, sys; print(int(os.stat(sys.argv[1]).st_mtime))" "$f" 2>/dev/null
+}
+
+# -----------------------------------------------------------------------------
+# _audit_trust_store_status — auto-verify the active trust-store, returning
+# one of: BOOTSTRAP-PENDING | VERIFIED | INVALID | MISSING (printed on stdout).
+#
+# Issue #690 (Sprint 1.5): runtime auto-verify hook called from audit_emit +
+# audit_verify_chain. Cached per-process, mtime-invalidated.
+#
+# BOOTSTRAP-PENDING is the graceful-fallback state for empty/un-signed trust
+# stores: the operator has not yet bootstrapped a signed trust-store, so
+# permitting reads/writes lets cycle-098 install incrementally without
+# requiring the maintainer-offline-root-key ceremony at install time.
+# Once any keys[] or revocations[] entries land, the trust-store MUST be
+# signed by the pinned root key — otherwise the trust-store is INVALID.
+# -----------------------------------------------------------------------------
+_audit_trust_store_status() {
+    local trust_store="${LOA_TRUST_STORE_FILE:-${_LOA_AUDIT_TRUST_STORE_DEFAULT}}"
+
+    # No trust-store file → BOOTSTRAP-PENDING (cycle-098 install-time default).
+    if [[ ! -f "$trust_store" ]]; then
+        echo "BOOTSTRAP-PENDING"
+        return 0
+    fi
+
+    local mtime
+    mtime="$(_audit_file_mtime "$trust_store" 2>/dev/null || true)"
+
+    # Cache hit?
+    if [[ "$_LOA_AUDIT_TS_CACHE_PATH" == "$trust_store" ]] && \
+       [[ -n "$_LOA_AUDIT_TS_CACHE_MTIME" ]] && \
+       [[ "$_LOA_AUDIT_TS_CACHE_MTIME" == "$mtime" ]] && \
+       [[ -n "$_LOA_AUDIT_TS_CACHE_STATUS" ]]; then
+        echo "$_LOA_AUDIT_TS_CACHE_STATUS"
+        return 0
+    fi
+
+    # Detect BOOTSTRAP-PENDING: empty signature + empty keys + empty revocations.
+    local detect
+    detect="$(python3 - "$trust_store" <<'PY' 2>/dev/null || true
+import sys
+try:
+    import yaml
+except ImportError:
+    print("NEEDS_VERIFY")
+    sys.exit(0)
+try:
+    with open(sys.argv[1]) as f:
+        doc = yaml.safe_load(f) or {}
+except Exception:
+    print("BOOTSTRAP-PENDING")
+    sys.exit(0)
+sig = ((doc.get("root_signature") or {}).get("signature") or "").strip()
+keys = doc.get("keys") or []
+revs = doc.get("revocations") or []
+if not sig and not keys and not revs:
+    print("BOOTSTRAP-PENDING")
+else:
+    print("NEEDS_VERIFY")
+PY
+)"
+
+    local status
+    if [[ "$detect" == "BOOTSTRAP-PENDING" ]]; then
+        status="BOOTSTRAP-PENDING"
+    else
+        if audit_trust_store_verify "$trust_store" >/dev/null 2>&1; then
+            status="VERIFIED"
+        else
+            status="INVALID"
+        fi
+    fi
+
+    _LOA_AUDIT_TS_CACHE_PATH="$trust_store"
+    _LOA_AUDIT_TS_CACHE_MTIME="$mtime"
+    _LOA_AUDIT_TS_CACHE_STATUS="$status"
+    echo "$status"
+}
+
+# -----------------------------------------------------------------------------
+# _audit_check_trust_store — gate function called at top of audit_emit and
+# audit_verify_chain. Returns 0 to permit, non-zero to block.
+# On INVALID: emits [TRUST-STORE-INVALID] BLOCKER on stderr.
+# -----------------------------------------------------------------------------
+_audit_check_trust_store() {
+    local status
+    status="$(_audit_trust_store_status)"
+    case "$status" in
+        BOOTSTRAP-PENDING|VERIFIED)
+            return 0
+            ;;
+        INVALID)
+            _audit_log "[TRUST-STORE-INVALID] trust-store root_signature does NOT verify against pinned root pubkey; refusing all writes/reads (issue #690)"
+            return 1
+            ;;
+        *)
+            _audit_log "[TRUST-STORE-INVALID] unrecognized trust-store status: $status"
+            return 1
+            ;;
+    esac
+}
+
+# -----------------------------------------------------------------------------
 # audit_trust_store_verify <trust_store_path>
 #
 # Verify the trust-store's root_signature against the pinned root pubkey at
@@ -409,6 +529,10 @@ audit_emit() {
         _audit_log "audit_emit: missing required argument"
         return 2
     fi
+
+    # Issue #690 (Sprint 1.5): auto-verify trust-store before any write.
+    # BOOTSTRAP-PENDING + VERIFIED permit; INVALID blocks with [TRUST-STORE-INVALID].
+    _audit_check_trust_store || return 1
 
     # Validate payload is JSON object.
     if ! printf '%s' "$payload_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
@@ -569,6 +693,11 @@ audit_verify_chain() {
         _audit_log "audit_verify_chain: file not found: $log_path"
         return 2
     fi
+
+    # Issue #690 (Sprint 1.5): auto-verify trust-store before chain walk.
+    # An attacker who tampers trust-store.yaml (adds malicious writer pubkey,
+    # signs entries with corresponding private key) is undetected without this.
+    _audit_check_trust_store || return 1
 
     local lineno=0
     local expected_prev="GENESIS"

--- a/.claude/scripts/audit-envelope.sh
+++ b/.claude/scripts/audit-envelope.sh
@@ -313,12 +313,14 @@ _audit_pubkey_for_key_id() {
 }
 
 # -----------------------------------------------------------------------------
-# Issue #690 auto-verify cache: per-process, mtime-keyed.
-# When LOA_TRUST_STORE_FILE (or default) is unchanged + mtime matches, reuse
-# last computed status without re-running the helper.
+# Issue #690 auto-verify cache: per-process, (mtime, size, sha256)-keyed.
+# Bridgebuilder F4 (Sprint 1.5): mtime-alone is racy on second-granularity
+# filesystems (ext4 without nsec, FAT, some NFS configs) — Linus's "racy git"
+# 2014 problem. Same-second tampering bypasses mtime invalidation. Adding
+# size + content-hash to the key closes the TOCTOU window.
 # -----------------------------------------------------------------------------
 _LOA_AUDIT_TS_CACHE_PATH=""
-_LOA_AUDIT_TS_CACHE_MTIME=""
+_LOA_AUDIT_TS_CACHE_KEY=""
 _LOA_AUDIT_TS_CACHE_STATUS=""
 
 # -----------------------------------------------------------------------------
@@ -330,6 +332,39 @@ _audit_file_mtime() {
     if stat -c %Y "$f" 2>/dev/null; then return 0; fi
     if stat -f %m "$f" 2>/dev/null; then return 0; fi
     python3 -c "import os, sys; print(int(os.stat(sys.argv[1]).st_mtime))" "$f" 2>/dev/null
+}
+
+# -----------------------------------------------------------------------------
+# _audit_file_size <path> — cross-platform size in bytes.
+# -----------------------------------------------------------------------------
+_audit_file_size() {
+    local f="$1"
+    [[ -f "$f" ]] || return 1
+    if stat -c %s "$f" 2>/dev/null; then return 0; fi
+    if stat -f %z "$f" 2>/dev/null; then return 0; fi
+    wc -c < "$f" 2>/dev/null | awk '{print $1}'
+}
+
+# -----------------------------------------------------------------------------
+# _audit_file_sha256 <path> — content-hash for cache key (bridgebuilder F4).
+# -----------------------------------------------------------------------------
+_audit_file_sha256_of() {
+    local f="$1"
+    [[ -f "$f" ]] || return 1
+    _audit_sha256 < "$f"
+}
+
+# -----------------------------------------------------------------------------
+# _audit_ts_cache_key <path> — emit "mtime:size:sha256" for trust-store path.
+# Used as the auto-verify cache key (F4 hardening).
+# -----------------------------------------------------------------------------
+_audit_ts_cache_key() {
+    local f="$1"
+    local mtime size sha
+    mtime="$(_audit_file_mtime "$f" 2>/dev/null || echo "0")"
+    size="$(_audit_file_size "$f" 2>/dev/null || echo "0")"
+    sha="$(_audit_file_sha256_of "$f" 2>/dev/null || echo "")"
+    printf '%s:%s:%s' "$mtime" "$size" "$sha"
 }
 
 # -----------------------------------------------------------------------------
@@ -355,13 +390,13 @@ _audit_trust_store_status() {
         return 0
     fi
 
-    local mtime
-    mtime="$(_audit_file_mtime "$trust_store" 2>/dev/null || true)"
+    local cache_key
+    cache_key="$(_audit_ts_cache_key "$trust_store")"
 
-    # Cache hit?
+    # Cache hit? Key is (mtime, size, sha256) — F4 bridgebuilder hardening.
     if [[ "$_LOA_AUDIT_TS_CACHE_PATH" == "$trust_store" ]] && \
-       [[ -n "$_LOA_AUDIT_TS_CACHE_MTIME" ]] && \
-       [[ "$_LOA_AUDIT_TS_CACHE_MTIME" == "$mtime" ]] && \
+       [[ -n "$_LOA_AUDIT_TS_CACHE_KEY" ]] && \
+       [[ "$_LOA_AUDIT_TS_CACHE_KEY" == "$cache_key" ]] && \
        [[ -n "$_LOA_AUDIT_TS_CACHE_STATUS" ]]; then
         echo "$_LOA_AUDIT_TS_CACHE_STATUS"
         return 0
@@ -404,7 +439,7 @@ PY
     fi
 
     _LOA_AUDIT_TS_CACHE_PATH="$trust_store"
-    _LOA_AUDIT_TS_CACHE_MTIME="$mtime"
+    _LOA_AUDIT_TS_CACHE_KEY="$cache_key"
     _LOA_AUDIT_TS_CACHE_STATUS="$status"
     echo "$status"
 }

--- a/.claude/scripts/audit-secret-redaction-scan.sh
+++ b/.claude/scripts/audit-secret-redaction-scan.sh
@@ -13,6 +13,17 @@
 #   audit-secret-redaction-scan.sh
 #     no stdin → defaults to `git ls-files`
 #
+# Input contract (bridgebuilder F7 — explicit, not implicit):
+#   - When stdin is a pipe OR has bytes available (`-p` / `-s` test), paths are
+#     read from stdin and the git-ls-files fallback is NOT consulted. Tests
+#     can pass a curated path list deterministically.
+#   - When stdin is empty AND not a pipe, the script falls back to
+#     `git ls-files` against the current working directory's repo. This is
+#     the production code path called from .github/workflows/audit-secret-redaction.yml.
+#   - To force git-ls-files mode in a test, pass `</dev/null` (no pipe + no
+#     bytes available; falls back to git).
+#   - To force stdin-only mode, pass paths via `<<<` or `printf | ...`.
+#
 # Exit codes:
 #   0 — no violations (clean)
 #   1 — violations found (path:lineno:match printed on stdout)

--- a/.claude/scripts/audit-secret-redaction-scan.sh
+++ b/.claude/scripts/audit-secret-redaction-scan.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# =============================================================================
+# audit-secret-redaction-scan.sh — cycle-098 Sprint 1.5 (#695 F8 hardening).
+#
+# Single-source-of-truth for the LOA_AUDIT_KEY_PASSWORD assignment-pattern
+# scanner. Extracted from `.github/workflows/audit-secret-redaction.yml` so
+# the allowlist + scan logic can be unit-tested
+# (tests/security/audit-secret-redaction-allowlist.bats).
+#
+# Usage:
+#   echo path1\\npath2 | audit-secret-redaction-scan.sh
+#     reads repo-relative paths from stdin
+#   audit-secret-redaction-scan.sh
+#     no stdin → defaults to `git ls-files`
+#
+# Exit codes:
+#   0 — no violations (clean)
+#   1 — violations found (path:lineno:match printed on stdout)
+#
+# Pre-fix (issue #695 F8): allowlist included broad globs over agent-writable
+# paths (`grimoires/loa/.*\.md$`, `*progress*\.md$`, `*-handoff*\.md$`). Agents
+# write into those paths routinely during normal sprint work; broad globs make
+# them redaction blind spots — exactly the GitHub 2020 path-glob class
+# bridgebuilder cited.
+#
+# Post-fix: allowlist restricted to a small set of NAMED files that legitimately
+# reference the deprecated env var assignment pattern:
+#   - The workflow itself (mentions the pattern in a comment + grep arg)
+#   - audit-envelope.sh / audit-signing-helper.py / audit_envelope.py
+#     (intercept the deprecated env var with a stderr warning + scrub)
+#   - tests/security/no-env-var-leakage.bats (security test)
+#   - grimoires/loa/runbooks/audit-keys-bootstrap.md (operator runbook —
+#     documents the deprecation in fenced code)
+#   - grimoires/loa/sdd.md, grimoires/loa/sprint.md (architectural rationale +
+#     acceptance criteria — pinned by name, not glob)
+# =============================================================================
+
+set -euo pipefail
+
+# Allowlist regex: anchored end-of-string ($), one entry per allowed path.
+# IMPORTANT (#695 F8): no broad globs over agent-writable paths
+# (progress/, handoffs/, a2a/, or grimoires/loa/*.md).
+ALLOWLIST='\.github/workflows/audit-secret-redaction\.yml$|\.claude/scripts/lib/audit-signing-helper\.py$|\.claude/adapters/loa_cheval/audit_envelope\.py$|\.claude/scripts/audit-envelope\.sh$|tests/security/no-env-var-leakage\.bats$|grimoires/loa/runbooks/audit-keys-bootstrap\.md$|grimoires/loa/sdd\.md$|grimoires/loa/sprint\.md$|\.claude/scripts/audit-secret-redaction-scan\.sh$|tests/security/audit-secret-redaction-allowlist\.bats$'
+
+# Forbidden pattern: any literal `LOA_AUDIT_KEY_PASSWORD=...` assignment.
+PATTERN='LOA_AUDIT_KEY_PASSWORD='
+
+# Source: stdin if piped, else git ls-files.
+if [[ -p /dev/stdin || -s /dev/stdin ]]; then
+    paths_input="$(cat)"
+else
+    paths_input="$(git ls-files 2>/dev/null || true)"
+fi
+
+if [[ -z "${paths_input// }" ]]; then
+    # Empty input → vacuously clean.
+    exit 0
+fi
+
+# Filter through allowlist (-vE strips matching paths from consideration), then
+# grep each remaining file for the assignment pattern. Skip nonexistent paths
+# silently so test fixtures with intentional gaps don't false-positive.
+#
+# `|| :` on each grep swallows the non-match exit code (1) so the pipeline
+# doesn't trip pipefail when:
+#   - all paths are allowlisted (first grep produces no output → exit 1)
+#   - a file has no assignment pattern (per-file grep exits 1)
+violations="$(
+    {
+        printf '%s\n' "$paths_input" \
+            | { grep -vE "$ALLOWLIST" || :; } \
+            | while IFS= read -r p; do
+                [[ -n "$p" ]] || continue
+                [[ -f "$p" ]] || continue
+                grep -nE "$PATTERN" "$p" 2>/dev/null \
+                    | sed -e "s|^|${p}:|" || :
+              done
+    }
+)"
+
+if [[ -n "$violations" ]]; then
+    echo "ERROR: LOA_AUDIT_KEY_PASSWORD assignment pattern found outside allowlist (issue #695 F8)" >&2
+    echo "$violations"
+    exit 1
+fi
+
+exit 0

--- a/.claude/scripts/lib/audit-signing-helper.py
+++ b/.claude/scripts/lib/audit-signing-helper.py
@@ -243,7 +243,14 @@ def cmd_trust_store_verify(args: argparse.Namespace) -> int:
       schema_version, root_signature {algorithm, signer_pubkey, signed_at, signature},
       keys[], revocations[], trust_cutoff{...}
 
-    Signed bytes: JCS canonicalization of {keys, revocations, trust_cutoff}.
+    Signed bytes: JCS canonicalization of
+      {schema_version, keys, revocations, trust_cutoff}.
+
+    Sprint 1.5 (#695 F9): `schema_version` is INCLUDED in the signed payload to
+    close a downgrade vector (cf. TLS version rollback, JWT alg confusion).
+    A tampered schema_version produces a signature mismatch — the parser-
+    behavior gate cannot be silently rolled back. SDD §1.9.3.1 is explicit
+    about this signed-payload scope.
 
     Multi-channel pubkey verification:
       - Pinned pubkey at args.pinned_pubkey (System Zone, frozen)
@@ -333,7 +340,16 @@ def cmd_trust_store_verify(args: argparse.Namespace) -> int:
         return EX_VERIFY_FAIL
 
     # Construct the signed core (deterministic JCS canonicalization).
+    # Sprint 1.5 (#695 F9): include `schema_version` in the signed payload
+    # to defeat downgrade-rollback attacks. Missing schema_version is
+    # treated as an explicit empty string (causes signature mismatch by
+    # design — operators must populate it).
+    schema_version = ts_doc.get("schema_version")
+    if schema_version is None:
+        _err("trust-store: missing schema_version field (required for signed payload)")
+        return EX_VERIFY_FAIL
     core = {
+        "schema_version": schema_version,
         "keys": ts_doc.get("keys") or [],
         "revocations": ts_doc.get("revocations") or [],
         "trust_cutoff": ts_doc.get("trust_cutoff") or {},

--- a/.github/workflows/audit-secret-redaction.yml
+++ b/.github/workflows/audit-secret-redaction.yml
@@ -27,19 +27,18 @@ jobs:
 
       - name: Scan tracked files for LOA_AUDIT_KEY_PASSWORD assignments
         run: |
-          # Forbidden patterns: assignment of the deprecated env var ANYWHERE
-          # in tracked files except this workflow file (which mentions the name)
-          # and audit-signing-helper.py + audit_envelope.py + audit-envelope.sh
-          # (which intentionally reference it for deprecation warning).
-          ALLOWLIST='\.github/workflows/audit-secret-redaction\.yml$|\.claude/scripts/lib/audit-signing-helper\.py$|\.claude/adapters/loa_cheval/audit_envelope\.py$|\.claude/scripts/audit-envelope\.sh$|tests/security/no-env-var-leakage\.bats$|grimoires/loa/.*\.md$|grimoires/loa/.*-handoff.*\.md$|grimoires/loa/.*progress.*\.md$'
-
-          # Look for `LOA_AUDIT_KEY_PASSWORD=<value>` outside the allowlist.
-          violations=$(git ls-files | grep -vE "$ALLOWLIST" | xargs -r grep -nE 'LOA_AUDIT_KEY_PASSWORD=' 2>/dev/null || true)
-
-          if [ -n "$violations" ]; then
+          # Single-source-of-truth scanner extracted to a script so the
+          # allowlist + scan logic is unit-tested
+          # (tests/security/audit-secret-redaction-allowlist.bats).
+          #
+          # cycle-098 Sprint 1.5 (#695 F8): allowlist tightened — broad globs
+          # over agent-writable paths (progress/, handoffs/, a2a/, *.md) removed
+          # in favor of named files. Bridgebuilder cited the GitHub 2020
+          # path-glob class of incidents — agents write into those paths
+          # routinely, so they cannot be redaction blind spots.
+          if .claude/scripts/audit-secret-redaction-scan.sh; then
+            echo "OK — no LOA_AUDIT_KEY_PASSWORD assignments in tracked source"
+          else
             echo "::error::LOA_AUDIT_KEY_PASSWORD leak detected (SKP-002 violation)"
-            echo "Affected lines:"
-            echo "$violations"
             exit 1
           fi
-          echo "OK — no LOA_AUDIT_KEY_PASSWORD assignments in tracked source"

--- a/grimoires/loa/a2a/sprint-1/progress-1B.md
+++ b/grimoires/loa/a2a/sprint-1/progress-1B.md
@@ -55,7 +55,7 @@ identity primitives.
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/audit-secret-redaction.yml` | SKP-002 mandatory CI gate: scans tracked files for `LOA_AUDIT_KEY_PASSWORD=` patterns; fails on match (allowlist for code that must reference the deprecated name) |
+| `.github/workflows/audit-secret-redaction.yml` | SKP-002 mandatory CI gate: scans tracked files for assignments of the deprecated `LOA_AUDIT_KEY_PASSWORD` env var; fails on match (allowlist for code that must reference the deprecated name) |
 
 ### Tests (6 files, 35 new assertions; 67 total when including 1A regression)
 
@@ -96,7 +96,7 @@ Verified at HEAD: 67 PASS for the 1B-relevant suite (signing + chain + schema + 
 
 - `--password-fd N` and `--password-file <path>` flags added to `audit-signing-helper.py`. Path mode-0600 enforcement.
 - `LOA_AUDIT_KEY_PASSWORD` env var DEPRECATED — emits stderr deprecation warning on use; scrubbed from environment after consumption (defense-in-depth).
-- CI redaction check at `.github/workflows/audit-secret-redaction.yml` — scans tracked files for `LOA_AUDIT_KEY_PASSWORD=` patterns; fails on match outside an explicit allowlist (audit-envelope.sh, helper, security tests).
+- CI redaction check at `.github/workflows/audit-secret-redaction.yml` — scans tracked files for assignments of the deprecated `LOA_AUDIT_KEY_PASSWORD` env var; fails on match outside an explicit allowlist (audit-envelope.sh, helper, security tests).
 - Process inspection test (`/proc/<pid>/cmdline`) confirms passphrase is NOT in argv when using --password-fd.
 
 ## Schema bump policy

--- a/grimoires/loa/sdd.md
+++ b/grimoires/loa/sdd.md
@@ -849,12 +849,43 @@ root_signature:
   algorithm: ed25519
   signer_pubkey: "MCowBQYDK2VwAyEA..."   # maintainer's offline root pubkey
   signed_at: "2026-05-02T00:00:00Z"
-  signature: "...JCS-canonicalized signature of the keys+revocations sections..."
+  signature: "...JCS-canonicalized signature of the signed-payload core..."
 keys: [...]
 revocations: [...]
 trust_cutoff: {...}
 ---
 ```
+
+**Signed-payload scope** (Sprint 1.5 #695 F9 hardening — explicit boundary):
+
+The `root_signature.signature` covers the JCS canonicalization (RFC 8785) of:
+
+```python
+{
+    "schema_version": <yaml.schema_version>,
+    "keys":           <yaml.keys>,
+    "revocations":    <yaml.revocations>,
+    "trust_cutoff":   <yaml.trust_cutoff>,
+}
+```
+
+`schema_version` is INCLUDED in the signed payload to defeat downgrade-rollback
+attacks (cf. TLS version rollback, JWT alg confusion). Without this, an
+attacker with repo-write access could swap `schema_version: "1.0"` →
+`schema_version: "0.9"` and force the parser into a permissive earlier mode
+without invalidating the signature.
+
+`root_signature.{algorithm, signer_pubkey, signed_at, signature}` are
+DELIBERATELY excluded from the signed payload — they are signature metadata,
+not signed material. `algorithm` is enforced by code (`ed25519` only).
+`signer_pubkey` is cross-checked against the pinned root pubkey via the
+multi-channel verification path (`[ROOT-PUBKEY-DIVERGENCE]` BLOCKER on
+mismatch). `signed_at` is informational. `signature` is the artifact itself.
+
+Reference implementation: `.claude/scripts/lib/audit-signing-helper.py
+:cmd_trust_store_verify`. Test coverage:
+`tests/unit/trust-store-signed-payload-scope.bats` (4 tests covering positive
++ downgrade + forward-rollback + missing-field tampering).
 
 **Root-of-trust workflow**:
 

--- a/grimoires/loa/sdd.md
+++ b/grimoires/loa/sdd.md
@@ -887,6 +887,43 @@ Reference implementation: `.claude/scripts/lib/audit-signing-helper.py
 `tests/unit/trust-store-signed-payload-scope.bats` (4 tests covering positive
 + downgrade + forward-rollback + missing-field tampering).
 
+**Auto-verify status table** (Sprint 1.5 #690 + bridgebuilder iter-2 F7
+documentation):
+
+| Trust-store state | Detection | Auto-verify status | Reads/writes |
+|-------------------|-----------|--------------------|--------------|
+| File missing | `not is_file()` | `BOOTSTRAP-PENDING` | PERMITTED |
+| Empty signature + empty `keys[]` + empty `revocations[]` | YAML parse | `BOOTSTRAP-PENDING` | PERMITTED |
+| `root_signature` populated AND verifies | helper `cmd_trust_store_verify` | `VERIFIED` | PERMITTED |
+| `root_signature` populated but verification fails | helper non-zero exit | `INVALID` | REFUSED (`[TRUST-STORE-INVALID]` BLOCKER) |
+| `keys[]` or `revocations[]` populated but `root_signature` empty | YAML parse + helper | `INVALID` | REFUSED |
+
+`BOOTSTRAP-PENDING` is a deliberate operator-recovery affordance, **not** a
+security boundary: cycle-098 ships into a repo with no pre-existing trust-store,
+and forcing the maintainer-offline-root-key ceremony at first install would
+block all audit emissions until ceremony completion. The acceptable threat
+model:
+
+1. The trust-store path is on a write-controlled mount post-bootstrap. An
+   attacker with arbitrary write access to `grimoires/loa/trust-store.yaml`
+   (e.g., via PR merge to main without CODEOWNERS approval, or via local
+   filesystem compromise) can `rm` the file and revert to permissive mode.
+   This is **detected at the next CODEOWNERS review** when the missing file
+   surfaces in `git status`, but is NOT prevented at runtime.
+2. Operators MUST commit the post-bootstrap trust-store to git so file removal
+   produces a tracked-deletion diff that CODEOWNERS catches.
+3. When repo-write access cannot be assumed (e.g., self-hosted CI runners
+   without strong permissions hygiene), operators SHOULD set
+   `LOA_TRUST_STORE_REQUIRED=1` (future cycle work — issue tracked as
+   `vision-018-required-trust-store`) which inverts the missing-file
+   default to `INVALID`.
+
+The graceful-vs-strict tradeoff is intentional and named here so future
+maintainers do not "fix" the permissive path as if it were a bug. AWS IAM's
+2006-2011 evolution from permissive defaults to deny-by-default is the
+canonical reference for the security cost; cycle-098 chose ergonomics for the
+install path with the failsafe being CODEOWNERS review on trust-store changes.
+
 **Root-of-trust workflow**:
 
 1. **Maintainer holds offline root key** — physical hardware token (YubiKey) or air-gapped machine; root key never touches a session machine.

--- a/tests/fixtures/trust-store-sign.py
+++ b/tests/fixtures/trust-store-sign.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+trust-store-sign.py — cycle-098 Sprint 1.5 (#695 F9 + bridgebuilder F-001
+remediation).
+
+Standalone test fixture for signing trust-stores in tests. Replaces the
+brittle bats `_sign_*_trust_store` heredoc helpers that injected Python via
+shell here-docs, and the cross-runtime `declare -f` injection used in mtime
+invalidation tests.
+
+This is a single source of truth: bats tests + Python subprocesses both call
+this fixture directly with stable CLI arguments. No nested-quoting brittleness;
+no cross-language scope leakage.
+
+Usage:
+  trust-store-sign.py \\
+      --out PATH                  \\
+      --signer-priv PRIV.pem      \\
+      [--mode bootstrap-pending|empty|populated] \\
+      [--schema-version 1.0]      \\
+      [--keys-pubkey PUB.pem]     \\
+      [--cutoff 2026-05-02T00:00:00Z]
+
+Modes:
+  bootstrap-pending — empty signature, empty keys, empty revocations
+                      (cycle-098 install-time default)
+  empty             — sign empty {keys, revocations} but with valid root_signature
+  populated         — sign with one writer key in keys[]
+
+Sprint 1.5 #695 F9: schema_version IS in the signed payload.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+from pathlib import Path
+
+try:
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+    from cryptography.hazmat.primitives import serialization
+    import rfc8785
+except ImportError as exc:
+    sys.stderr.write(f"trust-store-sign: missing dep: {exc}\n")
+    sys.exit(78)
+
+
+def _yaml_block(pem: str, indent: int = 4) -> str:
+    pad = " " * indent
+    return "\n".join(pad + line for line in pem.strip().split("\n"))
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", required=True, type=Path)
+    p.add_argument("--signer-priv", required=True, type=Path,
+                   help="Private key PEM file (PKCS8) — used only when mode != bootstrap-pending")
+    p.add_argument("--mode", choices=("bootstrap-pending", "empty", "populated"),
+                   default="empty")
+    p.add_argument("--schema-version", default="1.0")
+    p.add_argument("--cutoff", default="2026-05-02T00:00:00Z")
+    p.add_argument("--writer-pubkey-out", type=Path, default=None,
+                   help="Optional: write a generated writer pubkey PEM to this path "
+                        "(populated mode only).")
+    args = p.parse_args()
+
+    if args.mode == "bootstrap-pending":
+        # No signing — empty signature, empty keys.
+        yaml_text = f"""---
+schema_version: "{args.schema_version}"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: ""
+  signed_at: ""
+  signature: ""
+keys: []
+revocations: []
+trust_cutoff:
+  default_strict_after: "2099-01-01T00:00:00Z"
+"""
+        args.out.write_text(yaml_text)
+        return 0
+
+    # Sign: load signer priv, build core, canonicalize, sign.
+    priv = serialization.load_pem_private_key(args.signer_priv.read_bytes(), password=None)
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+    keys: list = []
+    if args.mode == "populated":
+        writer = ed25519.Ed25519PrivateKey.generate()
+        writer_pub_pem = writer.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        keys = [{
+            "writer_id": "test-writer-1",
+            "operator_id": "test-operator",
+            "pubkey_pem": writer_pub_pem,
+            "valid_from": "2026-05-03T00:00:00Z",
+            "valid_until": None,
+        }]
+        if args.writer_pubkey_out:
+            args.writer_pubkey_out.write_text(writer_pub_pem)
+
+    # Sprint 1.5 #695 F9: schema_version IS in the signed payload.
+    core = {
+        "schema_version": args.schema_version,
+        "keys": keys,
+        "revocations": [],
+        "trust_cutoff": {"default_strict_after": args.cutoff},
+    }
+    sig_b64 = base64.b64encode(priv.sign(rfc8785.dumps(core))).decode()
+
+    # Hand-write YAML to keep field order stable.
+    keys_yaml = "[]"
+    if keys:
+        k0 = keys[0]
+        keys_yaml = (
+            "\n  - writer_id: \"test-writer-1\""
+            "\n    operator_id: \"test-operator\""
+            "\n    pubkey_pem: |\n"
+            f"{_yaml_block(k0['pubkey_pem'], 6)}"
+            "\n    valid_from: \"2026-05-03T00:00:00Z\""
+            "\n    valid_until: null"
+        )
+
+    yaml_text = f"""---
+schema_version: "{args.schema_version}"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: |
+{_yaml_block(pub_pem, 4)}
+  signed_at: "2026-05-03T00:00:00Z"
+  signature: "{sig_b64}"
+keys: {keys_yaml}
+revocations: []
+trust_cutoff:
+  default_strict_after: "{args.cutoff}"
+"""
+    args.out.write_text(yaml_text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/audit-envelope-python-concurrent.bats
+++ b/tests/integration/audit-envelope-python-concurrent.bats
@@ -72,9 +72,17 @@ audit_emit('L1', 'panel.bind', {'decision_id': 'd-$i'}, '$LOG')
 " &
         pids+=($!)
     done
+    # Bridgebuilder F-002: assert each child exited 0. Without this, a crashing
+    # writer can leave a log that satisfies line-count + chain-verify checks
+    # while masking the bug as a flaky green.
+    local failures=0
     for pid in "${pids[@]}"; do
-        wait "$pid"
+        wait "$pid" || failures=$((failures + 1))
     done
+    [[ "$failures" -eq 0 ]] || {
+        echo "$failures concurrent writer(s) exited non-zero"
+        return 1
+    }
 
     local lines
     lines=$(wc -l < "$LOG")
@@ -116,9 +124,15 @@ audit_emit('L1', 'panel.bind', {'decision_id': 'd-$i'}, '$LOG')
 " &
         pids+=($!)
     done
+    # Bridgebuilder F-002: assert each child exited 0.
+    local failures=0
     for pid in "${pids[@]}"; do
-        wait "$pid"
+        wait "$pid" || failures=$((failures + 1))
     done
+    [[ "$failures" -eq 0 ]] || {
+        echo "$failures concurrent writer(s) exited non-zero"
+        return 1
+    }
 
     local lines
     lines=$(wc -l < "$LOG")
@@ -151,6 +165,51 @@ audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, '$LOG')
 }
 
 # -----------------------------------------------------------------------------
+# F10 (bridgebuilder): stress-mode race coverage. Default CI runs at N=10;
+# stress mode at N=50 surfaces races that smaller pools miss (Kingsbury/Jepsen:
+# race bugs typically appear only at N>50 with adversarial scheduling).
+# Gated by LOA_STRESS_TESTS=1; skipped by default to keep CI fast.
+# -----------------------------------------------------------------------------
+@test "py-concurrent: 50 forked Python writers (stress, env-gated)" {
+    [[ "${LOA_STRESS_TESTS:-0}" == "1" ]] || skip "stress mode (LOA_STRESS_TESTS=1 to enable)"
+    local N=50
+    local i
+    local pids=()
+    for i in $(seq 1 $N); do
+        python3 -c "
+from loa_cheval.audit_envelope import audit_emit
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-$i'}, '$LOG')
+" &
+        pids+=($!)
+    done
+    local failures=0
+    for pid in "${pids[@]}"; do
+        wait "$pid" || failures=$((failures + 1))
+    done
+    [[ "$failures" -eq 0 ]] || {
+        echo "$failures concurrent writer(s) exited non-zero (stress N=$N)"
+        return 1
+    }
+
+    local lines
+    lines=$(wc -l < "$LOG")
+    [[ "$lines" -eq "$N" ]] || {
+        echo "Expected $N lines, got $lines (race lost entries)"
+        return 1
+    }
+
+    run python3 -c "
+import sys
+from loa_cheval.audit_envelope import audit_verify_chain
+ok, msg = audit_verify_chain('$LOG')
+print(msg)
+sys.exit(0 if ok else 1)
+"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"OK $N entries"* ]]
+}
+
+# -----------------------------------------------------------------------------
 # Cross-adapter concurrent (bash + Python) — defense against the dual-writer
 # scenario Sprint 2's L2 ships. Bash audit_emit and Python audit_emit must
 # share the same lock file.
@@ -174,9 +233,15 @@ audit_emit('L1', 'panel.bind', {'decision_id': 'py-$i'}, '$LOG')
 " &
         pids+=($!)
     done
+    # Bridgebuilder F-002: assert each child exited 0.
+    local failures=0
     for pid in "${pids[@]}"; do
-        wait "$pid"
+        wait "$pid" || failures=$((failures + 1))
     done
+    [[ "$failures" -eq 0 ]] || {
+        echo "$failures concurrent writer(s) exited non-zero"
+        return 1
+    }
 
     local lines
     lines=$(wc -l < "$LOG")

--- a/tests/integration/audit-envelope-python-concurrent.bats
+++ b/tests/integration/audit-envelope-python-concurrent.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/audit-envelope-python-concurrent.bats
+#
+# cycle-098 Sprint 1.5 hardening — issue #689 (L1 audit MED-1).
+#
+# Mirror of audit-envelope-concurrent-write.bats for the Python adapter.
+# audit_envelope.py:300-302 appends without flock; bash adapter (post-Sprint-1
+# F3 fix) does flock. Without parity, concurrent writers from bash + Python
+# (Sprint 2's L2 ships the first Python writers) race on tail-read/append.
+#
+# This test forks 5 (then 10) concurrent Python writers and asserts all
+# entries land in the chain with prev_hash continuity intact. Pre-fix:
+# race conditions cause missing entries or broken chain. Post-fix:
+# deterministic.
+#
+# Cross-adapter test (bash + Python interleaved) lives in audit-envelope-chain.bats.
+# This file isolates the Python-only path.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    AUDIT_ENVELOPE="$PROJECT_ROOT/.claude/scripts/audit-envelope.sh"
+    PYTHON_ADAPTER_DIR="$PROJECT_ROOT/.claude/adapters"
+
+    [[ -f "$AUDIT_ENVELOPE" ]] || skip "audit-envelope.sh not present"
+    [[ -d "$PYTHON_ADAPTER_DIR/loa_cheval" ]] || skip "loa_cheval not present"
+    command -v flock >/dev/null 2>&1 || skip "flock required for this test"
+    python3 -c "import fcntl, jsonschema" 2>/dev/null || skip "python fcntl + jsonschema required"
+
+    TEST_DIR="$(mktemp -d)"
+    LOG="$TEST_DIR/python-concurrent.jsonl"
+
+    # Permissive trust-store (F1 isolation: pre-cutoff entries, sign-optional).
+    TEST_TRUST_STORE="$TEST_DIR/trust-store.yaml"
+    cat > "$TEST_TRUST_STORE" <<'EOF'
+schema_version: "1.0"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: ""
+  signed_at: ""
+  signature: ""
+keys: []
+revocations: []
+trust_cutoff:
+  default_strict_after: "2099-01-01T00:00:00Z"
+EOF
+    export LOA_TRUST_STORE_FILE="$TEST_TRUST_STORE"
+    export PYTHONPATH="$PYTHON_ADAPTER_DIR"
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_TRUST_STORE_FILE PYTHONPATH
+}
+
+# -----------------------------------------------------------------------------
+# 5 concurrent Python writers: all entries land + chain valid
+# -----------------------------------------------------------------------------
+@test "py-concurrent: 5 forked Python writers all land + chain remains valid" {
+    local N=5
+    local i
+    local pids=()
+    for i in $(seq 1 $N); do
+        python3 -c "
+from loa_cheval.audit_envelope import audit_emit
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-$i'}, '$LOG')
+" &
+        pids+=($!)
+    done
+    for pid in "${pids[@]}"; do
+        wait "$pid"
+    done
+
+    local lines
+    lines=$(wc -l < "$LOG")
+    [[ "$lines" -eq "$N" ]] || {
+        echo "Expected $N lines, got $lines"
+        cat "$LOG"
+        return 1
+    }
+
+    # Chain must validate via Python adapter.
+    run python3 -c "
+import sys
+from loa_cheval.audit_envelope import audit_verify_chain
+ok, msg = audit_verify_chain('$LOG')
+print(msg)
+sys.exit(0 if ok else 1)
+"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"OK $N entries"* ]]
+
+    # And via bash adapter (cross-adapter validation).
+    source "$AUDIT_ENVELOPE"
+    run audit_verify_chain "$LOG"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"OK $N entries"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# 10 concurrent Python writers (stress): all entries land + chain valid
+# -----------------------------------------------------------------------------
+@test "py-concurrent: 10 forked Python writers all land + chain remains valid (stress)" {
+    local N=10
+    local i
+    local pids=()
+    for i in $(seq 1 $N); do
+        python3 -c "
+from loa_cheval.audit_envelope import audit_emit
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-$i'}, '$LOG')
+" &
+        pids+=($!)
+    done
+    for pid in "${pids[@]}"; do
+        wait "$pid"
+    done
+
+    local lines
+    lines=$(wc -l < "$LOG")
+    [[ "$lines" -eq "$N" ]] || {
+        echo "Expected $N lines, got $lines"
+        cat "$LOG"
+        return 1
+    }
+
+    run python3 -c "
+import sys
+from loa_cheval.audit_envelope import audit_verify_chain
+ok, msg = audit_verify_chain('$LOG')
+print(msg)
+sys.exit(0 if ok else 1)
+"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"OK $N entries"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# Lock-file pattern parity with bash adapter
+# -----------------------------------------------------------------------------
+@test "py-concurrent: Python adapter creates lock file at <log_path>.lock" {
+    python3 -c "
+from loa_cheval.audit_envelope import audit_emit
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, '$LOG')
+"
+    [[ -f "${LOG}.lock" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Cross-adapter concurrent (bash + Python) — defense against the dual-writer
+# scenario Sprint 2's L2 ships. Bash audit_emit and Python audit_emit must
+# share the same lock file.
+# -----------------------------------------------------------------------------
+@test "py-concurrent: 5 bash + 5 python interleaved writers (cross-adapter, 10 total)" {
+    local pids=()
+    # 5 bash writers
+    for i in 1 2 3 4 5; do
+        bash -c "
+            source '$AUDIT_ENVELOPE'
+            export LOA_TRUST_STORE_FILE='$LOA_TRUST_STORE_FILE'
+            audit_emit L1 panel.bind '{\"decision_id\":\"bash-$i\"}' '$LOG' >/dev/null 2>&1
+        " &
+        pids+=($!)
+    done
+    # 5 python writers
+    for i in 1 2 3 4 5; do
+        python3 -c "
+from loa_cheval.audit_envelope import audit_emit
+audit_emit('L1', 'panel.bind', {'decision_id': 'py-$i'}, '$LOG')
+" &
+        pids+=($!)
+    done
+    for pid in "${pids[@]}"; do
+        wait "$pid"
+    done
+
+    local lines
+    lines=$(wc -l < "$LOG")
+    [[ "$lines" -eq 10 ]] || {
+        echo "Expected 10 lines, got $lines"
+        cat "$LOG"
+        return 1
+    }
+
+    # Chain valid via both adapters.
+    source "$AUDIT_ENVELOPE"
+    run audit_verify_chain "$LOG"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"OK 10 entries"* ]]
+}

--- a/tests/integration/audit-trust-store-auto-verify.bats
+++ b/tests/integration/audit-trust-store-auto-verify.bats
@@ -80,134 +80,29 @@ teardown() {
     unset LOA_PINNED_ROOT_PUBKEY_PATH LOA_TRUST_STORE_FILE PYTHONPATH
 }
 
-# Helper: write a BOOTSTRAP-PENDING trust-store (empty keys + empty signature).
+# Helpers delegate to a single Python fixture script (tests/fixtures/trust-store-sign.py).
+# Refactored from heredoc-injection helpers per bridgebuilder F-001/F6 (cycle-098 Sprint 1.5):
+# heredoc-in-bash-via-python-via-subprocess was three quoting layers brittle to any change,
+# and the cross-runtime declare-f trick the mtime test used was a Meta "cross-runtime
+# fixture leakage" anti-pattern. Now: standalone CLI fixture, deterministic across both
+# bats and Python subprocess callers.
+#
+# `_FIXTURE_SIGN` is resolved inside helpers (not at file-load time) because bats sets
+# PROJECT_ROOT inside setup(), per-test.
+
 _bootstrap_pending_trust_store() {
-    local out_path="$1"
-    cat > "$out_path" <<'EOF'
-schema_version: "1.0"
-root_signature:
-  algorithm: ed25519
-  signer_pubkey: ""
-  signed_at: ""
-  signature: ""
-keys: []
-revocations: []
-trust_cutoff:
-  default_strict_after: "2099-01-01T00:00:00Z"
-EOF
+    python3 "$PROJECT_ROOT/tests/fixtures/trust-store-sign.py" \
+        --out "$1" --signer-priv "$TEST_DIR/root.priv" --mode bootstrap-pending
 }
 
-# Helper: write a legitimately signed trust-store with NO populated keys.
 _signed_empty_trust_store() {
-    local out_path="$1"
-    local signer_priv="$2"
-    python3 - "$out_path" "$signer_priv" <<'PY'
-import sys, base64
-from pathlib import Path
-from cryptography.hazmat.primitives.asymmetric import ed25519
-from cryptography.hazmat.primitives import serialization
-import rfc8785
-
-out = Path(sys.argv[1])
-priv = serialization.load_pem_private_key(Path(sys.argv[2]).read_bytes(), password=None)
-pub_pem = priv.public_key().public_bytes(
-    encoding=serialization.Encoding.PEM,
-    format=serialization.PublicFormat.SubjectPublicKeyInfo,
-).decode()
-
-# Sprint 1.5 (#695 F9): schema_version IS in the signed payload.
-core = {
-    "schema_version": "1.0",
-    "keys": [],
-    "revocations": [],
-    "trust_cutoff": {"default_strict_after": "2026-05-02T00:00:00Z"},
-}
-sig_b64 = base64.b64encode(priv.sign(rfc8785.dumps(core))).decode()
-
-yaml_text = f"""---
-schema_version: "1.0"
-root_signature:
-  algorithm: ed25519
-  signer_pubkey: |
-{chr(10).join("    " + line for line in pub_pem.strip().split(chr(10)))}
-  signed_at: "2026-05-03T00:00:00Z"
-  signature: "{sig_b64}"
-keys: []
-revocations: []
-trust_cutoff:
-  default_strict_after: "2026-05-02T00:00:00Z"
-"""
-out.write_text(yaml_text)
-PY
+    python3 "$PROJECT_ROOT/tests/fixtures/trust-store-sign.py" \
+        --out "$1" --signer-priv "$2" --mode empty
 }
 
-# Helper: write a legitimately signed trust-store WITH a populated key.
 _signed_populated_trust_store() {
-    local out_path="$1"
-    local signer_priv="$2"
-    python3 - "$out_path" "$signer_priv" <<'PY'
-import sys, base64
-from pathlib import Path
-from cryptography.hazmat.primitives.asymmetric import ed25519
-from cryptography.hazmat.primitives import serialization
-import rfc8785
-
-out = Path(sys.argv[1])
-priv = serialization.load_pem_private_key(Path(sys.argv[2]).read_bytes(), password=None)
-pub_pem = priv.public_key().public_bytes(
-    encoding=serialization.Encoding.PEM,
-    format=serialization.PublicFormat.SubjectPublicKeyInfo,
-).decode()
-
-# Generate a writer key and add to populated trust-store.
-writer = ed25519.Ed25519PrivateKey.generate()
-writer_pub_pem = writer.public_key().public_bytes(
-    encoding=serialization.Encoding.PEM,
-    format=serialization.PublicFormat.SubjectPublicKeyInfo,
-).decode()
-
-keys = [{
-    "writer_id": "test-writer-1",
-    "operator_id": "test-operator",
-    "pubkey_pem": writer_pub_pem,
-    "valid_from": "2026-05-03T00:00:00Z",
-    "valid_until": None,
-}]
-
-# Sprint 1.5 (#695 F9): schema_version IS in the signed payload.
-core = {
-    "schema_version": "1.0",
-    "keys": keys,
-    "revocations": [],
-    "trust_cutoff": {"default_strict_after": "2026-05-02T00:00:00Z"},
-}
-sig_b64 = base64.b64encode(priv.sign(rfc8785.dumps(core))).decode()
-
-# Hand-write YAML to keep field order stable.
-def _yaml_indent(s, n=4):
-    return chr(10).join((" " * n) + line for line in s.strip().split(chr(10)))
-
-yaml_text = f"""---
-schema_version: "1.0"
-root_signature:
-  algorithm: ed25519
-  signer_pubkey: |
-{_yaml_indent(pub_pem)}
-  signed_at: "2026-05-03T00:00:00Z"
-  signature: "{sig_b64}"
-keys:
-  - writer_id: "test-writer-1"
-    operator_id: "test-operator"
-    pubkey_pem: |
-{_yaml_indent(writer_pub_pem, 6)}
-    valid_from: "2026-05-03T00:00:00Z"
-    valid_until: null
-revocations: []
-trust_cutoff:
-  default_strict_after: "2026-05-02T00:00:00Z"
-"""
-out.write_text(yaml_text)
-PY
+    python3 "$PROJECT_ROOT/tests/fixtures/trust-store-sign.py" \
+        --out "$1" --signer-priv "$2" --mode populated
 }
 
 # -----------------------------------------------------------------------------
@@ -292,8 +187,10 @@ audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, '$LOG')
     # Now replace trust-store with imposter-signed populated trust-store.
     _signed_populated_trust_store "$TS" "$TEST_DIR/imposter.priv"
 
-    # Ensure the cache is invalidated by mtime bump.
-    touch -d "1 second" "$TS"
+    # Ensure the cache is invalidated by mtime bump. F-003 (bridgebuilder):
+    # `touch -d "1 second"` is GNU-coreutils-specific (BSD/macOS rejects it).
+    # Portable alternative: sleep + touch.
+    sleep 1; touch "$TS"
 
     # Fresh shell so cache is empty.
     run bash -c "
@@ -388,41 +285,83 @@ audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, '$LOG')
     _signed_populated_trust_store "$TS" "$TEST_DIR/root.priv"
     export LOA_TRUST_STORE_FILE="$TS"
 
-    # Single Python process: emit, tamper, emit again.
-    run python3 -c "
+    # Single Python process: emit, tamper via fixture script (no cross-runtime
+    # declare -f injection — F-001/F6 remediation), emit again.
+    # Fixture path passed as env var; Python invokes it via subprocess with stable args.
+    run env LOA_FIXTURE_SIGN="$PROJECT_ROOT/tests/fixtures/trust-store-sign.py" \
+        LOA_TS_PATH="$TS" \
+        LOA_LOG_PATH="$LOG" \
+        LOA_IMPOSTER_PRIV="$TEST_DIR/imposter.priv" \
+        python3 - <<'PY'
 import sys, time, os, subprocess
 from pathlib import Path
 from loa_cheval.audit_envelope import audit_emit
 
-ts_path = '$TS'
-log_path = '$LOG'
+ts_path = os.environ["LOA_TS_PATH"]
+log_path = os.environ["LOA_LOG_PATH"]
+fixture = os.environ["LOA_FIXTURE_SIGN"]
+imposter = os.environ["LOA_IMPOSTER_PRIV"]
 
 # 1. First emit: valid trust-store; should succeed.
-audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, log_path)
+audit_emit("L1", "panel.bind", {"decision_id": "d-1"}, log_path)
 
-# 2. Tamper: replace with imposter-signed.
+# 2. Tamper via fixture script (single source of truth — no declare -f leakage).
 time.sleep(0.05)
-subprocess.run(['bash', '-c', '''
-$(declare -f _signed_populated_trust_store)
-_signed_populated_trust_store \"\$1\" \"\$2\"
-''', '_', ts_path, '$TEST_DIR/imposter.priv'], check=True, env={
-    **os.environ,
-    'PATH': os.environ.get('PATH', ''),
-})
+subprocess.run(
+    ["python3", fixture,
+     "--out", ts_path,
+     "--signer-priv", imposter,
+     "--mode", "populated"],
+    check=True,
+)
 Path(ts_path).touch()
 
 # 3. Second emit: should FAIL due to mtime cache invalidation.
 try:
-    audit_emit('L1', 'panel.bind', {'decision_id': 'd-2'}, log_path)
-    print('UNEXPECTED: second emit succeeded')
+    audit_emit("L1", "panel.bind", {"decision_id": "d-2"}, log_path)
+    print("UNEXPECTED: second emit succeeded")
     sys.exit(0)
 except RuntimeError as e:
-    print(f'BLOCKED: {e}')
+    print(f"BLOCKED: {e}")
     sys.exit(1)
-"
+PY
     [[ "$status" -ne 0 ]]
-    echo "$output" | grep -qE 'TRUST-STORE-INVALID|ROOT-PUBKEY-DIVERGENCE' || {
-        echo "Expected [TRUST-STORE-INVALID] BLOCKER after mtime change, got: $output"
+    echo "$output" | grep -q 'TRUST-STORE-INVALID' || {
+        echo "Expected [TRUST-STORE-INVALID] token in output, got: $output"
+        return 1
+    }
+}
+
+# -----------------------------------------------------------------------------
+# F4 (bridgebuilder): same-second tampering must be caught by content-hash
+# even when mtime resolves identically.
+# -----------------------------------------------------------------------------
+@test "auto-verify: same-second tampering (mtime-coarse FS) detected via content-hash" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _signed_populated_trust_store "$TS" "$TEST_DIR/root.priv"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    # First emit primes the cache.
+    source "$AUDIT_ENVELOPE"
+    audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$LOG"
+
+    # Capture mtime, then write imposter trust-store WITHOUT advancing mtime
+    # (force exact-mtime collision via touch -r, simulating coarse-granularity FS).
+    local mtime_before
+    mtime_before="$(stat -c %Y "$TS" 2>/dev/null || stat -f %m "$TS" 2>/dev/null)"
+    _signed_populated_trust_store "$TS" "$TEST_DIR/imposter.priv"
+    # Pin mtime to exactly what it was — defeats mtime-only invalidation.
+    touch -r "$LOG" "$TS" 2>/dev/null || true
+    # Best-effort: try to set mtime to mtime_before; on coarse FS this collides.
+    # We use a separate file as the time source. If "stat" failed, this is a no-op.
+
+    # Second emit: mtime cache says "valid" but content-hash should detect change.
+    # If content-hash is missing from cache key, this would PASS (bypass).
+    # Post-F4: it should FAIL with [TRUST-STORE-INVALID].
+    run audit_emit L1 panel.bind '{"decision_id":"d-2"}' "$LOG"
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -q 'TRUST-STORE-INVALID' || {
+        echo "Expected [TRUST-STORE-INVALID] (content-hash must catch same-mtime tamper), got: $output"
         return 1
     }
 }

--- a/tests/integration/audit-trust-store-auto-verify.bats
+++ b/tests/integration/audit-trust-store-auto-verify.bats
@@ -1,0 +1,451 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/audit-trust-store-auto-verify.bats
+#
+# cycle-098 Sprint 1.5 hardening — issue #690 (L1 audit MED-2).
+#
+# audit_trust_store_verify exists and works (5/5 tests in
+# trust-store-root-of-trust.bats) but is NOT invoked automatically from
+# audit_verify_chain or audit_emit. Once an operator populates trust-store.yaml
+# (post-bootstrap), runtime auto-verify becomes critical: an attacker who
+# tampers trust-store.yaml (adds malicious writer pubkey + signs entries with
+# the corresponding private key) is undetected at runtime.
+#
+# This test exercises:
+#   1. BOOTSTRAP-PENDING: empty keys + empty signature → reads/writes permitted
+#   2. VERIFIED: legitimately signed trust-store + populated keys → permitted
+#   3. INVALID: tampered trust-store (non-empty keys, missing/bad signature)
+#      → audit_emit + audit_verify_chain refuse with [TRUST-STORE-INVALID]
+#   4. mtime cache invalidation: change trust-store mtime → re-verify on next call
+#   5. No trust-store file (graceful fallback to BOOTSTRAP-PENDING)
+#
+# Acceptance criteria from issue #690:
+#   - audit_verify_chain auto-calls audit_trust_store_verify once per process
+#   - Trust-store substitution test: tamper trust-store.yaml; chain ops fail
+#   - BOOTSTRAP-PENDING state still permits reads/writes (graceful fallback)
+#   - Cached verify result invalidated on trust-store mtime change
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    AUDIT_ENVELOPE="$PROJECT_ROOT/.claude/scripts/audit-envelope.sh"
+    PYTHON_ADAPTER_DIR="$PROJECT_ROOT/.claude/adapters"
+
+    [[ -f "$AUDIT_ENVELOPE" ]] || skip "audit-envelope.sh not present"
+    [[ -d "$PYTHON_ADAPTER_DIR/loa_cheval" ]] || skip "loa_cheval not present"
+    if ! python3 -c "import cryptography, yaml, rfc8785" 2>/dev/null; then
+        skip "python cryptography + yaml + rfc8785 required"
+    fi
+
+    TEST_DIR="$(mktemp -d)"
+    PINNED_PUBKEY="$TEST_DIR/pinned-root-pubkey.txt"
+    LOG="$TEST_DIR/test.jsonl"
+
+    # Generate root + imposter keypairs (mirrors trust-store-root-of-trust.bats).
+    python3 - "$TEST_DIR" <<'PY'
+import sys
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+
+td = Path(sys.argv[1])
+for tag in ["root", "imposter"]:
+    priv = ed25519.Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    (td / f"{tag}.pub").write_bytes(pub_pem)
+    (td / f"{tag}.priv").write_bytes(priv_pem)
+
+import shutil
+shutil.copy(td / "root.pub", td / "pinned-root-pubkey.txt")
+PY
+
+    export LOA_PINNED_ROOT_PUBKEY_PATH="$PINNED_PUBKEY"
+    export PYTHONPATH="$PYTHON_ADAPTER_DIR"
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_PINNED_ROOT_PUBKEY_PATH LOA_TRUST_STORE_FILE PYTHONPATH
+}
+
+# Helper: write a BOOTSTRAP-PENDING trust-store (empty keys + empty signature).
+_bootstrap_pending_trust_store() {
+    local out_path="$1"
+    cat > "$out_path" <<'EOF'
+schema_version: "1.0"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: ""
+  signed_at: ""
+  signature: ""
+keys: []
+revocations: []
+trust_cutoff:
+  default_strict_after: "2099-01-01T00:00:00Z"
+EOF
+}
+
+# Helper: write a legitimately signed trust-store with NO populated keys.
+_signed_empty_trust_store() {
+    local out_path="$1"
+    local signer_priv="$2"
+    python3 - "$out_path" "$signer_priv" <<'PY'
+import sys, base64
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+import rfc8785
+
+out = Path(sys.argv[1])
+priv = serialization.load_pem_private_key(Path(sys.argv[2]).read_bytes(), password=None)
+pub_pem = priv.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+).decode()
+
+# Sprint 1.5 (#695 F9): schema_version IS in the signed payload.
+core = {
+    "schema_version": "1.0",
+    "keys": [],
+    "revocations": [],
+    "trust_cutoff": {"default_strict_after": "2026-05-02T00:00:00Z"},
+}
+sig_b64 = base64.b64encode(priv.sign(rfc8785.dumps(core))).decode()
+
+yaml_text = f"""---
+schema_version: "1.0"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: |
+{chr(10).join("    " + line for line in pub_pem.strip().split(chr(10)))}
+  signed_at: "2026-05-03T00:00:00Z"
+  signature: "{sig_b64}"
+keys: []
+revocations: []
+trust_cutoff:
+  default_strict_after: "2026-05-02T00:00:00Z"
+"""
+out.write_text(yaml_text)
+PY
+}
+
+# Helper: write a legitimately signed trust-store WITH a populated key.
+_signed_populated_trust_store() {
+    local out_path="$1"
+    local signer_priv="$2"
+    python3 - "$out_path" "$signer_priv" <<'PY'
+import sys, base64
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+import rfc8785
+
+out = Path(sys.argv[1])
+priv = serialization.load_pem_private_key(Path(sys.argv[2]).read_bytes(), password=None)
+pub_pem = priv.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+).decode()
+
+# Generate a writer key and add to populated trust-store.
+writer = ed25519.Ed25519PrivateKey.generate()
+writer_pub_pem = writer.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+).decode()
+
+keys = [{
+    "writer_id": "test-writer-1",
+    "operator_id": "test-operator",
+    "pubkey_pem": writer_pub_pem,
+    "valid_from": "2026-05-03T00:00:00Z",
+    "valid_until": None,
+}]
+
+# Sprint 1.5 (#695 F9): schema_version IS in the signed payload.
+core = {
+    "schema_version": "1.0",
+    "keys": keys,
+    "revocations": [],
+    "trust_cutoff": {"default_strict_after": "2026-05-02T00:00:00Z"},
+}
+sig_b64 = base64.b64encode(priv.sign(rfc8785.dumps(core))).decode()
+
+# Hand-write YAML to keep field order stable.
+def _yaml_indent(s, n=4):
+    return chr(10).join((" " * n) + line for line in s.strip().split(chr(10)))
+
+yaml_text = f"""---
+schema_version: "1.0"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: |
+{_yaml_indent(pub_pem)}
+  signed_at: "2026-05-03T00:00:00Z"
+  signature: "{sig_b64}"
+keys:
+  - writer_id: "test-writer-1"
+    operator_id: "test-operator"
+    pubkey_pem: |
+{_yaml_indent(writer_pub_pem, 6)}
+    valid_from: "2026-05-03T00:00:00Z"
+    valid_until: null
+revocations: []
+trust_cutoff:
+  default_strict_after: "2026-05-02T00:00:00Z"
+"""
+out.write_text(yaml_text)
+PY
+}
+
+# -----------------------------------------------------------------------------
+# BOOTSTRAP-PENDING: empty keys + empty signature → reads/writes permitted
+# -----------------------------------------------------------------------------
+@test "auto-verify: BOOTSTRAP-PENDING permits audit_emit (bash)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _bootstrap_pending_trust_store "$TS"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    source "$AUDIT_ENVELOPE"
+    run audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$LOG"
+    [[ "$status" -eq 0 ]]
+    [[ -f "$LOG" ]]
+    local lines
+    lines=$(wc -l < "$LOG")
+    [[ "$lines" -eq 1 ]]
+}
+
+@test "auto-verify: BOOTSTRAP-PENDING permits audit_verify_chain (bash)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _bootstrap_pending_trust_store "$TS"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    source "$AUDIT_ENVELOPE"
+    audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$LOG"
+    audit_emit L1 panel.bind '{"decision_id":"d-2"}' "$LOG"
+    run audit_verify_chain "$LOG"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"OK 2 entries"* ]]
+}
+
+@test "auto-verify: BOOTSTRAP-PENDING permits audit_emit (Python)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _bootstrap_pending_trust_store "$TS"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    run python3 -c "
+from loa_cheval.audit_envelope import audit_emit
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, '$LOG')
+"
+    [[ "$status" -eq 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# No trust-store file → BOOTSTRAP-PENDING (graceful fallback)
+# -----------------------------------------------------------------------------
+@test "auto-verify: missing trust-store file is treated as BOOTSTRAP-PENDING (bash)" {
+    export LOA_TRUST_STORE_FILE="$TEST_DIR/nonexistent.yaml"
+
+    source "$AUDIT_ENVELOPE"
+    run audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$LOG"
+    [[ "$status" -eq 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Tampered trust-store (substitution attack)
+# -----------------------------------------------------------------------------
+@test "auto-verify: trust-store substitution (signed by imposter) blocks audit_emit (bash)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _signed_populated_trust_store "$TS" "$TEST_DIR/imposter.priv"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    source "$AUDIT_ENVELOPE"
+    run audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$LOG"
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -qE 'TRUST-STORE-INVALID|ROOT-PUBKEY-DIVERGENCE' || {
+        echo "Expected [TRUST-STORE-INVALID] BLOCKER, got: $output"
+        return 1
+    }
+}
+
+@test "auto-verify: trust-store substitution (signed by imposter) blocks audit_verify_chain (bash)" {
+    # First write the log under a permissive bootstrap-pending trust-store.
+    TS="$TEST_DIR/trust-store.yaml"
+    _bootstrap_pending_trust_store "$TS"
+    export LOA_TRUST_STORE_FILE="$TS"
+    source "$AUDIT_ENVELOPE"
+    audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$LOG"
+    audit_emit L1 panel.bind '{"decision_id":"d-2"}' "$LOG"
+
+    # Now replace trust-store with imposter-signed populated trust-store.
+    _signed_populated_trust_store "$TS" "$TEST_DIR/imposter.priv"
+
+    # Ensure the cache is invalidated by mtime bump.
+    touch -d "1 second" "$TS"
+
+    # Fresh shell so cache is empty.
+    run bash -c "
+        source '$AUDIT_ENVELOPE'
+        export LOA_TRUST_STORE_FILE='$TS'
+        export LOA_PINNED_ROOT_PUBKEY_PATH='$LOA_PINNED_ROOT_PUBKEY_PATH'
+        audit_verify_chain '$LOG' 2>&1
+    "
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -qE 'TRUST-STORE-INVALID|ROOT-PUBKEY-DIVERGENCE' || {
+        echo "Expected [TRUST-STORE-INVALID] BLOCKER, got: $output"
+        return 1
+    }
+}
+
+@test "auto-verify: trust-store substitution blocks audit_emit (Python)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _signed_populated_trust_store "$TS" "$TEST_DIR/imposter.priv"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    run python3 -c "
+import sys
+from loa_cheval.audit_envelope import audit_emit
+try:
+    audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, '$LOG')
+    sys.exit(0)
+except RuntimeError as e:
+    print(f'BLOCKED: {e}')
+    sys.exit(1)
+"
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -qE 'TRUST-STORE-INVALID|ROOT-PUBKEY-DIVERGENCE' || {
+        echo "Expected [TRUST-STORE-INVALID] BLOCKER, got: $output"
+        return 1
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Legitimately signed populated trust-store → audit_emit succeeds
+# -----------------------------------------------------------------------------
+@test "auto-verify: legitimately signed populated trust-store permits audit_emit (bash)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _signed_populated_trust_store "$TS" "$TEST_DIR/root.priv"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    source "$AUDIT_ENVELOPE"
+    run audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$LOG"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "auto-verify: legitimately signed populated trust-store permits audit_emit (Python)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _signed_populated_trust_store "$TS" "$TEST_DIR/root.priv"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    run python3 -c "
+from loa_cheval.audit_envelope import audit_emit
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, '$LOG')
+"
+    [[ "$status" -eq 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# mtime cache invalidation
+# -----------------------------------------------------------------------------
+@test "auto-verify: mtime change invalidates cache (bash, single-process)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    # Start with valid signed trust-store.
+    _signed_populated_trust_store "$TS" "$TEST_DIR/root.priv"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    source "$AUDIT_ENVELOPE"
+    # First call: caches VERIFIED.
+    audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$LOG"
+
+    # Tamper trust-store: replace with imposter-signed populated trust-store.
+    sleep 0.05  # ensure mtime changes (filesystem granularity)
+    _signed_populated_trust_store "$TS" "$TEST_DIR/imposter.priv"
+    touch "$TS"  # ensure mtime bumps even if writes too fast
+
+    # Second call: cache should be invalidated; auto-verify should fire and FAIL.
+    run audit_emit L1 panel.bind '{"decision_id":"d-2"}' "$LOG"
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -qE 'TRUST-STORE-INVALID|ROOT-PUBKEY-DIVERGENCE' || {
+        echo "Expected [TRUST-STORE-INVALID] BLOCKER after mtime change, got: $output"
+        return 1
+    }
+}
+
+@test "auto-verify: mtime change invalidates cache (Python, single-process)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _signed_populated_trust_store "$TS" "$TEST_DIR/root.priv"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    # Single Python process: emit, tamper, emit again.
+    run python3 -c "
+import sys, time, os, subprocess
+from pathlib import Path
+from loa_cheval.audit_envelope import audit_emit
+
+ts_path = '$TS'
+log_path = '$LOG'
+
+# 1. First emit: valid trust-store; should succeed.
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, log_path)
+
+# 2. Tamper: replace with imposter-signed.
+time.sleep(0.05)
+subprocess.run(['bash', '-c', '''
+$(declare -f _signed_populated_trust_store)
+_signed_populated_trust_store \"\$1\" \"\$2\"
+''', '_', ts_path, '$TEST_DIR/imposter.priv'], check=True, env={
+    **os.environ,
+    'PATH': os.environ.get('PATH', ''),
+})
+Path(ts_path).touch()
+
+# 3. Second emit: should FAIL due to mtime cache invalidation.
+try:
+    audit_emit('L1', 'panel.bind', {'decision_id': 'd-2'}, log_path)
+    print('UNEXPECTED: second emit succeeded')
+    sys.exit(0)
+except RuntimeError as e:
+    print(f'BLOCKED: {e}')
+    sys.exit(1)
+"
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -qE 'TRUST-STORE-INVALID|ROOT-PUBKEY-DIVERGENCE' || {
+        echo "Expected [TRUST-STORE-INVALID] BLOCKER after mtime change, got: $output"
+        return 1
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Cache hit: same mtime → no re-verification (smoke test for caching presence)
+# -----------------------------------------------------------------------------
+@test "auto-verify: cached result reused within same process (Python)" {
+    TS="$TEST_DIR/trust-store.yaml"
+    _signed_populated_trust_store "$TS" "$TEST_DIR/root.priv"
+    export LOA_TRUST_STORE_FILE="$TS"
+
+    # Two emits in same Python process; both must succeed AND second must
+    # be faster (or at least not slower than re-verify cost). We don't time;
+    # we just verify both work.
+    run python3 -c "
+from loa_cheval.audit_envelope import audit_emit
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-1'}, '$LOG')
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-2'}, '$LOG')
+audit_emit('L1', 'panel.bind', {'decision_id': 'd-3'}, '$LOG')
+"
+    [[ "$status" -eq 0 ]]
+    local lines
+    lines=$(wc -l < "$LOG")
+    [[ "$lines" -eq 3 ]]
+}

--- a/tests/integration/audit-trust-store-auto-verify.bats
+++ b/tests/integration/audit-trust-store-auto-verify.bats
@@ -345,19 +345,38 @@ PY
     source "$AUDIT_ENVELOPE"
     audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$LOG"
 
-    # Capture mtime, then write imposter trust-store WITHOUT advancing mtime
-    # (force exact-mtime collision via touch -r, simulating coarse-granularity FS).
-    local mtime_before
-    mtime_before="$(stat -c %Y "$TS" 2>/dev/null || stat -f %m "$TS" 2>/dev/null)"
-    _signed_populated_trust_store "$TS" "$TEST_DIR/imposter.priv"
-    # Pin mtime to exactly what it was — defeats mtime-only invalidation.
-    touch -r "$LOG" "$TS" 2>/dev/null || true
-    # Best-effort: try to set mtime to mtime_before; on coarse FS this collides.
-    # We use a separate file as the time source. If "stat" failed, this is a no-op.
+    # Capture exact ns mtime (Python — portable across GNU/BSD).
+    # Iter-2 F1 remediation: must pin mtime to the EXACT pre-tamper value, otherwise
+    # the mtime-change branch fires first (silent dispatch shadowing per Tricorder
+    # ISSTA 2018) and the test becomes a tautology proving "mtime OR content-hash"
+    # rather than "content-hash" specifically.
+    local mtime_ns
+    mtime_ns="$(python3 -c "import os, sys; st = os.stat(sys.argv[1]); print(st.st_mtime_ns)" "$TS")"
 
-    # Second emit: mtime cache says "valid" but content-hash should detect change.
-    # If content-hash is missing from cache key, this would PASS (bypass).
-    # Post-F4: it should FAIL with [TRUST-STORE-INVALID].
+    # Tamper: imposter-signed trust-store with same byte-size if possible.
+    _signed_populated_trust_store "$TS" "$TEST_DIR/imposter.priv"
+
+    # Pin mtime to the EXACT ns value before tamper. Now the cache key sees
+    # identical mtime; only size or sha256 change can invalidate the cache.
+    python3 -c "
+import os, sys
+ts = sys.argv[1]
+mtime_ns = int(sys.argv[2])
+sec, ns = divmod(mtime_ns, 1_000_000_000)
+os.utime(ts, ns=(mtime_ns, mtime_ns))
+" "$TS" "$mtime_ns"
+
+    # Confirm mtime is identical to pre-tamper.
+    local mtime_after
+    mtime_after="$(python3 -c "import os, sys; print(os.stat(sys.argv[1]).st_mtime_ns)" "$TS")"
+    [[ "$mtime_ns" == "$mtime_after" ]] || {
+        echo "Test setup failed: could not pin mtime ($mtime_ns != $mtime_after)"
+        return 1
+    }
+
+    # Second emit: mtime is byte-identical to cache. If cache is mtime-only,
+    # this would pass through (bypass). With F4's (mtime, size, sha256) tuple,
+    # content-hash detects the tamper.
     run audit_emit L1 panel.bind '{"decision_id":"d-2"}' "$LOG"
     [[ "$status" -ne 0 ]]
     echo "$output" | grep -q 'TRUST-STORE-INVALID' || {

--- a/tests/security/audit-secret-redaction-allowlist.bats
+++ b/tests/security/audit-secret-redaction-allowlist.bats
@@ -172,3 +172,32 @@ grimoires/loa/a2a/sprint-1/progress-1B.md"
 src/lib.rs"
     [[ "$status" -eq 0 ]]
 }
+
+# -----------------------------------------------------------------------------
+# F7 (bridgebuilder): explicit stdin contract — paths from stdin must NOT
+# silently fall through to git ls-files. The test fixture tree is not a git
+# repo, so a fallback would behave differently in CI vs. local.
+# -----------------------------------------------------------------------------
+@test "f7-contract: stdin paths used; no silent git ls-files fallback" {
+    # Set up a non-git fixture tree.
+    _write_fixture "grimoires/loa/some-random-doc.md" 'LOA_AUDIT_KEY_PASSWORD=violation'
+    [[ ! -d "$TEST_DIR/.git" ]]  # confirm not a git repo
+
+    # When stdin is a pipe with one path, only that path is scanned.
+    run _run_scanner "grimoires/loa/some-random-doc.md"
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -q 'some-random-doc.md'
+
+    # When stdin contains an empty path list (zero lines), exit 0 (vacuously
+    # clean — git fallback NOT triggered because we piped explicit input).
+    run bash -c "printf '' | '$SCAN_SCRIPT'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "f7-contract: empty stdin path list yields vacuously clean (no git fallback)" {
+    # Pipe an empty string so /dev/stdin is a pipe but with no content. Scanner
+    # must NOT then fall through to git ls-files — that would be the contract
+    # the F7 finding warned against.
+    run bash -c "printf '\n' | '$SCAN_SCRIPT'"
+    [[ "$status" -eq 0 ]]
+}

--- a/tests/security/audit-secret-redaction-allowlist.bats
+++ b/tests/security/audit-secret-redaction-allowlist.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/security/audit-secret-redaction-allowlist.bats
+#
+# cycle-098 Sprint 1.5 hardening — issue #695 F8 (security tightening).
+#
+# Bridgebuilder iter-1 review of PR #693 surfaced that the audit-secret-redaction
+# workflow allowlist was overly broad (`grimoires/loa/.*\.md$` etc.). Agents
+# write into `progress/`, `handoffs/`, `a2a/` paths at scale during normal
+# sprint work — those paths cannot be redaction blind spots. Secrets that leak
+# through agent writes would slip past the workflow.
+#
+# This test exercises the redaction scanner against fixture paths to assert:
+#   1. Assignment patterns in agent-writable paths (progress/, handoffs/, a2a/)
+#      are FLAGGED (not allowlisted)
+#   2. Assignment patterns in named system files (audit-envelope.sh, etc.) are
+#      ALLOWED (these intentionally reference the deprecated env var)
+#   3. Assignment patterns in named documentation (audit-keys-bootstrap.md,
+#      sdd.md, sprint.md) are ALLOWED
+#
+# The single-source-of-truth allowlist + scan logic lives in
+# `.claude/scripts/audit-secret-redaction-scan.sh` (extracted from the workflow
+# so it can be unit-tested). The workflow calls this script.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    SCAN_SCRIPT="$PROJECT_ROOT/.claude/scripts/audit-secret-redaction-scan.sh"
+    [[ -f "$SCAN_SCRIPT" ]] || skip "audit-secret-redaction-scan.sh not present (Sprint 1.5 #695 F8)"
+
+    TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+}
+
+# Helper: write a fixture file at a repo-relative path and feed it to the scanner.
+_write_fixture() {
+    local rel_path="$1"
+    local content="$2"
+    local abs="$TEST_DIR/$rel_path"
+    mkdir -p "$(dirname "$abs")"
+    printf '%s' "$content" > "$abs"
+}
+
+# Helper: invoke the scanner with a list of repo-relative paths.
+# Args: scanner --root <test-root> < file with paths
+_run_scanner() {
+    local stdin_paths="$1"
+    cd "$TEST_DIR" && printf '%s' "$stdin_paths" | "$SCAN_SCRIPT"
+}
+
+# -----------------------------------------------------------------------------
+# Allowlisted: named system files (intentionally reference deprecated env var)
+# -----------------------------------------------------------------------------
+@test "allowlist: .claude/scripts/audit-envelope.sh ALLOWED" {
+    _write_fixture ".claude/scripts/audit-envelope.sh" 'LOA_AUDIT_KEY_PASSWORD=foo'
+    run _run_scanner ".claude/scripts/audit-envelope.sh"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "allowlist: .claude/scripts/lib/audit-signing-helper.py ALLOWED" {
+    _write_fixture ".claude/scripts/lib/audit-signing-helper.py" 'LOA_AUDIT_KEY_PASSWORD=foo'
+    run _run_scanner ".claude/scripts/lib/audit-signing-helper.py"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "allowlist: .claude/adapters/loa_cheval/audit_envelope.py ALLOWED" {
+    _write_fixture ".claude/adapters/loa_cheval/audit_envelope.py" 'LOA_AUDIT_KEY_PASSWORD=foo'
+    run _run_scanner ".claude/adapters/loa_cheval/audit_envelope.py"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "allowlist: tests/security/no-env-var-leakage.bats ALLOWED" {
+    _write_fixture "tests/security/no-env-var-leakage.bats" 'LOA_AUDIT_KEY_PASSWORD=foo'
+    run _run_scanner "tests/security/no-env-var-leakage.bats"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "allowlist: .github/workflows/audit-secret-redaction.yml ALLOWED" {
+    _write_fixture ".github/workflows/audit-secret-redaction.yml" 'LOA_AUDIT_KEY_PASSWORD=foo'
+    run _run_scanner ".github/workflows/audit-secret-redaction.yml"
+    [[ "$status" -eq 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Allowlisted: named documentation files (deprecation rationale + ACs)
+# -----------------------------------------------------------------------------
+@test "allowlist: grimoires/loa/runbooks/audit-keys-bootstrap.md ALLOWED" {
+    _write_fixture "grimoires/loa/runbooks/audit-keys-bootstrap.md" 'See LOA_AUDIT_KEY_PASSWORD=value example'
+    run _run_scanner "grimoires/loa/runbooks/audit-keys-bootstrap.md"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "allowlist: grimoires/loa/sdd.md ALLOWED" {
+    _write_fixture "grimoires/loa/sdd.md" 'LOA_AUDIT_KEY_PASSWORD= patterns documented'
+    run _run_scanner "grimoires/loa/sdd.md"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "allowlist: grimoires/loa/sprint.md ALLOWED" {
+    _write_fixture "grimoires/loa/sprint.md" 'LOA_AUDIT_KEY_PASSWORD= scan ACs'
+    run _run_scanner "grimoires/loa/sprint.md"
+    [[ "$status" -eq 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# REJECTED: agent-writable paths (the F8 hardening)
+# -----------------------------------------------------------------------------
+@test "reject: grimoires/loa/a2a/sprint-1/progress-1B.md REJECTED" {
+    _write_fixture "grimoires/loa/a2a/sprint-1/progress-1B.md" 'A reference to LOA_AUDIT_KEY_PASSWORD=secret'
+    run _run_scanner "grimoires/loa/a2a/sprint-1/progress-1B.md"
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -q 'progress-1B.md' || {
+        echo "Expected progress-1B.md in violations, got: $output"
+        return 1
+    }
+}
+
+@test "reject: grimoires/loa/a2a/cycle-099/handoff/spam.md REJECTED" {
+    _write_fixture "grimoires/loa/a2a/cycle-099/handoff/spam.md" 'LOA_AUDIT_KEY_PASSWORD=leak'
+    run _run_scanner "grimoires/loa/a2a/cycle-099/handoff/spam.md"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "reject: grimoires/loa/cycles/cycle-099/progress.md REJECTED" {
+    _write_fixture "grimoires/loa/cycles/cycle-099/progress.md" 'oops LOA_AUDIT_KEY_PASSWORD=leak'
+    run _run_scanner "grimoires/loa/cycles/cycle-099/progress.md"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "reject: grimoires/loa/handoffs/random.md REJECTED" {
+    _write_fixture "grimoires/loa/handoffs/random.md" 'LOA_AUDIT_KEY_PASSWORD=leak'
+    run _run_scanner "grimoires/loa/handoffs/random.md"
+    [[ "$status" -ne 0 ]]
+}
+
+# Random unrelated grimoires markdown — also rejected per F8 (broad glob removed).
+@test "reject: grimoires/loa/some-random-doc.md REJECTED" {
+    _write_fixture "grimoires/loa/some-random-doc.md" 'LOA_AUDIT_KEY_PASSWORD=leak'
+    run _run_scanner "grimoires/loa/some-random-doc.md"
+    [[ "$status" -ne 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Mixed batch: violations + allowed in same scan
+# -----------------------------------------------------------------------------
+@test "mixed: scanner reports only violations, not allowlisted matches" {
+    _write_fixture ".claude/scripts/audit-envelope.sh" 'LOA_AUDIT_KEY_PASSWORD=ok'
+    _write_fixture "grimoires/loa/a2a/sprint-1/progress-1B.md" 'LOA_AUDIT_KEY_PASSWORD=violation'
+
+    run _run_scanner ".claude/scripts/audit-envelope.sh
+grimoires/loa/a2a/sprint-1/progress-1B.md"
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -q 'progress-1B.md'
+    ! echo "$output" | grep -q 'audit-envelope.sh'
+}
+
+# -----------------------------------------------------------------------------
+# Clean batch: no violations
+# -----------------------------------------------------------------------------
+@test "clean: no LOA_AUDIT_KEY_PASSWORD= in any file → exit 0" {
+    _write_fixture "grimoires/loa/some-random-doc.md" 'No assignment here'
+    _write_fixture "src/lib.rs" 'fn main() {}'
+
+    run _run_scanner "grimoires/loa/some-random-doc.md
+src/lib.rs"
+    [[ "$status" -eq 0 ]]
+}

--- a/tests/security/audit-secret-redaction-allowlist.bats
+++ b/tests/security/audit-secret-redaction-allowlist.bats
@@ -201,3 +201,37 @@ src/lib.rs"
     run bash -c "printf '\n' | '$SCAN_SCRIPT'"
     [[ "$status" -eq 0 ]]
 }
+
+# -----------------------------------------------------------------------------
+# Iter-2 F4 (bridgebuilder): the production workflow invokes the scanner with
+# no stdin, falling through to `git ls-files`. The 17 tests above feed paths
+# via stdin and never exercise that production dispatch. This test closes the
+# loop by initializing a real git repo + committing fixtures + invoking the
+# scanner with no stdin.
+# -----------------------------------------------------------------------------
+@test "f4-dispatch: scanner with no stdin uses git ls-files (production path)" {
+    command -v git >/dev/null 2>&1 || skip "git required for this test"
+
+    cd "$TEST_DIR"
+    # Configure git for this scoped repo so commit succeeds in CI.
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+
+    # Tracked allowlisted file: must NOT trigger a violation.
+    mkdir -p .claude/scripts
+    echo 'LOA_AUDIT_KEY_PASSWORD=ok' > .claude/scripts/audit-envelope.sh
+
+    # Tracked rejected file: MUST trigger a violation.
+    mkdir -p grimoires/loa/a2a/sprint-1
+    echo 'oops LOA_AUDIT_KEY_PASSWORD=violation' > grimoires/loa/a2a/sprint-1/progress-X.md
+
+    git add .claude/scripts/audit-envelope.sh grimoires/loa/a2a/sprint-1/progress-X.md
+    git commit -q -m "fixtures"
+
+    # Invoke scanner with NO stdin → triggers git ls-files dispatch.
+    run "$SCAN_SCRIPT" </dev/null
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -q 'progress-X.md'
+    ! echo "$output" | grep -q 'audit-envelope.sh'
+}

--- a/tests/unit/trust-store-root-of-trust.bats
+++ b/tests/unit/trust-store-root-of-trust.bats
@@ -91,8 +91,11 @@ pub_pem = priv.public_key().public_bytes(
     format=serialization.PublicFormat.SubjectPublicKeyInfo,
 ).decode()
 
-# Trust-store core (the part that gets signed: keys + revocations + trust_cutoff).
+# Trust-store core (the part that gets signed).
+# Sprint 1.5 (#695 F9): schema_version is included in the signed payload to
+# defeat downgrade-rollback attacks. Must match the YAML schema_version field.
 core = {
+    "schema_version": "1.0",
     "keys": [],
     "revocations": [],
     "trust_cutoff": {"default_strict_after": "2026-05-02T00:00:00Z"},

--- a/tests/unit/trust-store-signed-payload-scope.bats
+++ b/tests/unit/trust-store-signed-payload-scope.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/unit/trust-store-signed-payload-scope.bats
+#
+# cycle-098 Sprint 1.5 hardening — issue #695 F9.
+#
+# Bridgebuilder iter-1 of PR #693 surfaced that the trust-store signed payload
+# (`{keys, revocations, trust_cutoff}`) excluded `schema_version`. Anything
+# outside the signed envelope is attacker-controlled. Schema version often
+# gates parser behavior — leaving it unsigned is a classic downgrade vector
+# (cf. TLS version rollback, JWT alg confusion).
+#
+# Decision (Option 1 — security tightening): include `schema_version` in the
+# signed payload. This removes the downgrade attack surface entirely.
+#
+# Acceptance criteria:
+#   - Decision documented (Option 1: include in signature)
+#   - Negative test: schema_version tampering → trust-store verify fails
+#   - SDD §1.9.3.1 updated to make signed-payload boundary explicit
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    AUDIT_ENVELOPE="$PROJECT_ROOT/.claude/scripts/audit-envelope.sh"
+
+    [[ -f "$AUDIT_ENVELOPE" ]] || skip "audit-envelope.sh not present"
+    if ! python3 -c "import cryptography, yaml, rfc8785" 2>/dev/null; then
+        skip "python cryptography + yaml + rfc8785 required"
+    fi
+
+    TEST_DIR="$(mktemp -d)"
+    PINNED_PUBKEY="$TEST_DIR/pinned-root-pubkey.txt"
+    TRUST_STORE="$TEST_DIR/trust-store.yaml"
+
+    python3 - "$TEST_DIR" <<'PY'
+import sys
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+
+td = Path(sys.argv[1])
+priv = ed25519.Ed25519PrivateKey.generate()
+pub_pem = priv.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+)
+priv_pem = priv.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+)
+(td / "root.pub").write_bytes(pub_pem)
+(td / "root.priv").write_bytes(priv_pem)
+import shutil
+shutil.copy(td / "root.pub", td / "pinned-root-pubkey.txt")
+PY
+
+    export LOA_PINNED_ROOT_PUBKEY_PATH="$PINNED_PUBKEY"
+
+    # shellcheck disable=SC1090
+    source "$AUDIT_ENVELOPE"
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_PINNED_ROOT_PUBKEY_PATH
+}
+
+# Sign a trust-store with `schema_version` INCLUDED in signed payload.
+_sign_with_schema_version() {
+    local out_path="$1"
+    local signer_priv="$2"
+    local schema_v="${3:-1.0}"
+    python3 - "$out_path" "$signer_priv" "$schema_v" <<'PY'
+import sys, base64
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+import rfc8785
+
+out = Path(sys.argv[1])
+priv = serialization.load_pem_private_key(Path(sys.argv[2]).read_bytes(), password=None)
+schema_v = sys.argv[3]
+pub_pem = priv.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+).decode()
+
+# F9: schema_version IS part of the signed core (Option 1 — security tightening).
+core = {
+    "schema_version": schema_v,
+    "keys": [],
+    "revocations": [],
+    "trust_cutoff": {"default_strict_after": "2026-05-02T00:00:00Z"},
+}
+sig_b64 = base64.b64encode(priv.sign(rfc8785.dumps(core))).decode()
+
+yaml_text = f"""---
+schema_version: "{schema_v}"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: |
+{chr(10).join("    " + line for line in pub_pem.strip().split(chr(10)))}
+  signed_at: "2026-05-03T00:00:00Z"
+  signature: "{sig_b64}"
+keys: []
+revocations: []
+trust_cutoff:
+  default_strict_after: "2026-05-02T00:00:00Z"
+"""
+out.write_text(yaml_text)
+PY
+}
+
+# -----------------------------------------------------------------------------
+# Positive: schema_version IS in signed payload → legitimate sig validates
+# -----------------------------------------------------------------------------
+@test "f9: legitimately signed trust-store (schema_version in signed payload) validates" {
+    _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
+    run audit_trust_store_verify "$TRUST_STORE"
+    [[ "$status" -eq 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Negative: tamper schema_version (downgrade attack) → verification fails
+# -----------------------------------------------------------------------------
+@test "f9: tampered schema_version (downgrade attack) fails verification" {
+    _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
+
+    # Attacker swaps schema_version "1.0" → "0.9" (rollback to permissive parser).
+    sed -i.bak 's/^schema_version: "1.0"$/schema_version: "0.9"/' "$TRUST_STORE"
+    rm -f "$TRUST_STORE.bak"
+
+    run audit_trust_store_verify "$TRUST_STORE"
+    [[ "$status" -ne 0 ]]
+    echo "$output" | grep -qE 'verify|signature|TRUST-STORE' || {
+        echo "Expected verification-failure indicator in output, got: $output"
+        return 1
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Negative: schema_version tampering inside YAML (top-level) detected
+# -----------------------------------------------------------------------------
+@test "f9: tampered schema_version forward-version (e.g. 1.0 → 2.0) fails verification" {
+    _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
+
+    # Attacker bumps schema_version to a future incompatible version.
+    sed -i.bak 's/^schema_version: "1.0"$/schema_version: "2.0"/' "$TRUST_STORE"
+    rm -f "$TRUST_STORE.bak"
+
+    run audit_trust_store_verify "$TRUST_STORE"
+    [[ "$status" -ne 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Defensive: missing schema_version in YAML body (but present in signed payload)
+# fails — schema_version MUST be present and consistent.
+# -----------------------------------------------------------------------------
+@test "f9: trust-store missing schema_version field fails verification" {
+    _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
+
+    # Strip schema_version line from the YAML body.
+    sed -i.bak '/^schema_version: /d' "$TRUST_STORE"
+    rm -f "$TRUST_STORE.bak"
+
+    run audit_trust_store_verify "$TRUST_STORE"
+    [[ "$status" -ne 0 ]]
+}

--- a/tests/unit/trust-store-signed-payload-scope.bats
+++ b/tests/unit/trust-store-signed-payload-scope.bats
@@ -137,8 +137,12 @@ PY
 
     run audit_trust_store_verify "$TRUST_STORE"
     [[ "$status" -ne 0 ]]
-    echo "$output" | grep -qE 'verify|signature|TRUST-STORE' || {
-        echo "Expected verification-failure indicator in output, got: $output"
+    # Bridgebuilder F8: tightened to the exact failure token emitted by
+    # audit-signing-helper.py:cmd_trust_store_verify (`InvalidSignature` →
+    # "root_signature does NOT verify"). Permissive `verify|signature|...` regex
+    # caught hypothetical success banners; this assertion is now load-bearing.
+    echo "$output" | grep -q 'root_signature does NOT verify' || {
+        echo "Expected 'root_signature does NOT verify' marker in output, got: $output"
         return 1
     }
 }
@@ -155,6 +159,40 @@ PY
 
     run audit_trust_store_verify "$TRUST_STORE"
     [[ "$status" -ne 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# F2 (bridgebuilder): cross-adapter parity. The trust-store signed payload
+# (now {schema_version, keys, revocations, trust_cutoff} per F9) MUST be
+# byte-identical across adapters. Both bash and Python adapters delegate
+# verification to audit-signing-helper.py so this test guards against future
+# drift if a Python-only signing path is introduced.
+# -----------------------------------------------------------------------------
+@test "f9-parity: bash adapter verifies trust-store signed via fixture (Python)" {
+    _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
+    # Bash adapter path: source audit-envelope.sh and call audit_trust_store_verify.
+    run audit_trust_store_verify "$TRUST_STORE"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "f9-parity: Python adapter verifies trust-store signed via fixture" {
+    _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
+
+    # Python adapter path: import loa_cheval and call audit_trust_store_verify.
+    PYTHON_ADAPTER_DIR="$(cd "$BATS_TEST_FILENAME" && cd ../../../.claude/adapters && pwd 2>/dev/null || \
+                          cd "$(dirname "$BATS_TEST_FILENAME")/../../.claude/adapters" && pwd)"
+    [[ -d "$PYTHON_ADAPTER_DIR/loa_cheval" ]] || skip "loa_cheval adapter not found"
+
+    run env PYTHONPATH="$PYTHON_ADAPTER_DIR" \
+        LOA_PINNED_ROOT_PUBKEY_PATH="$LOA_PINNED_ROOT_PUBKEY_PATH" \
+        python3 -c "
+import sys
+from loa_cheval.audit_envelope import audit_trust_store_verify
+ok, msg = audit_trust_store_verify('$TRUST_STORE')
+print(msg)
+sys.exit(0 if ok else 1)
+"
+    [[ "$status" -eq 0 ]]
 }
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/trust-store-signed-payload-scope.bats
+++ b/tests/unit/trust-store-signed-payload-scope.bats
@@ -70,6 +70,17 @@ teardown() {
     unset LOA_PINNED_ROOT_PUBKEY_PATH
 }
 
+# Iter-2 F-001 portability helper: GNU vs BSD sed disagree on `-i` semantics.
+# Write-to-tempfile-then-mv is portable across both. (No backup file leftover.)
+_portable_sed() {
+    local expr="$1"
+    local file="$2"
+    local tmp
+    tmp="$(mktemp)"
+    sed "$expr" "$file" > "$tmp"
+    mv "$tmp" "$file"
+}
+
 # Sign a trust-store with `schema_version` INCLUDED in signed payload.
 _sign_with_schema_version() {
     local out_path="$1"
@@ -132,8 +143,9 @@ PY
     _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
 
     # Attacker swaps schema_version "1.0" → "0.9" (rollback to permissive parser).
-    sed -i.bak 's/^schema_version: "1.0"$/schema_version: "0.9"/' "$TRUST_STORE"
-    rm -f "$TRUST_STORE.bak"
+    # Iter-2 F-001 (bridgebuilder): `sed -i.bak` semantics differ between GNU and
+    # BSD sed (macOS). Portable form: write-temp-then-mv.
+    _portable_sed 's/^schema_version: "1.0"$/schema_version: "0.9"/' "$TRUST_STORE"
 
     run audit_trust_store_verify "$TRUST_STORE"
     [[ "$status" -ne 0 ]]
@@ -154,8 +166,7 @@ PY
     _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
 
     # Attacker bumps schema_version to a future incompatible version.
-    sed -i.bak 's/^schema_version: "1.0"$/schema_version: "2.0"/' "$TRUST_STORE"
-    rm -f "$TRUST_STORE.bak"
+    _portable_sed 's/^schema_version: "1.0"$/schema_version: "2.0"/' "$TRUST_STORE"
 
     run audit_trust_store_verify "$TRUST_STORE"
     [[ "$status" -ne 0 ]]
@@ -196,6 +207,49 @@ sys.exit(0 if ok else 1)
 }
 
 # -----------------------------------------------------------------------------
+# Iter-2 F6 (bridgebuilder): YAML parity. The fixture trust-store-sign.py
+# emits YAML via hand-rolled f-strings; production trust-stores would be
+# emitted by maintainers (likely also hand-rolled today, but might switch to
+# a canonical writer in a future cycle). This parity test asserts that
+# `yaml.safe_load(fixture_yaml)` produces the same dict shape as a directly-
+# constructed reference dict. Future drift (e.g., reordered fields, comment
+# headers) breaks this test rather than silently producing non-representative
+# fixtures.
+# -----------------------------------------------------------------------------
+@test "f6-parity: fixture-emitted trust-store loads to canonical dict shape" {
+    _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
+
+    run python3 -c "
+import sys, yaml
+with open('$TRUST_STORE') as f:
+    doc = yaml.safe_load(f)
+# Required top-level fields.
+required = ['schema_version', 'root_signature', 'keys', 'revocations', 'trust_cutoff']
+for k in required:
+    assert k in doc, f'missing field: {k}'
+# root_signature shape.
+rs = doc['root_signature']
+for k in ('algorithm', 'signer_pubkey', 'signed_at', 'signature'):
+    assert k in rs, f'missing root_signature.{k}'
+assert rs['algorithm'] == 'ed25519'
+# Schema version explicitly stringified.
+assert isinstance(doc['schema_version'], str)
+assert doc['schema_version'] == '1.0'
+# Lists are lists.
+assert isinstance(doc['keys'], list)
+assert isinstance(doc['revocations'], list)
+# Signature is non-empty + valid base64.
+import base64
+sig = rs['signature']
+assert sig
+base64.b64decode(sig, validate=True)
+print('PARITY OK')
+"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"PARITY OK"* ]]
+}
+
+# -----------------------------------------------------------------------------
 # Defensive: missing schema_version in YAML body (but present in signed payload)
 # fails — schema_version MUST be present and consistent.
 # -----------------------------------------------------------------------------
@@ -203,8 +257,7 @@ sys.exit(0 if ok else 1)
     _sign_with_schema_version "$TRUST_STORE" "$TEST_DIR/root.priv" "1.0"
 
     # Strip schema_version line from the YAML body.
-    sed -i.bak '/^schema_version: /d' "$TRUST_STORE"
-    rm -f "$TRUST_STORE.bak"
+    _portable_sed '/^schema_version: /d' "$TRUST_STORE"
 
     run audit_trust_store_verify "$TRUST_STORE"
     [[ "$status" -ne 0 ]]


### PR DESCRIPTION
## Summary

Sprint 2 prerequisite hardening per Sprint 1 audit + bridgebuilder follow-ups. Closes #689, #690, #695.

- **#689** (P2 MED, audit MED-1) — Python `audit_emit` flock parity with bash adapter (post-F3 CC-3 fix). Mixed bash + Python writers now serialize on the same `<log_path>.lock` file. Sprint 2's L2 reconciliation cron + verdict-engine are the first cross-adapter audit-envelope writers — this fixes the prerequisite race.
- **#690** (P2 MED, audit MED-2) — `audit_trust_store_verify` auto-called from `audit_verify_chain` + `audit_emit` (bash + Python). `BOOTSTRAP-PENDING` graceful fallback (empty signature + empty `keys[]` + empty `revocations[]`) keeps cycle-098 install ergonomic; once any keys land, the trust-store **MUST** be signed by the pinned root key — `INVALID` raises `[TRUST-STORE-INVALID]` BLOCKER. Cached per-process, mtime-invalidated.
- **#695 F8** (P2 MED, bridgebuilder iter-1) — Audit-secret-redaction allowlist tightened. Broad globs over agent-writable paths (`progress/`, `handoffs/`, `a2a/`, `grimoires/loa/*.md`) replaced with named files only. Single-source-of-truth scanner extracted to `.claude/scripts/audit-secret-redaction-scan.sh` so allowlist + scan logic is unit-tested. `progress-1B.md` sanitized (assignment patterns rephrased).
- **#695 F9** (P2 MED, bridgebuilder iter-1) — Trust-store signed-payload boundary made **explicit**. `schema_version` is now **included** in the signed payload (Option 1 — security tightening) to defeat downgrade-rollback attacks (cf. TLS version rollback, JWT alg confusion). SDD §1.9.3.1 documents the signed-payload scope explicitly.

## Files changed

| File | Change | Issue |
|------|--------|-------|
| `.claude/adapters/loa_cheval/audit_envelope.py` | Add fcntl flock + trust-store auto-verify | #689 + #690 |
| `.claude/scripts/audit-envelope.sh` | Add trust-store auto-verify gate (with mtime cache) | #690 |
| `.claude/scripts/lib/audit-signing-helper.py` | Include `schema_version` in signed core | #695 F9 |
| `.claude/scripts/audit-secret-redaction-scan.sh` | NEW — single-source-of-truth scanner | #695 F8 |
| `.github/workflows/audit-secret-redaction.yml` | Use scanner; tightened allowlist | #695 F8 |
| `grimoires/loa/sdd.md` | §1.9.3.1 signed-payload scope explicit | #695 F9 |
| `grimoires/loa/a2a/sprint-1/progress-1B.md` | Sanitize assignment patterns | #695 F8 |
| `tests/integration/audit-envelope-python-concurrent.bats` | NEW — 4 tests | #689 |
| `tests/integration/audit-trust-store-auto-verify.bats` | NEW — 12 tests | #690 |
| `tests/security/audit-secret-redaction-allowlist.bats` | NEW — 15 tests | #695 F8 |
| `tests/unit/trust-store-signed-payload-scope.bats` | NEW — 4 tests | #695 F9 |
| `tests/unit/trust-store-root-of-trust.bats` | Update sign helper for F9 scope | #695 F9 |

## Test plan

35 new tests added; 175 audit-related tests in the regression suite all pass.

- [x] `bats tests/integration/audit-envelope-python-concurrent.bats` — 4 tests
- [x] `bats tests/integration/audit-trust-store-auto-verify.bats` — 12 tests
- [x] `bats tests/security/audit-secret-redaction-allowlist.bats` — 15 tests
- [x] `bats tests/unit/trust-store-signed-payload-scope.bats` — 4 tests
- [x] `bats tests/unit/trust-store-root-of-trust.bats` — 5 tests (sign helper updated for F9)
- [x] `bats tests/integration/audit-envelope-{chain,signing,bootstrap,concurrent-write}.bats` — 26 tests
- [x] `bats tests/integration/hash-chain-recovery-{tracked,untracked}.bats` — 6 tests
- [x] `bats tests/integration/{panel-fallback-matrix,panel-protected-class,protected-class-router-cli}.bats` — multi
- [x] `bats tests/integration/{hitl-jury-panel-skill,sanitize-for-session-start,skill-audit,parser-cross-language}.bats` — multi
- [x] `bats tests/security/{audit-envelope-strip-attack,no-env-var-leakage}.bats` — 27 tests
- [x] `bats tests/conformance/jcs/test-jcs-bash.bats` — JCS conformance
- [x] `.claude/scripts/audit-secret-redaction-scan.sh` clean on the real repo (no violations)
- [x] Python + bash syntax checks (`ast.parse`, `bash -n`)

## Acceptance criteria

### #689 — Python adapter flock parity
- [x] Python `audit_emit` acquires flock identical to bash semantics
- [x] 5+ concurrent Python `audit_emit` writes preserve chain integrity
- [x] Test added (`tests/integration/audit-envelope-python-concurrent.bats`); passes post-fix
- [x] No regressions in existing Python audit tests

### #690 — audit_trust_store_verify auto-call
- [x] `audit_verify_chain` auto-calls `audit_trust_store_verify` once per process
- [x] Trust-store substitution test: tamper trust-store.yaml; chain ops fail
- [x] BOOTSTRAP-PENDING state still permits reads/writes (graceful fallback)
- [x] Cached verify result invalidated on trust-store mtime change

### #695 F8 — Audit-secret-redaction allowlist
- [x] Allowlist tightened to named files (no glob over agent-writable paths)
- [x] Agent-writable paths (`progress/`, `handoffs/`, `a2a/`) explicitly excluded
- [x] Test: deliberately committed fake secret in `progress/` markdown → workflow catches it

### #695 F9 — Trust-store signature scope
- [x] Decision documented (Option 1 — include `schema_version` in signed payload)
- [x] Negative test: schema_version tampering → trust-store verify fails
- [x] SDD §1.9.3.1 updated to make signed-payload boundary explicit

## Notes for reviewer

- **Test-first**: failing tests added first for each issue; fixes verified to make them pass.
- **No regression**: Sprint 1 regression suite (175 tests) all pass after changes.
- **Beads UNHEALTHY (#661)**: commit used `--no-verify` per documented workaround.
- **Karpathy-tight scope**: surgical changes only; no refactoring of adjacent code.
- **System Zone authorization**: cycle-098 PRD authorizes cross-cycle hardening to `.claude/scripts/`, `.claude/adapters/`, `.claude/data/`. This work is contained to that scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)