### PR TITLE
fix(t2-t3): hardening bundle — close #636 + #681 + #687 + #691 + #692

### DIFF
--- a/.claude/scripts/construct-compose.sh
+++ b/.claude/scripts/construct-compose.sh
@@ -392,7 +392,7 @@ for (( i=0; i<STAGE_COUNT; i++ )); do
   outcome="completed"
   if (( exec_rc != 0 )); then
     outcome="failed"
-    "$SCRIPT_DIR/construct-invoke.sh" exit "$persona" "$construct" "$dur_ms" "$outcome" "/compose:$COMPOSITION_NAME#$stage_label" >/dev/null 2>&1 || true
+    "$SCRIPT_DIR/construct-invoke.sh" exit "$persona" "$construct" "$dur_ms" "$outcome" "/compose:$COMPOSITION_NAME#$stage_label" "$session_id" >/dev/null 2>&1 || true
     die 3 "stage $stage_label ($construct/$skill) executor exited $exec_rc"
   fi
 

--- a/.claude/scripts/construct-invoke.sh
+++ b/.claude/scripts/construct-invoke.sh
@@ -183,14 +183,13 @@ do_exit() {
     key=$(session_key "$persona" "$construct_slug")
     rm -f "$(session_temp_path "$key")" 2>/dev/null || true
   else
-    # DEPRECATED FALLBACK: filesystem-as-shared-memory, keyed by
-    # (persona, construct). Race-prone under parallel entry calls with the
-    # same key — see Bridgebuilder PR #617 iter-3 HIGH_CONSENSUS finding +
-    # iter-4 escalation. Tracked for removal in issue #636. Until then we
-    # emit a per-call warning
-    # to nudge callers toward explicit value-passing. Set
-    # LOA_INVOKE_FALLBACK_QUIET=1 to suppress (e.g., when the caller is
-    # known to be sequential and the noise is undesirable).
+    # Issue #636 (sprint-bug-141): temp-file LOOKUP retained as backward-compat
+    # for callers that haven't yet threaded session_id through. PR #617
+    # deprecated this path; sprint-bug-141 completes the migration by:
+    #   - removing the per-call DEPRECATION warning emission (noise reduction)
+    #   - rejecting calls where neither explicit nor temp-file marker resolves,
+    #     instead of silently emitting `session_id: null` which broke
+    #     downstream pair-matching in trajectory analysis.
     local key
     key=$(session_key "$persona" "$construct_slug")
     local temp_path
@@ -198,15 +197,17 @@ do_exit() {
     if [[ -f "$temp_path" ]]; then
       session_id=$(cat "$temp_path" 2>/dev/null || echo "")
       rm -f "$temp_path" 2>/dev/null || true
-      if [[ "${LOA_INVOKE_FALLBACK_QUIET:-0}" != "1" ]]; then
-        echo "[construct-invoke] DEPRECATION: relying on temp-file session-id correlation for $persona/$construct_slug. This path is race-prone under parallel callers. Pass session_id explicitly (positional arg 6 or LOA_SESSION_ID env). Set LOA_INVOKE_FALLBACK_QUIET=1 to suppress." >&2
-      fi
     fi
   fi
 
   if [[ -z "$session_id" ]]; then
-    echo "[construct-invoke] WARNING: no session_id found for $persona/$construct_slug — exit row will have null session_id" >&2
-    session_id="null"
+    # Hard reject — no explicit value, no env, no temp-file marker. Pre-fix
+    # silently emitted a session_id: null row that broke trajectory analysis;
+    # post-fix surfaces the misuse so the caller wires up explicit threading.
+    echo "[construct-invoke] ERROR: no session_id resolvable for $persona/$construct_slug" >&2
+    echo "[construct-invoke]   Pass explicitly: positional arg 6 OR LOA_SESSION_ID env." >&2
+    echo "[construct-invoke]   Issue #636 / sprint-bug-141 — see grimoires/loa/a2a/bug-20260504-i636-cb9b6d/triage.md" >&2
+    return 2
   fi
 
   # Validate/normalize duration_ms
@@ -227,33 +228,22 @@ do_exit() {
   local stream_type="${LOA_STREAM_TYPE:-Signal}"
   local read_mode="${LOA_READ_MODE:-orient}"
 
+  # Issue #636 (sprint-bug-141): session_id is now always non-empty (hard
+  # reject earlier prevents the empty case). The pre-fix `session_id: null`
+  # branch is removed.
   local row
-  if [[ "$session_id" == "null" ]]; then
-    row=$(jq -cn \
-      --arg event "exit" \
-      --arg persona "$persona" \
-      --arg trigger "$trigger" \
-      --arg construct_slug "$construct_slug" \
-      --arg timestamp "$ts" \
-      --argjson duration_ms "$dur_json" \
-      --arg outcome "$outcome" \
-      --arg stream_type "$stream_type" \
-      --arg read_mode "$read_mode" \
-      '{event: $event, session_id: null, persona: $persona, trigger: $trigger, construct_slug: $construct_slug, stream_type: $stream_type, read_mode: $read_mode, timestamp: $timestamp, duration_ms: $duration_ms, outcome: $outcome}')
-  else
-    row=$(jq -cn \
-      --arg event "exit" \
-      --arg session_id "$session_id" \
-      --arg persona "$persona" \
-      --arg trigger "$trigger" \
-      --arg construct_slug "$construct_slug" \
-      --arg timestamp "$ts" \
-      --argjson duration_ms "$dur_json" \
-      --arg outcome "$outcome" \
-      --arg stream_type "$stream_type" \
-      --arg read_mode "$read_mode" \
-      '{event: $event, session_id: $session_id, persona: $persona, trigger: $trigger, construct_slug: $construct_slug, stream_type: $stream_type, read_mode: $read_mode, timestamp: $timestamp, duration_ms: $duration_ms, outcome: $outcome}')
-  fi
+  row=$(jq -cn \
+    --arg event "exit" \
+    --arg session_id "$session_id" \
+    --arg persona "$persona" \
+    --arg trigger "$trigger" \
+    --arg construct_slug "$construct_slug" \
+    --arg timestamp "$ts" \
+    --argjson duration_ms "$dur_json" \
+    --arg outcome "$outcome" \
+    --arg stream_type "$stream_type" \
+    --arg read_mode "$read_mode" \
+    '{event: $event, session_id: $session_id, persona: $persona, trigger: $trigger, construct_slug: $construct_slug, stream_type: $stream_type, read_mode: $read_mode, timestamp: $timestamp, duration_ms: $duration_ms, outcome: $outcome}')
 
   emit_row "$row"
 }

--- a/.claude/scripts/construct-invoke.sh
+++ b/.claude/scripts/construct-invoke.sh
@@ -19,6 +19,14 @@
 # Exit Codes:
 #   0 = success (JSONL write failure is non-fatal — logs warning)
 #   1 = invalid subcommand
+#   2 = `exit` subcommand called with no resolvable session_id (sprint-bug-141
+#       #636 — pre-fix this emitted a session_id:null row + warning at exit 0;
+#       post-fix it hard-rejects so trajectory pair-matching stays clean).
+#       Callers that previously ignored exit codes MUST now thread session_id
+#       explicitly via positional arg 6 or LOA_SESSION_ID env. The temp-file
+#       LOOKUP path is preserved as silent backward-compat for sequential
+#       callers (a one-line "tempfile_fallback_used" stderr signal is emitted
+#       per call; LOA_INVOKE_FALLBACK_QUIET=1 to suppress).
 #
 # Cycle: loa-constructs-cycle-001 (Leg D — Construct Trajectory Emission)
 # =============================================================================
@@ -197,6 +205,15 @@ do_exit() {
     if [[ -f "$temp_path" ]]; then
       session_id=$(cat "$temp_path" 2>/dev/null || echo "")
       rm -f "$temp_path" 2>/dev/null || true
+      # Bridgebuilder iter-1 (sprint-bug-141 #636 review): per-call DEPRECATION
+      # warning was removed for noise reduction, but keeping the signal silent
+      # makes the racy path permanent. Emit ONE structured stderr line per
+      # process invocation (LOA_INVOKE_STRICT_EXIT=1 to silence) so operators
+      # auditing test logs can still see + measure fallback usage.
+      if [[ "${LOA_INVOKE_FALLBACK_QUIET:-0}" != "1" ]]; then
+        printf '[construct-invoke] info: tempfile_fallback_used persona=%s construct=%s issue=#636\n' \
+          "$persona" "$construct_slug" >&2
+      fi
     fi
   fi
 

--- a/.claude/scripts/lib/hitl-jury-panel-lib.sh
+++ b/.claude/scripts/lib/hitl-jury-panel-lib.sh
@@ -176,12 +176,25 @@ panel_solicit() {
     # NB: do NOT use --preserve-status — that masks timeout (124) with the
     # killed child's exit status. Also: `if ! cmd; then rc=$?; fi` does NOT
     # preserve rc reliably under bats/`set -e` — use `cmd || rc=$?`.
+    # Issue #692 (sprint-bug-141): pass prompt content via --input <tmpfile>
+    # rather than --prompt "$(cat ...)" so the deliberation context never
+    # transits argv. Pre-fix `ps -o args=` exposed the entire context to any
+    # local user during the model-invoke fork window. Mirrors sprint-bug-131
+    # / #675 fd-vs-argv pattern.
+    local prompt_file
+    prompt_file=$(mktemp)
+    chmod 600 "$prompt_file" 2>/dev/null || true
+    # Read context into the tmpfile (silently fall through on missing/empty
+    # context to preserve pre-fix tolerance — empty stdin to model-invoke
+    # is the same as empty --prompt).
+    cat "$context_path" 2>/dev/null > "$prompt_file" || true
+
     local timed_out=false
     rc=0
     if command -v timeout >/dev/null 2>&1; then
         LOA_PANEL_TEST_PANELIST="$panelist_id" \
             timeout "$timeout_s" \
-                model-invoke --model "$model" --prompt "$(cat "$context_path" 2>/dev/null || true)" \
+                model-invoke --model "$model" --input "$prompt_file" \
                 </dev/null >"$out_file" 2>"$err_file" \
             || rc=$?
         # `timeout` exits 124 on its SIGTERM, 137 (=128+9) on SIGKILL,
@@ -192,10 +205,11 @@ panel_solicit() {
         fi
     else
         LOA_PANEL_TEST_PANELIST="$panelist_id" \
-            model-invoke --model "$model" --prompt "$(cat "$context_path" 2>/dev/null || true)" \
+            model-invoke --model "$model" --input "$prompt_file" \
                 </dev/null >"$out_file" 2>"$err_file" \
             || rc=$?
     fi
+    rm -f "$prompt_file"
 
     ended=$(date +%s)
     duration=$((ended - started))

--- a/.claude/scripts/panel-distribution-audit.sh
+++ b/.claude/scripts/panel-distribution-audit.sh
@@ -117,9 +117,17 @@ fi
 # We delegate the per-line filter + counter aggregation to a Python helper so
 # the date-window arithmetic and ordered-dict traversal are uniform across
 # Linux + macOS.
+#
+# Issue #691 (sprint-bug-141): use mktemp instead of /tmp/panel-...$$.
+# Pre-fix used a predictable path that an attacker could pre-create as a
+# symlink on a multi-user system. mktemp atomically creates a uniquely-named
+# file with mode 0600; the EXIT trap guarantees cleanup even on signal.
+RESULT_FILE="$(mktemp)"
+chmod 600 "$RESULT_FILE" 2>/dev/null || true
+trap 'rm -f "$RESULT_FILE"' EXIT
 LOA_DA_LOG="$LOG_PATH" \
 LOA_DA_WINDOW="$WINDOW_DAYS" \
-python3 - <<'PY' > /tmp/panel-distribution-audit-result.$$ 2>&1
+python3 - <<'PY' > "$RESULT_FILE" 2>&1
 import json
 import os
 import sys
@@ -205,13 +213,13 @@ PY_EXIT=$?
 
 if [[ "$PY_EXIT" -ne 0 ]]; then
     echo "panel-distribution-audit: aggregation helper failed (exit=$PY_EXIT)" >&2
-    cat /tmp/panel-distribution-audit-result.$$ >&2
-    rm -f /tmp/panel-distribution-audit-result.$$
+    cat "$RESULT_FILE" >&2
     exit 2
 fi
 
-REPORT_JSON=$(cat /tmp/panel-distribution-audit-result.$$)
-rm -f /tmp/panel-distribution-audit-result.$$
+REPORT_JSON=$(cat "$RESULT_FILE")
+# EXIT trap removes RESULT_FILE on script exit; explicit rm here is no longer
+# required. Issue #691 (sprint-bug-141) — mktemp + trap pattern.
 
 # ---- Output -----------------------------------------------------------------
 if [[ "$JSON_MODE" -eq 1 ]]; then

--- a/.github/workflows/no-backup-files.yml
+++ b/.github/workflows/no-backup-files.yml
@@ -1,0 +1,72 @@
+name: No Backup Files
+
+# Issue #681 (sprint-bug-141, vision-014): CI guard rejecting *.bak / -bak /
+# *~ / *.orig / *.swp / *.swo siblings in PR diffs. Planning tooling
+# (`/sprint-plan`, `/archive-cycle`) historically emitted defensive backup
+# siblings (e.g. `sprint.md.cycle-096-bak`) that accidentally landed in PRs.
+# Bridgebuilder caught + removed them in PR #678; this workflow makes the
+# guarantee enforced rather than discovered post-hoc.
+#
+# Bypass: include `[allow-bak]` in the PR title to skip this check (e.g.,
+# when a vendored or documentation snapshot legitimately includes a .bak
+# file). The bypass token is delivered via env var per cycle-098 untrusted-
+# input pattern (NEVER direct `${{ ... }}` interpolation in shell bodies).
+
+on:
+  pull_request:
+
+jobs:
+  no-backup-files:
+    name: Reject backup-sibling files
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        # actions/checkout@v4.3.1 (pinned per cycle-098 supply-chain pattern)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0  # need history for git diff vs base ref
+
+      - name: Check for backup-sibling files in PR diff
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          # Bypass — `[allow-bak]` token in PR title. Read from env var to
+          # avoid GitHub-context-injection vector (see cycle-098 SDD §1.9.3.2).
+          if [[ "${PR_TITLE}" == *'[allow-bak]'* ]]; then
+            echo "::notice::PR title contains [allow-bak] — backup-file check bypassed"
+            exit 0
+          fi
+
+          # Compute the diff vs base ref.
+          git fetch origin "${BASE_REF}" --depth=1 || true
+          changed_files=$(git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null || git diff --name-only HEAD~1)
+
+          # Pattern: *.bak, -bak (suffix), *~, *.orig, *.swp, *.swo.
+          # NB: trailing-dot extensions only — does NOT reject `bakery/` dirs.
+          violations=$(printf '%s\n' "$changed_files" \
+            | grep -E '(\.bak$|-bak$|~$|\.orig$|\.swp$|\.swo$)' \
+            || true)
+
+          if [[ -n "$violations" ]]; then
+            echo "::error::Backup-sibling files detected in PR diff (issue #681 / vision-014)"
+            echo "Affected files:"
+            printf '  - %s\n' $violations
+            echo ""
+            echo "Remediation:"
+            echo "  git rm --cached <file>      # untrack the backup"
+            echo "  echo '<pattern>' >> .gitignore"
+            echo "  git commit --amend --no-edit"
+            echo ""
+            echo "If this backup file is INTENTIONALLY part of the PR (rare — "
+            echo "e.g., a vendored snapshot or test fixture), include the bypass"
+            echo "token in your PR title: [allow-bak]"
+            echo ""
+            echo "Reference: https://github.com/0xHoneyJar/loa/issues/681"
+            exit 1
+          fi
+
+          echo "OK — no backup-sibling files in PR diff"

--- a/.github/workflows/no-backup-files.yml
+++ b/.github/workflows/no-backup-files.yml
@@ -41,9 +41,13 @@ jobs:
             exit 0
           fi
 
-          # Compute the diff vs base ref.
-          git fetch origin "${BASE_REF}" --depth=1 || true
-          changed_files=$(git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null || git diff --name-only HEAD~1)
+          # Compute the diff vs base ref. Fail-closed per Tricorder principle:
+          # if the diff cannot be computed, the workflow MUST refuse to emit
+          # a green signal — silent fallback to HEAD~1 would only inspect the
+          # latest commit and miss multi-commit PRs that introduced the .bak
+          # earlier (bridgebuilder iter-1 finding).
+          git fetch origin "${BASE_REF}" --depth=1
+          changed_files=$(git diff --name-only "origin/${BASE_REF}...HEAD")
 
           # Pattern: *.bak, -bak (suffix), *~, *.orig, *.swp, *.swo.
           # NB: trailing-dot extensions only — does NOT reject `bakery/` dirs.

--- a/.github/workflows/no-backup-files.yml
+++ b/.github/workflows/no-backup-files.yml
@@ -58,7 +58,12 @@ jobs:
           if [[ -n "$violations" ]]; then
             echo "::error::Backup-sibling files detected in PR diff (issue #681 / vision-014)"
             echo "Affected files:"
-            printf '  - %s\n' $violations
+            # Iter-2 lint: quote violations during expansion. Filenames with
+            # whitespace would otherwise word-split incorrectly. We DO want
+            # newline-splitting (each file on its own line) — preserve via IFS.
+            while IFS= read -r f; do
+              printf '  - %s\n' "$f"
+            done <<< "$violations"
             echo ""
             echo "Remediation:"
             echo "  git rm --cached <file>      # untrack the backup"

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -875,9 +875,28 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260503-i674-84adf8/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260503-i674-84adf8/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260504-i636-cb9b6d",
+      "label": "Bug Fix — T2+T3 hardening bundle (#636+#681+#687+#691+#692)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issues": [
+        636,
+        681,
+        687,
+        691,
+        692
+      ],
+      "created_at": "2026-05-03T15:07:52Z",
+      "sprints": [
+        "sprint-bug-141"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260504-i636-cb9b6d/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260504-i636-cb9b6d/sprint.md"
     }
   ],
-  "global_sprint_counter": 140,
+  "global_sprint_counter": 141,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/security/hitl-jury-panel-argv-safety.bats
+++ b/tests/security/hitl-jury-panel-argv-safety.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/security/hitl-jury-panel-argv-safety.bats — issue #692
+#
+# sprint-bug-141 (T2+T3 hardening). Pre-fix: hitl-jury-panel-lib.sh
+# panel_solicit invokes `model-invoke --prompt "$(cat "$context_path")"`
+# which puts the entire prompt content on argv. Briefly visible in
+# `ps aux` between fork+exec; sensitive context (e.g., panel deliberation
+# input) leaks to anyone with /proc read access.
+#
+# Post-fix: switch to `model-invoke --input <tmpfile>` so prompt content
+# only ever transits a mode-0600 file, never argv. Mirrors the
+# sprint-bug-131 cheval HTTP/2 + argv-safety pattern that closed #675.
+# =============================================================================
+
+setup() {
+    BATS_TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT_REAL="$(cd "$BATS_TEST_DIR/../.." && pwd)"
+    PANEL_LIB="$PROJECT_ROOT_REAL/.claude/scripts/lib/hitl-jury-panel-lib.sh"
+
+    [[ -f "$PANEL_LIB" ]] || skip "hitl-jury-panel-lib.sh not present"
+
+    TEST_DIR="$(mktemp -d)"
+    BIN_DIR="$TEST_DIR/bin"
+    mkdir -p "$BIN_DIR"
+    ARGV_LOG="$TEST_DIR/argv.log"
+    INPUT_LOG="$TEST_DIR/input.log"
+    export ARGV_LOG INPUT_LOG
+
+    # Stub model-invoke captures argv + (if --input passed) the file content.
+    # Argv is written verbatim as a single line per invocation. The post-fix
+    # invocation should NOT include the prompt content on argv.
+    cat > "$BIN_DIR/model-invoke" <<'SHIM'
+#!/usr/bin/env bash
+# Capture every arg as one quoted line so the test can grep without ambiguity.
+{
+    for a in "$@"; do
+        printf '%s\n' "$a"
+    done
+    printf '---END---\n'
+} >> "$ARGV_LOG"
+# When --input <file> is used, also capture the file's content (so we can
+# verify the lib actually populated the tmpfile correctly).
+input_path=""
+seen_input=false
+for arg in "$@"; do
+    if [[ "$seen_input" == "true" ]]; then
+        input_path="$arg"
+        break
+    fi
+    [[ "$arg" == "--input" ]] && seen_input=true
+done
+if [[ -n "$input_path" && -f "$input_path" ]]; then
+    cat "$input_path" >> "$INPUT_LOG"
+    printf '---END---\n' >> "$INPUT_LOG"
+fi
+# Emit a valid JSON view so the panel function doesn't error.
+printf '{"view":"OK","reasoning_summary":"stub"}\n'
+exit 0
+SHIM
+    chmod +x "$BIN_DIR/model-invoke"
+
+    export PATH="$BIN_DIR:$PATH"
+    export LOA_PANEL_TEST_INVOKE_DIR="$TEST_DIR/invoke"
+    mkdir -p "$LOA_PANEL_TEST_INVOKE_DIR"
+}
+
+teardown() {
+    cd /
+    [[ -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+# -----------------------------------------------------------------------------
+# Pre-fix this test FAILS: prompt content is on argv via --prompt "$(cat ...)".
+# Post-fix: prompt content goes through --input <tmpfile>; argv carries only
+# the tmpfile path, not the content.
+# -----------------------------------------------------------------------------
+@test "argv-safety: prompt content is NOT exposed on model-invoke argv" {
+    # Source the lib in a subshell with stub PATH.
+    local context_path="$TEST_DIR/context.txt"
+    # Choose a recognizable secret marker that should NEVER show up on argv.
+    local secret_marker="LOA_ARGV_LEAK_CANARY_$(date +%s)"
+    printf 'Confidential panel deliberation content. %s\n' "$secret_marker" > "$context_path"
+
+    # Invoke panel_solicit (via the lib's source).
+    # panel_solicit signature: (panelist_id, model, persona_path, context_path, [--timeout N])
+    run bash -c "
+        source '$PANEL_LIB'
+        # Persona path can be empty/dummy (lib reads it but doesn't fail on empty).
+        persona='$TEST_DIR/persona.md'; printf 'You are a panelist.' > \"\$persona\"
+        panel_solicit 'panelist-A' 'claude-test-stub' \"\$persona\" '$context_path' --timeout 5 || true
+    "
+    [[ "$status" -eq 0 ]] || {
+        echo "panel_solicit failed: $output"
+        echo "--- argv log ---"
+        cat "$ARGV_LOG" 2>/dev/null
+        return 1
+    }
+
+    [[ -f "$ARGV_LOG" ]] || {
+        echo "model-invoke stub never invoked"
+        return 1
+    }
+
+    # Argv MUST NOT contain the secret marker. Pre-fix, --prompt \"\$(cat ...)\"
+    # places the entire prompt body on argv → secret marker present.
+    if grep -qF "$secret_marker" "$ARGV_LOG"; then
+        echo "ERROR: secret marker leaked to argv (issue #692 not fixed)"
+        echo "--- argv log ---"
+        cat "$ARGV_LOG"
+        return 1
+    fi
+}
+
+@test "argv-safety: prompt content IS reachable via --input <tmpfile>" {
+    local context_path="$TEST_DIR/context.txt"
+    local secret_marker="LOA_INPUT_REACHABLE_$(date +%s)"
+    printf 'Panel context. %s\n' "$secret_marker" > "$context_path"
+
+    run bash -c "
+        source '$PANEL_LIB'
+        persona='$TEST_DIR/persona.md'; printf 'You are a panelist.' > \"\$persona\"
+        panel_solicit 'panelist-A' 'claude-test-stub' \"\$persona\" '$context_path' --timeout 5 || true
+    "
+    [[ "$status" -eq 0 ]]
+
+    # Post-fix uses --input → INPUT_LOG should contain the secret marker
+    # (proving the prompt content was successfully passed via the file path).
+    [[ -f "$INPUT_LOG" ]] || {
+        echo "model-invoke was not called with --input <file>"
+        echo "--- argv log ---"
+        cat "$ARGV_LOG"
+        return 1
+    }
+    grep -qF "$secret_marker" "$INPUT_LOG" || {
+        echo "Prompt content not delivered via --input file"
+        echo "--- input log ---"
+        cat "$INPUT_LOG"
+        return 1
+    }
+}
+
+@test "argv-safety: --input flag is on argv (not --prompt)" {
+    local context_path="$TEST_DIR/context.txt"
+    printf 'short context\n' > "$context_path"
+
+    run bash -c "
+        source '$PANEL_LIB'
+        persona='$TEST_DIR/persona.md'; printf 'You are a panelist.' > \"\$persona\"
+        panel_solicit 'panelist-A' 'claude-test-stub' \"\$persona\" '$context_path' --timeout 5 || true
+    "
+    [[ "$status" -eq 0 ]]
+    [[ -f "$ARGV_LOG" ]]
+
+    grep -qF -- '--input' "$ARGV_LOG" || {
+        echo "Expected --input on argv (post-fix); got:"
+        cat "$ARGV_LOG"
+        return 1
+    }
+    if grep -qF -- '--prompt' "$ARGV_LOG"; then
+        echo "ERROR: --prompt still on argv (pre-fix pattern)"
+        cat "$ARGV_LOG"
+        return 1
+    fi
+}

--- a/tests/unit/construct-invoke.bats
+++ b/tests/unit/construct-invoke.bats
@@ -108,13 +108,34 @@ teardown() {
     [ "$dur" = "null" ]
 }
 
-@test "construct-invoke: exit without preceding entry emits row with null session_id and warns" {
+# Issue #636 (sprint-bug-141): pre-fix, exit-without-entry emitted a
+# session_id: null row + warning. Post-fix, the call is rejected (return 2)
+# so downstream pair-matching never sees orphan rows.
+@test "construct-invoke: exit without resolvable session_id rejects (no row emitted)" {
     run "$SCRIPT" exit ALEXANDER unmatched 100 completed
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"no session_id resolvable"* ]]
+    [[ "$output" == *"#636"* ]] || [[ "$output" == *"sprint-bug-141"* ]]
+    # No trajectory row should have been emitted.
+    if [[ -f "$LOA_TRAJECTORY_FILE" ]]; then
+        ! grep -q '"event":"exit"' "$LOA_TRAJECTORY_FILE" || {
+            echo "Unexpected exit row emitted despite missing session_id"
+            cat "$LOA_TRAJECTORY_FILE"
+            return 1
+        }
+    fi
+}
+
+@test "construct-invoke: explicit-only mode succeeds without temp-file marker" {
+    # Issue #636: explicit value-passing is the canonical path. No temp file,
+    # no env var — just positional arg 6.
+    local sid="bug-141-explicit-only-test"
+    run "$SCRIPT" exit ALEXANDER artisan 100 completed "" "$sid"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"no session_id found"* ]]
-    local sid
-    sid=$(jq -r '.session_id' "$LOA_TRAJECTORY_FILE")
-    [ "$sid" = "null" ]
+    [[ "$output" != *"DEPRECATION"* ]]
+    local emitted_sid
+    emitted_sid=$(jq -r '.session_id' "$LOA_TRAJECTORY_FILE")
+    [ "$emitted_sid" = "$sid" ]
 }
 
 @test "construct-invoke: trigger derives from persona handle when not supplied" {
@@ -213,29 +234,24 @@ teardown() {
     [ "$emitted_sid" = "$positional_sid" ]
 }
 
-@test "construct-invoke: temp-file fallback emits deprecation warning by default" {
-    # Iter-4 escalation: the temp-file fallback path is documented as racy
-    # under concurrency. Make the racy path noisy so callers see it and
-    # migrate to explicit session_id passing.
+# Issue #636 (sprint-bug-141): the 3 deprecation-warning tests that lived
+# here have been removed. The DEPRECATION warning emission was retired with
+# the fallback-path completion (PR #617 deprecated; sprint-bug-141 finished
+# the migration). The temp-file LOOKUP path is preserved silently as
+# backward-compat for sequential callers; the canonical-path tests above
+# (explicit-only, env, positional) carry the load-bearing assertions.
+
+@test "construct-invoke: temp-file fallback (entry+exit) still works without DEPRECATION noise" {
+    # Backward-compat assurance: the lookup path resolves session_id from the
+    # temp file when no explicit value is passed. No warning should be emitted
+    # post-#636 fix.
     "$SCRIPT" entry ALEXANDER artisan >/dev/null
     run "$SCRIPT" exit ALEXANDER artisan 100 completed
     [ "$status" -eq 0 ]
-    [[ "$output" == *"DEPRECATION"* ]]
-    [[ "$output" == *"explicit"* ]]
-}
-
-@test "construct-invoke: LOA_INVOKE_FALLBACK_QUIET=1 silences the deprecation warning" {
-    "$SCRIPT" entry ALEXANDER artisan >/dev/null
-    LOA_INVOKE_FALLBACK_QUIET=1 run "$SCRIPT" exit ALEXANDER artisan 100 completed
-    [ "$status" -eq 0 ]
-    [[ "$output" != *"DEPRECATION"* ]]
-}
-
-@test "construct-invoke: explicit session_id never triggers the deprecation warning" {
-    local sid="explicit-no-warn"
-    run "$SCRIPT" exit ALEXANDER artisan 100 completed "" "$sid"
-    [ "$status" -eq 0 ]
-    [[ "$output" != *"DEPRECATION"* ]]
+    [[ "$output" != *"DEPRECATION"* ]] || {
+        echo "Unexpected DEPRECATION warning post-#636: $output"
+        return 1
+    }
 }
 
 @test "construct-invoke: explicit session_id survives concurrent entries that would race the temp-file fallback" {

--- a/tests/unit/no-backup-files-workflow.bats
+++ b/tests/unit/no-backup-files-workflow.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Unit tests for .github/workflows/no-backup-files.yml core check logic
+#
+# sprint-bug-141 / issue #681. The workflow's check is shell-only — we extract
+# the regex + violation logic and exercise it against fixture file lists. This
+# avoids spinning up a GitHub Actions runner while still pinning the contract.
+# =============================================================================
+
+setup() {
+    BATS_TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT_REAL="$(cd "$BATS_TEST_DIR/../.." && pwd)"
+    WORKFLOW="$PROJECT_ROOT_REAL/.github/workflows/no-backup-files.yml"
+
+    [[ -f "$WORKFLOW" ]] || skip "no-backup-files.yml not present"
+
+    export TEST_TMPDIR="$(mktemp -d)"
+}
+
+teardown() {
+    cd /
+    [[ -d "$TEST_TMPDIR" ]] && rm -rf "$TEST_TMPDIR"
+}
+
+# Extract the violation pattern from the workflow. Single source of truth.
+_workflow_pattern() {
+    grep -E "grep -E" "$WORKFLOW" | head -1 | grep -oE "'[^']+'" | head -1 | tr -d "'"
+}
+
+# Run the same grep used by the workflow against a list of candidate files.
+_check_violations() {
+    local files="$1"
+    local pattern
+    pattern="$(_workflow_pattern)"
+    printf '%s\n' "$files" | grep -E "$pattern" || true
+}
+
+# -----------------------------------------------------------------------------
+# Match cases — these files MUST be flagged as violations
+# -----------------------------------------------------------------------------
+@test "no-backup: flags .bak suffix" {
+    local v
+    v=$(_check_violations "src/foo.sh.bak")
+    [[ "$v" == "src/foo.sh.bak" ]]
+}
+
+@test "no-backup: flags -bak suffix (planning-tool pattern)" {
+    local v
+    v=$(_check_violations "grimoires/loa/sprint.md.cycle-096-bak")
+    [[ "$v" == "grimoires/loa/sprint.md.cycle-096-bak" ]]
+}
+
+@test "no-backup: flags emacs ~ suffix" {
+    local v
+    v=$(_check_violations "src/foo.py~")
+    [[ "$v" == "src/foo.py~" ]]
+}
+
+@test "no-backup: flags .orig suffix (merge artifact)" {
+    local v
+    v=$(_check_violations "README.md.orig")
+    [[ "$v" == "README.md.orig" ]]
+}
+
+@test "no-backup: flags .swp / .swo (vim swap)" {
+    local v
+    v=$(_check_violations $'src/.foo.swp\nsrc/.bar.swo')
+    # Use grep for multi-line containment (bash `[[ == * ]]` does not span \n).
+    echo "$v" | grep -q '\.swp$' || { echo "missed .swp"; return 1; }
+    echo "$v" | grep -q '\.swo$' || { echo "missed .swo"; return 1; }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases — these MUST NOT be flagged
+# -----------------------------------------------------------------------------
+@test "no-backup: does NOT flag bakery/ directory" {
+    local v
+    v=$(_check_violations "src/bakery/oven.sh")
+    [[ -z "$v" ]] || {
+        echo "False positive on bakery/: $v"
+        return 1
+    }
+}
+
+@test "no-backup: does NOT flag legitimate .md / .yml / .sh / .py" {
+    local v
+    v=$(_check_violations $'README.md\n.github/workflows/foo.yml\nscripts/bar.sh\nlib/baz.py')
+    [[ -z "$v" ]]
+}
+
+@test "no-backup: does NOT flag '-bak-feature' branch-style names (no trailing -bak)" {
+    # Only the file's terminal suffix matters. `-bak` MUST be at end.
+    local v
+    v=$(_check_violations "src/feature-bakery-tools.sh")
+    [[ -z "$v" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Workflow-shape sanity: pinned action; bypass token; env var passing
+# -----------------------------------------------------------------------------
+@test "no-backup: workflow uses SHA-pinned actions/checkout (cycle-098 supply-chain)" {
+    grep -qE "actions/checkout@[0-9a-f]{40}" "$WORKFLOW" || {
+        echo "Expected SHA-pinned actions/checkout (40-char hex)"
+        return 1
+    }
+}
+
+@test "no-backup: workflow declares [allow-bak] bypass token" {
+    grep -qF '[allow-bak]' "$WORKFLOW"
+}
+
+@test "no-backup: workflow passes github context via env vars (NOT \${{ }} in shell)" {
+    # Pre-existing security pattern: untrusted GitHub context vars must be
+    # delivered to shell via env, not direct interpolation.
+    grep -qF 'PR_TITLE: ${{ github.event.pull_request.title }}' "$WORKFLOW"
+    grep -qF '"${PR_TITLE}"' "$WORKFLOW"
+}
+
+@test "no-backup: workflow remediation message includes git rm --cached" {
+    grep -qF 'git rm --cached' "$WORKFLOW"
+}

--- a/tests/unit/sync-readme-version.bats
+++ b/tests/unit/sync-readme-version.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Unit tests for sync-readme-version.sh — issue #687
+#
+# sprint-bug-141 (T2+T3 hardening bundle). The script shipped with PR #686
+# without bats coverage. Bridgebuilder iter-1 of #686 flagged this as MEDIUM
+# non-blocking follow-up. Tests cover --check / --apply / idempotency /
+# error modes / lock-step pattern updates.
+# =============================================================================
+
+setup() {
+    BATS_TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT_REAL="$(cd "$BATS_TEST_DIR/../.." && pwd)"
+    SCRIPT="$PROJECT_ROOT_REAL/.claude/scripts/sync-readme-version.sh"
+
+    [[ -f "$SCRIPT" ]] || skip "sync-readme-version.sh not present"
+    command -v jq >/dev/null 2>&1 || skip "jq not installed"
+
+    # Create an isolated tmp repo with a fake .claude/scripts/ + README.md +
+    # .loa-version.json. The script resolves REPO_ROOT relative to its own
+    # path (../.. from .claude/scripts/), so we must mirror that layout in
+    # the tmp tree so the script reads OUR fixtures, not the real repo.
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    export TEST_TMPDIR="$BATS_TMPDIR/sync-readme-test-$$"
+    mkdir -p "$TEST_TMPDIR/.claude/scripts"
+    cp "$SCRIPT" "$TEST_TMPDIR/.claude/scripts/"
+    chmod +x "$TEST_TMPDIR/.claude/scripts/sync-readme-version.sh"
+
+    export TEST_SCRIPT="$TEST_TMPDIR/.claude/scripts/sync-readme-version.sh"
+    export TEST_README="$TEST_TMPDIR/README.md"
+    export TEST_VERSION_FILE="$TEST_TMPDIR/.loa-version.json"
+}
+
+teardown() {
+    cd /
+    [[ -d "$TEST_TMPDIR" ]] && rm -rf "$TEST_TMPDIR"
+}
+
+# Helper: write a baseline in-sync README + version file at a given version.
+_write_synced() {
+    local version="$1"
+    cat > "$TEST_README" <<EOF
+# Loa Framework
+
+A multi-agent development framework.
+
+Version: $version
+
+[![Version](https://img.shields.io/badge/version-$version-blue.svg)](CHANGELOG.md)
+
+## Overview
+
+Test fixture content.
+EOF
+    jq -n --arg v "$version" '{
+        framework_version: $v,
+        schema_version: 2,
+        last_sync: "2026-05-03T00:00:00Z"
+    }' > "$TEST_VERSION_FILE"
+}
+
+# -----------------------------------------------------------------------------
+# Case 1: --check on in-sync state → exit 0
+# -----------------------------------------------------------------------------
+@test "sync-readme: --check on in-sync state exits 0" {
+    _write_synced "1.110.1"
+
+    run "$TEST_SCRIPT" --check
+    [[ "$status" -eq 0 ]] || {
+        echo "Expected exit 0; got $status"
+        echo "output: $output"
+        return 1
+    }
+    echo "$output" | grep -qE 'OK|in sync' || {
+        echo "Expected 'OK' / 'in sync' message; got: $output"
+        return 1
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Case 2: --check on drifted state → exit 1 with structured stderr
+# -----------------------------------------------------------------------------
+@test "sync-readme: --check on drifted state exits 1 with diagnostic" {
+    _write_synced "1.0.0"
+    # Bump version file but leave README behind.
+    jq '.framework_version = "2.0.0"' "$TEST_VERSION_FILE" > "$TEST_VERSION_FILE.tmp"
+    mv "$TEST_VERSION_FILE.tmp" "$TEST_VERSION_FILE"
+
+    run "$TEST_SCRIPT" --check
+    [[ "$status" -eq 1 ]] || {
+        echo "Expected exit 1 (drift detected); got $status"
+        echo "output: $output"
+        return 1
+    }
+    # Stderr should explain the drift and recommend --apply.
+    echo "$output" | grep -q 'DRIFT' || {
+        echo "Expected DRIFT marker; got: $output"
+        return 1
+    }
+    echo "$output" | grep -qE '\-\-apply' || {
+        echo "Expected --apply remediation hint; got: $output"
+        return 1
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Case 3: --apply on drifted state → rewrites README correctly
+# -----------------------------------------------------------------------------
+@test "sync-readme: --apply on drifted state rewrites README" {
+    _write_synced "1.0.0"
+    jq '.framework_version = "2.5.3"' "$TEST_VERSION_FILE" > "$TEST_VERSION_FILE.tmp"
+    mv "$TEST_VERSION_FILE.tmp" "$TEST_VERSION_FILE"
+
+    run "$TEST_SCRIPT" --apply
+    [[ "$status" -eq 0 ]] || {
+        echo "Expected exit 0; got $status, output: $output"
+        return 1
+    }
+
+    # Both patterns must update.
+    grep -qF 'Version: 2.5.3' "$TEST_README" || {
+        echo "HTML comment 'Version: 2.5.3' not in README"
+        cat "$TEST_README"
+        return 1
+    }
+    grep -qF 'version-2.5.3-blue.svg' "$TEST_README" || {
+        echo "Badge 'version-2.5.3-blue.svg' not in README"
+        cat "$TEST_README"
+        return 1
+    }
+    # Old version should be gone.
+    if grep -qF '1.0.0' "$TEST_README"; then
+        echo "Old version 1.0.0 still in README"
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Case 4: --apply is idempotent
+# -----------------------------------------------------------------------------
+@test "sync-readme: --apply is idempotent (run twice, no change)" {
+    _write_synced "1.0.0"
+    jq '.framework_version = "2.0.0"' "$TEST_VERSION_FILE" > "$TEST_VERSION_FILE.tmp"
+    mv "$TEST_VERSION_FILE.tmp" "$TEST_VERSION_FILE"
+
+    "$TEST_SCRIPT" --apply >/dev/null
+    local first_md5
+    first_md5=$(md5sum "$TEST_README" | awk '{print $1}')
+
+    run "$TEST_SCRIPT" --apply
+    [[ "$status" -eq 0 ]] || {
+        echo "Second --apply failed: $output"
+        return 1
+    }
+    # Idempotent run reports either "OK: in sync" (early exit before sed)
+    # OR "NO-OP" (sed produced byte-identical output).
+    echo "$output" | grep -qE 'NO-OP|OK.*in sync|already' || {
+        echo "Expected idempotent signal; got: $output"
+        return 1
+    }
+
+    local second_md5
+    second_md5=$(md5sum "$TEST_README" | awk '{print $1}')
+    [[ "$first_md5" == "$second_md5" ]] || {
+        echo "README mutated on idempotent run (md5 differs)"
+        return 1
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Case 5: missing .loa-version.json → exit 2
+# -----------------------------------------------------------------------------
+@test "sync-readme: missing .loa-version.json exits 2" {
+    _write_synced "1.0.0"
+    rm -f "$TEST_VERSION_FILE"
+
+    run "$TEST_SCRIPT" --check
+    [[ "$status" -eq 2 ]] || {
+        echo "Expected exit 2 for missing version file; got $status"
+        return 1
+    }
+    echo "$output" | grep -qE 'ERROR|not found' || {
+        echo "Expected error message; got: $output"
+        return 1
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Case 6: malformed framework_version (not semver) → exit 2
+# -----------------------------------------------------------------------------
+@test "sync-readme: non-semver framework_version exits 2" {
+    _write_synced "1.0.0"
+    jq '.framework_version = "not-a-version"' "$TEST_VERSION_FILE" > "$TEST_VERSION_FILE.tmp"
+    mv "$TEST_VERSION_FILE.tmp" "$TEST_VERSION_FILE"
+
+    run "$TEST_SCRIPT" --check
+    [[ "$status" -eq 2 ]] || {
+        echo "Expected exit 2 for malformed version; got $status"
+        return 1
+    }
+    echo "$output" | grep -qE 'semver|not.*X\.Y\.Z' || {
+        echo "Expected semver validation error; got: $output"
+        return 1
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Case 7: lock-step update — both HTML comment AND badge update together
+# -----------------------------------------------------------------------------
+@test "sync-readme: --apply updates both patterns in lock-step (no partial drift)" {
+    # Start with a README where ONLY the badge is wrong (HTML comment correct).
+    cat > "$TEST_README" <<'EOF'
+# Loa
+Version: 2.0.0
+
+[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](CHANGELOG.md)
+EOF
+    jq -n '{framework_version: "2.0.0", schema_version: 2}' > "$TEST_VERSION_FILE"
+
+    run "$TEST_SCRIPT" --apply
+    [[ "$status" -eq 0 ]]
+
+    grep -qF 'Version: 2.0.0' "$TEST_README"
+    grep -qF 'version-2.0.0-blue.svg' "$TEST_README"
+    # Pre-update mismatched badge must be gone.
+    if grep -qF 'version-1.0.0-blue.svg' "$TEST_README"; then
+        echo "Stale badge still present after lock-step update"
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Case 8: --help / no args / unknown mode → exit 2 with usage
+# -----------------------------------------------------------------------------
+@test "sync-readme: --help exits 2 with usage banner" {
+    run "$TEST_SCRIPT" --help
+    [[ "$status" -eq 2 ]]
+    echo "$output" | grep -qE 'Usage:|--check|--apply'
+}
+
+@test "sync-readme: unknown mode exits 2" {
+    run "$TEST_SCRIPT" --bogus
+    [[ "$status" -eq 2 ]]
+    echo "$output" | grep -q 'Unknown mode'
+}


### PR DESCRIPTION
## Summary

sprint-bug-141 (cycle-098 follow-up). Five focused hardening / coverage fixes landed as one cohesive micro-sprint, ordered by ascending risk so the green-bar advances each step.

| # | Issue | Status |
|---|-------|--------|
| 1 | [#687](https://github.com/0xHoneyJar/loa/issues/687) — sync-readme-version.sh bats coverage | **Fixed** (9 tests) |
| 2 | [#691](https://github.com/0xHoneyJar/loa/issues/691) — panel-distribution-audit `/tmp/$$` → `mktemp` | **Fixed** |
| 3 | [#692](https://github.com/0xHoneyJar/loa/issues/692) — model-invoke `--prompt` argv exposure | **Fixed** (3 argv-safety tests) |
| 4 | [#636](https://github.com/0xHoneyJar/loa/issues/636) — construct-invoke session-id race | **Fixed** (deprecation completed) |
| 5 | [#681](https://github.com/0xHoneyJar/loa/issues/681) — CI guard for `*.bak` files | **Fixed** (vision-014 path; 12 tests) |
| 6 | [#561](https://github.com/0xHoneyJar/loa/issues/561) — post-merge.yml workflow classifier | **Stale** — closed pre-bundle (already fixed by PR #670 commit 9310d30) |

### #687 — sync-readme-version.sh bats coverage

PR #686 shipped the script without bats coverage; bridgebuilder iter-1 flagged this MEDIUM non-blocking. New `tests/unit/sync-readme-version.bats` with 9 tests covering `--check` / `--apply` / idempotency / missing version file / non-semver validation / lock-step pattern updates / help / unknown mode.

### #691 — panel-distribution-audit `/tmp/$$` → `mktemp`

Pre-fix used a predictable path (`/tmp/panel-distribution-audit-result.$$`) that an attacker could pre-create as a symlink on a multi-user system. Now uses `mktemp` + EXIT trap; mode 0600. Closes Sprint-1 audit LOW-1.

### #692 — hitl-jury-panel argv exposure → fd/file

`panel_solicit` invoked `model-invoke --prompt "$(cat "$context_path")"` — the entire deliberation context was on argv, briefly visible in `ps -o args=` during the model-invoke fork window. Switched to `model-invoke --input <tmpfile>` (mode 0600 + cleanup). Mirrors sprint-bug-131 / #675 fd-vs-argv pattern.

Test-first regression at `tests/security/hitl-jury-panel-argv-safety.bats` — 3 tests asserting:
- prompt content **NOT** on argv (post-fix)
- prompt content IS reachable via `--input` file (post-fix)
- `--input` flag on argv, NOT `--prompt` (post-fix)

### #636 — construct-invoke session-id race

PR #617 deprecated the temp-file fallback path; sprint-bug-141 completes the migration:

- **`construct-compose.sh`** now threads `session_id` explicitly to BOTH exit call sites (lines 395 + 400) using the value already captured at line 372
- **`construct-invoke.sh do_exit`**:
  - Removes the per-call DEPRECATION warning (noise reduction)
  - Removes the silent `session_id: null` emission path (broke trajectory pair-matching)
  - Now hard-rejects (`return 2`) when neither explicit (positional/env) nor temp-file marker resolves
- **Tests**: removed 3 deprecation-warning tests; added 2 new tests (no-id rejection emits clear error; explicit-only mode succeeds); 4 race-doc tests preserved

### #681 — CI guard for backup files

vision-014 path. Pre-fix, planning tooling emitted defensive `.bak` siblings that accidentally landed in PRs (PR #678 was caught + cleaned by bridgebuilder). New `.github/workflows/no-backup-files.yml` enforces the guarantee at PR-time:

- Detects: `*.bak`, `*-bak`, `*~`, `*.orig`, `*.swp`, `*.swo`
- Bypass via `[allow-bak]` in PR title for legitimate vendored snapshots
- SHA-pinned `actions/checkout@v4.3.1` per cycle-098 supply-chain pattern
- GitHub-context vars passed via env (not direct `${{ }}` interpolation per cycle-098 SDD §1.9.3.2)
- 12 unit tests in `tests/unit/no-backup-files-workflow.bats` exercise the regex contract + workflow shape

## Files changed

| File | Change | Issue |
|------|--------|-------|
| `.claude/scripts/sync-readme-version.sh` | (none — test coverage only) | #687 |
| `.claude/scripts/panel-distribution-audit.sh` | `mktemp` + trap | #691 |
| `.claude/scripts/lib/hitl-jury-panel-lib.sh` | `--input` tmpfile | #692 |
| `.claude/scripts/construct-invoke.sh` | hard-reject + DEPRECATION removed | #636 |
| `.claude/scripts/construct-compose.sh` | thread session_id to exit calls | #636 |
| `.github/workflows/no-backup-files.yml` | NEW — backup-file CI guard | #681 |
| `tests/unit/sync-readme-version.bats` | NEW — 9 tests | #687 |
| `tests/security/hitl-jury-panel-argv-safety.bats` | NEW — 3 tests | #692 |
| `tests/unit/construct-invoke.bats` | refactored tests | #636 |
| `tests/unit/no-backup-files-workflow.bats` | NEW — 12 tests | #681 |

## Test plan

- [x] `bats tests/unit/sync-readme-version.bats` — 9/9 pass
- [x] `bats tests/unit/panel-distribution-audit.bats` — 7/7 pass (no regression after #691)
- [x] `bats tests/security/hitl-jury-panel-argv-safety.bats` — 3/3 pass
- [x] `bats tests/unit/construct-invoke.bats` — 21/21 pass (incl. 2 new + 1 backward-compat replacement)
- [x] `bats tests/unit/construct-compose.bats` — 12/12 pass
- [x] `bats tests/unit/no-backup-files-workflow.bats` — 12/12 pass
- [x] `bats tests/integration/panel-fallback-matrix.bats tests/integration/panel-protected-class.bats tests/integration/protected-class-router-cli.bats tests/integration/hitl-jury-panel-skill.bats tests/unit/panel-audit-envelope.bats tests/unit/panel-deterministic-seed.bats tests/unit/panel-disagreement-no-op-default.bats` — all green
- [x] **Total audited regression**: 110 tests pass, 0 fail

## Acceptance criteria (from triage)

- [x] All five sub-tasks deliverables met (one per issue)
- [x] No regressions across 110 audited tests
- [x] Test-first invariant: at least one failing test landed BEFORE its corresponding fix (verified for #692 + #636)
- [x] All System Zone edits scoped to the four declared files (no incidental `.claude/` mutation)
- [x] PII redaction verified (no API keys / tokens / emails embedded in workflow / new tests)
- [x] All five GitHub issues referenced in PR body for auto-close on merge

## Notes for reviewer

- **Test-first**: #692 and #636 had failing tests landed and verified before the fix (visible in commit history if separated, or via the test additions vs. source mods)
- **Surgical scope**: 4 source files + 1 new workflow + 4 new test files + 1 modified test file
- **Beads UNHEALTHY (#661)**: commit used `--no-verify` per documented workaround
- **#561 closure**: handled pre-bundle in spike (already fixed upstream by PR #670)
- **Triage**: `grimoires/loa/a2a/bug-20260504-i636-cb9b6d/triage.md` (local-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)