### PR TITLE
feat(cycle-098-sprint-2): L2 cost-budget-enforcer + reconciliation cron + daily snapshot (#654)

### DIFF
--- a/.claude/data/trajectory-schemas/agent-network-envelope.schema.json
+++ b/.claude/data/trajectory-schemas/agent-network-envelope.schema.json
@@ -30,7 +30,7 @@
       "description": "Primitive-specific event type. Sprint 1 defines L1 events; Sprints 2-7 extend.",
       "examples": [
         "panel.invoke", "panel.solicit", "panel.bind", "panel.queued_protected",
-        "budget.allow", "budget.warn_90", "budget.halt_100", "budget.halt_uncertainty", "budget.reconcile",
+        "budget.allow", "budget.warn_90", "budget.halt_100", "budget.halt_uncertainty", "budget.reconcile", "budget.record_call",
         "cycle.start", "cycle.phase", "cycle.complete", "cycle.error",
         "trust.query", "trust.grant", "trust.auto_drop", "trust.force_grant", "trust.auto_raise_eligible",
         "cross_repo.read", "cross_repo.cache_hit", "cross_repo.partial_failure",

--- a/.claude/data/trajectory-schemas/budget-events/budget-allow.payload.schema.json
+++ b/.claude/data/trajectory-schemas/budget-events/budget-allow.payload.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/budget-events/budget-allow.payload.schema.json",
+  "title": "L2 budget.allow Payload",
+  "description": "Pre-call verdict payload emitted by budget_verdict when usage <90% AND data fresh. cycle-098 Sprint 2A.",
+  "type": "object",
+  "required": [
+    "verdict",
+    "usd_used",
+    "usd_remaining",
+    "daily_cap_usd",
+    "estimated_usd_for_call",
+    "billing_api_age_seconds",
+    "counter_age_seconds",
+    "provider",
+    "utc_day"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "verdict": { "const": "allow" },
+    "usd_used": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Cumulative paid usage for current UTC day (PRE-call; does not yet include estimated_usd_for_call)."
+    },
+    "usd_remaining": {
+      "type": "number",
+      "description": "daily_cap_usd - usd_used. May be negative if cap exceeded mid-flight."
+    },
+    "daily_cap_usd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Cap from .loa.config.yaml::cost_budget_enforcer.daily_cap_usd."
+    },
+    "estimated_usd_for_call": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Caller-supplied cost estimate for the proposed paid call."
+    },
+    "billing_api_age_seconds": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "description": "Seconds since the most recent billing API timestamp. null if billing API was not consulted."
+    },
+    "counter_age_seconds": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Seconds since the most recent budget.record_call event for this provider/aggregate."
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Provider id (e.g., 'anthropic', 'openai', 'bedrock') or 'aggregate' for cross-provider verdicts."
+    },
+    "utc_day": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "UTC calendar day this verdict applies to (YYYY-MM-DD)."
+    },
+    "cycle_id": {
+      "type": ["string", "null"],
+      "description": "Optional caller-supplied cycle identifier for cross-referencing."
+    },
+    "billing_observer_used": {
+      "type": "boolean",
+      "description": "Whether a billing-observer command was invoked (vs counter-only fallback)."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/budget-events/budget-halt-100.payload.schema.json
+++ b/.claude/data/trajectory-schemas/budget-events/budget-halt-100.payload.schema.json
@@ -13,7 +13,8 @@
     "billing_api_age_seconds",
     "counter_age_seconds",
     "provider",
-    "utc_day"
+    "utc_day",
+    "usage_pct"
   ],
   "additionalProperties": false,
   "properties": {
@@ -34,7 +35,7 @@
     "usage_pct": {
       "type": "number",
       "minimum": 100,
-      "description": "100 * usd_used / daily_cap_usd. >= 100."
+      "description": "Projected post-call usage: 100 * (usd_used + estimated_usd_for_call) / daily_cap_usd. >= 100. Verdict-trigger uses projected usage_pct, not current."
     }
   }
 }

--- a/.claude/data/trajectory-schemas/budget-events/budget-halt-100.payload.schema.json
+++ b/.claude/data/trajectory-schemas/budget-events/budget-halt-100.payload.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/budget-events/budget-halt-100.payload.schema.json",
+  "title": "L2 budget.halt_100 Payload",
+  "description": "Pre-call verdict payload emitted when usage >=100% AND data fresh. Cycle MUST halt before next paid call. Terminal until next UTC day rollover. cycle-098 Sprint 2A.",
+  "type": "object",
+  "required": [
+    "verdict",
+    "usd_used",
+    "usd_remaining",
+    "daily_cap_usd",
+    "estimated_usd_for_call",
+    "billing_api_age_seconds",
+    "counter_age_seconds",
+    "provider",
+    "utc_day"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "verdict": { "const": "halt-100" },
+    "usd_used": { "type": "number", "minimum": 0 },
+    "usd_remaining": {
+      "type": "number",
+      "description": "daily_cap_usd - usd_used (current). May be positive at decision time even when projected post-call usage exceeds cap; the verdict trigger uses projected usage_pct (>= 100)."
+    },
+    "daily_cap_usd": { "type": "number", "minimum": 0 },
+    "estimated_usd_for_call": { "type": "number", "minimum": 0 },
+    "billing_api_age_seconds": { "type": ["number", "null"], "minimum": 0 },
+    "counter_age_seconds": { "type": "number", "minimum": 0 },
+    "provider": { "type": "string", "minLength": 1 },
+    "utc_day": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+    "cycle_id": { "type": ["string", "null"] },
+    "billing_observer_used": { "type": "boolean" },
+    "usage_pct": {
+      "type": "number",
+      "minimum": 100,
+      "description": "100 * usd_used / daily_cap_usd. >= 100."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/budget-events/budget-halt-uncertainty.payload.schema.json
+++ b/.claude/data/trajectory-schemas/budget-events/budget-halt-uncertainty.payload.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/budget-events/budget-halt-uncertainty.payload.schema.json",
+  "title": "L2 budget.halt_uncertainty Payload",
+  "description": "Fail-closed verdict emitted under uncertainty modes per PRD §FR-L2-7. Five modes: billing_stale, counter_inconsistent, counter_drift, clock_drift, provider_lag. cycle-098 Sprint 2A.",
+  "type": "object",
+  "required": [
+    "verdict",
+    "uncertainty_reason",
+    "usd_used",
+    "usd_remaining",
+    "daily_cap_usd",
+    "estimated_usd_for_call",
+    "billing_api_age_seconds",
+    "counter_age_seconds",
+    "provider",
+    "utc_day"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "verdict": { "const": "halt-uncertainty" },
+    "uncertainty_reason": {
+      "type": "string",
+      "enum": [
+        "billing_stale",
+        "counter_inconsistent",
+        "counter_drift",
+        "clock_drift",
+        "provider_lag"
+      ]
+    },
+    "usd_used": { "type": "number" },
+    "usd_remaining": { "type": "number" },
+    "daily_cap_usd": { "type": "number", "minimum": 0 },
+    "estimated_usd_for_call": { "type": "number", "minimum": 0 },
+    "billing_api_age_seconds": { "type": ["number", "null"] },
+    "counter_age_seconds": { "type": "number" },
+    "provider": { "type": "string", "minLength": 1 },
+    "utc_day": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+    "cycle_id": { "type": ["string", "null"] },
+    "billing_observer_used": { "type": "boolean" },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Mode-specific diagnostic context. counter_inconsistent: {prev, current}; counter_drift: {drift_pct, threshold_pct}; clock_drift: {system_ts, billing_ts, delta_seconds}; provider_lag: {lag_seconds, threshold_seconds}."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/budget-events/budget-halt-uncertainty.payload.schema.json
+++ b/.claude/data/trajectory-schemas/budget-events/budget-halt-uncertainty.payload.schema.json
@@ -26,7 +26,8 @@
         "counter_inconsistent",
         "counter_drift",
         "clock_drift",
-        "provider_lag"
+        "provider_lag",
+        "counter_stale"
       ]
     },
     "usd_used": { "type": "number" },

--- a/.claude/data/trajectory-schemas/budget-events/budget-reconcile.payload.schema.json
+++ b/.claude/data/trajectory-schemas/budget-events/budget-reconcile.payload.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/budget-events/budget-reconcile.payload.schema.json",
+  "title": "L2 budget.reconcile Payload",
+  "description": "Reconciliation cron event emitted every reconciliation.interval_hours (default 6h). Compares internal counter to billing API for current UTC day; emits BLOCKER on drift > threshold. Counter NOT auto-corrected — operator must run force-reconcile. cycle-098 Sprint 2A/2B.",
+  "type": "object",
+  "required": [
+    "verdict",
+    "counter_usd",
+    "billing_usd",
+    "drift_pct",
+    "drift_threshold_pct",
+    "blocker",
+    "provider",
+    "utc_day"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "verdict": { "const": "reconcile" },
+    "counter_usd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Internal counter sum for current UTC day."
+    },
+    "billing_usd": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "description": "Billing API reported usage for current UTC day. null if billing API unreachable."
+    },
+    "drift_pct": {
+      "type": ["number", "null"],
+      "description": "abs(counter - billing) / max(billing, counter) * 100. null if billing_usd is null."
+    },
+    "drift_threshold_pct": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Configured drift threshold (default 5.0)."
+    },
+    "blocker": {
+      "type": "boolean",
+      "description": "True iff drift_pct > drift_threshold_pct OR billing API unreachable + counter near cap."
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "utc_day": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "billing_api_unreachable": {
+      "type": "boolean",
+      "description": "True iff billing API client failed (timeout, error, missing); reconcile defers without auto-correction."
+    },
+    "force_reconcile": {
+      "type": "boolean",
+      "description": "True iff this entry was emitted by an operator force-reconcile invocation."
+    },
+    "operator_reason": {
+      "type": ["string", "null"],
+      "description": "Operator-supplied reason for force-reconcile (required for force-reconcile=true)."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/budget-events/budget-record-call.payload.schema.json
+++ b/.claude/data/trajectory-schemas/budget-events/budget-record-call.payload.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/budget-events/budget-record-call.payload.schema.json",
+  "title": "L2 budget.record_call Payload",
+  "description": "Post-call record emitted by budget_record_call after a paid call completes. Increments the internal counter by actual_usd. Tail-scanning these events for the current UTC day yields the current counter value. cycle-098 Sprint 2A.",
+  "type": "object",
+  "required": [
+    "actual_usd",
+    "usd_used_post",
+    "provider",
+    "utc_day"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "actual_usd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Actual USD cost of the call as reported by the caller."
+    },
+    "usd_used_post": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Cumulative usd_used for current UTC day AFTER this call. Sum of all prior record_call.actual_usd in this UTC day + this actual_usd."
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "utc_day": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "cycle_id": {
+      "type": ["string", "null"]
+    },
+    "verdict_ref": {
+      "type": ["string", "null"],
+      "description": "Optional pointer to the prior allow/warn-90 verdict's prev_hash this call corresponds to (auditability)."
+    },
+    "model_id": {
+      "type": ["string", "null"],
+      "description": "Optional model/SKU charged (e.g., 'claude-opus-4-7')."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/budget-events/budget-warn-90.payload.schema.json
+++ b/.claude/data/trajectory-schemas/budget-events/budget-warn-90.payload.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/budget-events/budget-warn-90.payload.schema.json",
+  "title": "L2 budget.warn_90 Payload",
+  "description": "Pre-call verdict payload emitted when 90% <= usage <100% AND data fresh. Cycle MAY continue but operator is alerted. cycle-098 Sprint 2A.",
+  "type": "object",
+  "required": [
+    "verdict",
+    "usd_used",
+    "usd_remaining",
+    "daily_cap_usd",
+    "estimated_usd_for_call",
+    "billing_api_age_seconds",
+    "counter_age_seconds",
+    "provider",
+    "utc_day"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "verdict": { "const": "warn-90" },
+    "usd_used": { "type": "number", "minimum": 0 },
+    "usd_remaining": { "type": "number" },
+    "daily_cap_usd": { "type": "number", "minimum": 0 },
+    "estimated_usd_for_call": { "type": "number", "minimum": 0 },
+    "billing_api_age_seconds": { "type": ["number", "null"], "minimum": 0 },
+    "counter_age_seconds": { "type": "number", "minimum": 0 },
+    "provider": { "type": "string", "minLength": 1 },
+    "utc_day": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+    "cycle_id": { "type": ["string", "null"] },
+    "billing_observer_used": { "type": "boolean" },
+    "usage_pct": {
+      "type": "number",
+      "minimum": 90,
+      "maximum": 100,
+      "exclusiveMaximum": 100,
+      "description": "100 * usd_used / daily_cap_usd. Range [90, 100)."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/budget-events/budget-warn-90.payload.schema.json
+++ b/.claude/data/trajectory-schemas/budget-events/budget-warn-90.payload.schema.json
@@ -13,7 +13,8 @@
     "billing_api_age_seconds",
     "counter_age_seconds",
     "provider",
-    "utc_day"
+    "utc_day",
+    "usage_pct"
   ],
   "additionalProperties": false,
   "properties": {
@@ -33,7 +34,7 @@
       "minimum": 90,
       "maximum": 100,
       "exclusiveMaximum": 100,
-      "description": "100 * usd_used / daily_cap_usd. Range [90, 100)."
+      "description": "Projected post-call usage: 100 * (usd_used + estimated_usd_for_call) / daily_cap_usd. Range [90, 100). Verdict-trigger uses projected usage_pct, not current."
     }
   }
 }

--- a/.claude/scripts/audit-envelope.sh
+++ b/.claude/scripts/audit-envelope.sh
@@ -102,6 +102,13 @@ _audit_require_flock() {
 # Cross-platform: GNU date supports %N (nanoseconds); macOS does not.
 # -----------------------------------------------------------------------------
 _audit_now_iso8601() {
+    # Test override (Sprint 2 remediation): tests that set LOA_AUDIT_TEST_NOW
+    # to a fixed ISO-8601 timestamp get a deterministic clock for envelope
+    # ts_utc. Production callers don't set this; behavior identical to before.
+    if [[ -n "${LOA_AUDIT_TEST_NOW:-}" ]]; then
+        echo "$LOA_AUDIT_TEST_NOW"
+        return 0
+    fi
     if date +%6N 2>/dev/null | grep -q '^[0-9]\{6\}$'; then
         date -u +"%Y-%m-%dT%H:%M:%S.%6NZ"
     else
@@ -979,6 +986,45 @@ _audit_recover_from_snapshot() {
     snapshot_content="$(cat "$tmp")"
     if ! _audit_chain_validates_lines "$snapshot_content"; then
         _audit_log "snapshot at $snapshot has broken chain — refusing to restore"
+        return 1
+    fi
+
+    # Sprint 2C remediation (audit F3): when a .sig sidecar exists, verify it.
+    # Refuse recovery on signature mismatch — an attacker who swaps the .gz with
+    # a chain-internally-valid-but-malicious archive is detected here.
+    # When LOA_AUDIT_RECOVER_REQUIRE_SIG=1, refuse on missing .sig too
+    # (defense-in-depth for high-trust deployments).
+    local sig_path="${snapshot}.sig"
+    if [[ -f "$sig_path" ]]; then
+        local sig_kid sig_b64 sig_sha256
+        if ! sig_kid="$(jq -r '.signing_key_id // ""' "$sig_path" 2>/dev/null)" \
+            || ! sig_b64="$(jq -r '.signature // ""' "$sig_path" 2>/dev/null)" \
+            || ! sig_sha256="$(jq -r '.sha256 // ""' "$sig_path" 2>/dev/null)"; then
+            _audit_log "snapshot .sig sidecar at $sig_path is malformed — refusing to restore"
+            return 1
+        fi
+        if [[ -z "$sig_kid" || -z "$sig_b64" || -z "$sig_sha256" ]]; then
+            _audit_log "snapshot .sig sidecar at $sig_path missing required fields (signing_key_id/signature/sha256) — refusing to restore"
+            return 1
+        fi
+        local actual_sha256
+        actual_sha256="$(_audit_sha256 < "$snapshot")"
+        if [[ "$actual_sha256" != "$sig_sha256" ]]; then
+            _audit_log "snapshot $snapshot sha256 mismatch with .sig sidecar (got $actual_sha256, expected $sig_sha256) — possible tampering, refusing to restore"
+            return 1
+        fi
+        local pubkey_pem
+        if ! pubkey_pem="$(_audit_pubkey_for_key_id "$sig_kid" 2>/dev/null)"; then
+            _audit_log "cannot resolve pubkey for signing_key_id=$sig_kid (snapshot .sig at $sig_path) — refusing to restore"
+            return 1
+        fi
+        if ! _audit_verify_signature_inline "$pubkey_pem" "$actual_sha256" "$sig_b64"; then
+            _audit_log "snapshot signature verification FAILED for $snapshot (sig_kid=$sig_kid) — refusing to restore"
+            return 1
+        fi
+        _audit_log "snapshot $snapshot signature verified (sig_kid=$sig_kid)"
+    elif [[ "${LOA_AUDIT_RECOVER_REQUIRE_SIG:-0}" == "1" ]]; then
+        _audit_log "snapshot $snapshot has no .sig sidecar and LOA_AUDIT_RECOVER_REQUIRE_SIG=1 — refusing to restore"
         return 1
     fi
 

--- a/.claude/scripts/audit/audit-snapshot-install.sh
+++ b/.claude/scripts/audit/audit-snapshot-install.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# =============================================================================
+# audit-snapshot-install.sh — install/uninstall daily snapshot cron entry
+#
+# cycle-098 Sprint 2C — operator-facing helper for the daily snapshot cron.
+# Convention is identical to budget-reconcile-install.sh; one marker per
+# cron entry. Daily run at 04:00 UTC by default (per SDD §3.7).
+#
+# Subcommands:
+#   install     Append (idempotent) the daily snapshot cron line to the user's
+#               crontab. Time read from
+#               .loa.config.yaml::audit_snapshot.cron_expression
+#               (default "0 4 * * *").
+#   uninstall   Remove the snapshot cron line by marker comment.
+#   status      Print whether the cron entry is installed.
+#   show        Print the cron line that WOULD be installed (no side effects).
+#
+# Marker convention: `# loa-cycle098-audit-snapshot  managed entry`
+# =============================================================================
+
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "${_SCRIPT_DIR}/../../.." && pwd)"
+_SNAPSHOT_SCRIPT="${_REPO_ROOT}/.claude/scripts/audit/audit-snapshot.sh"
+_LOG_PATH="${_REPO_ROOT}/.run/audit-snapshot-cron.log"
+MARKER="# loa-cycle098-audit-snapshot  managed entry"
+
+usage() {
+    sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+    exit 0
+}
+
+read_cron_expr() {
+    local config="${LOA_BUDGET_CONFIG_FILE:-${_REPO_ROOT}/.loa.config.yaml}"
+    if [[ ! -f "$config" ]]; then
+        echo "0 4 * * *"
+        return 0
+    fi
+    if command -v yq >/dev/null 2>&1; then
+        local v
+        v="$(yq -r '.audit_snapshot.cron_expression // "0 4 * * *"' "$config" 2>/dev/null || echo "0 4 * * *")"
+        [[ -z "$v" || "$v" == "null" ]] && v="0 4 * * *"
+        echo "$v"
+        return 0
+    fi
+    python3 - "$config" <<'PY' 2>/dev/null || echo "0 4 * * *"
+import sys
+try:
+    import yaml
+except ImportError:
+    print("0 4 * * *")
+    sys.exit(0)
+try:
+    with open(sys.argv[1]) as f:
+        doc = yaml.safe_load(f) or {}
+except Exception:
+    print("0 4 * * *")
+    sys.exit(0)
+v = (doc.get('audit_snapshot') or {}).get('cron_expression', '0 4 * * *')
+print(v if v else '0 4 * * *')
+PY
+}
+
+# Validate cron expression (5 space-separated fields).
+validate_cron_expr() {
+    local expr="$1"
+    local field_count
+    field_count="$(echo "$expr" | awk '{print NF}')"
+    if [[ "$field_count" != "5" ]]; then
+        echo "Invalid cron expression: '$expr' (expected 5 space-separated fields)" >&2
+        return 1
+    fi
+}
+
+build_cron_line() {
+    local expr
+    expr="$(read_cron_expr)"
+    validate_cron_expr "$expr" || return 1
+    echo "${expr} ${_SNAPSHOT_SCRIPT} >> ${_LOG_PATH} 2>&1  ${MARKER}"
+}
+
+cmd_show() {
+    build_cron_line
+}
+
+cmd_status() {
+    if ! command -v crontab >/dev/null 2>&1; then
+        echo "crontab not available on this system"
+        return 1
+    fi
+    if crontab -l 2>/dev/null | grep -qF "$MARKER"; then
+        echo "INSTALLED"
+        crontab -l 2>/dev/null | grep -F "$MARKER"
+        return 0
+    fi
+    echo "NOT-INSTALLED"
+    return 0
+}
+
+cmd_install() {
+    if ! command -v crontab >/dev/null 2>&1; then
+        echo "crontab not available on this system" >&2
+        return 1
+    fi
+    [[ -x "$_SNAPSHOT_SCRIPT" ]] || chmod +x "$_SNAPSHOT_SCRIPT" 2>/dev/null || true
+    local desired
+    desired="$(build_cron_line)" || return 1
+    local existing
+    existing="$(crontab -l 2>/dev/null || true)"
+    if printf '%s\n' "$existing" | grep -qF "$MARKER"; then
+        local current_line
+        current_line="$(printf '%s\n' "$existing" | grep -F "$MARKER" | head -1)"
+        if [[ "$current_line" == "$desired" ]]; then
+            echo "Already installed (cadence matches): $desired"
+            return 0
+        fi
+        echo "Schedule changed; updating cron line."
+        echo "  was:  $current_line"
+        echo "  now:  $desired"
+        local updated
+        updated="$(printf '%s\n' "$existing" | grep -vF "$MARKER")"
+        printf '%s\n%s\n' "$updated" "$desired" | crontab -
+        return 0
+    fi
+    printf '%s\n%s\n' "$existing" "$desired" | crontab -
+    echo "Installed: $desired"
+}
+
+cmd_uninstall() {
+    if ! command -v crontab >/dev/null 2>&1; then
+        echo "crontab not available on this system" >&2
+        return 1
+    fi
+    local existing
+    existing="$(crontab -l 2>/dev/null || true)"
+    if ! printf '%s\n' "$existing" | grep -qF "$MARKER"; then
+        echo "Not installed; nothing to remove."
+        return 0
+    fi
+    local updated
+    updated="$(printf '%s\n' "$existing" | grep -vF "$MARKER")"
+    printf '%s\n' "$updated" | crontab -
+    echo "Uninstalled."
+}
+
+if [[ $# -eq 0 ]]; then
+    usage
+fi
+case "$1" in
+    install)   cmd_install ;;
+    uninstall) cmd_uninstall ;;
+    status)    cmd_status ;;
+    show)      cmd_show ;;
+    --help|-h) usage ;;
+    *) echo "unknown subcommand: $1" >&2; exit 2 ;;
+esac

--- a/.claude/scripts/audit/audit-snapshot.sh
+++ b/.claude/scripts/audit/audit-snapshot.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# =============================================================================
+# audit-snapshot.sh — Daily snapshot of UNTRACKED chain-critical audit logs
+#
+# cycle-098 Sprint 2C — RPO 24h for L1/L2 per SDD §3.4.4 ↔ §3.7 reconciliation
+# (formerly weekly per Flatline pass #4 SKP-001 MUTUAL HIGH).
+#
+# Reads .claude/data/audit-retention-policy.yaml for the list of primitives
+# where chain_critical=true AND git_tracked=false. For each:
+#   1. Locate the rolling log at .run/<log_basename>
+#   2. Verify chain integrity (audit_verify_chain)
+#   3. Compress to grimoires/loa/audit-archive/<utc-date>-<primitive>.jsonl.gz
+#   4. Optionally sign (when LOA_AUDIT_SIGNING_KEY_ID is set) — produces a
+#      <archive>.sig sidecar containing base64(Ed25519(sha256(<archive>)))
+#
+# The archive directory is git-tracked. Operators commit the archives in their
+# regular workflow. The recovery path (audit_recover_chain) consumes these.
+#
+# Subcommands / flags:
+#   --dry-run               Print intent only; no file writes
+#   --primitive <id>        Snapshot a single primitive (e.g., L1, L2)
+#   --policy <yaml-path>    Override retention-policy yaml location
+#   --archive-dir <path>    Override output archive directory
+#   --logs-dir <path>       Override .run/ rolling-log directory
+#   --help, -h              Show usage
+#
+# Exit codes:
+#   0  success (or all primitives skipped — already-snapshotted today)
+#   1  any primitive's snapshot failed
+#   2  invalid arguments
+# =============================================================================
+
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "${_SCRIPT_DIR}/../../.." && pwd)"
+
+usage() {
+    sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+    exit 0
+}
+
+DRY_RUN=0
+SCOPE_PRIMITIVE=""
+POLICY_FILE="${LOA_AUDIT_RETENTION_POLICY:-${_REPO_ROOT}/.claude/data/audit-retention-policy.yaml}"
+ARCHIVE_DIR="${LOA_AUDIT_ARCHIVE_DIR:-${_REPO_ROOT}/grimoires/loa/audit-archive}"
+LOGS_DIR="${LOA_AUDIT_LOGS_DIR:-${_REPO_ROOT}/.run}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --primitive) SCOPE_PRIMITIVE="$2"; shift 2 ;;
+        --policy) POLICY_FILE="$2"; shift 2 ;;
+        --archive-dir) ARCHIVE_DIR="$2"; shift 2 ;;
+        --logs-dir) LOGS_DIR="$2"; shift 2 ;;
+        --help|-h) usage ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Source audit-envelope.sh to access audit_verify_chain.
+# shellcheck source=../audit-envelope.sh
+source "${_REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+
+_log() { echo "[audit-snapshot] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Read snapshot-eligible primitives from policy file:
+# - chain_critical: true
+# - git_tracked: false
+# Returns lines of "<id>:<log_basename>".
+# ---------------------------------------------------------------------------
+read_eligible_primitives() {
+    if [[ ! -f "$POLICY_FILE" ]]; then
+        _log "policy file missing: $POLICY_FILE"
+        return 1
+    fi
+    if command -v yq >/dev/null 2>&1; then
+        yq -r '
+          .primitives | to_entries[]
+          | select(.value.chain_critical == true and .value.git_tracked == false)
+          | "\(.key):\(.value.log_basename)"
+        ' "$POLICY_FILE"
+        return $?
+    fi
+    python3 - "$POLICY_FILE" <<'PY'
+import sys
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("yq not in PATH and PyYAML not installed; cannot read policy\n")
+    sys.exit(2)
+with open(sys.argv[1]) as f:
+    doc = yaml.safe_load(f) or {}
+for pid, attrs in (doc.get("primitives") or {}).items():
+    if (attrs or {}).get("chain_critical") and not (attrs or {}).get("git_tracked"):
+        print(f"{pid}:{attrs['log_basename']}")
+PY
+}
+
+# ---------------------------------------------------------------------------
+# Compute UTC day in YYYY-MM-DD form, allowing test override via
+# LOA_AUDIT_SNAPSHOT_TEST_DAY.
+# ---------------------------------------------------------------------------
+utc_day() {
+    if [[ -n "${LOA_AUDIT_SNAPSHOT_TEST_DAY:-}" ]]; then
+        echo "$LOA_AUDIT_SNAPSHOT_TEST_DAY"
+    else
+        date -u +%Y-%m-%d
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# snapshot_one <primitive_id> <log_basename>
+# Returns:
+#   0  success (snapshot written or already-existing)
+#   1  failure
+#   2  source log missing (not an error per se — primitive may not be active)
+# ---------------------------------------------------------------------------
+snapshot_one() {
+    local primitive_id="$1"
+    local log_basename="$2"
+    local source_log="${LOGS_DIR}/${log_basename}"
+    local day archive
+    day="$(utc_day)"
+    archive="${ARCHIVE_DIR}/${day}-${primitive_id}.jsonl.gz"
+
+    if [[ ! -f "$source_log" ]]; then
+        _log "skip: source log missing for $primitive_id at $source_log"
+        return 2
+    fi
+
+    # Idempotency: if archive already exists for this UTC day, skip.
+    if [[ -f "$archive" ]]; then
+        _log "skip: archive exists for $primitive_id on $day at $archive"
+        return 0
+    fi
+
+    # Verify source chain before snapshotting (refuse to archive a broken chain).
+    if ! audit_verify_chain "$source_log" >/dev/null 2>&1; then
+        _log "ERROR: chain verification failed for $primitive_id at $source_log — refusing to snapshot"
+        return 1
+    fi
+
+    if (( DRY_RUN )); then
+        _log "DRY-RUN: would write $archive (gzip $source_log)"
+        return 0
+    fi
+
+    mkdir -p "$ARCHIVE_DIR"
+    # Atomically write via temp + rename.
+    local tmp
+    tmp="$(mktemp "${archive}.XXXXXX.tmp")"
+    if ! gzip -c "$source_log" > "$tmp"; then
+        _log "ERROR: gzip failed for $source_log"
+        rm -f "$tmp"
+        return 1
+    fi
+    chmod 644 "$tmp"
+    mv "$tmp" "$archive"
+    _log "wrote: $archive ($(wc -c < "$archive") bytes)"
+
+    # Optional Ed25519 sidecar signature when signing key is configured.
+    if [[ -n "${LOA_AUDIT_SIGNING_KEY_ID:-}" ]]; then
+        local sig_path="${archive}.sig"
+        local archive_sha256
+        archive_sha256="$(_audit_sha256 < "$archive")"
+        local pw_args=()
+        if [[ -n "${LOA_AUDIT_FORWARD_PW_ARGS+set}" ]]; then
+            pw_args=(${LOA_AUDIT_FORWARD_PW_ARGS[@]+"${LOA_AUDIT_FORWARD_PW_ARGS[@]}"})
+        fi
+        local sig_b64
+        if sig_b64="$(printf '%s' "$archive_sha256" | _audit_sign_stdin "$LOA_AUDIT_SIGNING_KEY_ID" ${pw_args[@]+"${pw_args[@]}"})"; then
+            jq -nc \
+                --arg kid "$LOA_AUDIT_SIGNING_KEY_ID" \
+                --arg sha256 "$archive_sha256" \
+                --arg sig "$sig_b64" \
+                --arg ts "$(_audit_now_iso8601)" \
+                --arg primitive "$primitive_id" \
+                --arg day "$day" \
+                '{
+                    schema_version: "1.0",
+                    primitive_id: $primitive,
+                    utc_day: $day,
+                    sha256: $sha256,
+                    signing_key_id: $kid,
+                    signed_at: $ts,
+                    signature: $sig
+                }' > "$sig_path"
+            chmod 644 "$sig_path"
+            _log "signed: $sig_path"
+        else
+            _log "WARNING: signing failed for $archive (key_id=$LOA_AUDIT_SIGNING_KEY_ID); archive written unsigned"
+        fi
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main loop.
+# ---------------------------------------------------------------------------
+overall=0
+total_attempted=0
+total_succeeded=0
+total_skipped=0
+
+while IFS=: read -r pid basename; do
+    [[ -z "$pid" ]] && continue
+    if [[ -n "$SCOPE_PRIMITIVE" && "$pid" != "$SCOPE_PRIMITIVE" ]]; then
+        continue
+    fi
+    total_attempted=$((total_attempted + 1))
+    rc=0
+    snapshot_one "$pid" "$basename" || rc=$?
+    case "$rc" in
+        0) total_succeeded=$((total_succeeded + 1)) ;;
+        2) total_skipped=$((total_skipped + 1)) ;;
+        *) overall=1 ;;
+    esac
+done < <(read_eligible_primitives)
+
+_log "summary: attempted=$total_attempted succeeded=$total_succeeded skipped=$total_skipped failed=$((total_attempted - total_succeeded - total_skipped))"
+exit "$overall"

--- a/.claude/scripts/budget/budget-cli.sh
+++ b/.claude/scripts/budget/budget-cli.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# =============================================================================
+# budget-cli.sh — operator + caller-facing CLI for L2 cost-budget-enforcer
+#
+# cycle-098 Sprint 2D — thin CLI wrapper over cost-budget-enforcer-lib.sh.
+#
+# Subcommands:
+#   verdict <estimated_usd> [--provider <id>] [--cycle-id <id>]
+#       Pre-call gate. Stdout: verdict payload JSON.
+#       Exit 0=allow/warn-90, 1=halt-100/halt-uncertainty.
+#
+#   usage [--provider <id>]
+#       Read-only state query. Stdout: state JSON.
+#
+#   record <actual_usd> --provider <id> [--cycle-id <id>] [--model-id <id>]
+#                                       [--verdict-ref <hash>]
+#       Post-call accounting. Stdout: record envelope.
+#
+#   reconcile [--provider <id>] [--force-reason <text>]
+#       Reconciliation event. Exit 0=OK, 1=BLOCKER, 2=DEFER.
+#
+#   --help, -h
+#       Show usage.
+# =============================================================================
+
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "${_SCRIPT_DIR}/../../.." && pwd)"
+
+usage() {
+    sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+    exit 0
+}
+
+if [[ $# -eq 0 ]]; then
+    usage
+fi
+
+# shellcheck source=../lib/cost-budget-enforcer-lib.sh
+source "${_REPO_ROOT}/.claude/scripts/lib/cost-budget-enforcer-lib.sh"
+
+cmd="$1"
+shift
+
+case "$cmd" in
+    verdict)   budget_verdict "$@" ;;
+    usage)     budget_get_usage "$@" ;;
+    record)    budget_record_call "$@" ;;
+    reconcile) budget_reconcile "$@" ;;
+    --help|-h) usage ;;
+    *)         echo "unknown subcommand: $cmd" >&2; exit 2 ;;
+esac

--- a/.claude/scripts/budget/budget-reconcile-cron.sh
+++ b/.claude/scripts/budget/budget-reconcile-cron.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# =============================================================================
+# budget-reconcile-cron.sh — L2 reconciliation cron entrypoint (Sprint 2B)
+#
+# cycle-098 Sprint 2B — un-deferred reconciliation cron per SKP-005.
+#
+# Designed to be invoked from a crontab entry every 6h (default cadence):
+#
+#   0 */6 * * * /path/to/.claude/scripts/budget/budget-reconcile-cron.sh \
+#     >> /path/to/repo/.run/cost-budget-cron.log 2>&1
+#
+# Behavior:
+#   - Sources cost-budget-enforcer-lib.sh
+#   - Iterates over configured providers (or "aggregate" default)
+#   - Runs budget_reconcile per provider
+#   - Acquires flock per repo to prevent overlapping invocations
+#   - Exits non-zero if any provider's reconciliation emits a BLOCKER
+#
+# Flags:
+#   --provider <id>       Reconcile a single provider (default: all configured)
+#   --force-reason <text> Operator force-reconcile with audit-logged reason
+#   --dry-run             Print intent; no audit-log writes (useful for ops)
+#   --once                Single-shot (default cron behavior)
+#   --help                Show usage
+# =============================================================================
+
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "${_SCRIPT_DIR}/../../.." && pwd)"
+
+usage() {
+    sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+    exit 0
+}
+
+# Parse args.
+PROVIDER=""
+FORCE_REASON=""
+DRY_RUN=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --provider) PROVIDER="$2"; shift 2 ;;
+        --force-reason) FORCE_REASON="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --once) shift ;;
+        --help|-h) usage ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Source the lib (idempotent).
+# shellcheck source=../lib/cost-budget-enforcer-lib.sh
+source "${_REPO_ROOT}/.claude/scripts/lib/cost-budget-enforcer-lib.sh"
+
+# Resolve the lock + log paths.
+RECONCILE_LOCK="${LOA_BUDGET_RECONCILE_LOCK:-${_REPO_ROOT}/.run/budget-reconcile.lock}"
+mkdir -p "$(dirname "$RECONCILE_LOCK")"
+: > "$RECONCILE_LOCK" 2>/dev/null || touch "$RECONCILE_LOCK"
+
+_audit_require_flock || exit 1
+
+# Determine providers to reconcile.
+providers=()
+if [[ -n "$PROVIDER" ]]; then
+    providers=("$PROVIDER")
+else
+    # Read configured providers from .loa.config.yaml::cost_budget_enforcer.providers
+    # Fall back to "aggregate" if none configured.
+    config_providers="$(_l2_config_get '.cost_budget_enforcer.providers // []' '' 2>/dev/null || true)"
+    if [[ -n "$config_providers" && "$config_providers" != "[]" && "$config_providers" != "null" ]]; then
+        # Parse YAML list. yq path returns the YAML representation; we want a
+        # newline-separated list of provider ids.
+        if command -v yq >/dev/null 2>&1; then
+            mapfile -t providers < <(yq -r '.cost_budget_enforcer.providers[] // empty' "$(_l2_config_path)" 2>/dev/null || true)
+        fi
+    fi
+    if [[ ${#providers[@]} -eq 0 ]]; then
+        providers=("aggregate")
+    fi
+fi
+
+overall_status=0
+
+# Wrap the reconcile loop in a single flock so concurrent cron firings cannot
+# stomp each other. Wait up to 5min for the lock (cron runs every 6h, so 5min
+# is generous but bounded).
+{
+    if ! flock -w 300 9; then
+        echo "[budget-reconcile-cron] could not acquire lock at $RECONCILE_LOCK (timeout 300s)" >&2
+        exit 1
+    fi
+
+    for provider in ${providers[@]+"${providers[@]}"}; do
+        if (( DRY_RUN )); then
+            echo "[budget-reconcile-cron] DRY-RUN provider=$provider" >&2
+            continue
+        fi
+
+        rc=0
+        if [[ -n "$FORCE_REASON" ]]; then
+            budget_reconcile --provider "$provider" --force-reason "$FORCE_REASON" || rc=$?
+        else
+            budget_reconcile --provider "$provider" || rc=$?
+        fi
+
+        if (( rc == 0 )); then
+            echo "[budget-reconcile-cron] OK provider=$provider" >&2
+        elif (( rc == 1 )); then
+            # blocker emitted; log but continue with other providers.
+            echo "[budget-reconcile-cron] BLOCKER provider=$provider — operator review required" >&2
+            overall_status=1
+        elif (( rc == 2 )); then
+            # defer (e.g., 429); skip silently.
+            echo "[budget-reconcile-cron] DEFER provider=$provider — billing API rate-limited; will retry next interval" >&2
+        else
+            echo "[budget-reconcile-cron] ERROR provider=$provider rc=$rc" >&2
+            overall_status=1
+        fi
+    done
+} 9>"$RECONCILE_LOCK"
+
+exit "$overall_status"

--- a/.claude/scripts/budget/budget-reconcile-install.sh
+++ b/.claude/scripts/budget/budget-reconcile-install.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# =============================================================================
+# budget-reconcile-install.sh — install/uninstall L2 reconciliation cron entry
+#
+# cycle-098 Sprint 2B — operator-facing helper for crontab integration.
+#
+# Subcommands:
+#   install    Append (idempotent) the L2 reconciliation cron line to the
+#              current user's crontab. Cadence read from
+#              .loa.config.yaml::cost_budget_enforcer.reconciliation.interval_hours
+#              (default 6). Marker comment makes the line uninstallable.
+#   uninstall  Remove the L2 reconciliation cron line by marker comment.
+#   status     Print whether the cron entry is installed.
+#   show       Print the cron line that WOULD be installed (no side effects).
+#
+# Usage examples:
+#   .claude/scripts/budget/budget-reconcile-install.sh status
+#   .claude/scripts/budget/budget-reconcile-install.sh install
+#   .claude/scripts/budget/budget-reconcile-install.sh uninstall
+#
+# Marker convention: `# loa-cycle098-l2-reconcile  managed entry`
+# =============================================================================
+
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "${_SCRIPT_DIR}/../../.." && pwd)"
+_CRON_ENTRY_SCRIPT="${_REPO_ROOT}/.claude/scripts/budget/budget-reconcile-cron.sh"
+_LOG_PATH="${_REPO_ROOT}/.run/cost-budget-cron.log"
+MARKER="# loa-cycle098-l2-reconcile  managed entry"
+
+usage() {
+    sed -n '2,28p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+    exit 0
+}
+
+# Read interval_hours from config; default 6.
+read_interval_hours() {
+    local config="${LOA_BUDGET_CONFIG_FILE:-${_REPO_ROOT}/.loa.config.yaml}"
+    if [[ ! -f "$config" ]]; then
+        echo "6"
+        return 0
+    fi
+    if command -v yq >/dev/null 2>&1; then
+        local v
+        v="$(yq -r '.cost_budget_enforcer.reconciliation.interval_hours // 6' "$config" 2>/dev/null || echo 6)"
+        [[ "$v" == "null" || -z "$v" ]] && v=6
+        echo "$v"
+        return 0
+    fi
+    python3 - "$config" <<'PY' 2>/dev/null || echo 6
+import sys
+try:
+    import yaml
+except ImportError:
+    print(6)
+    sys.exit(0)
+try:
+    with open(sys.argv[1]) as f:
+        doc = yaml.safe_load(f) or {}
+except Exception:
+    print(6)
+    sys.exit(0)
+v = ((doc.get('cost_budget_enforcer') or {}).get('reconciliation') or {}).get('interval_hours', 6)
+print(v if v else 6)
+PY
+}
+
+# Build the cron line.
+build_cron_line() {
+    local hours
+    hours="$(read_interval_hours)"
+    if ! [[ "$hours" =~ ^[0-9]+$ ]] || (( hours < 1 || hours > 24 )); then
+        echo "Invalid reconciliation.interval_hours: $hours (must be 1..24)" >&2
+        return 1
+    fi
+    # Cron expression: every <hours> hours.
+    local cron_expr
+    if (( hours == 24 )); then
+        cron_expr="0 0 * * *"
+    else
+        cron_expr="0 */${hours} * * *"
+    fi
+    echo "${cron_expr} ${_CRON_ENTRY_SCRIPT} >> ${_LOG_PATH} 2>&1  ${MARKER}"
+}
+
+cmd_show() {
+    build_cron_line
+}
+
+cmd_status() {
+    if ! command -v crontab >/dev/null 2>&1; then
+        echo "crontab not available on this system"
+        return 1
+    fi
+    if crontab -l 2>/dev/null | grep -qF "$MARKER"; then
+        echo "INSTALLED"
+        crontab -l 2>/dev/null | grep -F "$MARKER"
+        return 0
+    else
+        echo "NOT-INSTALLED"
+        return 0
+    fi
+}
+
+cmd_install() {
+    if ! command -v crontab >/dev/null 2>&1; then
+        echo "crontab not available on this system; cannot install cron entry" >&2
+        return 1
+    fi
+    [[ -x "$_CRON_ENTRY_SCRIPT" ]] || chmod +x "$_CRON_ENTRY_SCRIPT" 2>/dev/null || true
+    local desired
+    desired="$(build_cron_line)"
+    local existing
+    existing="$(crontab -l 2>/dev/null || true)"
+    if printf '%s\n' "$existing" | grep -qF "$MARKER"; then
+        # Already installed. Idempotent: replace the line if cadence changed.
+        local current_line
+        current_line="$(printf '%s\n' "$existing" | grep -F "$MARKER" | head -1)"
+        if [[ "$current_line" == "$desired" ]]; then
+            echo "Already installed (cadence matches): $desired"
+            return 0
+        fi
+        echo "Cadence changed; updating cron line."
+        echo "  was:  $current_line"
+        echo "  now:  $desired"
+        local updated
+        updated="$(printf '%s\n' "$existing" | grep -vF "$MARKER")"
+        printf '%s\n%s\n' "$updated" "$desired" | crontab -
+        return 0
+    fi
+    # Append new line.
+    printf '%s\n%s\n' "$existing" "$desired" | crontab -
+    echo "Installed: $desired"
+}
+
+cmd_uninstall() {
+    if ! command -v crontab >/dev/null 2>&1; then
+        echo "crontab not available on this system" >&2
+        return 1
+    fi
+    local existing
+    existing="$(crontab -l 2>/dev/null || true)"
+    if ! printf '%s\n' "$existing" | grep -qF "$MARKER"; then
+        echo "Not installed; nothing to remove."
+        return 0
+    fi
+    local updated
+    updated="$(printf '%s\n' "$existing" | grep -vF "$MARKER")"
+    printf '%s\n' "$updated" | crontab -
+    echo "Uninstalled."
+}
+
+# Main.
+if [[ $# -eq 0 ]]; then
+    usage
+fi
+case "$1" in
+    install)   cmd_install ;;
+    uninstall) cmd_uninstall ;;
+    status)    cmd_status ;;
+    show)      cmd_show ;;
+    --help|-h) usage ;;
+    *) echo "unknown subcommand: $1" >&2; exit 2 ;;
+esac

--- a/.claude/scripts/lib/cost-budget-enforcer-lib.sh
+++ b/.claude/scripts/lib/cost-budget-enforcer-lib.sh
@@ -95,6 +95,34 @@ _L2_DEFAULT_CLOCK_TOLERANCE="60"
 _L2_DEFAULT_LAG_HALT_SECONDS="300"
 _L2_DEFAULT_BILLING_STALE_SECONDS="900"
 
+# Numeric / provider input validation regexes (review HIGH-3 / audit F1 + F2).
+# All numerics passed to python3 -c interpolation MUST match _L2_NUMERIC_RE.
+# All providers (free-form caller input) MUST match _L2_PROVIDER_RE.
+_L2_NUMERIC_RE='^[0-9]+(\.[0-9]+)?$'
+_L2_INT_RE='^[0-9]+$'
+_L2_PROVIDER_RE='^[a-z][a-z0-9_-]{0,63}$'
+
+# -----------------------------------------------------------------------------
+# _l2_validate_numeric <value> <field_name> [int|decimal]
+# Returns 0 valid; 1 invalid (and logs an error).
+# -----------------------------------------------------------------------------
+_l2_validate_numeric() {
+    local value="$1"
+    local field="$2"
+    local kind="${3:-decimal}"
+    local re
+    if [[ "$kind" == "int" ]]; then
+        re="$_L2_INT_RE"
+    else
+        re="$_L2_NUMERIC_RE"
+    fi
+    if [[ -z "$value" ]] || ! [[ "$value" =~ $re ]]; then
+        _l2_log "ERROR: invalid numeric value for $field: '$value' (expected $kind matching $re)"
+        return 1
+    fi
+    return 0
+}
+
 # -----------------------------------------------------------------------------
 # _l2_config_path — return resolved .loa.config.yaml path.
 # -----------------------------------------------------------------------------
@@ -157,41 +185,62 @@ PY
 # _l2_get_daily_cap — resolve daily cap. Env > config > error.
 # -----------------------------------------------------------------------------
 _l2_get_daily_cap() {
-    if [[ -n "${LOA_BUDGET_DAILY_CAP_USD:-}" ]]; then
-        echo "$LOA_BUDGET_DAILY_CAP_USD"
-        return 0
-    fi
     local cap
-    cap="$(_l2_config_get '.cost_budget_enforcer.daily_cap_usd' '')"
+    if [[ -n "${LOA_BUDGET_DAILY_CAP_USD:-}" ]]; then
+        cap="$LOA_BUDGET_DAILY_CAP_USD"
+    else
+        cap="$(_l2_config_get '.cost_budget_enforcer.daily_cap_usd' '')"
+    fi
     if [[ -z "$cap" ]]; then
         _l2_log "ERROR: daily_cap_usd not configured (set LOA_BUDGET_DAILY_CAP_USD or .loa.config.yaml::cost_budget_enforcer.daily_cap_usd)"
+        return 3
+    fi
+    if ! _l2_validate_numeric "$cap" "daily_cap_usd"; then
         return 3
     fi
     echo "$cap"
 }
 
 _l2_get_drift_threshold() {
-    echo "${LOA_BUDGET_DRIFT_THRESHOLD:-$(_l2_config_get '.cost_budget_enforcer.reconciliation.drift_threshold_pct' "$_L2_DEFAULT_DRIFT_THRESHOLD")}"
+    local v
+    v="${LOA_BUDGET_DRIFT_THRESHOLD:-$(_l2_config_get '.cost_budget_enforcer.reconciliation.drift_threshold_pct' "$_L2_DEFAULT_DRIFT_THRESHOLD")}"
+    _l2_validate_numeric "$v" "drift_threshold_pct" || { echo "$_L2_DEFAULT_DRIFT_THRESHOLD"; return 0; }
+    echo "$v"
 }
 
 _l2_get_freshness_seconds() {
-    echo "${LOA_BUDGET_FRESHNESS_SECONDS:-$(_l2_config_get '.cost_budget_enforcer.freshness_threshold_seconds' "$_L2_DEFAULT_FRESHNESS_SECONDS")}"
+    local v
+    v="${LOA_BUDGET_FRESHNESS_SECONDS:-$(_l2_config_get '.cost_budget_enforcer.freshness_threshold_seconds' "$_L2_DEFAULT_FRESHNESS_SECONDS")}"
+    _l2_validate_numeric "$v" "freshness_threshold_seconds" int || { echo "$_L2_DEFAULT_FRESHNESS_SECONDS"; return 0; }
+    echo "$v"
 }
 
 _l2_get_stale_halt_pct() {
-    echo "${LOA_BUDGET_STALE_HALT_PCT:-$(_l2_config_get '.cost_budget_enforcer.stale_halt_pct' "$_L2_DEFAULT_STALE_HALT_PCT")}"
+    local v
+    v="${LOA_BUDGET_STALE_HALT_PCT:-$(_l2_config_get '.cost_budget_enforcer.stale_halt_pct' "$_L2_DEFAULT_STALE_HALT_PCT")}"
+    _l2_validate_numeric "$v" "stale_halt_pct" || { echo "$_L2_DEFAULT_STALE_HALT_PCT"; return 0; }
+    echo "$v"
 }
 
 _l2_get_clock_tolerance() {
-    echo "${LOA_BUDGET_CLOCK_TOLERANCE:-$(_l2_config_get '.cost_budget_enforcer.clock_tolerance_seconds' "$_L2_DEFAULT_CLOCK_TOLERANCE")}"
+    local v
+    v="${LOA_BUDGET_CLOCK_TOLERANCE:-$(_l2_config_get '.cost_budget_enforcer.clock_tolerance_seconds' "$_L2_DEFAULT_CLOCK_TOLERANCE")}"
+    _l2_validate_numeric "$v" "clock_tolerance_seconds" int || { echo "$_L2_DEFAULT_CLOCK_TOLERANCE"; return 0; }
+    echo "$v"
 }
 
 _l2_get_lag_halt_seconds() {
-    echo "${LOA_BUDGET_LAG_HALT_SECONDS:-$(_l2_config_get '.cost_budget_enforcer.provider_lag_halt_seconds' "$_L2_DEFAULT_LAG_HALT_SECONDS")}"
+    local v
+    v="${LOA_BUDGET_LAG_HALT_SECONDS:-$(_l2_config_get '.cost_budget_enforcer.provider_lag_halt_seconds' "$_L2_DEFAULT_LAG_HALT_SECONDS")}"
+    _l2_validate_numeric "$v" "provider_lag_halt_seconds" int || { echo "$_L2_DEFAULT_LAG_HALT_SECONDS"; return 0; }
+    echo "$v"
 }
 
 _l2_get_billing_stale_seconds() {
-    echo "${LOA_BUDGET_BILLING_STALE_SECONDS:-$(_l2_config_get '.cost_budget_enforcer.billing_stale_halt_seconds' "$_L2_DEFAULT_BILLING_STALE_SECONDS")}"
+    local v
+    v="${LOA_BUDGET_BILLING_STALE_SECONDS:-$(_l2_config_get '.cost_budget_enforcer.billing_stale_halt_seconds' "$_L2_DEFAULT_BILLING_STALE_SECONDS")}"
+    _l2_validate_numeric "$v" "billing_stale_halt_seconds" int || { echo "$_L2_DEFAULT_BILLING_STALE_SECONDS"; return 0; }
+    echo "$v"
 }
 
 _l2_get_observer_cmd() {
@@ -209,6 +258,18 @@ _l2_get_log_path() {
         echo "$relpath"
     else
         echo "${_L2_REPO_ROOT}/${relpath}"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# _l2_propagate_test_now — when LOA_BUDGET_TEST_NOW is set, also propagate to
+# LOA_AUDIT_TEST_NOW so audit-envelope writes the same simulated ts_utc.
+# Call at the top of every public L2 entry function (must be in caller's
+# scope, not a subshell — command substitutions cannot propagate exports).
+# -----------------------------------------------------------------------------
+_l2_propagate_test_now() {
+    if [[ -n "${LOA_BUDGET_TEST_NOW:-}" ]]; then
+        export LOA_AUDIT_TEST_NOW="$LOA_BUDGET_TEST_NOW"
     fi
 }
 
@@ -254,14 +315,86 @@ except Exception:
 
 # -----------------------------------------------------------------------------
 # _l2_provider_normalize <provider> — default to "aggregate" if empty.
+# Validates against _L2_PROVIDER_RE to prevent yq path-expression injection
+# (audit F2). Returns non-zero (and a sanitized fallback "aggregate") on
+# invalid input — caller's burden to check exit code.
 # -----------------------------------------------------------------------------
 _l2_provider_normalize() {
     local provider="${1:-}"
     if [[ -z "$provider" ]]; then
         echo "aggregate"
-    else
-        echo "$provider"
+        return 0
     fi
+    if ! [[ "$provider" =~ $_L2_PROVIDER_RE ]]; then
+        _l2_log "ERROR: invalid provider id '$provider' (expected $_L2_PROVIDER_RE)"
+        echo "aggregate"
+        return 1
+    fi
+    echo "$provider"
+}
+
+# -----------------------------------------------------------------------------
+# _l2_recent_drift_blocker <provider> <utc_day>
+#
+# Scan the audit log for budget.reconcile events for <utc_day> + <provider>.
+# Returns the diagnostic JSON of the most-recent BLOCKER if one exists AND
+# is not yet cleared by a subsequent force-reconcile event. Otherwise empty.
+# A force-reconcile (force_reconcile=true) "clears" prior BLOCKERs because
+# the operator has explicitly reviewed the drift and decided to proceed
+# (counter NOT auto-corrected — but the operator-decision is auditable).
+#
+# Used by budget_verdict to honor MED-3 (counter_drift reachability): a
+# verdict made after an unresolved drift BLOCKER should halt-uncertainty.
+# -----------------------------------------------------------------------------
+_l2_recent_drift_blocker() {
+    local provider="$1"
+    local utc_day="$2"
+    local log_path
+    log_path="$(_l2_get_log_path)"
+    if [[ ! -f "$log_path" ]]; then
+        return 0
+    fi
+    python3 - "$log_path" "$provider" "$utc_day" <<'PY'
+import json, sys
+log_path, target_provider, target_day = sys.argv[1], sys.argv[2], sys.argv[3]
+last_blocker = None
+try:
+    with open(log_path, 'r', encoding='utf-8') as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith('['):
+                continue
+            try:
+                envelope = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if envelope.get('event_type') != 'budget.reconcile':
+                continue
+            payload = envelope.get('payload') or {}
+            if payload.get('utc_day') != target_day:
+                continue
+            ev_provider = payload.get('provider', 'aggregate')
+            if target_provider != 'aggregate' and ev_provider != target_provider:
+                continue
+            if payload.get('force_reconcile') is True:
+                # Operator explicit override clears prior blockers.
+                last_blocker = None
+                continue
+            if payload.get('blocker') is True:
+                last_blocker = {
+                    'drift_pct': payload.get('drift_pct'),
+                    'counter_usd': payload.get('counter_usd'),
+                    'billing_usd': payload.get('billing_usd'),
+                    'reconcile_ts': envelope.get('ts_utc'),
+                }
+            else:
+                # blocker=false reconcile clears the prior blocker too.
+                last_blocker = None
+except FileNotFoundError:
+    pass
+if last_blocker:
+    print(json.dumps(last_blocker))
+PY
 }
 
 # -----------------------------------------------------------------------------
@@ -499,6 +632,7 @@ _l2_compute_age_seconds() {
 #    freshness_seconds, provider, utc_day}
 # -----------------------------------------------------------------------------
 budget_get_usage() {
+    _l2_propagate_test_now
     local provider=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -506,7 +640,7 @@ budget_get_usage() {
             *) shift ;;
         esac
     done
-    provider="$(_l2_provider_normalize "$provider")"
+    if ! provider="$(_l2_provider_normalize "$provider")"; then return 2; fi
 
     local cap
     if ! cap="$(_l2_get_daily_cap)"; then
@@ -569,6 +703,7 @@ budget_get_usage() {
 # tail-scan + this actual_usd.
 # -----------------------------------------------------------------------------
 budget_record_call() {
+    _l2_propagate_test_now
     local actual_usd="${1:-}"
     if [[ -z "$actual_usd" ]]; then
         _l2_log "budget_record_call: actual_usd required"
@@ -586,7 +721,7 @@ budget_record_call() {
             *) shift ;;
         esac
     done
-    provider="$(_l2_provider_normalize "$provider")"
+    if ! provider="$(_l2_provider_normalize "$provider")"; then return 2; fi
 
     if ! [[ "$actual_usd" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
         _l2_log "budget_record_call: actual_usd must be a non-negative decimal"
@@ -737,6 +872,7 @@ _l2_emit_and_return() {
 # for allow/warn-90, exits 1 for halt-100/halt-uncertainty.
 # -----------------------------------------------------------------------------
 budget_verdict() {
+    _l2_propagate_test_now
     local estimated_usd="${1:-}"
     if [[ -z "$estimated_usd" ]]; then
         _l2_log "budget_verdict: estimated_usd required"
@@ -756,7 +892,7 @@ budget_verdict() {
             *) shift ;;
         esac
     done
-    provider="$(_l2_provider_normalize "$provider")"
+    if ! provider="$(_l2_provider_normalize "$provider")"; then return 2; fi
 
     local cap
     if ! cap="$(_l2_get_daily_cap)"; then
@@ -768,11 +904,16 @@ budget_verdict() {
 
     # Per-provider sub-cap (optional). When provider is specified and a sub-cap
     # is configured, the sub-cap overrides the aggregate cap for verdict math.
+    # provider has already been validated against _L2_PROVIDER_RE in
+    # _l2_provider_normalize, but defense-in-depth: we still validate the
+    # resulting sub_cap with _l2_validate_numeric before using it.
     if [[ "$provider" != "aggregate" ]]; then
         local sub_cap
         sub_cap="$(_l2_config_get ".cost_budget_enforcer.per_provider_caps.${provider}" "")"
         if [[ -n "$sub_cap" ]]; then
-            cap="$sub_cap"
+            if _l2_validate_numeric "$sub_cap" "per_provider_caps.${provider}"; then
+                cap="$sub_cap"
+            fi
         fi
     fi
 
@@ -822,10 +963,12 @@ budget_verdict() {
     # ----- Uncertainty checks (PRD §FR-L2 + SDD §1.5.3 ordering) -----
     # Order: most-severe first.
     # 1. counter_inconsistent — counter is corrupt regardless of billing state
-    # 2. billing_stale — billing API >billing_stale_threshold AND counter >cap_threshold
-    # 3. provider_lag — billing API lag in [lag_threshold, billing_stale_threshold) AND counter >cap_threshold
-    # 4. clock_drift — only when billing data is FRESH (billing_age <= freshness)
-    # 5. halt-100 / warn-90 / allow
+    # 2. counter_drift       — prior reconcile BLOCKER not yet operator-cleared
+    # 3. billing_stale — billing API >billing_stale_threshold AND counter >cap_threshold
+    # 4. provider_lag — billing API lag in [lag_threshold, billing_stale_threshold) AND counter >cap_threshold
+    # 5. clock_drift — only when billing data is FRESH (billing_age <= freshness)
+    # 6. counter_stale — no fresh signal at all (no observer + counter older than freshness)
+    # 7. halt-100 / warn-90 / allow
 
     # 1. counter_inconsistent (always halt-uncertainty regardless of usage)
     if [[ "$consistency" != "ok" ]]; then
@@ -833,6 +976,17 @@ budget_verdict() {
         diag_inc="$(jq -nc --arg c "$consistency" '{counter_state: $c}')"
         local payload
         payload="$(_l2_render_verdict "halt-uncertainty" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id" "counter_inconsistent" "$diag_inc")"
+        _l2_emit_and_return "budget.halt_uncertainty" "$payload"
+        return $?
+    fi
+
+    # 2. counter_drift — prior reconcile BLOCKER must be cleared by operator
+    #    via force-reconcile before allowing further verdicts (MED-3 review).
+    local drift_blocker
+    drift_blocker="$(_l2_recent_drift_blocker "$provider" "$utc_day")"
+    if [[ -n "$drift_blocker" ]]; then
+        local payload
+        payload="$(_l2_render_verdict "halt-uncertainty" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id" "counter_drift" "$drift_blocker")"
         _l2_emit_and_return "budget.halt_uncertainty" "$payload"
         return $?
     fi
@@ -848,7 +1002,7 @@ counter = float('${counter_usd}')
 print(0 if cap == 0 else round(100 * counter / cap, 6))
 ")"
 
-    # 2. billing_stale (billing API >= billing_stale threshold AND counter > stale_halt_pct)
+    # 3. billing_stale (billing API >= billing_stale threshold AND counter > stale_halt_pct)
     if [[ "$observer_used" == "true" && "$billing_age" != "null" ]]; then
         local billing_stale_threshold
         billing_stale_threshold="$(_l2_get_billing_stale_seconds)"
@@ -869,7 +1023,7 @@ print(0 if cap == 0 else round(100 * counter / cap, 6))
         fi
     fi
 
-    # 3. provider_lag (billing API lag >= lag_halt_seconds AND counter > stale_halt_pct)
+    # 4. provider_lag (billing API lag >= lag_halt_seconds AND counter > stale_halt_pct)
     #    Comes AFTER billing_stale so billing_stale wins for very-stale data.
     if [[ "$observer_used" == "true" && "$billing_age" != "null" ]]; then
         local lag_threshold
@@ -891,7 +1045,7 @@ print(0 if cap == 0 else round(100 * counter / cap, 6))
         fi
     fi
 
-    # 4. clock_drift — ONLY when billing data is fresh (billing_age <= freshness).
+    # 5. clock_drift — ONLY when billing data is fresh (billing_age <= freshness).
     #    Stale billing_ts will naturally appear "drifted" from system clock; that
     #    is not a clock-drift signal, it's a staleness signal (handled above).
     if [[ "$observer_used" == "true" && -n "$billing_ts" && "$billing_age" != "null" ]]; then
@@ -919,6 +1073,25 @@ print(0 if cap == 0 else round(100 * counter / cap, 6))
                 return $?
             fi
         fi
+    fi
+
+    # 6. counter_stale — no observer + counter is stale OR has positive value
+    #    but no fresh signal at all. Closes review HIGH-1 fail-open hole.
+    #    The check applies when observer_used=false AND data_fresh=false. When
+    #    no entries exist for today (counter_usd=0, counter_ts=null →
+    #    counter_age=0), data_fresh was set true above; allow proceeds.
+    if [[ "$data_fresh" != "true" ]]; then
+        local diag_cs
+        diag_cs="$(jq -nc \
+            --argjson counter_age "$counter_age" \
+            --argjson freshness_threshold "$fresh_threshold" \
+            --argjson counter_usd "$counter_usd" \
+            --arg observer_used "$observer_used" \
+            '{counter_age_seconds: $counter_age, freshness_threshold_seconds: $freshness_threshold, counter_usd: $counter_usd, observer_used: ($observer_used == "true")}')"
+        local payload
+        payload="$(_l2_render_verdict "halt-uncertainty" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id" "counter_stale" "$diag_cs")"
+        _l2_emit_and_return "budget.halt_uncertainty" "$payload"
+        return $?
     fi
 
     # ----- Threshold checks (data is fresh; cleanly bucket) -----
@@ -963,6 +1136,7 @@ print(0 if cap == 0 else round(100 * (used + est) / cap, 6))
 # Sprint 2A: function unit. Sprint 2B: cron registration via /schedule.
 # -----------------------------------------------------------------------------
 budget_reconcile() {
+    _l2_propagate_test_now
     local provider="" force_reason=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -971,7 +1145,7 @@ budget_reconcile() {
             *) shift ;;
         esac
     done
-    provider="$(_l2_provider_normalize "$provider")"
+    if ! provider="$(_l2_provider_normalize "$provider")"; then return 2; fi
 
     local utc_day
     utc_day="$(_l2_now_utc_day)"

--- a/.claude/scripts/lib/cost-budget-enforcer-lib.sh
+++ b/.claude/scripts/lib/cost-budget-enforcer-lib.sh
@@ -982,6 +982,15 @@ budget_reconcile() {
 
     local observer_json billing_usd billing_unreachable
     observer_json="$(_l2_invoke_observer "$provider")"
+    # Sprint 2B: observer may signal {"_defer": true, "_reason": "rate_limited"}
+    # to indicate transient failure; in that case we skip silently and let the
+    # next cron interval retry. Audit log is NOT touched.
+    if printf '%s' "$observer_json" | jq -e '._defer == true' >/dev/null 2>&1; then
+        local reason
+        reason="$(printf '%s' "$observer_json" | jq -r '._reason // "unspecified"')"
+        _l2_log "budget_reconcile: observer requested defer (provider=$provider reason=$reason)"
+        return 2
+    fi
     if printf '%s' "$observer_json" | jq -e '._unreachable == true' >/dev/null 2>&1; then
         billing_usd="null"
         billing_unreachable="true"

--- a/.claude/scripts/lib/cost-budget-enforcer-lib.sh
+++ b/.claude/scripts/lib/cost-budget-enforcer-lib.sh
@@ -1,0 +1,1064 @@
+#!/usr/bin/env bash
+# =============================================================================
+# cost-budget-enforcer-lib.sh — L2 cost-budget-enforcer (Sprint 2A)
+#
+# cycle-098 Sprint 2A — implementation of the L2 daily-cap enforcer per
+# RFC #654, PRD FR-L2 (10 ACs), SDD §1.4.2 + §5.4.
+#
+# Composition (does NOT reinvent):
+#   - 1A audit envelope:       audit_emit (writes JSONL with prev_hash chain)
+#   - 1B signing scheme:       audit_emit honors LOA_AUDIT_SIGNING_KEY_ID
+#   - 1B protected-class:      is_protected_class("budget.cap_increase") for cap raises
+#   - 1.5 trust-store check:   audit_emit auto-verifies trust-store
+#
+# Verdict semantics (PRD §FR-L2 state-transition table; SDD §1.5.3):
+#   - allow             usage <90% AND data fresh
+#   - warn-90           90% <= usage <100% AND data fresh
+#   - halt-100          usage >=100% AND data fresh
+#   - halt-uncertainty  one of 5 modes:
+#       billing_stale            billing API >15min stale AND counter near cap (>75%)
+#       counter_inconsistent     counter is negative, decreasing, or backwards
+#       counter_drift            reconciliation detected drift >5%
+#       clock_drift              system clock vs billing_ts diff >60s
+#       provider_lag             billing-API lag >=5min when counter shows >75%
+#
+# Public functions:
+#   budget_verdict <estimated_usd> [--provider <id>] [--cycle-id <id>]
+#       Returns a verdict via stdout JSON; side-effect appends to audit log.
+#       Exit 0 = allow/warn-90 (call may proceed); exit 1 = halt-100/halt-uncertainty.
+#
+#   budget_get_usage [--provider <id>]
+#       Read-only query of current usage state. Stdout JSON:
+#         {usd_used, usd_remaining, last_billing_ts, counter_ts, freshness_seconds}
+#
+#   budget_record_call <actual_usd> --provider <id> [--cycle-id <id>] [--model-id <id>]
+#       Post-call accounting; appends budget.record_call event to log.
+#
+#   budget_reconcile [--provider <id>] [--force-reason <text>]
+#       Cron-invoked or operator-invoked reconciliation. Compares internal
+#       counter to billing API for current UTC day; emits BLOCKER on drift.
+#       Sprint 2B wires the cron registration; this function is the unit.
+#
+# Environment variables:
+#   LOA_BUDGET_LOG                audit log path (default .run/cost-budget-events.jsonl)
+#   LOA_BUDGET_DAILY_CAP_USD      override daily_cap_usd
+#   LOA_BUDGET_DRIFT_THRESHOLD    override reconcile drift threshold pct (default 5.0)
+#   LOA_BUDGET_FRESHNESS_SECONDS  billing-API freshness threshold (default 300 = 5min)
+#   LOA_BUDGET_STALE_HALT_PCT     usage% triggering halt-uncertainty:billing_stale (default 75)
+#   LOA_BUDGET_CLOCK_TOLERANCE    UTC clock tolerance vs billing_ts in seconds (default 60)
+#   LOA_BUDGET_LAG_HALT_SECONDS   provider-lag threshold for halt-uncertainty:provider_lag
+#                                   (default 300 = 5min)
+#   LOA_BUDGET_BILLING_STALE_SECONDS  billing-stale threshold for halt-uncertainty:billing_stale
+#                                       (default 900 = 15min, per PRD §FR-L2-4)
+#   LOA_BUDGET_OBSERVER_CMD       caller-supplied billing-API observer command path
+#                                   Invoked as: <cmd> <provider> -> stdout JSON
+#                                   {"usd_used": <number>, "billing_ts": "<iso8601>"}
+#   LOA_BUDGET_TEST_NOW           test-only override for "now" (ISO-8601)
+#   LOA_BUDGET_CONFIG_FILE        override .loa.config.yaml path
+#
+# Exit codes:
+#   0 = allow / warn-90 (call may proceed; warn-90 logged but not blocking)
+#   1 = halt-100 or halt-uncertainty (call MUST NOT proceed)
+#   2 = invalid arguments
+#   3 = configuration error (e.g., missing daily_cap_usd)
+# =============================================================================
+
+set -euo pipefail
+
+if [[ "${_LOA_L2_LIB_SOURCED:-0}" == "1" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_LOA_L2_LIB_SOURCED=1
+
+_L2_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_L2_REPO_ROOT="$(cd "${_L2_DIR}/../../.." && pwd)"
+_L2_AUDIT_ENVELOPE="${_L2_REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+_L2_PROTECTED_ROUTER="${_L2_REPO_ROOT}/.claude/scripts/lib/protected-class-router.sh"
+_L2_SCHEMA_DIR="${_L2_REPO_ROOT}/.claude/data/trajectory-schemas/budget-events"
+
+# Source dependencies (idempotent — guards against double-source).
+# shellcheck source=../audit-envelope.sh
+source "${_L2_AUDIT_ENVELOPE}"
+# shellcheck source=protected-class-router.sh
+source "${_L2_PROTECTED_ROUTER}"
+
+_l2_log() { echo "[cost-budget-enforcer] $*" >&2; }
+
+# -----------------------------------------------------------------------------
+# Defaults (overridable via env vars or .loa.config.yaml).
+# -----------------------------------------------------------------------------
+_L2_DEFAULT_LOG=".run/cost-budget-events.jsonl"
+_L2_DEFAULT_DRIFT_THRESHOLD="5.0"
+_L2_DEFAULT_FRESHNESS_SECONDS="300"
+_L2_DEFAULT_STALE_HALT_PCT="75"
+_L2_DEFAULT_CLOCK_TOLERANCE="60"
+_L2_DEFAULT_LAG_HALT_SECONDS="300"
+_L2_DEFAULT_BILLING_STALE_SECONDS="900"
+
+# -----------------------------------------------------------------------------
+# _l2_config_path — return resolved .loa.config.yaml path.
+# -----------------------------------------------------------------------------
+_l2_config_path() {
+    echo "${LOA_BUDGET_CONFIG_FILE:-${_L2_REPO_ROOT}/.loa.config.yaml}"
+}
+
+# -----------------------------------------------------------------------------
+# _l2_config_get <yaml_path> [default]
+# Read a value from .loa.config.yaml using yq if available, else PyYAML.
+# Returns the value on stdout; default on missing.
+# -----------------------------------------------------------------------------
+_l2_config_get() {
+    local yq_path="$1"
+    local default="${2:-}"
+    local config
+    config="$(_l2_config_path)"
+    [[ -f "$config" ]] || { echo "$default"; return 0; }
+    if command -v yq >/dev/null 2>&1; then
+        local result
+        result="$(yq -r "${yq_path} // \"\"" "$config" 2>/dev/null || true)"
+        if [[ -z "$result" || "$result" == "null" ]]; then
+            echo "$default"
+        else
+            echo "$result"
+        fi
+        return 0
+    fi
+    # Python fallback. Path is dotted (e.g., "cost_budget_enforcer.daily_cap_usd").
+    local clean_path="${yq_path#.}"
+    python3 - "$config" "$clean_path" "$default" <<'PY' 2>/dev/null || echo "$default"
+import sys
+try:
+    import yaml
+except ImportError:
+    print(sys.argv[3])
+    sys.exit(0)
+try:
+    with open(sys.argv[1]) as f:
+        doc = yaml.safe_load(f) or {}
+except Exception:
+    print(sys.argv[3])
+    sys.exit(0)
+parts = sys.argv[2].split('.')
+node = doc
+for p in parts:
+    if isinstance(node, dict) and p in node:
+        node = node[p]
+    else:
+        print(sys.argv[3])
+        sys.exit(0)
+if node is None or node == "":
+    print(sys.argv[3])
+else:
+    print(node)
+PY
+}
+
+# -----------------------------------------------------------------------------
+# _l2_get_daily_cap — resolve daily cap. Env > config > error.
+# -----------------------------------------------------------------------------
+_l2_get_daily_cap() {
+    if [[ -n "${LOA_BUDGET_DAILY_CAP_USD:-}" ]]; then
+        echo "$LOA_BUDGET_DAILY_CAP_USD"
+        return 0
+    fi
+    local cap
+    cap="$(_l2_config_get '.cost_budget_enforcer.daily_cap_usd' '')"
+    if [[ -z "$cap" ]]; then
+        _l2_log "ERROR: daily_cap_usd not configured (set LOA_BUDGET_DAILY_CAP_USD or .loa.config.yaml::cost_budget_enforcer.daily_cap_usd)"
+        return 3
+    fi
+    echo "$cap"
+}
+
+_l2_get_drift_threshold() {
+    echo "${LOA_BUDGET_DRIFT_THRESHOLD:-$(_l2_config_get '.cost_budget_enforcer.reconciliation.drift_threshold_pct' "$_L2_DEFAULT_DRIFT_THRESHOLD")}"
+}
+
+_l2_get_freshness_seconds() {
+    echo "${LOA_BUDGET_FRESHNESS_SECONDS:-$(_l2_config_get '.cost_budget_enforcer.freshness_threshold_seconds' "$_L2_DEFAULT_FRESHNESS_SECONDS")}"
+}
+
+_l2_get_stale_halt_pct() {
+    echo "${LOA_BUDGET_STALE_HALT_PCT:-$(_l2_config_get '.cost_budget_enforcer.stale_halt_pct' "$_L2_DEFAULT_STALE_HALT_PCT")}"
+}
+
+_l2_get_clock_tolerance() {
+    echo "${LOA_BUDGET_CLOCK_TOLERANCE:-$(_l2_config_get '.cost_budget_enforcer.clock_tolerance_seconds' "$_L2_DEFAULT_CLOCK_TOLERANCE")}"
+}
+
+_l2_get_lag_halt_seconds() {
+    echo "${LOA_BUDGET_LAG_HALT_SECONDS:-$(_l2_config_get '.cost_budget_enforcer.provider_lag_halt_seconds' "$_L2_DEFAULT_LAG_HALT_SECONDS")}"
+}
+
+_l2_get_billing_stale_seconds() {
+    echo "${LOA_BUDGET_BILLING_STALE_SECONDS:-$(_l2_config_get '.cost_budget_enforcer.billing_stale_halt_seconds' "$_L2_DEFAULT_BILLING_STALE_SECONDS")}"
+}
+
+_l2_get_observer_cmd() {
+    echo "${LOA_BUDGET_OBSERVER_CMD:-$(_l2_config_get '.cost_budget_enforcer.billing_observer_cmd' '')}"
+}
+
+_l2_get_log_path() {
+    if [[ -n "${LOA_BUDGET_LOG:-}" ]]; then
+        echo "$LOA_BUDGET_LOG"
+        return 0
+    fi
+    local relpath
+    relpath="$(_l2_config_get '.cost_budget_enforcer.audit_log' "$_L2_DEFAULT_LOG")"
+    if [[ "$relpath" = /* ]]; then
+        echo "$relpath"
+    else
+        echo "${_L2_REPO_ROOT}/${relpath}"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# _l2_now_iso8601 — wraps _audit_now_iso8601, honoring LOA_BUDGET_TEST_NOW.
+# -----------------------------------------------------------------------------
+_l2_now_iso8601() {
+    if [[ -n "${LOA_BUDGET_TEST_NOW:-}" ]]; then
+        echo "$LOA_BUDGET_TEST_NOW"
+    else
+        _audit_now_iso8601
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# _l2_now_utc_day — current UTC day as YYYY-MM-DD.
+# -----------------------------------------------------------------------------
+_l2_now_utc_day() {
+    local now
+    now="$(_l2_now_iso8601)"
+    echo "${now:0:10}"
+}
+
+# -----------------------------------------------------------------------------
+# _l2_iso_to_epoch <iso8601> — convert ISO-8601 timestamp to Unix epoch seconds.
+# Returns "" on parse failure.
+# -----------------------------------------------------------------------------
+_l2_iso_to_epoch() {
+    local ts="$1"
+    [[ -z "$ts" ]] && return 0
+    python3 -c "
+from datetime import datetime
+import sys
+try:
+    s = sys.argv[1]
+    if s.endswith('Z'):
+        s = s[:-1] + '+00:00'
+    print(int(datetime.fromisoformat(s).timestamp()))
+except Exception:
+    pass
+" "$ts" 2>/dev/null
+}
+
+# -----------------------------------------------------------------------------
+# _l2_provider_normalize <provider> — default to "aggregate" if empty.
+# -----------------------------------------------------------------------------
+_l2_provider_normalize() {
+    local provider="${1:-}"
+    if [[ -z "$provider" ]]; then
+        echo "aggregate"
+    else
+        echo "$provider"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# _l2_compute_counter <provider> <utc_day>
+#
+# Tail-scan the audit log for budget.record_call events matching <provider>
+# (or aggregate across all providers if provider="aggregate") for <utc_day>.
+# Returns JSON: {"counter_usd": <number>, "counter_ts": "<iso8601 or null>",
+#                "consistency": "ok" | "negative" | "decreasing" | "backwards"}
+#
+# Consistency semantics:
+#   - negative:   any actual_usd < 0 detected
+#   - decreasing: usd_used_post in a later entry < earlier entry (counter went down)
+#   - backwards:  ts_utc not monotonic (out-of-order entries)
+# -----------------------------------------------------------------------------
+_l2_compute_counter() {
+    local provider="$1"
+    local utc_day="$2"
+    local log_path
+    log_path="$(_l2_get_log_path)"
+    if [[ ! -f "$log_path" ]]; then
+        printf '{"counter_usd":0,"counter_ts":null,"consistency":"ok"}\n'
+        return 0
+    fi
+
+    python3 - "$log_path" "$provider" "$utc_day" <<'PY'
+import json
+import sys
+
+log_path = sys.argv[1]
+target_provider = sys.argv[2]
+target_day = sys.argv[3]
+
+counter = 0.0
+last_ts = None
+consistency = "ok"
+prev_post = -1.0
+prev_ts = None
+
+try:
+    with open(log_path, 'r', encoding='utf-8') as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith('['):
+                continue
+            try:
+                envelope = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if envelope.get('event_type') != 'budget.record_call':
+                continue
+            payload = envelope.get('payload') or {}
+            if payload.get('utc_day') != target_day:
+                continue
+            ev_provider = payload.get('provider', 'aggregate')
+            if target_provider != 'aggregate' and ev_provider != target_provider:
+                continue
+            try:
+                actual = float(payload.get('actual_usd', 0))
+                post = float(payload.get('usd_used_post', 0))
+            except (TypeError, ValueError):
+                consistency = "negative"  # malformed treated as inconsistent
+                continue
+            if actual < 0:
+                consistency = "negative"
+            ts = envelope.get('ts_utc')
+            if prev_ts is not None and ts is not None and ts < prev_ts:
+                consistency = "backwards"
+            if prev_post >= 0 and post < prev_post and consistency == "ok":
+                consistency = "decreasing"
+            prev_post = post
+            prev_ts = ts
+            counter += actual
+            last_ts = ts
+except FileNotFoundError:
+    pass
+
+print(json.dumps({
+    "counter_usd": round(counter, 6),
+    "counter_ts": last_ts,
+    "consistency": consistency,
+}))
+PY
+}
+
+# -----------------------------------------------------------------------------
+# _l2_invoke_observer <provider>
+#
+# Invoke caller-supplied billing-observer command. Output expected on stdout:
+#   {"usd_used": <number>, "billing_ts": "<iso8601>"}
+# Returns: same JSON on success; '{"_unreachable": true}' on failure.
+# -----------------------------------------------------------------------------
+_l2_invoke_observer() {
+    local provider="$1"
+    local cmd
+    cmd="$(_l2_get_observer_cmd)"
+    if [[ -z "$cmd" ]]; then
+        printf '{"_unreachable":true,"_reason":"no_observer_configured"}\n'
+        return 0
+    fi
+    if [[ ! -x "$cmd" && ! -f "$cmd" ]]; then
+        printf '{"_unreachable":true,"_reason":"observer_not_found"}\n'
+        return 0
+    fi
+    local out
+    if ! out="$(timeout 30 "$cmd" "$provider" 2>/dev/null)"; then
+        printf '{"_unreachable":true,"_reason":"observer_error_or_timeout"}\n'
+        return 0
+    fi
+    if ! printf '%s' "$out" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        printf '{"_unreachable":true,"_reason":"observer_invalid_json"}\n'
+        return 0
+    fi
+    printf '%s\n' "$out"
+}
+
+# -----------------------------------------------------------------------------
+# _l2_validate_payload <event_type> <payload_json>
+#
+# Validate payload against per-event-type schema. event_type "budget.allow" →
+# schema "budget-allow.payload.schema.json". Tries ajv first, then python.
+# Returns 0 valid; 1 invalid.
+# -----------------------------------------------------------------------------
+_l2_validate_payload() {
+    local event_type="$1"
+    local payload_json="$2"
+    local basename
+    basename="${event_type#budget.}"
+    basename="${basename//_/-}"
+    local schema_path="${_L2_SCHEMA_DIR}/budget-${basename}.payload.schema.json"
+    if [[ ! -f "$schema_path" ]]; then
+        _l2_log "ERROR: per-event schema missing for $event_type at $schema_path"
+        return 1
+    fi
+    if command -v ajv >/dev/null 2>&1; then
+        local tmp_data
+        tmp_data="$(mktemp)"
+        chmod 600 "$tmp_data"
+        # shellcheck disable=SC2064
+        trap "rm -f '$tmp_data'" RETURN
+        printf '%s' "$payload_json" > "$tmp_data"
+        if ajv validate -s "$schema_path" -d "$tmp_data" --spec=draft2020 >/dev/null 2>&1; then
+            return 0
+        fi
+        return 1
+    fi
+    python3 - "$schema_path" "$payload_json" <<'PY' 2>/dev/null
+import json, sys
+try:
+    import jsonschema
+except ImportError:
+    sys.exit(0)  # No validator → permissive (envelope schema still validates the wrapper)
+with open(sys.argv[1]) as f:
+    schema = json.load(f)
+try:
+    payload = json.loads(sys.argv[2])
+except json.JSONDecodeError:
+    sys.exit(1)
+try:
+    jsonschema.validate(payload, schema)
+except jsonschema.ValidationError:
+    sys.exit(1)
+PY
+}
+
+# -----------------------------------------------------------------------------
+# _l2_audit_emit_event <event_type> <payload_json>
+#
+# Validate payload via per-event-type schema, then call audit_emit (which
+# validates envelope, signs, and writes atomically under flock).
+# Returns 0 on success; non-zero on failure.
+# -----------------------------------------------------------------------------
+_l2_audit_emit_event() {
+    local event_type="$1"
+    local payload_json="$2"
+    local log_path
+    log_path="$(_l2_get_log_path)"
+
+    if ! _l2_validate_payload "$event_type" "$payload_json"; then
+        _l2_log "payload schema validation failed for $event_type"
+        return 1
+    fi
+    audit_emit "L2" "$event_type" "$payload_json" "$log_path"
+}
+
+# -----------------------------------------------------------------------------
+# _l2_check_clock_drift <billing_ts>
+#
+# Returns 0 if system clock and billing_ts agree within tolerance; 1 if drift
+# exceeds tolerance (caller halts with halt-uncertainty:clock_drift); 2 on
+# parse failure (treated as no-clock-check possible).
+# Stdout: delta_seconds (signed) on success or drift case; empty on parse fail.
+# -----------------------------------------------------------------------------
+_l2_check_clock_drift() {
+    local billing_ts="$1"
+    [[ -z "$billing_ts" || "$billing_ts" == "null" ]] && return 2
+    local sys_epoch billing_epoch
+    sys_epoch="$(_l2_iso_to_epoch "$(_l2_now_iso8601)")"
+    billing_epoch="$(_l2_iso_to_epoch "$billing_ts")"
+    [[ -z "$sys_epoch" || -z "$billing_epoch" ]] && return 2
+    local delta
+    delta=$(( sys_epoch - billing_epoch ))
+    local abs_delta=${delta#-}
+    local tolerance
+    tolerance="$(_l2_get_clock_tolerance)"
+    echo "$delta"
+    if (( abs_delta > tolerance )); then
+        return 1
+    fi
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# _l2_compute_age_seconds <ts> — seconds between now and ts.
+# -----------------------------------------------------------------------------
+_l2_compute_age_seconds() {
+    local ts="$1"
+    [[ -z "$ts" || "$ts" == "null" ]] && { echo "null"; return 0; }
+    local sys_epoch ts_epoch
+    sys_epoch="$(_l2_iso_to_epoch "$(_l2_now_iso8601)")"
+    ts_epoch="$(_l2_iso_to_epoch "$ts")"
+    [[ -z "$sys_epoch" || -z "$ts_epoch" ]] && { echo "null"; return 0; }
+    local age=$(( sys_epoch - ts_epoch ))
+    if (( age < 0 )); then
+        age=0
+    fi
+    echo "$age"
+}
+
+# -----------------------------------------------------------------------------
+# budget_get_usage [--provider <id>]
+#
+# Stdout JSON:
+#   {usd_used, usd_remaining, daily_cap_usd, last_billing_ts, counter_ts,
+#    freshness_seconds, provider, utc_day}
+# -----------------------------------------------------------------------------
+budget_get_usage() {
+    local provider=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --provider) provider="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    provider="$(_l2_provider_normalize "$provider")"
+
+    local cap
+    if ! cap="$(_l2_get_daily_cap)"; then
+        return 3
+    fi
+
+    local utc_day
+    utc_day="$(_l2_now_utc_day)"
+
+    local counter_json counter_usd counter_ts
+    counter_json="$(_l2_compute_counter "$provider" "$utc_day")"
+    counter_usd="$(printf '%s' "$counter_json" | jq -r '.counter_usd')"
+    counter_ts="$(printf '%s' "$counter_json" | jq -r '.counter_ts')"
+
+    local observer_json billing_usd billing_ts freshness
+    observer_json="$(_l2_invoke_observer "$provider")"
+    billing_usd="$(printf '%s' "$observer_json" | jq -r '.usd_used // null')"
+    billing_ts="$(printf '%s' "$observer_json" | jq -r '.billing_ts // null')"
+    freshness="$(_l2_compute_age_seconds "$billing_ts")"
+
+    # Authoritative usd_used: prefer billing API (when fresh), fall back to counter.
+    local usd_used="$counter_usd"
+    if [[ "$billing_usd" != "null" ]]; then
+        local fresh_threshold
+        fresh_threshold="$(_l2_get_freshness_seconds)"
+        if [[ "$freshness" != "null" ]] && (( freshness <= fresh_threshold )); then
+            usd_used="$billing_usd"
+        fi
+    fi
+
+    local remaining
+    remaining="$(python3 -c "print(round(${cap} - ${usd_used}, 6))")"
+
+    jq -nc \
+        --argjson used "$usd_used" \
+        --argjson remaining "$remaining" \
+        --argjson cap "$cap" \
+        --argjson freshness "${freshness:-null}" \
+        --arg billing_ts "${billing_ts:-}" \
+        --arg counter_ts "${counter_ts:-}" \
+        --arg provider "$provider" \
+        --arg utc_day "$utc_day" \
+        '{
+            usd_used: $used,
+            usd_remaining: $remaining,
+            daily_cap_usd: $cap,
+            last_billing_ts: ($billing_ts | select(length>0) // null),
+            counter_ts: ($counter_ts | select(length>0 and . != "null") // null),
+            freshness_seconds: $freshness,
+            provider: $provider,
+            utc_day: $utc_day
+        }'
+}
+
+# -----------------------------------------------------------------------------
+# budget_record_call <actual_usd> --provider <id> [--cycle-id <id>]
+#                                 [--model-id <id>] [--verdict-ref <hash>]
+#
+# Append a budget.record_call event. Computes usd_used_post from prior
+# tail-scan + this actual_usd.
+# -----------------------------------------------------------------------------
+budget_record_call() {
+    local actual_usd="${1:-}"
+    if [[ -z "$actual_usd" ]]; then
+        _l2_log "budget_record_call: actual_usd required"
+        return 2
+    fi
+    shift || true
+
+    local provider="" cycle_id="" model_id="" verdict_ref=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --provider) provider="$2"; shift 2 ;;
+            --cycle-id) cycle_id="$2"; shift 2 ;;
+            --model-id) model_id="$2"; shift 2 ;;
+            --verdict-ref) verdict_ref="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    provider="$(_l2_provider_normalize "$provider")"
+
+    if ! [[ "$actual_usd" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+        _l2_log "budget_record_call: actual_usd must be a non-negative decimal"
+        return 2
+    fi
+
+    local utc_day
+    utc_day="$(_l2_now_utc_day)"
+
+    local prior counter_usd
+    prior="$(_l2_compute_counter "$provider" "$utc_day")"
+    counter_usd="$(printf '%s' "$prior" | jq -r '.counter_usd')"
+    local post
+    post="$(python3 -c "print(round(${counter_usd} + ${actual_usd}, 6))")"
+
+    local payload
+    payload="$(jq -nc \
+        --argjson actual "$actual_usd" \
+        --argjson post "$post" \
+        --arg provider "$provider" \
+        --arg utc_day "$utc_day" \
+        --arg cycle_id "$cycle_id" \
+        --arg model_id "$model_id" \
+        --arg verdict_ref "$verdict_ref" \
+        '{
+            actual_usd: $actual,
+            usd_used_post: $post,
+            provider: $provider,
+            utc_day: $utc_day
+        }
+        | if $cycle_id != "" then . + {cycle_id: $cycle_id} else . + {cycle_id: null} end
+        | if $model_id != "" then . + {model_id: $model_id} else . + {model_id: null} end
+        | if $verdict_ref != "" then . + {verdict_ref: $verdict_ref} else . + {verdict_ref: null} end')"
+
+    _l2_audit_emit_event "budget.record_call" "$payload"
+}
+
+# -----------------------------------------------------------------------------
+# _l2_render_verdict <verdict> <usd_used> <cap> <estimated> <provider>
+#                    <utc_day> <billing_age> <counter_age> <observer_used>
+#                    [<uncertainty_reason> [<diagnostic_json>]]
+#
+# Build the payload JSON for a verdict event. usage_pct is computed for
+# warn-90 / halt-100 only.
+# -----------------------------------------------------------------------------
+_l2_render_verdict() {
+    local verdict="$1"
+    local usd_used="$2"
+    local cap="$3"
+    local estimated="$4"
+    local provider="$5"
+    local utc_day="$6"
+    local billing_age="$7"
+    local counter_age="$8"
+    local observer_used="$9"
+    local cycle_id="${10:-}"
+    local uncertainty_reason="${11:-}"
+    local diagnostic="${12:-}"
+
+    local remaining
+    remaining="$(python3 -c "print(round(${cap} - ${usd_used}, 6))")"
+    # usage_pct: for warn-90/halt-100, this is the PROJECTED post-call usage %
+    # (used + estimated). For other verdicts, it's the current usage %.
+    # Schemas warn-90.usage_pct (>=90) and halt-100.usage_pct (>=100) are
+    # interpreted against the projected percentage, since the verdict trigger
+    # is based on projection.
+    local usage_pct
+    if [[ "$verdict" == "warn-90" || "$verdict" == "halt-100" ]]; then
+        usage_pct="$(python3 -c "
+cap = float('${cap}')
+used = float('${usd_used}')
+est = float('${estimated}')
+print(0 if cap == 0 else round(100 * (used + est) / cap, 6))
+")"
+    else
+        usage_pct="$(python3 -c "
+cap = float('${cap}')
+used = float('${usd_used}')
+print(0 if cap == 0 else round(100 * used / cap, 6))
+")"
+    fi
+
+    local payload
+    payload="$(jq -nc \
+        --arg verdict "$verdict" \
+        --argjson usd_used "$usd_used" \
+        --argjson remaining "$remaining" \
+        --argjson cap "$cap" \
+        --argjson estimated "$estimated" \
+        --argjson billing_age "${billing_age:-null}" \
+        --argjson counter_age "$counter_age" \
+        --argjson usage_pct "$usage_pct" \
+        --arg provider "$provider" \
+        --arg utc_day "$utc_day" \
+        --arg cycle_id "$cycle_id" \
+        --arg observer_used "$observer_used" \
+        '{
+            verdict: $verdict,
+            usd_used: $usd_used,
+            usd_remaining: $remaining,
+            daily_cap_usd: $cap,
+            estimated_usd_for_call: $estimated,
+            billing_api_age_seconds: $billing_age,
+            counter_age_seconds: $counter_age,
+            provider: $provider,
+            utc_day: $utc_day,
+            billing_observer_used: ($observer_used == "true")
+        }
+        | if $cycle_id != "" then . + {cycle_id: $cycle_id} else . + {cycle_id: null} end')"
+
+    # Add usage_pct only for warn-90 and halt-100 (their schemas include it).
+    if [[ "$verdict" == "warn-90" || "$verdict" == "halt-100" ]]; then
+        payload="$(printf '%s' "$payload" | jq -c --argjson up "$usage_pct" '. + {usage_pct: $up}')"
+    fi
+
+    if [[ "$verdict" == "halt-uncertainty" && -n "$uncertainty_reason" ]]; then
+        payload="$(printf '%s' "$payload" | jq -c --arg r "$uncertainty_reason" '. + {uncertainty_reason: $r}')"
+        if [[ -n "$diagnostic" ]]; then
+            payload="$(printf '%s' "$payload" | jq -c --argjson d "$diagnostic" '. + {diagnostic: $d}')"
+        fi
+    fi
+    echo "$payload"
+}
+
+# -----------------------------------------------------------------------------
+# _l2_emit_and_return <event_type> <verdict_payload>
+# Emit the event and return verdict-appropriate exit code.
+# -----------------------------------------------------------------------------
+_l2_emit_and_return() {
+    local event_type="$1"
+    local payload="$2"
+    if ! _l2_audit_emit_event "$event_type" "$payload"; then
+        _l2_log "audit emit failed for $event_type"
+        return 1
+    fi
+    printf '%s\n' "$payload"
+    case "$event_type" in
+        budget.allow|budget.warn_90) return 0 ;;
+        budget.halt_100|budget.halt_uncertainty) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# -----------------------------------------------------------------------------
+# budget_verdict <estimated_usd> [--provider <id>] [--cycle-id <id>]
+#
+# Main entry. Returns verdict via stdout JSON; appends to audit log; exits 0
+# for allow/warn-90, exits 1 for halt-100/halt-uncertainty.
+# -----------------------------------------------------------------------------
+budget_verdict() {
+    local estimated_usd="${1:-}"
+    if [[ -z "$estimated_usd" ]]; then
+        _l2_log "budget_verdict: estimated_usd required"
+        return 2
+    fi
+    if ! [[ "$estimated_usd" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+        _l2_log "budget_verdict: estimated_usd must be a non-negative decimal"
+        return 2
+    fi
+    shift || true
+
+    local provider="" cycle_id=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --provider) provider="$2"; shift 2 ;;
+            --cycle-id) cycle_id="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    provider="$(_l2_provider_normalize "$provider")"
+
+    local cap
+    if ! cap="$(_l2_get_daily_cap)"; then
+        return 3
+    fi
+
+    local utc_day
+    utc_day="$(_l2_now_utc_day)"
+
+    # Per-provider sub-cap (optional). When provider is specified and a sub-cap
+    # is configured, the sub-cap overrides the aggregate cap for verdict math.
+    if [[ "$provider" != "aggregate" ]]; then
+        local sub_cap
+        sub_cap="$(_l2_config_get ".cost_budget_enforcer.per_provider_caps.${provider}" "")"
+        if [[ -n "$sub_cap" ]]; then
+            cap="$sub_cap"
+        fi
+    fi
+
+    # Read counter (tail-scan for current UTC day + provider).
+    local counter_json counter_usd counter_ts consistency
+    counter_json="$(_l2_compute_counter "$provider" "$utc_day")"
+    counter_usd="$(printf '%s' "$counter_json" | jq -r '.counter_usd')"
+    counter_ts="$(printf '%s' "$counter_json" | jq -r '.counter_ts // empty')"
+    consistency="$(printf '%s' "$counter_json" | jq -r '.consistency')"
+
+    # Read billing API.
+    local observer_json billing_usd billing_ts billing_age observer_used
+    observer_json="$(_l2_invoke_observer "$provider")"
+    if printf '%s' "$observer_json" | jq -e '._unreachable == true' >/dev/null 2>&1; then
+        billing_usd=""
+        billing_ts=""
+        billing_age="null"
+        observer_used="false"
+    else
+        billing_usd="$(printf '%s' "$observer_json" | jq -r '.usd_used // empty')"
+        billing_ts="$(printf '%s' "$observer_json" | jq -r '.billing_ts // empty')"
+        billing_age="$(_l2_compute_age_seconds "$billing_ts")"
+        observer_used="true"
+    fi
+
+    local counter_age
+    counter_age="$(_l2_compute_age_seconds "$counter_ts")"
+    if [[ "$counter_age" == "null" ]]; then
+        counter_age="0"
+    fi
+
+    # Authoritative usd_used. Default = counter; override with billing if fresh.
+    local usd_used="$counter_usd"
+    local fresh_threshold
+    fresh_threshold="$(_l2_get_freshness_seconds)"
+    local data_fresh="false"
+    if [[ "$observer_used" == "true" && "$billing_age" != "null" ]] && (( billing_age <= fresh_threshold )); then
+        usd_used="$billing_usd"
+        data_fresh="true"
+    fi
+    # Counter-only freshness: counter is "fresh" if counter_age <= 5 min and
+    # consistency is ok (no halt-uncertainty:counter_inconsistent).
+    if [[ "$data_fresh" == "false" && "$consistency" == "ok" ]] && (( counter_age <= fresh_threshold )); then
+        data_fresh="true"
+    fi
+
+    # ----- Uncertainty checks (PRD §FR-L2 + SDD §1.5.3 ordering) -----
+    # Order: most-severe first.
+    # 1. counter_inconsistent — counter is corrupt regardless of billing state
+    # 2. billing_stale — billing API >billing_stale_threshold AND counter >cap_threshold
+    # 3. provider_lag — billing API lag in [lag_threshold, billing_stale_threshold) AND counter >cap_threshold
+    # 4. clock_drift — only when billing data is FRESH (billing_age <= freshness)
+    # 5. halt-100 / warn-90 / allow
+
+    # 1. counter_inconsistent (always halt-uncertainty regardless of usage)
+    if [[ "$consistency" != "ok" ]]; then
+        local diag_inc
+        diag_inc="$(jq -nc --arg c "$consistency" '{counter_state: $c}')"
+        local payload
+        payload="$(_l2_render_verdict "halt-uncertainty" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id" "counter_inconsistent" "$diag_inc")"
+        _l2_emit_and_return "budget.halt_uncertainty" "$payload"
+        return $?
+    fi
+
+    local stale_halt_pct
+    stale_halt_pct="$(_l2_get_stale_halt_pct)"
+
+    # Compute counter_pct (used by 2,3 below).
+    local counter_pct
+    counter_pct="$(python3 -c "
+cap = float('${cap}')
+counter = float('${counter_usd}')
+print(0 if cap == 0 else round(100 * counter / cap, 6))
+")"
+
+    # 2. billing_stale (billing API >= billing_stale threshold AND counter > stale_halt_pct)
+    if [[ "$observer_used" == "true" && "$billing_age" != "null" ]]; then
+        local billing_stale_threshold
+        billing_stale_threshold="$(_l2_get_billing_stale_seconds)"
+        if (( billing_age >= billing_stale_threshold )); then
+            if python3 -c "import sys; sys.exit(0 if float('$counter_pct') > float('$stale_halt_pct') else 1)"; then
+                local diag_stale
+                diag_stale="$(jq -nc \
+                    --argjson billing_age "$billing_age" \
+                    --argjson stale_threshold "$billing_stale_threshold" \
+                    --argjson counter_pct "$counter_pct" \
+                    --argjson stale_halt_pct "$stale_halt_pct" \
+                    '{billing_age_seconds: $billing_age, stale_threshold_seconds: $stale_threshold, counter_pct: $counter_pct, stale_halt_pct: $stale_halt_pct}')"
+                local payload
+                payload="$(_l2_render_verdict "halt-uncertainty" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id" "billing_stale" "$diag_stale")"
+                _l2_emit_and_return "budget.halt_uncertainty" "$payload"
+                return $?
+            fi
+        fi
+    fi
+
+    # 3. provider_lag (billing API lag >= lag_halt_seconds AND counter > stale_halt_pct)
+    #    Comes AFTER billing_stale so billing_stale wins for very-stale data.
+    if [[ "$observer_used" == "true" && "$billing_age" != "null" ]]; then
+        local lag_threshold
+        lag_threshold="$(_l2_get_lag_halt_seconds)"
+        if (( billing_age >= lag_threshold )); then
+            if python3 -c "import sys; sys.exit(0 if float('$counter_pct') > float('$stale_halt_pct') else 1)"; then
+                local diag_lag
+                diag_lag="$(jq -nc \
+                    --argjson lag "$billing_age" \
+                    --argjson lag_threshold "$lag_threshold" \
+                    --argjson counter_pct "$counter_pct" \
+                    --argjson stale_halt_pct "$stale_halt_pct" \
+                    '{lag_seconds: $lag, threshold_seconds: $lag_threshold, counter_pct: $counter_pct, stale_halt_pct: $stale_halt_pct}')"
+                local payload
+                payload="$(_l2_render_verdict "halt-uncertainty" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id" "provider_lag" "$diag_lag")"
+                _l2_emit_and_return "budget.halt_uncertainty" "$payload"
+                return $?
+            fi
+        fi
+    fi
+
+    # 4. clock_drift — ONLY when billing data is fresh (billing_age <= freshness).
+    #    Stale billing_ts will naturally appear "drifted" from system clock; that
+    #    is not a clock-drift signal, it's a staleness signal (handled above).
+    if [[ "$observer_used" == "true" && -n "$billing_ts" && "$billing_age" != "null" ]]; then
+        if (( billing_age <= fresh_threshold )); then
+            local drift_delta drift_rc
+            drift_delta="$(_l2_check_clock_drift "$billing_ts" || true)"
+            if _l2_check_clock_drift "$billing_ts" >/dev/null; then
+                drift_rc=0
+            else
+                drift_rc=$?
+            fi
+            if (( drift_rc == 1 )); then
+                local sys_ts tolerance diag_clk
+                sys_ts="$(_l2_now_iso8601)"
+                tolerance="$(_l2_get_clock_tolerance)"
+                diag_clk="$(jq -nc \
+                    --arg sys_ts "$sys_ts" \
+                    --arg billing_ts "$billing_ts" \
+                    --argjson delta "$drift_delta" \
+                    --argjson tol "$tolerance" \
+                    '{system_ts: $sys_ts, billing_ts: $billing_ts, delta_seconds: $delta, tolerance_seconds: $tol}')"
+                local payload
+                payload="$(_l2_render_verdict "halt-uncertainty" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id" "clock_drift" "$diag_clk")"
+                _l2_emit_and_return "budget.halt_uncertainty" "$payload"
+                return $?
+            fi
+        fi
+    fi
+
+    # ----- Threshold checks (data is fresh; cleanly bucket) -----
+    # Compute usage% projected (post-call, for halt-100 / warn-90 transition)
+    local projected_pct
+    projected_pct="$(python3 -c "
+cap = float('${cap}')
+used = float('${usd_used}')
+est = float('${estimated_usd}')
+print(0 if cap == 0 else round(100 * (used + est) / cap, 6))
+")"
+
+    # halt-100: post-call usage would be >= 100%
+    if python3 -c "import sys; sys.exit(0 if float('$projected_pct') >= 100 else 1)"; then
+        local payload
+        payload="$(_l2_render_verdict "halt-100" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id")"
+        _l2_emit_and_return "budget.halt_100" "$payload"
+        return $?
+    fi
+
+    # warn-90: post-call usage would be >= 90% (still fresh, still below 100%)
+    if python3 -c "import sys; sys.exit(0 if float('$projected_pct') >= 90 else 1)"; then
+        local payload
+        payload="$(_l2_render_verdict "warn-90" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id")"
+        _l2_emit_and_return "budget.warn_90" "$payload"
+        return $?
+    fi
+
+    # default: allow. Fail-closed safety: when no observer AND no fresh counter,
+    # we treated counter_age==0 (no entries today) as fresh; this is correct
+    # because zero-usage is unambiguous.
+    local payload
+    payload="$(_l2_render_verdict "allow" "$usd_used" "$cap" "$estimated_usd" "$provider" "$utc_day" "$billing_age" "$counter_age" "$observer_used" "$cycle_id")"
+    _l2_emit_and_return "budget.allow" "$payload"
+}
+
+# -----------------------------------------------------------------------------
+# budget_reconcile [--provider <id>] [--force-reason <text>]
+#
+# Compare counter to billing API for current UTC day; emit budget.reconcile
+# event with drift_pct + blocker flag. Counter NOT auto-corrected.
+# Sprint 2A: function unit. Sprint 2B: cron registration via /schedule.
+# -----------------------------------------------------------------------------
+budget_reconcile() {
+    local provider="" force_reason=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --provider) provider="$2"; shift 2 ;;
+            --force-reason) force_reason="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    provider="$(_l2_provider_normalize "$provider")"
+
+    local utc_day
+    utc_day="$(_l2_now_utc_day)"
+
+    local counter_json counter_usd
+    counter_json="$(_l2_compute_counter "$provider" "$utc_day")"
+    counter_usd="$(printf '%s' "$counter_json" | jq -r '.counter_usd')"
+
+    local observer_json billing_usd billing_unreachable
+    observer_json="$(_l2_invoke_observer "$provider")"
+    if printf '%s' "$observer_json" | jq -e '._unreachable == true' >/dev/null 2>&1; then
+        billing_usd="null"
+        billing_unreachable="true"
+    else
+        billing_usd="$(printf '%s' "$observer_json" | jq -r '.usd_used // null')"
+        billing_unreachable="false"
+    fi
+
+    local drift_threshold
+    drift_threshold="$(_l2_get_drift_threshold)"
+
+    local drift_pct blocker
+    if [[ "$billing_unreachable" == "true" ]]; then
+        drift_pct="null"
+        # blocker iff counter > stale_halt_pct (defer-to-next-interval policy).
+        local stale_halt_pct cap counter_pct
+        stale_halt_pct="$(_l2_get_stale_halt_pct)"
+        if cap="$(_l2_get_daily_cap 2>/dev/null)"; then
+            counter_pct="$(python3 -c "
+cap = float('${cap}')
+counter = float('${counter_usd}')
+print(0 if cap == 0 else round(100 * counter / cap, 6))
+")"
+            if python3 -c "import sys; sys.exit(0 if float('$counter_pct') > float('$stale_halt_pct') else 1)"; then
+                blocker="true"
+            else
+                blocker="false"
+            fi
+        else
+            blocker="false"
+        fi
+    else
+        drift_pct="$(python3 -c "
+counter = float('${counter_usd}')
+billing = float('${billing_usd}')
+denom = max(counter, billing)
+if denom == 0:
+    print(0)
+else:
+    print(round(100 * abs(counter - billing) / denom, 6))
+")"
+        if python3 -c "import sys; sys.exit(0 if float('$drift_pct') > float('$drift_threshold') else 1)"; then
+            blocker="true"
+        else
+            blocker="false"
+        fi
+    fi
+
+    local payload
+    payload="$(jq -nc \
+        --argjson counter "$counter_usd" \
+        --argjson billing "$billing_usd" \
+        --argjson drift_pct "$drift_pct" \
+        --argjson threshold "$drift_threshold" \
+        --argjson blocker "$blocker" \
+        --argjson unreach "$billing_unreachable" \
+        --arg provider "$provider" \
+        --arg utc_day "$utc_day" \
+        --arg force_reason "$force_reason" \
+        '{
+            verdict: "reconcile",
+            counter_usd: $counter,
+            billing_usd: $billing,
+            drift_pct: $drift_pct,
+            drift_threshold_pct: $threshold,
+            blocker: $blocker,
+            provider: $provider,
+            utc_day: $utc_day,
+            billing_api_unreachable: $unreach,
+            force_reconcile: ($force_reason != "")
+        }
+        | if $force_reason != "" then . + {operator_reason: $force_reason} else . + {operator_reason: null} end')"
+
+    _l2_audit_emit_event "budget.reconcile" "$payload" || return 1
+    printf '%s\n' "$payload"
+    if [[ "$blocker" == "true" ]]; then
+        return 1
+    fi
+    return 0
+}

--- a/.claude/skills/cost-budget-enforcer/SKILL.md
+++ b/.claude/skills/cost-budget-enforcer/SKILL.md
@@ -215,8 +215,13 @@ against these schemas before sealing the envelope.
 
 ## Testing
 
-Unit tests: `tests/unit/cost-budget-enforcer-state-machine.bats` (31 tests)
-Integration tests: `tests/integration/cost-budget-enforcer-reconciliation-cron.bats` (11 tests)
-Snapshot tests: `tests/integration/audit-snapshot.bats` (13 tests)
+Unit tests:
+- `tests/unit/cost-budget-enforcer-state-machine.bats` (31 tests — state machine, schemas)
+- `tests/unit/cost-budget-enforcer-remediation.bats` (21 tests — review/audit-finding remediations)
 
-Cumulative: 55 / 55 PASS.
+Integration tests:
+- `tests/integration/cost-budget-enforcer-reconciliation-cron.bats` (11 tests)
+- `tests/integration/audit-snapshot.bats` (17 tests, including F3 .sig verification)
+- `tests/integration/budget-cli.bats` (12 tests)
+
+Cumulative: **92 / 92 PASS** (Sprint 1 regression: 39 / 39 PASS).

--- a/.claude/skills/cost-budget-enforcer/SKILL.md
+++ b/.claude/skills/cost-budget-enforcer/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: cost-budget-enforcer
+description: L2 cost-budget enforcer — daily token cap with fail-closed semantics under uncertainty (billing-API primary, internal counter fallback, periodic reconciliation cron)
+agent: general-purpose
+context: scoped
+parallel_threshold: 3000
+timeout_minutes: 5
+zones:
+  system:
+    path: .claude
+    permission: read
+  state:
+    paths: [grimoires/loa, .run]
+    permission: read-write
+  app:
+    paths: [src, lib, app]
+    permission: read
+allowed-tools: Read, Bash
+capabilities:
+  schema_version: 1
+  read_files: true
+  search_code: false
+  write_files: false
+  execute_commands: true
+  web_access: false
+  user_interaction: false
+  agent_spawn: false
+  task_management: false
+cost-profile: lightweight
+---
+
+# cost-budget-enforcer — L2 Daily-Cap Skill (cycle-098 Sprint 2)
+
+## Purpose
+
+Daily token-cap enforcement for autonomous Loa cycles. Replaces the
+free-running `make-an-API-call-and-hope-it-doesn't-cost-too-much` pattern
+with an explicit pre-call gate that returns one of:
+
+| Verdict | Meaning | Caller behavior |
+|---------|---------|-----------------|
+| `allow` | <90% of cap, fresh data | proceed |
+| `warn-90` | 90-100% projected, fresh data | proceed but operator alerted |
+| `halt-100` | ≥100% projected, fresh data | **MUST NOT** proceed |
+| `halt-uncertainty` | One of 5 uncertainty modes | **MUST NOT** proceed (fail-closed) |
+
+The 5 uncertainty modes (`uncertainty_reason` field):
+- `billing_stale` — billing API >15min unreachable AND counter >75% of cap
+- `counter_inconsistent` — counter is negative, decreasing, or backwards
+- `counter_drift` — reconciliation detected drift >5% from billing API
+- `clock_drift` — system clock vs billing_ts diff >60s tolerance
+- `provider_lag` — billing API lag ≥5min when counter shows >75% of cap
+
+The verdict order is **severity-first**:
+`counter_inconsistent → billing_stale → provider_lag → clock_drift → halt-100 → warn-90 → allow`
+
+## Source
+
+- RFC: [#654](https://github.com/0xHoneyJar/loa/issues/654)
+- PRD: `grimoires/loa/prd.md` §FR-L2 (10 ACs)
+- SDD: `grimoires/loa/sdd.md` §1.4.2 (component spec) + §1.5.3 (state diagram) + §5.4 (full API)
+- Decisions: SKP-005 (un-deferred reconciliation cron); SKP-001 (RPO 24h for L1/L2 untracked logs)
+
+## When to use
+
+| Scenario | Use this skill? |
+|----------|-----------------|
+| Pre-call cost check during a sleep window or autonomous run | YES |
+| Post-call counter update after billing-API confirms a charge | YES (`budget_record_call`) |
+| Operator force-reconcile after billing-API drift incident | YES (`budget_reconcile --force-reason "..."`) |
+| Manual ad-hoc usage query (not gated) | YES (`budget_get_usage`) |
+| Mid-cycle daily-cap raise (operator action) | NO — protected-class `budget.cap_increase` short-circuits to operator queue |
+
+## Configuration
+
+`.loa.config.yaml::cost_budget_enforcer.*` (opt-in; disabled by default per `agent_network.primitives.L2.enabled: false`):
+
+```yaml
+cost_budget_enforcer:
+  daily_cap_usd: 50.00
+  freshness_threshold_seconds: 300       # 5 min — billing data is "fresh"
+  stale_halt_pct: 75                     # counter % triggering stale_halt + provider_lag
+  clock_tolerance_seconds: 60            # ±60s for clock_drift
+  provider_lag_halt_seconds: 300         # 5 min provider_lag threshold
+  billing_stale_halt_seconds: 900        # 15 min billing_stale threshold
+  audit_log: .run/cost-budget-events.jsonl
+  billing_observer_cmd: /path/to/observer-shim.sh   # caller-supplied UsageObserver
+  per_provider_caps:                                # optional sub-caps per provider
+    openai: 5.00
+    anthropic: 30.00
+  providers:                                        # used by reconciliation cron
+    - aggregate
+    - anthropic
+    - openai
+  reconciliation:
+    interval_hours: 6                    # cron cadence for budget_reconcile
+    drift_threshold_pct: 5.0
+audit_snapshot:
+  cron_expression: "0 4 * * *"          # daily snapshot of L1/L2 logs
+```
+
+Environment variable overrides (highest precedence): see lib header.
+
+## Library API
+
+The skill is implemented as `.claude/scripts/lib/cost-budget-enforcer-lib.sh`.
+Source it and call:
+
+```bash
+source .claude/scripts/lib/cost-budget-enforcer-lib.sh
+
+# Pre-call verdict
+budget_verdict <estimated_usd> [--provider <id>] [--cycle-id <id>]
+# Stdout: verdict payload JSON; exit 0=allow/warn-90, 1=halt-100/halt-uncertainty.
+
+# Read-only state query
+budget_get_usage [--provider <id>]
+# Stdout: {usd_used, usd_remaining, daily_cap_usd, last_billing_ts, counter_ts,
+#          freshness_seconds, provider, utc_day}
+
+# Post-call accounting
+budget_record_call <actual_usd> --provider <id> [--cycle-id <id>] [--model-id <id>] [--verdict-ref <hash>]
+
+# Reconciliation (cron-driven; can be invoked ad-hoc)
+budget_reconcile [--provider <id>] [--force-reason <text>]
+# Exit codes: 0=OK, 1=BLOCKER (drift>threshold), 2=DEFER (rate-limited/transient)
+```
+
+CLI form:
+
+```bash
+.claude/scripts/budget/budget-cli.sh verdict 1.50 --provider anthropic
+.claude/scripts/budget/budget-cli.sh usage --provider anthropic
+.claude/scripts/budget/budget-cli.sh record 1.42 --provider anthropic --model-id claude-opus-4-7
+.claude/scripts/budget/budget-cli.sh reconcile --provider anthropic
+```
+
+## UsageObserver Interface
+
+The lib invokes `LOA_BUDGET_OBSERVER_CMD <provider>` (or
+`cost_budget_enforcer.billing_observer_cmd`). The command is expected to
+print one of three JSON shapes on stdout:
+
+| Shape | Meaning |
+|-------|---------|
+| `{"usd_used": <number>, "billing_ts": "<iso8601>"}` | Success — usage from billing API |
+| `{"_unreachable": true, "_reason": "<text>"}` | Billing API unreachable (logs reconcile event with `billing_api_unreachable: true`) |
+| `{"_defer": true, "_reason": "rate_limited"}` | Transient — skip without writing audit event; next 6h interval retries |
+
+The lib applies a 30-second timeout. Provider-agnostic: keep
+provider-specific HTTP client logic in the observer shim.
+
+## Reconciliation cron + Daily snapshot
+
+Two separate crontab entries support L2 production operation:
+
+```bash
+# 6h cadence reconciliation (Sprint 2B)
+.claude/scripts/budget/budget-reconcile-install.sh install
+
+# Daily snapshot for chain-recovery RPO 24h (Sprint 2C)
+.claude/scripts/audit/audit-snapshot-install.sh install
+```
+
+Operator runbook for recovery: `grimoires/loa/runbooks/audit-log-recovery.md`.
+
+## Composition with other primitives
+
+- **L1 hitl-jury-panel**: when L1 panel decisions involve cost — `panel_invoke` MAY call `budget_verdict` first to short-circuit on halt-uncertainty
+- **L3 scheduled-cycle-template** (Sprint 3): scheduled-cycle reader phase invokes `budget_verdict` as part of pre-read budget pre-check
+- **Protected-class router**: `budget.cap_increase` (mid-cycle daily-cap raise) is a protected class — use `protected-class-router.sh check budget.cap_increase` and route to operator queue rather than auto-applying
+
+## Observability
+
+Every verdict appends one envelope to `.run/cost-budget-events.jsonl`:
+
+```json
+{
+  "schema_version": "1.1.0",
+  "primitive_id": "L2",
+  "event_type": "budget.allow",
+  "ts_utc": "2026-05-04T12:00:00.000000Z",
+  "prev_hash": "<sha256-hex>",
+  "payload": {
+    "verdict": "allow",
+    "usd_used": 8.50,
+    "usd_remaining": 41.50,
+    "daily_cap_usd": 50.00,
+    "estimated_usd_for_call": 1.50,
+    ...
+  },
+  "redaction_applied": null,
+  "signature": "<base64-when-signed>",
+  "signing_key_id": "<writer-key>"
+}
+```
+
+Per-event-type schemas live at
+`.claude/data/trajectory-schemas/budget-events/`. The lib validates payloads
+against these schemas before sealing the envelope.
+
+## Safety guarantees
+
+- **Fail-closed**: NEVER `allow` under uncertainty (PRD §FR-L2-7); 5
+  uncertainty modes covered with mode-specific diagnostic context
+- **Hash-chained**: every envelope's `prev_hash` chains to prior entry
+  (Sprint 1A); `audit_verify_chain` walks the chain at every read
+- **Ed25519-signed**: when `LOA_AUDIT_SIGNING_KEY_ID` is configured, every
+  envelope is signed; trust-store strict-after enforcement (Sprint 1B F1)
+  rejects strip-attack downgrade attempts
+- **Recoverable**: chain-critical L2 log is UNTRACKED for privacy; daily
+  snapshot job (Sprint 2C) ships RPO 24h restore via `audit_recover_chain`
+- **flock-serialized**: concurrent verdicts and reconciliation cron firings
+  serialize via per-log flock (Sprint 1 review remediation F3)
+
+## Testing
+
+Unit tests: `tests/unit/cost-budget-enforcer-state-machine.bats` (31 tests)
+Integration tests: `tests/integration/cost-budget-enforcer-reconciliation-cron.bats` (11 tests)
+Snapshot tests: `tests/integration/audit-snapshot.bats` (13 tests)
+
+Cumulative: 55 / 55 PASS.

--- a/.loa.config.yaml.example
+++ b/.loa.config.yaml.example
@@ -2255,3 +2255,73 @@ qmd_context:
 #   LOA_PANEL_MIN_PANELISTS           min surviving panelists for BOUND (default 2)
 #   LOA_PANEL_DISAGREEMENT_FN         path to caller-supplied disagreement script
 #                                      (default: no-op pass per FR-L1-6)
+
+# -----------------------------------------------------------------------------
+# L2 cost-budget-enforcer — daily token cap with fail-closed semantics
+# -----------------------------------------------------------------------------
+# When enabled, paid calls go through budget_verdict before execution. The
+# verdict is one of {allow, warn-90, halt-100, halt-uncertainty}. The fifth
+# halt-uncertainty mode covers 5 failure cases (billing API stale, counter
+# inconsistent, counter drift, clock drift, provider lag) — fail-closed under
+# all uncertainty.
+#
+# Sprint 2 ships: state machine, reconciliation cron (default 6h cadence),
+# daily snapshot job for hash-chain recovery (RPO 24h).
+#
+# Source: RFC #654; PRD §FR-L2; SDD §1.4.2 + §1.5.3 + §5.4
+#
+# cost_budget_enforcer:
+#   daily_cap_usd: 50.00                          # FR-L2-1..4 reference
+#   freshness_threshold_seconds: 300              # 5 min — billing data is "fresh"
+#   stale_halt_pct: 75                            # counter % triggering stale_halt + provider_lag
+#   clock_tolerance_seconds: 60                   # ±60s for clock_drift
+#   provider_lag_halt_seconds: 300                # 5 min provider_lag threshold
+#   billing_stale_halt_seconds: 900               # 15 min billing_stale threshold
+#   audit_log: .run/cost-budget-events.jsonl
+#   billing_observer_cmd: /path/to/observer-shim.sh   # caller-supplied UsageObserver
+#   per_provider_caps:                            # optional sub-caps per provider
+#     openai: 5.00
+#     anthropic: 30.00
+#   providers:                                    # used by reconciliation cron
+#     - aggregate
+#     - anthropic
+#     - openai
+#   reconciliation:
+#     interval_hours: 6                           # cron cadence (1..24)
+#     drift_threshold_pct: 5.0                    # FR-L2-5 BLOCKER threshold
+#
+# Environment variable overrides (see .claude/scripts/lib/cost-budget-enforcer-lib.sh):
+#   LOA_BUDGET_LOG                  override audit log path
+#   LOA_BUDGET_DAILY_CAP_USD        override daily cap
+#   LOA_BUDGET_DRIFT_THRESHOLD      override reconcile drift threshold pct
+#   LOA_BUDGET_FRESHNESS_SECONDS    override freshness threshold
+#   LOA_BUDGET_STALE_HALT_PCT       override stale-halt counter %
+#   LOA_BUDGET_CLOCK_TOLERANCE      override clock tolerance seconds
+#   LOA_BUDGET_LAG_HALT_SECONDS     override provider-lag threshold
+#   LOA_BUDGET_BILLING_STALE_SECONDS override billing-stale threshold
+#   LOA_BUDGET_OBSERVER_CMD         override billing-observer path
+#   LOA_BUDGET_TEST_NOW             test-only override for "now"
+#
+# To install/uninstall the reconciliation cron:
+#   .claude/scripts/budget/budget-reconcile-install.sh install
+#   .claude/scripts/budget/budget-reconcile-install.sh uninstall
+
+# -----------------------------------------------------------------------------
+# Audit-log daily snapshot — RPO 24h for L1/L2 chain-critical untracked logs
+# -----------------------------------------------------------------------------
+# Sprint 2C ships the producer side of the L1/L2 hash-chain recovery loop.
+# Snapshots gzip-compress and optionally Ed25519-sign each rolling log to
+# grimoires/loa/audit-archive/<utc-date>-<primitive>.jsonl.gz; the archive
+# directory is git-tracked. The recovery side
+# (audit_recover_chain) consumes these to restore corrupted/lost logs.
+#
+# Source: SDD §3.4.4 (recovery procedure) + §3.7 (persistence policy)
+#
+# audit_snapshot:
+#   cron_expression: "0 4 * * *"          # daily at 04:00 UTC (default)
+#
+# Operator runbook: grimoires/loa/runbooks/audit-log-recovery.md
+#
+# To install/uninstall the daily snapshot cron:
+#   .claude/scripts/audit/audit-snapshot-install.sh install
+#   .claude/scripts/audit/audit-snapshot-install.sh uninstall

--- a/grimoires/loa/a2a/sprint-2/progress-2A.md
+++ b/grimoires/loa/a2a/sprint-2/progress-2A.md
@@ -1,0 +1,173 @@
+# Sub-sprint 2A Progress Report — L2 verdict-engine foundation
+
+**Cycle**: cycle-098-agent-network
+**Sprint**: 2 (L2 cost-budget-enforcer + reconciliation cron + daily snapshot)
+**Sub-sprint**: 2A (1 of 4)
+**Branch**: `feat/cycle-098-sprint-2`
+**Status**: COMPLETED
+
+## Outcome
+
+The L2 verdict-engine foundation is in place. State machine implements
+all 5 verdicts × 5 uncertainty modes per PRD §FR-L2 + SDD §1.5.3. Per-event
+schema registry pattern (IMP-001 v1.1) lives in
+`.claude/data/trajectory-schemas/budget-events/`, validated at write-time
+by the L2 lib before the audit envelope is sealed and signed.
+
+## Files added (1 lib + 6 schemas + 1 bats file)
+
+### L2 library (Sprint 2A foundation)
+
+| File | Purpose |
+|------|---------|
+| `.claude/scripts/lib/cost-budget-enforcer-lib.sh` | L2 lib — `budget_verdict`, `budget_get_usage`, `budget_record_call`, `budget_reconcile`. ~720 lines. |
+
+### Per-event-type payload schemas (IMP-001 v1.1 registry pattern)
+
+| File | Event type |
+|------|-----------|
+| `.claude/data/trajectory-schemas/budget-events/budget-allow.payload.schema.json` | `budget.allow` |
+| `.claude/data/trajectory-schemas/budget-events/budget-warn-90.payload.schema.json` | `budget.warn_90` |
+| `.claude/data/trajectory-schemas/budget-events/budget-halt-100.payload.schema.json` | `budget.halt_100` |
+| `.claude/data/trajectory-schemas/budget-events/budget-halt-uncertainty.payload.schema.json` | `budget.halt_uncertainty` (5 reasons) |
+| `.claude/data/trajectory-schemas/budget-events/budget-reconcile.payload.schema.json` | `budget.reconcile` |
+| `.claude/data/trajectory-schemas/budget-events/budget-record-call.payload.schema.json` | `budget.record_call` |
+
+### Tests
+
+| File | Type | Count | Status |
+|------|------|-------|--------|
+| `tests/unit/cost-budget-enforcer-state-machine.bats` | bats | 31 | 31 PASS / 0 FAIL |
+
+## Sprint 2 ACs — partial coverage by 2A
+
+### Functional requirements (PRD §FR-L2)
+
+- **FR-L2-1** allow when usage <90% AND data fresh — DONE (covers test #1, #2)
+- **FR-L2-2** warn-90 when projected usage in [90, 100)% — DONE (test #3)
+- **FR-L2-3** halt-100 when projected usage >=100% — DONE (test #4, #5)
+- **FR-L2-4** halt-uncertainty:billing_stale — DONE (test #6)
+- **FR-L2-5** Reconciliation drift >5% emits BLOCKER — DONE (test #20, #21)
+  *(2B will wire the cron registration via /schedule)*
+- **FR-L2-6** Counter inconsistency triggers halt-uncertainty — DONE (#7, #8)
+- **FR-L2-7** Fail-closed under all uncertainty modes — DONE (#15)
+- **FR-L2-8** Per-repo / per-provider caps — DONE (#12, #13)
+- **FR-L2-9** Verdicts logged to JSONL — DONE (#16)
+- **FR-L2-10** Integration tests for billing outage / drift / cap change — partial; 2B/2D round out
+
+### Cross-cutting (CC-2 + CC-11)
+
+- envelope is versioned (`schema_version`), hash-chained (`prev_hash`), signed when key present
+- per-event-type schemas validated via ajv (R15 fallback to python `jsonschema`)
+- chain integrity verified via `audit_verify_chain` (test #27)
+
+### State machine (SDD §1.5.3 + IMP-004)
+
+- 5 verdicts implemented: allow, warn-90, halt-100, halt-uncertainty, reconcile
+- 5 uncertainty reasons: `billing_stale`, `counter_inconsistent`, `counter_drift`,
+  `clock_drift`, `provider_lag`
+- Verdict-trigger order: counter_inconsistent → billing_stale → provider_lag →
+  clock_drift → halt-100 → warn-90 → allow
+
+## TODO hooks for Sprint 2B (reconciliation cron)
+
+`budget_reconcile` is implemented as a function unit (test #20-23). 2B wires:
+1. `/schedule` registration (default 6h cadence; configurable
+   `cost_budget_enforcer.reconciliation.interval_hours`)
+2. `force-reconcile` operator action with reason capture (already supported in
+   the function)
+3. Cron-deregister on `enabled: false` lifecycle event
+4. Integration tests — 6h cadence semantics; idempotent re-runs;
+   billing-API 429 deferral
+
+## TODO hooks for Sprint 2C (daily snapshot job)
+
+The L2 audit log (`.run/cost-budget-events.jsonl`) is UNTRACKED and chain-critical
+per SDD §3.4.4 + §3.7. 2C ships:
+1. `/loa audit snapshot` command — exports L1 + L2 logs to
+   `grimoires/loa/audit-archive/<utc-date>-<primitive>.jsonl.gz`
+2. Snapshots Ed25519-signed by operator's writer key
+3. Operator runbook update at `grimoires/loa/runbooks/audit-log-recovery.md`
+4. Integration with `audit_recover_chain` UNTRACKED snapshot-restore path
+
+## TODO hooks for Sprint 2D (L2 skill + integration)
+
+1. `.claude/skills/cost-budget-enforcer/SKILL.md`
+2. CLI entrypoint script `.claude/scripts/budget/budget_verdict.sh` (or
+   per-skill convention)
+3. `.loa.config.yaml.example` — `cost_budget_enforcer` block documentation
+4. CLAUDE.md update — agent-network-audit-envelope section addition
+5. Lore entry "fail-closed cost gate" at `grimoires/loa/lore/`
+6. Compose hooks for L1 (FR-L1-9 cost-estimation integration) and L3 (L3 budget
+   pre-check integration)
+7. Protected-class router invocation for `budget.cap_increase` mid-cycle raises
+
+## Design decisions worth recording
+
+### 1. Counter is derived from audit log (single source of truth)
+
+Counter for current UTC day is computed by tail-scanning the audit log for
+`budget.record_call` events with matching `payload.utc_day` and provider.
+No separate counter state file. This avoids dual-source-of-truth pitfalls.
+
+### 2. Verdict-trigger order: severity-first
+
+```
+counter_inconsistent → billing_stale → provider_lag → clock_drift →
+halt-100 → warn-90 → allow
+```
+
+Order matters because uncertainty modes overlap (e.g., billing_age >= 15min
+implies billing_age >= 5min). Most-severe wins.
+
+### 3. clock_drift is gated on freshness
+
+Stale `billing_ts` will appear "drifted" from system clock — but that's a
+staleness signal, not a clock-drift signal. Clock-drift check fires only
+when `billing_age <= freshness_threshold`.
+
+### 4. Per-event-type schema registry (IMP-001 v1.1)
+
+Each event_type has its own payload schema at
+`.claude/data/trajectory-schemas/budget-events/<event_type>.payload.schema.json`.
+Lookup: `event_type` "budget.warn_90" → `budget-warn-90.payload.schema.json`
+(underscore → dash, drop "budget." prefix).
+
+### 5. Caller-supplied `UsageObserver` interface
+
+Per SDD §1.6, the billing API client is caller-supplied. `LOA_BUDGET_OBSERVER_CMD`
+or `cost_budget_enforcer.billing_observer_cmd` points to an executable that:
+- Receives the provider id as `$1`
+- Returns JSON `{"usd_used": <number>, "billing_ts": "<iso8601>"}` on stdout
+- Returns non-zero or non-JSON on error (treated as `_unreachable`)
+- Has 30s timeout (`timeout 30 <cmd> ...`)
+
+This keeps the lib provider-agnostic and testable without external deps.
+
+### 6. usd_remaining semantics (schema relaxation)
+
+The `halt-100` schema previously required `usd_remaining: maximum 0`. Relaxed
+to permit positive remaining at decision time — the verdict trigger uses the
+*projected* `usage_pct` (which is `>= 100` per the schema), not the current
+`usd_remaining`. The current remaining can be positive at the moment a call
+about to push usage over the cap is rejected.
+
+## Constraints honored
+
+- Test-first: 31 BATS tests cover state machine, schema validation,
+  argument validation, audit-log integrity, UTC-day rollover, per-provider
+  isolation, and reconciliation
+- Karpathy: surgical lib introduction; existing `audit-envelope.sh` and
+  `protected-class-router.sh` reused unchanged
+- Beads UNHEALTHY (#661): no beads writes
+- System Zone authorization: cycle-098 PRD/SDD scope `.claude/scripts/lib/`,
+  `.claude/data/trajectory-schemas/budget-events/`, and (Sprint 2D)
+  `.claude/skills/cost-budget-enforcer/`. All within authorized expansion.
+
+## Outcome stats
+
+- Files added: 8 (1 lib + 6 schemas + 1 test)
+- Lines: ~720 lib + ~150 schemas + ~570 tests = ~1440 added
+- Tests: 31 (31 PASS / 0 FAIL)
+- Regression: Sprint 1 audit-envelope and panel tests still PASS
+- Ready for: Sub-sprint 2B (reconciliation cron + /schedule wiring)

--- a/grimoires/loa/a2a/sprint-2/progress-2B.md
+++ b/grimoires/loa/a2a/sprint-2/progress-2B.md
@@ -1,0 +1,143 @@
+# Sub-sprint 2B Progress Report — Reconciliation cron + /schedule wiring
+
+**Cycle**: cycle-098-agent-network
+**Sprint**: 2 (L2 cost-budget-enforcer + reconciliation cron + daily snapshot)
+**Sub-sprint**: 2B (2 of 4)
+**Branch**: `feat/cycle-098-sprint-2`
+**Status**: COMPLETED
+
+## Outcome
+
+The L2 reconciliation cron is wired to `crontab` (the same registration model
+used elsewhere in the repo, e.g., `compact-trajectory.sh`). Sprint 2A's
+`budget_reconcile` function unit is now driven by an idempotent shell
+entrypoint that:
+
+1. Reads providers from `.loa.config.yaml::cost_budget_enforcer.providers`
+   (or defaults to `aggregate`)
+2. Acquires a flock to serialize concurrent cron firings
+3. Invokes `budget_reconcile` per provider
+4. Maps reconciliation outcomes to exit codes:
+   - 0 OK — no blocker
+   - 1 BLOCKER — drift exceeded; operator review required
+   - 2 DEFER — observer signaled `_defer: true` (rate-limit / transient)
+
+An installer (`budget-reconcile-install.sh`) ships the standard
+`crontab -e` lifecycle (status / install / uninstall / show) using a marker
+comment for idempotency.
+
+## Files added
+
+### Cron entrypoints
+
+| File | Purpose |
+|------|---------|
+| `.claude/scripts/budget/budget-reconcile-cron.sh` | Cron entry script — flock-serialized, multi-provider loop, dry-run support |
+| `.claude/scripts/budget/budget-reconcile-install.sh` | Operator helper: `install`, `uninstall`, `status`, `show` (idempotent crontab management) |
+
+### Tests
+
+| File | Type | Count | Status |
+|------|------|-------|--------|
+| `tests/integration/cost-budget-enforcer-reconciliation-cron.bats` | bats | 11 | 11 PASS / 0 FAIL |
+
+### Lib modification
+
+`cost-budget-enforcer-lib.sh::budget_reconcile` extended with `_defer`
+handling: when the caller-supplied `UsageObserver` returns
+`{"_defer": true, "_reason": "rate_limited"}`, `budget_reconcile` returns
+exit code 2 without writing a reconcile event (transient failure should
+not surface in the audit log; the next 6h interval will retry).
+
+## ACs satisfied
+
+### Sprint 2 deliverables (sprint.md)
+
+- **Reconciliation cron (un-deferred per SKP-005)**: DONE
+  - default 6h cadence (configurable `cost_budget_enforcer.reconciliation.interval_hours`)
+  - runs even when no cycle is active (independent crontab entry)
+  - compares internal counter to billing API
+  - emits BLOCKER on drift >5%
+  - counter NOT auto-corrected — operator decides via `--force-reason`
+- **`/schedule deregister` integration**: DONE via `budget-reconcile-install.sh uninstall`
+
+### FR-L2-5 (PRD)
+
+- Reconciliation job detects drift >5% — DONE (test #2)
+- BLOCKER emitted on drift exceedance — DONE (test #2, exit 1)
+- Configurable threshold via `LOA_BUDGET_DRIFT_THRESHOLD` /
+  `cost_budget_enforcer.reconciliation.drift_threshold_pct` — DONE
+
+### Risk mitigations (sprint.md table)
+
+- Reconciliation cron deregistration leaves orphan cron entries — Low /
+  MITIGATED via `budget-reconcile-install.sh uninstall` lifecycle test (#9)
+- Provider billing API rate limits during reconciliation — Med / MITIGATED
+  via `_defer` semantics: observer signals defer, no audit write, next
+  interval retries (test #3)
+
+## Idempotency guarantees
+
+1. **`install`** subcommand:
+   - First run appends marker-tagged crontab line
+   - Re-run with same cadence: prints "Already installed (cadence matches)"
+     and exits 0
+   - Re-run with changed cadence (config edited): replaces the marker line
+     with new cron expression
+2. **`uninstall`** subcommand:
+   - First run removes marker-tagged line
+   - Re-run prints "Not installed; nothing to remove" and exits 0
+3. **Cron entrypoint** itself:
+   - flock-serialized — concurrent firings (e.g., crond firing while a long
+     prior invocation still runs) wait up to 5min for the lock
+   - Each invocation appends exactly one `budget.reconcile` envelope per
+     provider per call (regardless of how often called)
+   - Tested: 3 sequential invocations append 3 reconcile events with intact
+     hash chain (test #7)
+   - Tested: 3 concurrent invocations serialize via flock; chain still
+     intact (test #11)
+
+## Lifecycle: enabled/disabled boundary
+
+When operator sets `agent_network.primitives.L2.enabled: false`:
+- Reconciliation cron deregistered via
+  `.claude/scripts/budget/budget-reconcile-install.sh uninstall`
+- Counter preserved (read-only); audit log sealed via Sprint 1's
+  `audit_seal_chain` with `[L2-DISABLED]` marker (Sprint 2D wires the
+  skill-level enable/disable hook)
+
+## Operator runbook addition (Sprint 2B)
+
+Sprint 2C will produce the full `audit-log-recovery.md` runbook. For now,
+the install helper is self-documenting via `--help`:
+
+```bash
+# Install (read interval_hours from .loa.config.yaml)
+.claude/scripts/budget/budget-reconcile-install.sh install
+
+# Show what would be installed (no side effects)
+.claude/scripts/budget/budget-reconcile-install.sh show
+
+# Status (installed / not-installed)
+.claude/scripts/budget/budget-reconcile-install.sh status
+
+# Uninstall (idempotent)
+.claude/scripts/budget/budget-reconcile-install.sh uninstall
+```
+
+## Testing strategy
+
+Tests use a mock `OBSERVER` shell-script that emits whatever JSON is in
+`OBSERVER_OUT` — making it easy to stage:
+- success cases: `{"usd_used": <num>, "billing_ts": "<iso>"}`
+- unreachable: missing OUT file → `{"_unreachable": true}`
+- defer (rate-limited): `{"_defer": true, "_reason": "rate_limited"}`
+
+The flock test runs 3 cron invocations concurrently and verifies all 3
+reconcile envelopes appended in order with intact hash chain.
+
+## Outcome stats
+
+- Files added: 2 scripts + 1 BATS + lib delta = 4 changes
+- Tests: 11 (11 PASS / 0 FAIL); cumulative Sprint 2 total: 42 / 42
+- Sub-sprint 2B unblocks: 2C (snapshot job) + 2D (skill + integration)

--- a/grimoires/loa/a2a/sprint-2/progress-2C.md
+++ b/grimoires/loa/a2a/sprint-2/progress-2C.md
@@ -1,0 +1,118 @@
+# Sub-sprint 2C Progress Report — Daily snapshot job
+
+**Cycle**: cycle-098-agent-network
+**Sprint**: 2 (L2 cost-budget-enforcer + reconciliation cron + daily snapshot)
+**Sub-sprint**: 2C (3 of 4)
+**Branch**: `feat/cycle-098-sprint-2`
+**Status**: COMPLETED
+
+## Outcome
+
+The producer side of the L1/L2 hash-chain recovery loop is in place. Sprint 1C
+shipped `_audit_recover_from_snapshot` in `audit-envelope.sh` (consumer); 2C
+ships `audit-snapshot.sh` (producer) and the operator runbook so RPO 24h is
+genuinely 24h, not aspirational.
+
+The daily snapshot reads `.claude/data/audit-retention-policy.yaml`,
+filters to chain-critical UNTRACKED primitives (L1, L2 by default),
+gzip-compresses each rolling log to
+`grimoires/loa/audit-archive/<utc-date>-<primitive>.jsonl.gz`, and
+optionally signs the archive (`.sig` JSON sidecar) when an operator
+writer key is configured.
+
+The runbook (`grimoires/loa/runbooks/audit-log-recovery.md`) is the
+operator's playbook for 4 recovery scenarios: corruption mid-session,
+file deleted, no snapshot available, and signature failure.
+
+## Files added
+
+### Snapshot scripts
+
+| File | Purpose |
+|------|---------|
+| `.claude/scripts/audit/audit-snapshot.sh` | Snapshot writer — reads retention policy, validates source chain, gzip-compresses, optionally signs |
+| `.claude/scripts/audit/audit-snapshot-install.sh` | Operator helper for crontab integration (`install`/`uninstall`/`status`/`show`) |
+
+### Tests
+
+| File | Type | Count | Status |
+|------|------|-------|--------|
+| `tests/integration/audit-snapshot.bats` | bats | 13 | 13 PASS / 0 FAIL |
+
+### Runbook
+
+| File | Purpose |
+|------|---------|
+| `grimoires/loa/runbooks/audit-log-recovery.md` | Operator runbook — 4 recovery scenarios, install/uninstall, RPO/RTO docs |
+
+## ACs satisfied
+
+### Sprint 2 deliverable (sprint.md)
+
+- **Daily snapshot job for L1/L2 untracked logs** (per SKP-001 §3.4.4↔§3.7
+  reconciliation, RPO 24h, was 7d) — DONE
+- **Snapshot-archive restore path documented in runbook** — DONE
+
+### Cross-cutting (CC-2 + CC-11 round-out)
+
+- Snapshots flow into the existing `_audit_recover_from_snapshot` pathway —
+  verified end-to-end by integration test #10 (snapshot → corrupt log →
+  audit_recover_chain → markers present)
+- Optional Ed25519 signature sidecar `.jsonl.gz.sig` carries
+  `{schema_version, primitive_id, utc_day, sha256, signing_key_id, signed_at, signature}`
+- `.gitkeep`-equivalent: `grimoires/loa/audit-archive/` is created on first
+  snapshot
+
+### Idempotency + safety guarantees
+
+- Same-day re-runs do not overwrite existing archives (test #3)
+- Broken source chain refuses to snapshot (test #5) — never archive corruption
+- Missing source log gracefully skipped, not errored (test #6)
+- chain_critical=false primitives skipped (test #7)
+- git_tracked=true primitives skipped (test #8) — no double-archival
+
+## Recovery flow (end-to-end demonstrated)
+
+```
+Steady state (each day at 04:00 UTC):
+  daily cron → audit-snapshot.sh →
+    For each chain-critical, untracked primitive:
+      1. Read .run/<basename> rolling log
+      2. audit_verify_chain — refuse if broken
+      3. gzip → grimoires/loa/audit-archive/<utc-day>-<P>.jsonl.gz
+      4. Optionally Ed25519-sign → <archive>.sig
+
+Failure recovery (mid-session corruption or accidental rm):
+  audit_recover_chain .run/<basename> →
+    1. audit_verify_chain — chain broken? continue
+    2. Try git history (TRACKED logs only) — fail for L1/L2 (UNTRACKED)
+    3. Try snapshot archive — locate latest <date>-<P>.jsonl.gz
+    4. Validate snapshot's internal chain integrity — refuse if broken
+    5. Decompress + restore + append markers:
+         [CHAIN-GAP-RESTORED-FROM-SNAPSHOT-RPO-24H snapshot=<basename>]
+         [CHAIN-RECOVERED source=snapshot_archive snapshot=<basename>]
+```
+
+## Lifecycle: enabled/disabled boundary
+
+When operator sets `agent_network.primitives.L2.enabled: false`:
+- `.claude/scripts/budget/budget-reconcile-install.sh uninstall` (Sprint 2B)
+- `.claude/scripts/audit/audit-snapshot-install.sh uninstall` (Sprint 2C) is
+  optional — operator may want to keep the daily snapshot of L1 even when
+  L2 is disabled. The snapshot script gracefully skips primitives whose
+  source log is missing.
+
+## Operator runbook scenarios
+
+The runbook covers:
+1. Corruption mid-session — `audit_recover_chain` Just Works
+2. File deleted — `audit_recover_chain` finds latest snapshot and restores
+3. No snapshot available — capture forensic, restart with [CHAIN-LOST] marker
+4. Snapshot signature failure — treat as no-snapshot + investigate tampering
+
+## Outcome stats
+
+- Files added: 2 scripts + 1 BATS + 1 runbook = 4 artifacts
+- Tests: 13 (13 PASS / 0 FAIL); cumulative Sprint 2 (2A+2B+2C) = 55 / 55
+- Sub-sprint 2C unblocks: 2D (skill + integration with full runbook
+  reference)

--- a/grimoires/loa/a2a/sprint-2/progress-2D.md
+++ b/grimoires/loa/a2a/sprint-2/progress-2D.md
@@ -1,0 +1,146 @@
+# Sub-sprint 2D Progress Report — L2 skill + integration
+
+**Cycle**: cycle-098-agent-network
+**Sprint**: 2 (L2 cost-budget-enforcer + reconciliation cron + daily snapshot)
+**Sub-sprint**: 2D (4 of 4)
+**Branch**: `feat/cycle-098-sprint-2`
+**Status**: COMPLETED
+
+## Outcome
+
+L2 is operator-facing. The skill (`/cost-budget-enforcer`) advertises the
+verdict gate to autonomous workflows; the CLI wrapper makes the same API
+available from any shell context; the lore entry "fail-closed cost gate"
+captures the architectural pattern for future cycle-098 sprints + cycle-099
+candidates; and the config example documents every knob with environment-
+variable overrides.
+
+The full Sprint 2 surface is now:
+- 6 per-event-type schemas
+- 1 lib (`cost-budget-enforcer-lib.sh`)
+- 1 SKILL.md
+- 5 operator-facing scripts (`budget-cli.sh`, 2 reconcile-cron scripts,
+  2 snapshot-cron scripts)
+- 1 operator runbook
+- 1 lore entry
+- 4 BATS test files (67 tests cumulative)
+
+## Files added
+
+### Skill + CLI
+
+| File | Purpose |
+|------|---------|
+| `.claude/skills/cost-budget-enforcer/SKILL.md` | Skill manifest — agent: general-purpose, allowed-tools Read+Bash; passes `validate-skill-capabilities.sh` |
+| `.claude/scripts/budget/budget-cli.sh` | Thin CLI wrapper: `verdict`, `usage`, `record`, `reconcile` subcommands |
+
+### Lore + config
+
+| File | Purpose |
+|------|---------|
+| `grimoires/loa/lore/patterns.yaml` | New "fail-closed-cost-gate" entry; ~50 lines |
+| `grimoires/loa/lore/index.yaml` | Index points at fail-closed-cost-gate (Active) |
+| `.loa.config.yaml.example` | New `cost_budget_enforcer.*` + `audit_snapshot.cron_expression` blocks; ~70 lines |
+
+### Schema example update
+
+| File | Change |
+|------|--------|
+| `.claude/data/trajectory-schemas/agent-network-envelope.schema.json` | `event_type.examples` updated to include `budget.record_call` (the 6th L2 event type, per Sprint 2A) |
+
+### Tests
+
+| File | Type | Count | Status |
+|------|------|-------|--------|
+| `tests/integration/budget-cli.bats` | bats | 12 | 12 PASS / 0 FAIL |
+
+## ACs satisfied — Sprint 2 final round-out
+
+### CC-1..CC-11 (cross-cutting per sprint.md)
+
+- CC-1 schema versioning: every envelope carries `schema_version: 1.1.0` (Sprint 1B major)
+- CC-2 hash-chained: `prev_hash` chains L2 events; verified by `audit_verify_chain` (test #27)
+- CC-3 flock atomicity: 3 concurrent cron firings serialize cleanly (Sprint 2B test #11)
+- CC-4 envelope schema validation: ajv (R15 Python fallback) on every write
+- CC-5 `/loa status` integration: not in 2D scope (Sprint 4.5 buffer task)
+- CC-6 trust-store auto-verify: inherited from Sprint 1.5 #690
+- CC-7 redaction allowlist: inherited (Sprint 1.5 #695 F8)
+- CC-8 retention metadata: L2 retention_days=90, archive_after_days=90 (per
+  `.claude/data/audit-retention-policy.yaml`)
+- CC-9 compose-when-available: protected-class `budget.cap_increase` registered;
+  L1 + L3 integration hooks documented (sprint plan deliverable for L1
+  FR-L1-9 and L3 §3.3 task)
+- CC-10 per-event schema registry: 6 schemas at
+  `.claude/data/trajectory-schemas/budget-events/` (CC-10 + IMP-001 v1.1)
+- CC-11 envelope schema additivity: examples extended with
+  `budget.record_call` without breaking existing consumers
+
+### Sprint plan deliverables (sprint.md)
+
+- `.claude/skills/cost-budget-enforcer/SKILL.md` — DONE
+- `lib/cost-budget-enforcer-lib.sh` — DONE (Sprint 2A)
+- 10 ACs FR-L2-1..FR-L2-10 — DONE (with comprehensive test coverage)
+- State machine: 5 verdicts × 5 uncertainty modes — DONE
+- UTC-windowed daily cap, ±60s clock validation — DONE
+- Per-provider counter + aggregate cap + sub-caps — DONE
+- Reconciliation cron — DONE (Sprint 2B)
+- BLOCKER on drift >5%, configurable threshold — DONE
+- Audit-envelope event types — DONE (6 types)
+- **Daily snapshot job for L1/L2 untracked logs** — DONE (Sprint 2C)
+- Lore entry "fail-closed cost gate" — DONE
+- Integration tests for billing API outage, counter drift, sudden cap
+  change, clock drift, provider lag — DONE (cumulative across 2A/2B)
+
+## Composition surface (compose-when-available)
+
+L2 is callable from autonomous workflows via 4 entry points:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Caller flow                                                    │
+│                                                                 │
+│  (1) Pre-call gate                                              │
+│      verdict = budget_verdict <est_usd> --provider <id>         │
+│      if exit 1: HALT (do not make the paid call)                │
+│                                                                 │
+│  (2) Make the paid call                                         │
+│                                                                 │
+│  (3) Post-call accounting                                       │
+│      budget_record_call <actual_usd> --provider <id>            │
+│      [optional --verdict-ref <prev_hash>]                       │
+│                                                                 │
+│  (4) Background (cron-driven)                                   │
+│      budget_reconcile every 6h                                  │
+│      audit-snapshot.sh every 24h                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Sprint 3 (L3 scheduled-cycle-template) consumes (1) in its pre-read phase
+per FR-L3-6. Sprint 1's L1 FR-L1-9 also calls (1) for cost estimation when
+L2 is enabled (compose-when-available stub already in L1 lib).
+
+## Skill validation
+
+`.claude/scripts/validate-skill-capabilities.sh`:
+- `[cost-budget-enforcer] PASS` (frontmatter + capabilities + zone declarations)
+
+## Outcome stats
+
+- Files added: 7 (1 SKILL.md + 1 CLI script + 1 BATS + 1 lore entry +
+  1 lore-index entry + 1 config-example block + 1 schema-examples update)
+- Tests: 12 (12 PASS / 0 FAIL); cumulative Sprint 2 (2A+2B+2C+2D) = **67 / 67**
+- Lore entries: +1 (fail-closed-cost-gate, Active)
+- Skills: +1 (cost-budget-enforcer)
+- CLI surface: 4 subcommands (verdict, usage, record, reconcile) + 4
+  install/uninstall helpers across 2 cron families
+
+## Sprint 2 ready for review
+
+The sub-sprint 2D delivery completes Sprint 2's scope. The branch is ready
+for the consolidated quality-gate chain:
+
+1. `/review-sprint sprint-2` — expected iter-1 with 1-2 minor findings
+2. Cross-model adversarial (gpt-5.3-codex)
+3. `/audit-sprint sprint-2` — paranoid cypherpunk review
+4. Bridgebuilder kaironic (inline `entry.sh --pr <N>`)
+5. Admin-squash merge after convergence

--- a/grimoires/loa/lore/index.yaml
+++ b/grimoires/loa/lore/index.yaml
@@ -12,6 +12,8 @@ categories:
         status: Active
       - id: deliberative-council
         status: Active
+      - id: fail-closed-cost-gate
+        status: Active
 
   # Future categories (populated by bridge vision elevation):
   # - id: visions

--- a/grimoires/loa/lore/patterns.yaml
+++ b/grimoires/loa/lore/patterns.yaml
@@ -81,3 +81,53 @@
   superseded_by: null
   related:
     - governance-isomorphism
+
+- id: fail-closed-cost-gate
+  term: Fail-Closed Cost Gate
+  short: >-
+    Cost-budget enforcement that NEVER permits paid operations under
+    uncertainty. Any of five failure modes (billing API stale, counter
+    inconsistent, counter drift, clock drift, provider lag) yields
+    halt-uncertainty regardless of nominal usage percent.
+  context: >-
+    Most budget enforcers in production AI systems share a flaw: when their
+    information becomes uncertain, they default to "allow" because the cost of
+    a wrong-stop (cycle halts, operator paged) feels worse than a wrong-go
+    (one extra paid call). That intuition is correct only when the worst case
+    is bounded. For cost overruns, the worst case is unbounded — a runaway
+    autonomous cycle can spend ten or a hundred times the daily cap before
+    a human notices. cycle-098 L2 inverts the default: under any of five
+    explicitly-named uncertainty modes, the verdict is halt-uncertainty.
+    The order of the five checks is severity-first
+    (counter_inconsistent then billing_stale then provider_lag then
+    clock_drift then halt-100 then warn-90 then allow), so the most-severe
+    applicable verdict wins. The implementation pattern is general: any
+    consequential gate that consumes a noisy or asynchronous signal should
+    treat "I don't know what's happening" as the strongest signal to halt,
+    not the weakest. Verdicts are hash-chain-signed with the envelope's
+    prev_hash for forensic auditability post-incident; reconciliation cron
+    cross-checks counter against billing API every 6h with BLOCKER on drift
+    over 5 percent, but counter is NOT auto-corrected — operator
+    force-reconcile is required (counter could be the wrong source).
+    Pairs with the abundance-pruning pattern from Tricorder/Loa Flatline:
+    the system halts noisily when uncertain, which is the only way to
+    surface latent observability defects in production.
+  source:
+    cycle: "cycle-098-agent-network"
+    sprint: "Sprint 2 (L2 cost-budget-enforcer)"
+    rfc: "https://github.com/0xHoneyJar/loa/issues/654"
+    date: "2026-05-04"
+  tags:
+    - architecture
+    - safety
+    - fail-closed
+    - cost-control
+    - autonomous-systems
+    - pattern
+  status: Active
+  challenges: []
+  lineage: null
+  superseded_by: null
+  related:
+    - governance-isomorphism
+    - deliberative-council

--- a/grimoires/loa/runbooks/audit-log-recovery.md
+++ b/grimoires/loa/runbooks/audit-log-recovery.md
@@ -1,0 +1,185 @@
+# Audit-Log Recovery Runbook
+
+**Cycle**: cycle-098-agent-network
+**Source**: SDD §3.4.4 (recovery procedure) + §3.7 (persistence policy)
+**Audience**: Loa operators
+
+## Purpose
+
+L1 (panel-decisions) and L2 (cost-budget-events) audit logs are
+chain-critical and UNTRACKED — they are not in git, so `git checkout`
+cannot recover them after corruption or accidental deletion. This runbook
+is the operator's playbook when those logs are damaged or lost.
+
+## Persistence policy (per SDD §3.7)
+
+| Log | Path | git tracked? | chain critical? | Snapshot cadence |
+|-----|------|--------------|-----------------|------------------|
+| L1 panel-decisions | `.run/panel-decisions.jsonl` | No | Yes | **Daily** (RPO 24h) |
+| L2 cost-budget-events | `.run/cost-budget-events.jsonl` | No | Yes | **Daily** (RPO 24h) |
+| L3 cycles | `.run/cycles.jsonl` | No | No | Optional (re-emission idempotent) |
+| L4 trust-ledger | `grimoires/loa/trust-ledger.jsonl` | Yes | Yes | Standard PR cadence |
+
+**RPO (Recovery Point Objective) for L1 + L2: 24 hours.** Entries written
+between the most recent daily snapshot and the failure point are
+unrecoverable. Snapshots are tracked in `grimoires/loa/audit-archive/`.
+
+## Daily snapshot job (Sprint 2C)
+
+The daily snapshot is shipped as `.claude/scripts/audit/audit-snapshot.sh`.
+The entire flow is idempotent and safe to invoke ad-hoc.
+
+### Install (one-time setup)
+
+```bash
+.claude/scripts/audit/audit-snapshot-install.sh install
+```
+
+This appends a marker-tagged crontab line firing at 04:00 UTC by default.
+Override schedule via `.loa.config.yaml::audit_snapshot.cron_expression`
+(e.g., `"0 3 * * *"` for 03:00 UTC). The default avoids overlap with the
+6h reconciliation cron firing on `0 */6 * * *`.
+
+### Verify status
+
+```bash
+.claude/scripts/audit/audit-snapshot-install.sh status
+```
+
+### Uninstall
+
+```bash
+.claude/scripts/audit/audit-snapshot-install.sh uninstall
+```
+
+### Manual trigger (e.g., before a planned migration)
+
+```bash
+.claude/scripts/audit/audit-snapshot.sh
+```
+
+## Recovery procedures
+
+### Scenario 1: Corruption detected mid-session
+
+Symptoms:
+- `audit_verify_chain .run/cost-budget-events.jsonl` returns non-zero
+- A budget verdict halts with `[CHAIN-BROKEN]` in stderr
+- Log file still exists but integrity is suspect
+
+Procedure:
+
+```bash
+# 1. Stop active L2 invocations to avoid further writes during recovery.
+.claude/scripts/budget/budget-reconcile-install.sh uninstall
+
+# 2. Run the recovery procedure (re-source the lib).
+source .claude/scripts/audit-envelope.sh
+audit_recover_chain .run/cost-budget-events.jsonl
+
+# 3. Inspect the restored log.
+tail -5 .run/cost-budget-events.jsonl
+# Look for [CHAIN-RECOVERED source=snapshot_archive snapshot=...]
+# Followed by [CHAIN-GAP-RESTORED-FROM-SNAPSHOT-RPO-24H ...]
+
+# 4. Re-install the reconciliation cron.
+.claude/scripts/budget/budget-reconcile-install.sh install
+```
+
+If `audit_recover_chain` exits non-zero, no snapshot is available — see
+Scenario 3.
+
+### Scenario 2: File accidentally deleted
+
+Symptoms:
+- `.run/panel-decisions.jsonl` or `.run/cost-budget-events.jsonl` is gone
+- Active L1/L2 invocation creates a fresh empty file (chain restarts at
+  GENESIS, losing all prior history)
+
+Procedure:
+
+```bash
+# Stop active L2 (or L1) invocations.
+.claude/scripts/budget/budget-reconcile-install.sh uninstall
+
+# Manually decompress the most recent snapshot.
+ls -lt grimoires/loa/audit-archive/*-L2.jsonl.gz | head -1
+gzip -dc grimoires/loa/audit-archive/$(ls -t grimoires/loa/audit-archive/*-L2.jsonl.gz | head -1 | xargs basename) > .run/cost-budget-events.jsonl
+
+# Manually append the recovery markers (so the chain knows there's a gap).
+{
+    echo "[CHAIN-GAP-RESTORED-FROM-SNAPSHOT-RPO-24H snapshot=<basename>]"
+    echo "[CHAIN-RECOVERED source=snapshot_archive snapshot=<basename>]"
+} >> .run/cost-budget-events.jsonl
+
+# Re-verify.
+source .claude/scripts/audit-envelope.sh
+audit_verify_chain .run/cost-budget-events.jsonl
+```
+
+In practice, just calling `audit_recover_chain` does this for you.
+
+### Scenario 3: No snapshot available
+
+Symptoms:
+- `grimoires/loa/audit-archive/` has no `<date>-L2.jsonl.gz` archive for
+  the missing log
+- Either daily snapshot job never ran, or all archives lost
+
+Procedure:
+
+```bash
+# 1. Capture the broken state for forensic analysis.
+cp .run/cost-budget-events.jsonl /tmp/l2-broken-$(date +%s).jsonl
+
+# 2. Initialize a fresh chain with explicit gap markers.
+{
+    echo "[CHAIN-LOST audit_archive_missing reason=no_snapshot_for_recovery ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)]"
+    echo "[CHAIN-RESTARTED ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)]"
+} > .run/cost-budget-events.jsonl
+
+# 3. Verify and resume.
+source .claude/scripts/audit-envelope.sh
+audit_verify_chain .run/cost-budget-events.jsonl  # OK 0 entries
+
+# 4. File a forensic note in NOTES.md describing what was lost and when.
+
+# 5. Install the daily snapshot job to prevent recurrence.
+.claude/scripts/audit/audit-snapshot-install.sh install
+```
+
+### Scenario 4: Snapshot signature verification fails
+
+Symptoms:
+- `audit_recover_chain` reports the snapshot's chain integrity check
+  failed
+- Or `<archive>.sig` file exists but signature does not verify against
+  the writer's pubkey
+
+Procedure:
+1. Treat as Scenario 3 — no trusted snapshot available
+2. Investigate whether the snapshot was tampered with (compare against
+   any offsite backup)
+3. Rotate the writer's signing key (signing-key compromise playbook in
+   `grimoires/loa/runbooks/audit-keys-bootstrap/README.md`)
+
+## Operational expectations
+
+- Snapshots are committed to git as part of the operator's regular workflow
+  (e.g., a daily cron + commit hook, or a weekly batch)
+- The L1/L2 logs themselves remain UNTRACKED (per SDD §3.7's privacy
+  rationale: panelist reasoning + cost data may contain redacted-but-
+  sensitive content; daily snapshots are the controlled access path)
+- After every snapshot, expect 1 new file:
+  `grimoires/loa/audit-archive/<utc-date>-L1.jsonl.gz` (and `-L2`)
+- When `LOA_AUDIT_SIGNING_KEY_ID` is configured, a sidecar
+  `.jsonl.gz.sig` JSON file accompanies each archive
+
+## Related artifacts
+
+- Snapshot writer: `.claude/scripts/audit/audit-snapshot.sh`
+- Snapshot installer: `.claude/scripts/audit/audit-snapshot-install.sh`
+- Recovery function: `audit_recover_chain` in `.claude/scripts/audit-envelope.sh`
+- Retention policy: `.claude/data/audit-retention-policy.yaml`
+- SDD reference: §3.4.4 (recovery procedure), §3.7 (persistence policy)
+- Sprint reference: cycle-098 Sprint 2C

--- a/tests/integration/audit-snapshot.bats
+++ b/tests/integration/audit-snapshot.bats
@@ -1,0 +1,240 @@
+#!/usr/bin/env bats
+# =============================================================================
+# audit-snapshot.bats — Sprint 2C
+#
+# Daily snapshot writer for L1/L2 chain-critical UNTRACKED logs (RPO 24h
+# per SDD §3.4.4 ↔ §3.7 reconciliation).
+# =============================================================================
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    TEST_DIR="$(mktemp -d)"
+    LOGS_DIR="${TEST_DIR}/logs"
+    ARCHIVE_DIR="${TEST_DIR}/archive"
+    POLICY="${TEST_DIR}/retention-policy.yaml"
+    mkdir -p "$LOGS_DIR" "$ARCHIVE_DIR"
+
+    # Minimal policy for tests: L1 + L2 chain-critical, L3 not.
+    cat > "$POLICY" <<'YAML'
+schema_version: "1.0"
+primitives:
+  L1:
+    log_basename: "panel-decisions.jsonl"
+    chain_critical: true
+    git_tracked: false
+  L2:
+    log_basename: "cost-budget-events.jsonl"
+    chain_critical: true
+    git_tracked: false
+  L3:
+    log_basename: "cycles.jsonl"
+    chain_critical: false
+    git_tracked: false
+  L4:
+    log_basename: "trust-ledger.jsonl"
+    chain_critical: true
+    git_tracked: true
+YAML
+
+    SNAPSHOT_SCRIPT="${REPO_ROOT}/.claude/scripts/audit/audit-snapshot.sh"
+    INSTALL_SCRIPT="${REPO_ROOT}/.claude/scripts/audit/audit-snapshot-install.sh"
+    chmod +x "$SNAPSHOT_SCRIPT" "$INSTALL_SCRIPT" 2>/dev/null || true
+
+    export LOA_AUDIT_VERIFY_SIGS=0
+    export LOA_AUDIT_SNAPSHOT_TEST_DAY="2026-05-04"
+    unset LOA_AUDIT_SIGNING_KEY_ID
+
+    # Seed L1 + L2 logs with a couple of envelopes each (chain-intact).
+    write_envelope() {
+        local file="$1"
+        local pid="$2"
+        local etype="$3"
+        local ts="$4"
+        local prev="$5"
+        local payload="$6"
+        printf '%s\n' "$(jq -nc \
+            --arg pid "$pid" --arg et "$etype" --arg ts "$ts" --arg ph "$prev" \
+            --argjson payload "$payload" \
+            '{schema_version:"1.1.0",primitive_id:$pid,event_type:$et,ts_utc:$ts,prev_hash:$ph,payload:$payload,redaction_applied:null}')" \
+            >> "$file"
+    }
+    L1_LOG="${LOGS_DIR}/panel-decisions.jsonl"
+    L2_LOG="${LOGS_DIR}/cost-budget-events.jsonl"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# Helper: produce a 2-entry chain-intact JSONL log.
+seed_chain() {
+    local file="$1"
+    local pid="$2"
+    # Compute a realistic prev_hash for entry 2.
+    source "${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    # Entry 1.
+    local e1_payload='{"foo":"bar"}'
+    local e1
+    e1="$(jq -nc \
+        --arg pid "$pid" --arg et "test.event" --arg ts "2026-05-04T10:00:00.000000Z" \
+        --argjson p "$e1_payload" \
+        '{schema_version:"1.1.0",primitive_id:$pid,event_type:$et,ts_utc:$ts,prev_hash:"GENESIS",payload:$p,redaction_applied:null}')"
+    printf '%s\n' "$e1" > "$file"
+    local hash2
+    hash2="$(_audit_chain_input "$e1" | _audit_sha256)"
+    local e2_payload='{"foo":"baz"}'
+    local e2
+    e2="$(jq -nc \
+        --arg pid "$pid" --arg et "test.event" --arg ts "2026-05-04T10:01:00.000000Z" \
+        --arg ph "$hash2" --argjson p "$e2_payload" \
+        '{schema_version:"1.1.0",primitive_id:$pid,event_type:$et,ts_utc:$ts,prev_hash:$ph,payload:$p,redaction_applied:null}')"
+    printf '%s\n' "$e2" >> "$file"
+}
+
+# -----------------------------------------------------------------------------
+# snapshot writer
+# -----------------------------------------------------------------------------
+@test "snapshot: writes <date>-L1.jsonl.gz and <date>-L2.jsonl.gz from logs" {
+    seed_chain "$L1_LOG" L1
+    seed_chain "$L2_LOG" L2
+
+    run "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR"
+    [[ "$status" -eq 0 ]]
+    [[ -f "${ARCHIVE_DIR}/2026-05-04-L1.jsonl.gz" ]]
+    [[ -f "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz" ]]
+}
+
+@test "snapshot: archive content gunzip-equal to source log" {
+    seed_chain "$L2_LOG" L2
+    run "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L2
+    [[ "$status" -eq 0 ]]
+    diff <(gzip -dc "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz") "$L2_LOG"
+}
+
+@test "snapshot: idempotent — same UTC day re-run does not overwrite" {
+    seed_chain "$L2_LOG" L2
+    run "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L2
+    [[ "$status" -eq 0 ]]
+    local mtime1
+    mtime1="$(stat -c '%Y' "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz" 2>/dev/null || stat -f '%m' "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz")"
+    sleep 1
+    # Append a new entry — re-run should NOT overwrite (idempotent same-day).
+    seed_chain "$L2_LOG" L2  # appends another two entries, log now has 4 lines (chain breaks; that's OK for this test)
+    run "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L2
+    [[ "$status" -eq 0 ]]
+    local mtime2
+    mtime2="$(stat -c '%Y' "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz" 2>/dev/null || stat -f '%m' "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz")"
+    [[ "$mtime1" -eq "$mtime2" ]]
+}
+
+@test "snapshot: dry-run writes nothing" {
+    seed_chain "$L2_LOG" L2
+    run "$SNAPSHOT_SCRIPT" --dry-run --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR"
+    [[ "$status" -eq 0 ]]
+    [[ ! -f "${ARCHIVE_DIR}/2026-05-04-L1.jsonl.gz" ]]
+    [[ ! -f "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz" ]]
+}
+
+@test "snapshot: refuses broken chain — emits ERROR, exit non-zero" {
+    # L2 log with mismatched prev_hash on entry 2.
+    cat > "$L2_LOG" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"foo":"bar"},"redaction_applied":null}
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:01:00.000000Z","prev_hash":"deadbeef","payload":{"foo":"baz"},"redaction_applied":null}
+EOF
+    run "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L2
+    [[ "$status" -eq 1 ]]
+    [[ ! -f "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz" ]]
+}
+
+@test "snapshot: skips primitive whose source log is missing" {
+    seed_chain "$L1_LOG" L1
+    # No L2 log seeded.
+    run "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR"
+    [[ "$status" -eq 0 ]]
+    [[ -f "${ARCHIVE_DIR}/2026-05-04-L1.jsonl.gz" ]]
+    [[ ! -f "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz" ]]
+}
+
+@test "snapshot: skips primitives with chain_critical=false (L3)" {
+    # Seed an L3 log; should be ignored by the snapshot writer.
+    L3_LOG="${LOGS_DIR}/cycles.jsonl"
+    seed_chain "$L3_LOG" L3
+    run "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR"
+    [[ "$status" -eq 0 ]]
+    [[ ! -f "${ARCHIVE_DIR}/2026-05-04-L3.jsonl.gz" ]]
+}
+
+@test "snapshot: skips primitives with git_tracked=true (L4)" {
+    L4_LOG="${LOGS_DIR}/trust-ledger.jsonl"
+    seed_chain "$L4_LOG" L4
+    run "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR"
+    [[ "$status" -eq 0 ]]
+    [[ ! -f "${ARCHIVE_DIR}/2026-05-04-L4.jsonl.gz" ]]
+}
+
+@test "snapshot: --primitive L1 only writes L1 archive even when L2 also has log" {
+    seed_chain "$L1_LOG" L1
+    seed_chain "$L2_LOG" L2
+    run "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L1
+    [[ "$status" -eq 0 ]]
+    [[ -f "${ARCHIVE_DIR}/2026-05-04-L1.jsonl.gz" ]]
+    [[ ! -f "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Recovery integration: snapshot → audit_recover_chain restore
+# -----------------------------------------------------------------------------
+@test "recovery: audit_recover_chain reads our snapshot and restores chain" {
+    seed_chain "$L2_LOG" L2
+    "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L2 >/dev/null
+    [[ -f "${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz" ]]
+
+    # Corrupt the rolling log: tamper with entry 2's prev_hash (chain breaks).
+    cat > "$L2_LOG" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"foo":"bar"},"redaction_applied":null}
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:01:00.000000Z","prev_hash":"deadbeef","payload":{"foo":"baz"},"redaction_applied":null}
+EOF
+
+    # Invoke audit_recover_chain — chain is broken, should locate snapshot and restore.
+    source "${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    LOA_AUDIT_ARCHIVE_DIR="$ARCHIVE_DIR" run audit_recover_chain "$L2_LOG"
+    [[ "$status" -eq 0 ]]
+
+    # Restored log should contain recovery markers.
+    grep -q "CHAIN-RECOVERED source=snapshot_archive" "$L2_LOG"
+    grep -q "CHAIN-GAP-RESTORED-FROM-SNAPSHOT-RPO-24H" "$L2_LOG"
+}
+
+# -----------------------------------------------------------------------------
+# Install helper
+# -----------------------------------------------------------------------------
+@test "snapshot install: 'show' produces expected cron line at 04:00 UTC default" {
+    run "$INSTALL_SCRIPT" show
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"0 4 * * *"* ]]
+    [[ "$output" =~ "loa-cycle098-audit-snapshot" ]]
+    [[ "$output" =~ "audit-snapshot.sh" ]]
+}
+
+@test "snapshot install: respects configured cron_expression" {
+    local config
+    config="${TEST_DIR}/loa.config.yaml"
+    cat > "$config" <<'EOF'
+audit_snapshot:
+  cron_expression: "30 3 * * *"
+EOF
+    LOA_BUDGET_CONFIG_FILE="$config" run "$INSTALL_SCRIPT" show
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"30 3 * * *"* ]]
+}
+
+@test "snapshot install: rejects malformed cron expression" {
+    local config
+    config="${TEST_DIR}/loa.config.yaml"
+    cat > "$config" <<'EOF'
+audit_snapshot:
+  cron_expression: "not a cron"
+EOF
+    LOA_BUDGET_CONFIG_FILE="$config" run "$INSTALL_SCRIPT" show
+    [[ "$status" -ne 0 ]]
+}

--- a/tests/integration/audit-snapshot.bats
+++ b/tests/integration/audit-snapshot.bats
@@ -238,3 +238,80 @@ EOF
     LOA_BUDGET_CONFIG_FILE="$config" run "$INSTALL_SCRIPT" show
     [[ "$status" -ne 0 ]]
 }
+
+# -----------------------------------------------------------------------------
+# F3 remediation: .sig sidecar verification on recovery
+# -----------------------------------------------------------------------------
+@test "F3: recovery refuses snapshot whose .sig has wrong sha256 (tampered .gz)" {
+    seed_chain "$L2_LOG" L2
+    "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L2 >/dev/null
+
+    local archive="${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz"
+    [[ -f "$archive" ]]
+
+    # Manually create a malicious .sig sidecar pointing to a wrong sha256.
+    cat > "${archive}.sig" <<'EOF'
+{"schema_version":"1.0","primitive_id":"L2","utc_day":"2026-05-04","sha256":"0000000000000000000000000000000000000000000000000000000000000000","signing_key_id":"test-writer","signed_at":"2026-05-04T04:00:00Z","signature":"AAAA"}
+EOF
+
+    # Corrupt the rolling log to force recovery.
+    cat > "$L2_LOG" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"foo":"bar"},"redaction_applied":null}
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:01:00.000000Z","prev_hash":"deadbeef","payload":{"foo":"baz"},"redaction_applied":null}
+EOF
+
+    source "${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    LOA_AUDIT_ARCHIVE_DIR="$ARCHIVE_DIR" run audit_recover_chain "$L2_LOG"
+    # Should refuse to recover (sha256 mismatch).
+    [[ "$status" -ne 0 ]]
+}
+
+@test "F3: recovery refuses snapshot whose .sig is malformed JSON" {
+    seed_chain "$L2_LOG" L2
+    "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L2 >/dev/null
+
+    local archive="${ARCHIVE_DIR}/2026-05-04-L2.jsonl.gz"
+    # .sig present but missing required fields.
+    cat > "${archive}.sig" <<'EOF'
+{"schema_version":"1.0","sha256":"abc"}
+EOF
+
+    cat > "$L2_LOG" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"foo":"bar"},"redaction_applied":null}
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:01:00.000000Z","prev_hash":"deadbeef","payload":{"foo":"baz"},"redaction_applied":null}
+EOF
+
+    source "${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    LOA_AUDIT_ARCHIVE_DIR="$ARCHIVE_DIR" run audit_recover_chain "$L2_LOG"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "F3: recovery refuses unsigned snapshot when LOA_AUDIT_RECOVER_REQUIRE_SIG=1" {
+    seed_chain "$L2_LOG" L2
+    "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L2 >/dev/null
+
+    cat > "$L2_LOG" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"foo":"bar"},"redaction_applied":null}
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:01:00.000000Z","prev_hash":"deadbeef","payload":{"foo":"baz"},"redaction_applied":null}
+EOF
+
+    source "${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    LOA_AUDIT_RECOVER_REQUIRE_SIG=1 LOA_AUDIT_ARCHIVE_DIR="$ARCHIVE_DIR" run audit_recover_chain "$L2_LOG"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "F3: recovery proceeds for unsigned snapshot when REQUIRE_SIG=0 (backward compat)" {
+    seed_chain "$L2_LOG" L2
+    "$SNAPSHOT_SCRIPT" --policy "$POLICY" --logs-dir "$LOGS_DIR" --archive-dir "$ARCHIVE_DIR" --primitive L2 >/dev/null
+
+    cat > "$L2_LOG" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"foo":"bar"},"redaction_applied":null}
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"test.event","ts_utc":"2026-05-04T10:01:00.000000Z","prev_hash":"deadbeef","payload":{"foo":"baz"},"redaction_applied":null}
+EOF
+
+    source "${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    # No LOA_AUDIT_RECOVER_REQUIRE_SIG (default 0); no .sig file present.
+    LOA_AUDIT_ARCHIVE_DIR="$ARCHIVE_DIR" run audit_recover_chain "$L2_LOG"
+    [[ "$status" -eq 0 ]]
+    grep -q "CHAIN-RECOVERED source=snapshot_archive" "$L2_LOG"
+}

--- a/tests/integration/budget-cli.bats
+++ b/tests/integration/budget-cli.bats
@@ -80,7 +80,11 @@ set_observer() {
     set_observer '{"usd_used": 7.50, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
     run "$CLI" usage
     [[ "$status" -eq 0 ]]
-    [[ "$(echo "$output" | jq -r '.daily_cap_usd')" == "50.00" || "$(echo "$output" | jq -r '.daily_cap_usd')" == "50" ]]
+    # F12 fix: numeric comparison instead of string-equals so jq normalization
+    # (e.g., "50.0" vs "50.00") doesn't break the assertion.
+    local cap_value
+    cap_value="$(echo "$output" | jq -r '.daily_cap_usd')"
+    python3 -c "import sys; sys.exit(0 if abs(float('$cap_value') - 50.0) < 0.001 else 1)"
     # No new envelope written.
     [[ "$(wc -l < "$LOG_FILE")" -eq "$pre_lines" ]]
 }

--- a/tests/integration/budget-cli.bats
+++ b/tests/integration/budget-cli.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# =============================================================================
+# budget-cli.bats — Sprint 2D
+#
+# Integration tests for the operator CLI wrapper over the L2 lib.
+# Covers: verdict / usage / record / reconcile subcommands end-to-end.
+# =============================================================================
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    TEST_DIR="$(mktemp -d)"
+    LOG_FILE="${TEST_DIR}/cost-budget-events.jsonl"
+    OBSERVER="${TEST_DIR}/observer.sh"
+    OBSERVER_OUT="${TEST_DIR}/observer-out.json"
+
+    cat > "$OBSERVER" <<'EOF'
+#!/usr/bin/env bash
+out_file="${OBSERVER_OUT:-}"
+if [[ -n "$out_file" && -f "$out_file" ]]; then
+    cat "$out_file"
+else
+    echo '{"_unreachable": true}'
+fi
+EOF
+    chmod +x "$OBSERVER"
+
+    export LOA_BUDGET_LOG="$LOG_FILE"
+    export LOA_BUDGET_OBSERVER_CMD="$OBSERVER"
+    export OBSERVER_OUT
+    export LOA_BUDGET_DAILY_CAP_USD="50.00"
+    export LOA_BUDGET_TEST_NOW="2026-05-04T12:00:00.000000Z"
+    export LOA_AUDIT_VERIFY_SIGS=0
+    unset LOA_AUDIT_SIGNING_KEY_ID
+
+    CLI="${REPO_ROOT}/.claude/scripts/budget/budget-cli.sh"
+    chmod +x "$CLI" 2>/dev/null || true
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+set_observer() {
+    echo "$1" > "$OBSERVER_OUT"
+}
+
+# -----------------------------------------------------------------------------
+# verdict subcommand
+# -----------------------------------------------------------------------------
+@test "cli verdict: returns allow when usage is low" {
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run "$CLI" verdict 1.00
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "allow" ]]
+}
+
+@test "cli verdict: exits 1 on halt-100" {
+    set_observer '{"usd_used": 49.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run "$CLI" verdict 2.00
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "halt-100" ]]
+}
+
+@test "cli verdict: --provider scopes per-provider counter" {
+    "$CLI" record 10.00 --provider openai >/dev/null
+    set_observer '{"usd_used": 0.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run "$CLI" verdict 1.00 --provider anthropic
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "allow" ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.provider')" == "anthropic" ]]
+}
+
+# -----------------------------------------------------------------------------
+# usage subcommand
+# -----------------------------------------------------------------------------
+@test "cli usage: returns state JSON without writing audit log" {
+    "$CLI" record 7.50 --provider aggregate >/dev/null
+    local pre_lines
+    pre_lines="$(wc -l < "$LOG_FILE")"
+    set_observer '{"usd_used": 7.50, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run "$CLI" usage
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | jq -r '.daily_cap_usd')" == "50.00" || "$(echo "$output" | jq -r '.daily_cap_usd')" == "50" ]]
+    # No new envelope written.
+    [[ "$(wc -l < "$LOG_FILE")" -eq "$pre_lines" ]]
+}
+
+# -----------------------------------------------------------------------------
+# record subcommand
+# -----------------------------------------------------------------------------
+@test "cli record: appends budget.record_call envelope" {
+    run "$CLI" record 1.42 --provider anthropic --model-id claude-opus-4-7
+    [[ "$status" -eq 0 ]]
+    local last_line
+    last_line="$(tail -1 "$LOG_FILE")"
+    [[ "$(echo "$last_line" | jq -r '.event_type')" == "budget.record_call" ]]
+    [[ "$(echo "$last_line" | jq -r '.payload.actual_usd')" == "1.42" ]]
+    [[ "$(echo "$last_line" | jq -r '.payload.model_id')" == "claude-opus-4-7" ]]
+}
+
+# -----------------------------------------------------------------------------
+# reconcile subcommand
+# -----------------------------------------------------------------------------
+@test "cli reconcile: emits BLOCKER on drift > threshold" {
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":30.0,"usd_used_post":30.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    set_observer '{"usd_used": 20.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run "$CLI" reconcile
+    [[ "$status" -eq 1 ]]
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.payload.blocker')" == "true" ]]
+}
+
+@test "cli reconcile: --force-reason captured in audit envelope" {
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":5.0,"usd_used_post":5.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run "$CLI" reconcile --force-reason "operator review 2026-05-04"
+    [[ "$status" -eq 0 ]]
+    local last_line
+    last_line="$(tail -1 "$LOG_FILE")"
+    [[ "$(echo "$last_line" | jq -r '.payload.force_reconcile')" == "true" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Error handling
+# -----------------------------------------------------------------------------
+@test "cli unknown subcommand: exits 2 with error" {
+    run "$CLI" frobnicate
+    [[ "$status" -eq 2 ]]
+    [[ "$output" =~ "unknown subcommand" ]]
+}
+
+@test "cli no args: prints help and exits 0" {
+    run "$CLI"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "Subcommands:" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Composition with protected-class router
+# -----------------------------------------------------------------------------
+@test "protected-class router: 'budget.cap_increase' is registered as protected" {
+    source "${REPO_ROOT}/.claude/scripts/lib/protected-class-router.sh"
+    run is_protected_class "budget.cap_increase"
+    [[ "$status" -eq 0 ]]  # exit 0 = matched
+}
+
+# -----------------------------------------------------------------------------
+# Schema registry consistency — every emitted event has a corresponding schema
+# -----------------------------------------------------------------------------
+@test "schema registry: all 6 budget event-type schemas present" {
+    local schema_dir="${REPO_ROOT}/.claude/data/trajectory-schemas/budget-events"
+    [[ -d "$schema_dir" ]]
+    [[ -f "${schema_dir}/budget-allow.payload.schema.json" ]]
+    [[ -f "${schema_dir}/budget-warn-90.payload.schema.json" ]]
+    [[ -f "${schema_dir}/budget-halt-100.payload.schema.json" ]]
+    [[ -f "${schema_dir}/budget-halt-uncertainty.payload.schema.json" ]]
+    [[ -f "${schema_dir}/budget-reconcile.payload.schema.json" ]]
+    [[ -f "${schema_dir}/budget-record-call.payload.schema.json" ]]
+}
+
+@test "schema registry: every schema is valid JSON" {
+    local schema_dir="${REPO_ROOT}/.claude/data/trajectory-schemas/budget-events"
+    for schema in "$schema_dir"/*.schema.json; do
+        run jq empty "$schema"
+        [[ "$status" -eq 0 ]]
+    done
+}

--- a/tests/integration/cost-budget-enforcer-reconciliation-cron.bats
+++ b/tests/integration/cost-budget-enforcer-reconciliation-cron.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+# =============================================================================
+# cost-budget-enforcer-reconciliation-cron.bats — Sprint 2B
+#
+# Integration tests for the L2 reconciliation cron entrypoint + install helper.
+# Covers idempotent re-runs, billing-API 429 deferral, and crontab integration.
+# =============================================================================
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    TEST_DIR="$(mktemp -d)"
+    LOG_FILE="${TEST_DIR}/cost-budget-events.jsonl"
+    OBSERVER="${TEST_DIR}/observer.sh"
+    OBSERVER_OUT="${TEST_DIR}/observer-out.json"
+    RECONCILE_LOCK="${TEST_DIR}/budget-reconcile.lock"
+
+    cat > "$OBSERVER" <<'EOF'
+#!/usr/bin/env bash
+out_file="${OBSERVER_OUT:-}"
+if [[ -n "$out_file" && -f "$out_file" ]]; then
+    cat "$out_file"
+else
+    echo '{"_unreachable": true}'
+fi
+EOF
+    chmod +x "$OBSERVER"
+
+    export LOA_BUDGET_LOG="$LOG_FILE"
+    export LOA_BUDGET_OBSERVER_CMD="$OBSERVER"
+    export OBSERVER_OUT
+    export LOA_BUDGET_DAILY_CAP_USD="50.00"
+    export LOA_BUDGET_DRIFT_THRESHOLD="5.0"
+    export LOA_BUDGET_RECONCILE_LOCK="$RECONCILE_LOCK"
+    export LOA_BUDGET_TEST_NOW="2026-05-04T12:00:00.000000Z"
+    export LOA_AUDIT_VERIFY_SIGS=0
+    unset LOA_AUDIT_SIGNING_KEY_ID
+
+    CRON_SCRIPT="${REPO_ROOT}/.claude/scripts/budget/budget-reconcile-cron.sh"
+    INSTALL_SCRIPT="${REPO_ROOT}/.claude/scripts/budget/budget-reconcile-install.sh"
+    chmod +x "$CRON_SCRIPT" "$INSTALL_SCRIPT" 2>/dev/null || true
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+set_observer() {
+    echo "$1" > "$OBSERVER_OUT"
+}
+
+# -----------------------------------------------------------------------------
+# Cron entrypoint behavior
+# -----------------------------------------------------------------------------
+@test "cron entry: aggregate provider, no drift, OK status" {
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    # Pre-load matching counter.
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":5.0,"usd_used_post":5.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    run "$CRON_SCRIPT"
+    [[ "$status" -eq 0 ]]
+    # Reconcile event appended.
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.event_type')" == "budget.reconcile" ]]
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.payload.blocker')" == "false" ]]
+}
+
+@test "cron entry: BLOCKER on drift > threshold; exits 1" {
+    set_observer '{"usd_used": 20.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":30.0,"usd_used_post":30.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    run "$CRON_SCRIPT"
+    [[ "$status" -eq 1 ]]  # blocker
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.payload.blocker')" == "true" ]]
+}
+
+@test "cron entry: defer on observer _defer signal (rate-limited); no event emitted" {
+    set_observer '{"_defer": true, "_reason": "rate_limited"}'
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":5.0,"usd_used_post":5.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    local pre_count
+    pre_count="$(wc -l < "$LOG_FILE")"
+    run "$CRON_SCRIPT"
+    # Cron exits 0 — defer is not a blocker.
+    [[ "$status" -eq 0 ]]
+    # No new envelope appended.
+    [[ "$(wc -l < "$LOG_FILE")" -eq "$pre_count" ]]
+}
+
+@test "cron entry: dry-run prints intent, no audit log writes" {
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    [[ ! -f "$LOG_FILE" || "$(wc -l < "$LOG_FILE")" -eq 0 ]]
+    run "$CRON_SCRIPT" --dry-run
+    [[ "$status" -eq 0 ]]
+    [[ ! -f "$LOG_FILE" ]] || [[ "$(wc -l < "$LOG_FILE")" -eq 0 ]]
+}
+
+@test "cron entry: --provider scopes to single provider" {
+    set_observer '{"usd_used": 0.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run "$CRON_SCRIPT" --provider anthropic
+    [[ "$status" -eq 0 ]]
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.payload.provider')" == "anthropic" ]]
+}
+
+@test "cron entry: --force-reason captures operator audit context" {
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":5.0,"usd_used_post":5.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    run "$CRON_SCRIPT" --force-reason "operator audit 2026-05-04 incident #FOO"
+    [[ "$status" -eq 0 ]]
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.payload.force_reconcile')" == "true" ]]
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.payload.operator_reason')" == "operator audit 2026-05-04 incident #FOO" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Idempotency — repeated cron firings do not duplicate state errors
+# -----------------------------------------------------------------------------
+@test "cron entry: 3 sequential invocations append 3 reconcile events (chain intact)" {
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":5.0,"usd_used_post":5.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    run "$CRON_SCRIPT"; [[ "$status" -eq 0 ]]
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:01:00.000000Z" run "$CRON_SCRIPT"; [[ "$status" -eq 0 ]]
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:02:00.000000Z" run "$CRON_SCRIPT"; [[ "$status" -eq 0 ]]
+
+    # 1 record_call + 3 reconcile = 4 lines.
+    [[ "$(wc -l < "$LOG_FILE")" -eq 4 ]]
+    # Chain still intact.
+    source "${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    run audit_verify_chain "$LOG_FILE"
+    [[ "$status" -eq 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Install helper — show / status / install / uninstall
+# -----------------------------------------------------------------------------
+@test "install helper: 'show' prints the cron line that would be installed" {
+    run "$INSTALL_SCRIPT" show
+    [[ "$status" -eq 0 ]]
+    # Line should contain the cron expression and the marker.
+    [[ "$output" =~ "loa-cycle098-l2-reconcile" ]]
+    [[ "$output" =~ "budget-reconcile-cron.sh" ]]
+}
+
+@test "install helper: respects configured interval_hours" {
+    local config
+    config="${TEST_DIR}/loa.config.yaml"
+    cat > "$config" <<'EOF'
+cost_budget_enforcer:
+  reconciliation:
+    interval_hours: 12
+EOF
+    LOA_BUDGET_CONFIG_FILE="$config" run "$INSTALL_SCRIPT" show
+    [[ "$status" -eq 0 ]]
+    # Cron expression for 12h cadence: "0 */12 * * *"
+    [[ "$output" == *"0 */12 * * *"* ]]
+}
+
+@test "install helper: rejects invalid interval_hours" {
+    local config
+    config="${TEST_DIR}/loa.config.yaml"
+    cat > "$config" <<'EOF'
+cost_budget_enforcer:
+  reconciliation:
+    interval_hours: 99
+EOF
+    LOA_BUDGET_CONFIG_FILE="$config" run "$INSTALL_SCRIPT" show
+    [[ "$status" -ne 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Lock — concurrent invocations serialize via flock
+# -----------------------------------------------------------------------------
+@test "cron entry: concurrent invocations serialize (flock acquired)" {
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":5.0,"usd_used_post":5.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    # Run 3 in parallel, all should complete.
+    "$CRON_SCRIPT" &
+    pid1=$!
+    "$CRON_SCRIPT" &
+    pid2=$!
+    "$CRON_SCRIPT" &
+    pid3=$!
+    wait $pid1 $pid2 $pid3
+    # 3 reconcile events appended (one per invocation, serialized).
+    local reconcile_count
+    reconcile_count="$(grep -c '"event_type":"budget.reconcile"' "$LOG_FILE" || true)"
+    [[ "$reconcile_count" -eq 3 ]]
+    # Chain still intact.
+    source "${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    run audit_verify_chain "$LOG_FILE"
+    [[ "$status" -eq 0 ]]
+}

--- a/tests/unit/cost-budget-enforcer-remediation.bats
+++ b/tests/unit/cost-budget-enforcer-remediation.bats
@@ -1,0 +1,261 @@
+#!/usr/bin/env bats
+# =============================================================================
+# cost-budget-enforcer-remediation.bats — Sprint 2 review/audit remediation
+#
+# Tests the fixes for HIGH-1 (counter_stale mode), HIGH-3/F1 (numeric input
+# validation), F2 (provider regex), F3 (snapshot .sig verification), MED-3
+# (counter_drift reachability), MED-1/MED-2 (schema description + required).
+# =============================================================================
+
+load_lib() {
+    # shellcheck source=/dev/null
+    source "${BATS_TEST_DIRNAME}/../../.claude/scripts/lib/cost-budget-enforcer-lib.sh"
+}
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    TEST_DIR="$(mktemp -d)"
+    LOG_FILE="${TEST_DIR}/cost-budget-events.jsonl"
+    OBSERVER="${TEST_DIR}/observer.sh"
+    OBSERVER_OUT="${TEST_DIR}/observer-out.json"
+
+    cat > "$OBSERVER" <<'EOF'
+#!/usr/bin/env bash
+out_file="${OBSERVER_OUT:-}"
+if [[ -n "$out_file" && -f "$out_file" ]]; then
+    cat "$out_file"
+else
+    echo '{"_unreachable": true}'
+fi
+EOF
+    chmod +x "$OBSERVER"
+
+    export LOA_BUDGET_LOG="$LOG_FILE"
+    export LOA_BUDGET_OBSERVER_CMD="$OBSERVER"
+    export OBSERVER_OUT
+    export LOA_BUDGET_DAILY_CAP_USD="50.00"
+    export LOA_BUDGET_TEST_NOW="2026-05-04T12:00:00.000000Z"
+    export LOA_AUDIT_VERIFY_SIGS=0
+    unset LOA_AUDIT_SIGNING_KEY_ID
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+set_observer() {
+    echo "$1" > "$OBSERVER_OUT"
+}
+
+# -----------------------------------------------------------------------------
+# F2 — provider regex validation
+# -----------------------------------------------------------------------------
+@test "F2: budget_verdict rejects provider containing yq path-injection" {
+    load_lib
+    run budget_verdict 1.00 --provider 'aggregate // "999999"'
+    [[ "$status" -eq 2 ]]
+}
+
+@test "F2: budget_verdict rejects provider with shell metachars" {
+    load_lib
+    run budget_verdict 1.00 --provider '$(rm -rf /)'
+    [[ "$status" -eq 2 ]]
+}
+
+@test "F2: budget_verdict rejects provider with path traversal" {
+    load_lib
+    run budget_verdict 1.00 --provider '../../etc/passwd'
+    [[ "$status" -eq 2 ]]
+}
+
+@test "F2: budget_verdict accepts well-formed provider id" {
+    load_lib
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict 1.00 --provider anthropic
+    [[ "$status" -eq 0 ]]
+    run budget_verdict 1.00 --provider openai
+    [[ "$status" -eq 0 ]]
+    run budget_verdict 1.00 --provider bedrock-us-east-1
+    [[ "$status" -eq 0 ]]
+}
+
+@test "F2: budget_record_call rejects malicious provider" {
+    load_lib
+    run budget_record_call 1.00 --provider 'evil; rm -rf /'
+    [[ "$status" -eq 2 ]]
+}
+
+@test "F2: budget_reconcile rejects malicious provider" {
+    load_lib
+    run budget_reconcile --provider 'foo$(injection)'
+    [[ "$status" -eq 2 ]]
+}
+
+# -----------------------------------------------------------------------------
+# HIGH-3 / F1 — config-derived numeric validation
+# -----------------------------------------------------------------------------
+@test "F1: _l2_get_daily_cap rejects non-numeric cap" {
+    load_lib
+    LOA_BUDGET_DAILY_CAP_USD='50.00); __import__("os").system("touch /tmp/pwned")#' \
+        run _l2_get_daily_cap
+    [[ "$status" -eq 3 ]]
+}
+
+@test "F1: budget_verdict fails closed when cap is malformed" {
+    load_lib
+    LOA_BUDGET_DAILY_CAP_USD='not-a-number' run budget_verdict 1.00
+    [[ "$status" -eq 3 ]]
+}
+
+@test "F1: _l2_get_freshness_seconds falls back to default on malformed value" {
+    load_lib
+    # _l2_validate_numeric logs an ERROR to stderr; we want only stdout.
+    local out
+    out="$(LOA_BUDGET_FRESHNESS_SECONDS='300; touch /tmp/pwn' _l2_get_freshness_seconds 2>/dev/null)"
+    [[ "$out" == "300" ]]  # default
+}
+
+@test "F1: _l2_get_drift_threshold falls back to default on malformed value" {
+    load_lib
+    local out
+    out="$(LOA_BUDGET_DRIFT_THRESHOLD='5.0); evil()' _l2_get_drift_threshold 2>/dev/null)"
+    [[ "$out" == "5.0" ]]  # default
+}
+
+@test "F1: _l2_validate_numeric accepts well-formed decimals" {
+    load_lib
+    run _l2_validate_numeric "50.00" "test_field"
+    [[ "$status" -eq 0 ]]
+    run _l2_validate_numeric "0" "test_field"
+    [[ "$status" -eq 0 ]]
+    run _l2_validate_numeric "1234.567890" "test_field"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "F1: _l2_validate_numeric rejects empty + injection patterns" {
+    load_lib
+    run _l2_validate_numeric "" "test_field"
+    [[ "$status" -eq 1 ]]
+    run _l2_validate_numeric "1.0; rm -rf /" "test_field"
+    [[ "$status" -eq 1 ]]
+    run _l2_validate_numeric '$(echo bad)' "test_field"
+    [[ "$status" -eq 1 ]]
+    run _l2_validate_numeric "1e308" "test_field"
+    [[ "$status" -eq 1 ]]  # scientific notation rejected (not in regex)
+}
+
+# -----------------------------------------------------------------------------
+# HIGH-1 — counter_stale uncertainty mode
+# -----------------------------------------------------------------------------
+@test "HIGH-1: counter_stale fires when no observer + counter has stale entries" {
+    load_lib
+    # Inject record_call from 2 hours ago (stale per 5min freshness threshold).
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":30.0,"usd_used_post":30.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    # No observer configured.
+    unset LOA_BUDGET_OBSERVER_CMD
+    run budget_verdict "1.00"
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "halt-uncertainty" ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.uncertainty_reason')" == "counter_stale" ]]
+}
+
+@test "HIGH-1: counter_stale does NOT fire when counter is fresh + no observer (zero usage today)" {
+    load_lib
+    unset LOA_BUDGET_OBSERVER_CMD
+    # No record_calls today; counter_usd=0, counter_age=0 → fresh-by-zero.
+    run budget_verdict "1.00"
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "allow" ]]
+}
+
+@test "HIGH-1: counter_stale does NOT fire when counter has fresh entry + no observer" {
+    load_lib
+    unset LOA_BUDGET_OBSERVER_CMD
+    LOA_BUDGET_TEST_NOW="2026-05-04T11:58:30.000000Z" budget_record_call 5.00 --provider aggregate >/dev/null
+    # Counter entry from 90s ago, well under 5min freshness.
+    run budget_verdict "1.00"
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "allow" ]]
+}
+
+# -----------------------------------------------------------------------------
+# MED-3 — counter_drift reachability via prior reconcile BLOCKER
+# -----------------------------------------------------------------------------
+@test "MED-3: budget_verdict halts with counter_drift after reconcile BLOCKER" {
+    load_lib
+    # First, make a reconcile that BLOCKERs (drift > threshold).
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":30.0,"usd_used_post":30.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    set_observer '{"usd_used": 20.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_reconcile
+    [[ "$status" -eq 1 ]]  # BLOCKER
+
+    # Now budget_verdict must halt-uncertainty:counter_drift even with fresh data.
+    run budget_verdict "1.00"
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "halt-uncertainty" ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.uncertainty_reason')" == "counter_drift" ]]
+}
+
+@test "MED-3: force-reconcile clears prior counter_drift BLOCKER" {
+    load_lib
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":30.0,"usd_used_post":30.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    # Trigger BLOCKER (exit 1 is expected; capture so set -e doesn't kill the test).
+    # Use clock-aligned billing_ts so clock_drift doesn't mask counter_drift in step 5.
+    set_observer '{"usd_used": 20.00, "billing_ts": "2026-05-04T12:00:00.000000Z"}'
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:00:00.000000Z" budget_reconcile >/dev/null 2>&1 || true
+    # Force-reconcile clears the blocker. Counter is still 30 — this is OK; test
+    # is asserting only that the reconcile-blocker check passes, not threshold.
+    set_observer '{"usd_used": 30.00, "billing_ts": "2026-05-04T12:01:00.000000Z"}'
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:01:00.000000Z" budget_reconcile --force-reason "operator review" >/dev/null 2>&1 || true
+
+    # Now budget_verdict at 12:01:30 with billing_ts at 12:01 (30s old, within tolerance).
+    # Counter is 30; cap is 50; estimate is 1 → projected 31/50 = 62% → allow.
+    set_observer '{"usd_used": 30.00, "billing_ts": "2026-05-04T12:01:00.000000Z"}'
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:01:30.000000Z" run budget_verdict "1.00"
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "allow" ]]
+}
+
+# -----------------------------------------------------------------------------
+# MED-2 — usage_pct now required in warn-90 / halt-100 schemas
+# -----------------------------------------------------------------------------
+@test "MED-2: budget-warn-90.payload.schema.json requires usage_pct" {
+    local schema="${REPO_ROOT}/.claude/data/trajectory-schemas/budget-events/budget-warn-90.payload.schema.json"
+    run jq -r '.required[] | select(. == "usage_pct")' "$schema"
+    [[ "$status" -eq 0 ]]
+    [[ -n "$output" ]]
+}
+
+@test "MED-2: budget-halt-100.payload.schema.json requires usage_pct" {
+    local schema="${REPO_ROOT}/.claude/data/trajectory-schemas/budget-events/budget-halt-100.payload.schema.json"
+    run jq -r '.required[] | select(. == "usage_pct")' "$schema"
+    [[ "$status" -eq 0 ]]
+    [[ -n "$output" ]]
+}
+
+# -----------------------------------------------------------------------------
+# MED-1 — schema description matches projected-usage-pct semantics
+# -----------------------------------------------------------------------------
+@test "MED-1: warn-90 + halt-100 schemas describe usage_pct as projected" {
+    local warn90="${REPO_ROOT}/.claude/data/trajectory-schemas/budget-events/budget-warn-90.payload.schema.json"
+    local halt100="${REPO_ROOT}/.claude/data/trajectory-schemas/budget-events/budget-halt-100.payload.schema.json"
+    run jq -r '.properties.usage_pct.description' "$warn90"
+    [[ "$output" =~ "Projected post-call" ]]
+    run jq -r '.properties.usage_pct.description' "$halt100"
+    [[ "$output" =~ "Projected post-call" ]]
+}
+
+# -----------------------------------------------------------------------------
+# halt-uncertainty schema includes counter_stale
+# -----------------------------------------------------------------------------
+@test "halt-uncertainty schema enum includes counter_stale" {
+    local schema="${REPO_ROOT}/.claude/data/trajectory-schemas/budget-events/budget-halt-uncertainty.payload.schema.json"
+    run jq -r '.properties.uncertainty_reason.enum[] | select(. == "counter_stale")' "$schema"
+    [[ -n "$output" ]]
+}

--- a/tests/unit/cost-budget-enforcer-state-machine.bats
+++ b/tests/unit/cost-budget-enforcer-state-machine.bats
@@ -1,0 +1,502 @@
+#!/usr/bin/env bats
+# =============================================================================
+# cost-budget-enforcer-state-machine.bats — Sprint 2A
+#
+# Covers PRD FR-L2 state-transition table (PRD §FR-L2 + SDD §1.5.3 + IMP-004).
+# Each verdict path tested with controlled clock + mock billing observer.
+# =============================================================================
+
+load_lib() {
+    # shellcheck source=/dev/null
+    source "${BATS_TEST_DIRNAME}/../../.claude/scripts/lib/cost-budget-enforcer-lib.sh"
+}
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    TEST_DIR="$(mktemp -d)"
+    LOG_FILE="${TEST_DIR}/cost-budget-events.jsonl"
+    OBSERVER="${TEST_DIR}/observer.sh"
+    OBSERVER_OUT="${TEST_DIR}/observer-out.json"
+
+    # Default observer emits whatever is in OBSERVER_OUT or unreachable JSON.
+    cat > "$OBSERVER" <<'EOF'
+#!/usr/bin/env bash
+out_file="${OBSERVER_OUT:-}"
+if [[ -n "$out_file" && -f "$out_file" ]]; then
+    cat "$out_file"
+else
+    echo '{"_unreachable": true}'
+fi
+EOF
+    chmod +x "$OBSERVER"
+
+    export LOA_BUDGET_LOG="$LOG_FILE"
+    export LOA_BUDGET_OBSERVER_CMD="$OBSERVER"
+    export OBSERVER_OUT
+    export LOA_BUDGET_DAILY_CAP_USD="50.00"
+    export LOA_BUDGET_DRIFT_THRESHOLD="5.0"
+    export LOA_BUDGET_FRESHNESS_SECONDS="300"
+    export LOA_BUDGET_STALE_HALT_PCT="75"
+    export LOA_BUDGET_CLOCK_TOLERANCE="60"
+    export LOA_BUDGET_LAG_HALT_SECONDS="300"
+
+    # Reproducible "now" for clock-related tests.
+    export LOA_BUDGET_TEST_NOW="2026-05-04T12:00:00.000000Z"
+
+    # No signing in tests (envelope schema permits omitted signature/key_id
+    # since they are optional fields in the schema). The trust_cutoff in
+    # grimoires/loa/trust-store.yaml is 2026-05-03; our test envelopes are
+    # written at real-time (post-cutoff). LOA_AUDIT_VERIFY_SIGS=0 disables
+    # the strict-after signature requirement on chain-only verification.
+    unset LOA_AUDIT_SIGNING_KEY_ID
+    export LOA_AUDIT_VERIFY_SIGS=0
+}
+
+# Helper: numeric equality (handles 0 vs 0.0, 4 vs 4.0, etc.)
+num_eq() {
+    python3 -c "import sys; sys.exit(0 if abs(float('$1') - float('$2')) < 0.001 else 1)"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# Helper: write observer JSON and reset the OUT file path.
+set_observer() {
+    echo "$1" > "$OBSERVER_OUT"
+}
+
+# Helper: Read a verdict from log line N (1-indexed).
+verdict_at_line() {
+    sed -n "${1}p" "$LOG_FILE" | jq -r '.payload.verdict'
+}
+
+# -----------------------------------------------------------------------------
+# Verdict: allow
+# -----------------------------------------------------------------------------
+@test "FR-L2-1: allow when usage <90% AND data fresh (billing API)" {
+    load_lib
+    set_observer '{"usd_used": 10.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "5.00"
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "allow" ]]
+}
+
+@test "FR-L2-1: allow when no usage and no observer (counter=0 fresh by zero)" {
+    load_lib
+    # No observer configured; counter is 0; allow is correct.
+    unset LOA_BUDGET_OBSERVER_CMD
+    run budget_verdict "5.00"
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "allow" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Verdict: warn-90
+# -----------------------------------------------------------------------------
+@test "FR-L2-2: warn-90 when projected usage in [90, 100)%" {
+    load_lib
+    # cap=50, used=44 -> 88%. Estimate +1.50 -> 91% projected. warn-90.
+    set_observer '{"usd_used": 44.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "1.50"
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "warn-90" ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.usage_pct')" =~ ^9[0-9] ]]
+}
+
+# -----------------------------------------------------------------------------
+# Verdict: halt-100
+# -----------------------------------------------------------------------------
+@test "FR-L2-3: halt-100 when projected usage >=100%" {
+    load_lib
+    # cap=50, used=49 + estimate=1.5 -> 101%. halt-100.
+    set_observer '{"usd_used": 49.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "1.50"
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "halt-100" ]]
+}
+
+@test "FR-L2-3: halt-100 exactly at usage=100% (boundary)" {
+    load_lib
+    # cap=50, used=49.50 + estimate=0.50 -> exactly 100%. halt-100.
+    set_observer '{"usd_used": 49.50, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "0.50"
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "halt-100" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Verdict: halt-uncertainty:billing_stale
+# -----------------------------------------------------------------------------
+@test "FR-L2-4: halt-uncertainty:billing_stale when billing >5min stale AND counter near cap" {
+    load_lib
+    # Billing API stale (>5min ago) + counter via record_call shows >75%.
+    # Pre-load counter to 40 (80% of 50).
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:00:00.000000Z" budget_record_call 40.00 --provider aggregate >/dev/null
+    # Now billing observer reports an old timestamp (>5min stale).
+    set_observer '{"usd_used": 40.00, "billing_ts": "2026-05-04T11:30:00.000000Z"}'
+    run budget_verdict "1.00"
+    [[ "$status" -eq 1 ]]
+    local out
+    out="$(echo "$output" | tail -1)"
+    [[ "$(echo "$out" | jq -r '.verdict')" == "halt-uncertainty" ]]
+    [[ "$(echo "$out" | jq -r '.uncertainty_reason')" == "billing_stale" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Verdict: halt-uncertainty:counter_inconsistent
+# -----------------------------------------------------------------------------
+@test "FR-L2-6: halt-uncertainty:counter_inconsistent when counter has negative value" {
+    load_lib
+    # Manually inject a record_call with negative actual_usd via direct log write
+    # Actually cleanest: write a malformed envelope into the log directly.
+    mkdir -p "$(dirname "$LOG_FILE")"
+    # We can't easily write a negative actual_usd through the public API
+    # because it validates non-negative. So write the envelope directly to
+    # simulate a forensic break (this is the "negative value detected" case).
+    cat >> "$LOG_FILE" <<EOF
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":-5.0,"usd_used_post":0.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    set_observer '{"usd_used": 0.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "1.00"
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.uncertainty_reason')" == "counter_inconsistent" ]]
+}
+
+@test "FR-L2-6: counter_inconsistent when usd_used_post decreases between entries" {
+    load_lib
+    # Write two record_call envelopes — second has lower usd_used_post (decreasing).
+    mkdir -p "$(dirname "$LOG_FILE")"
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":10.0,"usd_used_post":10.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:30:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":2.0,"usd_used_post":5.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    run budget_verdict "1.00"
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.uncertainty_reason')" == "counter_inconsistent" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Verdict: halt-uncertainty:clock_drift
+# -----------------------------------------------------------------------------
+@test "halt-uncertainty:clock_drift when system clock vs billing_ts > tolerance" {
+    load_lib
+    # System now=12:00:00, billing_ts at 11:58:00 -> 120s delta > 60s tolerance.
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:58:00.000000Z"}'
+    run budget_verdict "1.00"
+    [[ "$status" -eq 1 ]]
+    local out
+    out="$(echo "$output" | tail -1)"
+    [[ "$(echo "$out" | jq -r '.verdict')" == "halt-uncertainty" ]]
+    [[ "$(echo "$out" | jq -r '.uncertainty_reason')" == "clock_drift" ]]
+}
+
+@test "no clock_drift when system clock is exactly aligned" {
+    load_lib
+    # billing_ts == LOA_BUDGET_TEST_NOW exactly -> delta=0, no drift.
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T12:00:00.000000Z"}'
+    run budget_verdict "1.00"
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "allow" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Verdict: halt-uncertainty:provider_lag (>=5min lag with counter >75%)
+# -----------------------------------------------------------------------------
+@test "halt-uncertainty:provider_lag when billing_age >= 5min AND counter >75%" {
+    load_lib
+    # Pre-load counter to 40 (80% of 50).
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:00:00.000000Z" budget_record_call 40.00 --provider aggregate >/dev/null
+    # Billing API stale at 5min30s — both billing_stale and provider_lag triggers fire,
+    # but billing_stale check runs first so we pin lag with a smaller billing_age.
+    # Instead, test provider_lag specifically: billing_age slightly above 300s but counter pct >75.
+    # Both trigger billing_stale first. To test provider_lag uniquely, set freshness very high
+    # so billing_stale doesn't fire (>15min), but lag_halt remains 5min.
+    LOA_BUDGET_FRESHNESS_SECONDS=900 set_observer '{"usd_used": 40.00, "billing_ts": "2026-05-04T11:54:00.000000Z"}'
+    LOA_BUDGET_FRESHNESS_SECONDS=900 run budget_verdict "1.00"
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.uncertainty_reason')" == "provider_lag" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Per-provider counter & sub-cap
+# -----------------------------------------------------------------------------
+@test "FR-L2-8: per-provider sub-cap overrides aggregate cap" {
+    load_lib
+    # Use config file with per_provider_caps.openai = 5.00.
+    local config
+    config="${TEST_DIR}/loa.config.yaml"
+    cat > "$config" <<'EOF'
+cost_budget_enforcer:
+  daily_cap_usd: 50.00
+  per_provider_caps:
+    openai: 5.00
+EOF
+    LOA_BUDGET_CONFIG_FILE="$config"
+    unset LOA_BUDGET_DAILY_CAP_USD
+    set_observer '{"usd_used": 4.50, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    LOA_BUDGET_CONFIG_FILE="$config" run budget_verdict "0.30" --provider openai
+    [[ "$status" -eq 0 ]]
+    # 4.50 + 0.30 = 4.80, 96% of 5.00 sub-cap → warn-90.
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "warn-90" ]]
+}
+
+@test "per-provider counter isolation: openai counter does not affect anthropic counter" {
+    load_lib
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:00:00.000000Z" budget_record_call 30.00 --provider openai >/dev/null
+    set_observer '{"usd_used": 0.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "1.00" --provider anthropic
+    [[ "$status" -eq 0 ]]
+    local payload
+    payload="$(echo "$output" | tail -1)"
+    [[ "$(echo "$payload" | jq -r '.verdict')" == "allow" ]]
+    num_eq "$(echo "$payload" | jq -r '.usd_used')" 0
+}
+
+# -----------------------------------------------------------------------------
+# Tail-scan day filtering — cross-day entries excluded
+# -----------------------------------------------------------------------------
+@test "tail-scan filters by UTC day: yesterday's record_call ignored today" {
+    load_lib
+    # Inject a yesterday-dated record_call directly (the log spans days).
+    mkdir -p "$(dirname "$LOG_FILE")"
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-03T23:50:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":40.0,"usd_used_post":40.0,"provider":"aggregate","utc_day":"2026-05-03","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    # Today's view: counter=0, allow expected.
+    set_observer '{"usd_used": 0.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "1.00"
+    [[ "$status" -eq 0 ]]
+    local payload
+    payload="$(echo "$output" | tail -1)"
+    [[ "$(echo "$payload" | jq -r '.verdict')" == "allow" ]]
+    num_eq "$(echo "$payload" | jq -r '.usd_used')" 0
+}
+
+# -----------------------------------------------------------------------------
+# Fail-closed semantics — never allow under doubt
+# -----------------------------------------------------------------------------
+@test "FR-L2-7: fail-closed under all 5 uncertainty modes returns halt-uncertainty" {
+    load_lib
+    # Mode 1: counter_inconsistent (negative)
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":-1.0,"usd_used_post":0.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "1.00"
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "halt-uncertainty" ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.uncertainty_reason')" == "counter_inconsistent" ]]
+}
+
+# -----------------------------------------------------------------------------
+# FR-L2-9: All verdicts logged to .run/cost-budget-events.jsonl
+# -----------------------------------------------------------------------------
+@test "FR-L2-9: every verdict appends one envelope to audit log" {
+    load_lib
+    set_observer '{"usd_used": 10.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "5.00"
+    [[ "$status" -eq 0 ]]
+    [[ -f "$LOG_FILE" ]]
+    local line_count
+    line_count="$(wc -l < "$LOG_FILE")"
+    [[ "$line_count" -eq 1 ]]
+    local envelope
+    envelope="$(head -1 "$LOG_FILE")"
+    [[ "$(echo "$envelope" | jq -r '.primitive_id')" == "L2" ]]
+    [[ "$(echo "$envelope" | jq -r '.event_type')" == "budget.allow" ]]
+    [[ "$(echo "$envelope" | jq -r '.payload.verdict')" == "allow" ]]
+}
+
+# -----------------------------------------------------------------------------
+# budget_record_call — counter accumulation
+# -----------------------------------------------------------------------------
+@test "budget_record_call accumulates usd_used_post correctly" {
+    load_lib
+    run budget_record_call "1.50" --provider anthropic
+    [[ "$status" -eq 0 ]]
+    run budget_record_call "2.50" --provider anthropic
+    [[ "$status" -eq 0 ]]
+    # Counter for anthropic should be 4.00.
+    local counter
+    counter="$(_l2_compute_counter anthropic 2026-05-04 | jq -r '.counter_usd')"
+    num_eq "$counter" 4
+    # Last entry's usd_used_post should be 4.0.
+    num_eq "$(tail -1 "$LOG_FILE" | jq -r '.payload.usd_used_post')" 4
+}
+
+@test "budget_record_call rejects negative actual_usd" {
+    load_lib
+    run budget_record_call "-1.00" --provider anthropic
+    [[ "$status" -eq 2 ]]
+}
+
+@test "budget_record_call rejects non-numeric actual_usd" {
+    load_lib
+    run budget_record_call "abc" --provider anthropic
+    [[ "$status" -eq 2 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Reconcile (Sprint 2A's reconcile-as-function — Sprint 2B wires the cron)
+# -----------------------------------------------------------------------------
+@test "FR-L2-5: budget_reconcile emits BLOCKER when drift > threshold" {
+    load_lib
+    # Counter has 30 (via direct injection). Billing reports 20. drift = 33%.
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":30.0,"usd_used_post":30.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    set_observer '{"usd_used": 20.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_reconcile
+    [[ "$status" -eq 1 ]]  # blocker
+    local last_line
+    last_line="$(tail -1 "$LOG_FILE")"
+    [[ "$(echo "$last_line" | jq -r '.event_type')" == "budget.reconcile" ]]
+    [[ "$(echo "$last_line" | jq -r '.payload.blocker')" == "true" ]]
+    local drift
+    drift="$(echo "$last_line" | jq -r '.payload.drift_pct')"
+    # drift = (30-20)/30 * 100 = 33.33...
+    [[ "${drift%%.*}" -ge 30 ]]
+}
+
+@test "budget_reconcile no blocker when drift below threshold" {
+    load_lib
+    # Counter 10, billing 9.80. drift = 2%.
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":10.0,"usd_used_post":10.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    set_observer '{"usd_used": 9.80, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_reconcile
+    [[ "$status" -eq 0 ]]
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.payload.blocker')" == "false" ]]
+}
+
+@test "budget_reconcile force-reconcile records operator_reason" {
+    load_lib
+    # Pre-load counter to 5.00 so drift = 0 (no blocker), then force-reconcile.
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":5.0,"usd_used_post":5.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    set_observer '{"usd_used": 5.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_reconcile --force-reason "operator drift review 2026-05-04"
+    [[ "$status" -eq 0 ]]
+    local last_line
+    last_line="$(tail -1 "$LOG_FILE")"
+    [[ "$(echo "$last_line" | jq -r '.payload.force_reconcile')" == "true" ]]
+    [[ "$(echo "$last_line" | jq -r '.payload.operator_reason')" == "operator drift review 2026-05-04" ]]
+}
+
+@test "budget_reconcile billing API unreachable + counter near cap = blocker" {
+    load_lib
+    # Counter 40 (80% of 50). Observer fails (no OUT file).
+    rm -f "$OBSERVER_OUT"
+    cat >> "$LOG_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L2","event_type":"budget.record_call","ts_utc":"2026-05-04T10:00:00.000000Z","prev_hash":"GENESIS","payload":{"actual_usd":40.0,"usd_used_post":40.0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"model_id":null,"verdict_ref":null},"redaction_applied":null}
+EOF
+    run budget_reconcile
+    [[ "$status" -eq 1 ]]
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.payload.billing_api_unreachable')" == "true" ]]
+    [[ "$(tail -1 "$LOG_FILE" | jq -r '.payload.blocker')" == "true" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Schema validation — per-event-type
+# -----------------------------------------------------------------------------
+@test "_l2_validate_payload accepts valid budget.allow payload" {
+    load_lib
+    local payload
+    payload='{"verdict":"allow","usd_used":5.0,"usd_remaining":45.0,"daily_cap_usd":50.0,"estimated_usd_for_call":1.0,"billing_api_age_seconds":60,"counter_age_seconds":0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"billing_observer_used":true}'
+    run _l2_validate_payload "budget.allow" "$payload"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "_l2_validate_payload rejects budget.allow payload with wrong verdict" {
+    load_lib
+    # If jsonschema is not installed, this test is permissive (skip).
+    if ! python3 -c "import jsonschema" 2>/dev/null; then
+        skip "jsonschema not installed; per-event-type validation is permissive"
+    fi
+    local payload
+    payload='{"verdict":"halt-100","usd_used":5.0,"usd_remaining":45.0,"daily_cap_usd":50.0,"estimated_usd_for_call":1.0,"billing_api_age_seconds":60,"counter_age_seconds":0,"provider":"aggregate","utc_day":"2026-05-04","cycle_id":null,"billing_observer_used":true}'
+    run _l2_validate_payload "budget.allow" "$payload"
+    [[ "$status" -eq 1 ]]
+}
+
+# -----------------------------------------------------------------------------
+# UTC day rollover — halt-100 in current day, allow in next day
+# -----------------------------------------------------------------------------
+@test "UTC day rollover: halt-100 today does not block tomorrow" {
+    load_lib
+    # Today=05-04, used=49 + estimate=2 = 51 = halt-100.
+    set_observer '{"usd_used": 49.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "2.00"
+    [[ "$status" -eq 1 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "halt-100" ]]
+
+    # Roll forward 1 day. Counter for new day = 0; billing observer reports 0.
+    LOA_BUDGET_TEST_NOW="2026-05-05T00:01:00.000000Z" set_observer '{"usd_used": 0.00, "billing_ts": "2026-05-05T00:00:30.000000Z"}'
+    LOA_BUDGET_TEST_NOW="2026-05-05T00:01:00.000000Z" run budget_verdict "5.00"
+    [[ "$status" -eq 0 ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.verdict')" == "allow" ]]
+    [[ "$(echo "$output" | tail -1 | jq -r '.utc_day')" == "2026-05-05" ]]
+}
+
+# -----------------------------------------------------------------------------
+# CC-2 + CC-11: envelope chain integrity (prev_hash chains across budget events)
+# -----------------------------------------------------------------------------
+@test "envelope chain: prev_hash links L2 events into a chain" {
+    load_lib
+    set_observer '{"usd_used": 0.00, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_verdict "1.00"
+    [[ "$status" -eq 0 ]]
+    run budget_record_call "0.95" --provider aggregate
+    [[ "$status" -eq 0 ]]
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:01:00.000000Z" set_observer '{"usd_used": 0.95, "billing_ts": "2026-05-04T12:00:30.000000Z"}'
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:01:00.000000Z" run budget_verdict "1.00"
+    [[ "$status" -eq 0 ]]
+
+    # Verify chain via audit_verify_chain.
+    run audit_verify_chain "$LOG_FILE"
+    [[ "$status" -eq 0 ]]
+    # 3 entries in the log.
+    [[ "$(wc -l < "$LOG_FILE")" -eq 3 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Argument validation
+# -----------------------------------------------------------------------------
+@test "budget_verdict rejects missing estimated_usd" {
+    load_lib
+    run budget_verdict
+    [[ "$status" -eq 2 ]]
+}
+
+@test "budget_verdict rejects negative estimated_usd" {
+    load_lib
+    run budget_verdict "-1.00"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "budget_verdict requires daily_cap_usd configuration" {
+    load_lib
+    unset LOA_BUDGET_DAILY_CAP_USD
+    LOA_BUDGET_CONFIG_FILE=/nonexistent run budget_verdict "1.00"
+    [[ "$status" -eq 3 ]]
+}
+
+# -----------------------------------------------------------------------------
+# budget_get_usage — read-only query
+# -----------------------------------------------------------------------------
+@test "budget_get_usage returns current state without emitting verdict" {
+    load_lib
+    LOA_BUDGET_TEST_NOW="2026-05-04T12:00:00.000000Z" budget_record_call 7.50 --provider aggregate >/dev/null
+    local prior_lines
+    prior_lines="$(wc -l < "$LOG_FILE")"
+    set_observer '{"usd_used": 7.50, "billing_ts": "2026-05-04T11:59:00.000000Z"}'
+    run budget_get_usage
+    [[ "$status" -eq 0 ]]
+    num_eq "$(echo "$output" | jq -r '.usd_used')" 7.5
+    num_eq "$(echo "$output" | jq -r '.usd_remaining')" 42.5
+    # No new envelope was written.
+    [[ "$(wc -l < "$LOG_FILE")" -eq "$prior_lines" ]]
+}

--- a/tests/unit/cost-budget-enforcer-state-machine.bats
+++ b/tests/unit/cost-budget-enforcer-state-machine.bats
@@ -48,6 +48,14 @@ EOF
     # grimoires/loa/trust-store.yaml is 2026-05-03; our test envelopes are
     # written at real-time (post-cutoff). LOA_AUDIT_VERIFY_SIGS=0 disables
     # the strict-after signature requirement on chain-only verification.
+    #
+    # NOTE (bridgebuilder iter-1 F-001): the global verify-sigs disable here
+    # creates a regression-blind-spot for the signed-mode happy path. Adding
+    # strict-mode integration tests requires test signing-key fixtures
+    # (out of Sprint 2 scope; tracked as a follow-up issue). The
+    # production deployment path uses LOA_AUDIT_SIGNING_KEY_ID + verify_sigs=1
+    # by default; tests intentionally bypass to keep envelope construction
+    # deterministic without key-management infrastructure.
     unset LOA_AUDIT_SIGNING_KEY_ID
     export LOA_AUDIT_VERIFY_SIGS=0
 }


### PR DESCRIPTION
## Sprint 2 — L2 cost-budget-enforcer + reconciliation cron + daily snapshot

Closes (per cycle-098 plan): #654

Implements the L2 daily-cap enforcer with **fail-closed semantics under all
uncertainty modes**, the un-deferred reconciliation cron (per SKP-005 CRITICAL,
promoted from FU-2), and the daily snapshot job for L1/L2 hash-chain recovery
(RPO 24h per SDD §3.4.4 ↔ §3.7 reconciliation).

### Sub-sprint commits

| Commit | Sub-sprint | Tests added | Cumulative |
|--------|-----------|-------------|------------|
| `94e2b23` | 2A — L2 verdict-engine foundation | 31 | 31 / 31 |
| `7b20038` | 2B — Reconciliation cron + installer | 11 | 42 / 42 |
| `d74ee61` | 2C — Daily snapshot job + runbook | 13 | 55 / 55 |
| `bde8088` | 2D — Skill + CLI + lore + config | 12 | **67 / 67** |

Sprint 1 regression: 39 / 39 PASS (envelope + chain + panel + tier-validator).

### Verdict state machine (PRD §FR-L2 + SDD §1.5.3 + IMP-004)

| Verdict | Trigger | Caller behavior |
|---------|---------|-----------------|
| `allow` | usage <90% AND data fresh | proceed |
| `warn-90` | 90% ≤ projected <100% AND data fresh | proceed but operator alerted |
| `halt-100` | projected ≥100% AND data fresh | **MUST NOT** proceed |
| `halt-uncertainty` | one of 5 uncertainty modes | **MUST NOT** proceed (fail-closed) |

The 5 uncertainty modes (`uncertainty_reason` field):
- `billing_stale` — billing API >15min unreachable AND counter >75% of cap
- `counter_inconsistent` — counter is negative, decreasing, or backwards
- `counter_drift` — reconciliation detected drift >5% from billing API
- `clock_drift` — system clock vs billing_ts diff >60s tolerance
- `provider_lag` — billing API lag ≥5min when counter shows >75% of cap

Verdict-trigger order is **severity-first** so the most-severe applicable
verdict wins:
`counter_inconsistent → billing_stale → provider_lag → clock_drift → halt-100 → warn-90 → allow`

### Key safety guarantees

- **Fail-closed** under all 5 uncertainty modes (PRD §FR-L2-7) — never `allow` under doubt
- **Hash-chained**: every envelope's `prev_hash` chains to prior entry (Sprint 1A)
- **Ed25519-signed** when `LOA_AUDIT_SIGNING_KEY_ID` is configured (Sprint 1B);
  trust-store strict-after enforcement (F1) rejects strip-attack downgrade
- **Recoverable**: chain-critical L2 log is UNTRACKED for privacy; daily
  snapshot job (Sprint 2C) ships RPO 24h restore via `audit_recover_chain`
- **flock-serialized**: concurrent verdicts and cron firings serialize via
  per-log flock (CC-3)

### What ships

#### L2 library + CLI (Sprint 2A + 2D)
- `.claude/scripts/lib/cost-budget-enforcer-lib.sh` — main lib (~720 lines)
- `.claude/scripts/budget/budget-cli.sh` — CLI wrapper:
  `verdict / usage / record / reconcile` subcommands
- `.claude/skills/cost-budget-enforcer/SKILL.md` — skill manifest
- 6 per-event-type schemas at `.claude/data/trajectory-schemas/budget-events/`
  (allow, warn-90, halt-100, halt-uncertainty, reconcile, record-call)

#### Reconciliation cron (Sprint 2B)
- `.claude/scripts/budget/budget-reconcile-cron.sh` — flock-serialized cron entrypoint
- `.claude/scripts/budget/budget-reconcile-install.sh` — idempotent crontab installer
- Default 6h cadence; configurable via `cost_budget_enforcer.reconciliation.interval_hours`
- BLOCKER on drift >5%; `_defer` semantics for billing API rate limits
- Counter NOT auto-corrected — operator force-reconcile required

#### Daily snapshot job (Sprint 2C)
- `.claude/scripts/audit/audit-snapshot.sh` — daily snapshot writer
- `.claude/scripts/audit/audit-snapshot-install.sh` — idempotent crontab installer
- Reads `.claude/data/audit-retention-policy.yaml`; filters to chain_critical=true AND git_tracked=false
- Writes `grimoires/loa/audit-archive/<utc-date>-<primitive>.jsonl.gz`
- Optional Ed25519 `.sig` sidecar when signing key is configured
- `grimoires/loa/runbooks/audit-log-recovery.md` — operator runbook (4 recovery scenarios)

#### Lore + docs (Sprint 2D)
- `grimoires/loa/lore/patterns.yaml` — new `fail-closed-cost-gate` entry
- `.loa.config.yaml.example` — `cost_budget_enforcer.*` + `audit_snapshot.*` blocks documented
- `agent-network-envelope.schema.json` — `budget.record_call` added to examples

### Compose-when-available

- L1 FR-L1-9: cost estimation hook ready (Sprint 1 placeholder consumes Sprint 2's `budget_verdict`)
- L3 FR-L3-6: budget pre-check hook ready (Sprint 3 will wire)
- Protected-class router: `budget.cap_increase` already registered

### Test plan

- [x] 67 / 67 BATS tests PASS (state machine, schemas, cron, snapshot, CLI)
- [x] Sprint 1 regression: 39 / 39 PASS
- [x] `validate-skill-capabilities.sh` — `cost-budget-enforcer` PASS
- [x] CLI smoke tests (verdict / usage / record / reconcile end-to-end)
- [x] Concurrent cron firings serialize via flock (3 parallel → 3 events, chain intact)
- [x] End-to-end recovery: snapshot → corrupt log → audit_recover_chain → markers present
- [x] Per-event-type schema validation (ajv → Python jsonschema fallback per R15)
- [x] Per-provider counter isolation (openai vs anthropic vs aggregate)
- [x] UTC day rollover (halt-100 today does not block tomorrow)

### References

- PRD: `grimoires/loa/prd.md` §FR-L2 (10 ACs), §3.4.4, §3.7
- SDD: `grimoires/loa/sdd.md` §1.4.2, §1.5.3, §5.4, §3.4.4, §3.7
- Sprint plan: `grimoires/loa/sprint.md` §"Sprint 2"
- Progress docs: `grimoires/loa/a2a/sprint-2/progress-2{A,B,C,D}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)