### PR TITLE
test(cycle-098-h1): signed-mode harness for L1 + L2 + L3 (closes #706 + #713)

### DIFF
--- a/tests/integration/cost-budget-enforcer-signed-mode.bats
+++ b/tests/integration/cost-budget-enforcer-signed-mode.bats
@@ -91,7 +91,11 @@ teardown() {
     run jq -sr '.[] | select(.event_type == "budget.allow") | .signature' "$BUDGET_LOG"
     [ -n "$output" ]
     [ "$output" != "null" ]
-    [[ "$output" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]
+    # Ed25519 base64 signatures are 88 chars (64 raw bytes). Tightened from
+    # `^[A-Za-z0-9+/]+={0,2}$` (review iter-1 H1-base64-regex-allows-empty)
+    # to catch silent truncation regressions.
+    [[ "$output" =~ ^[A-Za-z0-9+/]{86,88}={0,2}$ ]]
+    [ "${#output}" -eq 88 ]
     run jq -sr '.[] | select(.event_type == "budget.allow") | .signing_key_id' "$BUDGET_LOG"
     [ "$output" = "test-budget-writer" ]
 }
@@ -162,6 +166,27 @@ teardown() {
     } > "$tmp"
     run audit_verify_chain "$tmp"
     [ "$status" -ne 0 ]
+}
+
+@test "L2 signed-mode: budget_reconcile drift-BLOCKER ALSO emits a SIGNED envelope (covers drift code path)" {
+    # Sprint H1 review MEDIUM (H1-drift-threshold-magic-value): the other
+    # tests set DRIFT_THRESHOLD=999999 to suppress the BLOCKER. That means
+    # the drift code path gets ZERO signed-mode coverage. This test inverts:
+    # restore the default-ish 5% threshold, force a drift, and assert that
+    # whatever envelope budget_reconcile emits IS signed. Catches a regression
+    # where an early-return on drift-BLOCKER bypasses the signing path.
+    LOA_BUDGET_DRIFT_THRESHOLD="5" budget_record_call "1.00" --provider "anthropic"
+    # Aggregate observer reports usd_used=5 → vs counter=1 for anthropic =
+    # 80% drift > 5% threshold = BLOCKER fires.
+    LOA_BUDGET_DRIFT_THRESHOLD="5" budget_reconcile --provider "anthropic" || true
+    # Whatever budget.reconcile envelope was written, it MUST carry a sig.
+    run jq -sr '.[] | select(.event_type == "budget.reconcile") | .signature' "$BUDGET_LOG"
+    [ -n "$output" ]
+    [ "$output" != "null" ]
+    [ "${#output}" -eq 88 ]
+    # The envelope payload must reflect the BLOCKER state.
+    run jq -sr '.[] | select(.event_type == "budget.reconcile") | .payload.blocker' "$BUDGET_LOG"
+    [ "$output" = "true" ]
 }
 
 @test "L2 signed-mode: payload tamper detected by SIGNATURE (chain-repaired test isolates the gate)" {

--- a/tests/integration/cost-budget-enforcer-signed-mode.bats
+++ b/tests/integration/cost-budget-enforcer-signed-mode.bats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/cost-budget-enforcer-signed-mode.bats
+#
+# cycle-098 Sprint H1 (closes #706). End-to-end happy path for L2 with
+# Ed25519 signing enabled. The Sprint 2 unit + state-machine test suites all
+# run with LOA_AUDIT_VERIFY_SIGS=0 for envelope-construction determinism;
+# this file exercises the signed code path so a regression that drops
+# LOA_AUDIT_SIGNING_KEY_ID propagation through the L2 lib ships red.
+#
+# Coverage:
+#   - budget_verdict writes a SIGNED envelope (signature + signing_key_id)
+#   - budget_record_call writes a SIGNED envelope
+#   - budget_reconcile writes a SIGNED envelope
+#   - audit_verify_chain validates the full multi-event chain
+#   - Tampering one entry's signature → audit_verify_chain fails
+# =============================================================================
+
+load_fixtures() {
+    # shellcheck source=../lib/signing-fixtures.sh
+    source "${BATS_TEST_DIRNAME}/../lib/signing-fixtures.sh"
+}
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    L2_LIB="${REPO_ROOT}/.claude/scripts/lib/cost-budget-enforcer-lib.sh"
+    AUDIT_ENVELOPE="${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    [[ -f "$L2_LIB" ]] || skip "cost-budget-enforcer-lib.sh not present"
+    [[ -f "$AUDIT_ENVELOPE" ]] || skip "audit-envelope.sh not present"
+
+    load_fixtures
+    signing_fixtures_setup --strict --key-id "test-budget-writer"
+
+    BUDGET_LOG="${TEST_DIR}/cost-budget-events.jsonl"
+    OBSERVER="${TEST_DIR}/observer.sh"
+    OBSERVER_OUT="${TEST_DIR}/observer-out.json"
+
+    cat > "$OBSERVER" <<'EOF'
+#!/usr/bin/env bash
+out="${OBSERVER_OUT:-}"
+[[ -n "$out" && -f "$out" ]] && cat "$out" || echo '{"_unreachable":true}'
+EOF
+    chmod +x "$OBSERVER"
+    echo '{"usd_used": 5.00, "billing_ts": "2026-05-04T15:00:00.000000Z"}' > "$OBSERVER_OUT"
+
+    export LOA_BUDGET_LOG="$BUDGET_LOG"
+    export LOA_BUDGET_OBSERVER_CMD="$OBSERVER"
+    export OBSERVER_OUT
+    export LOA_BUDGET_DAILY_CAP_USD="50.00"
+    export LOA_BUDGET_FRESHNESS_SECONDS="300"
+    export LOA_BUDGET_STALE_HALT_PCT="75"
+    export LOA_BUDGET_CLOCK_TOLERANCE="60"
+    export LOA_BUDGET_LAG_HALT_SECONDS="300"
+    # Disable drift BLOCKER for these tests — they're about the signed-mode
+    # write path, not the reconciliation state machine. The drift-detection
+    # behavior is exhaustively covered by tests/unit/cost-budget-enforcer-*
+    # in unsigned mode; we only need reconcile to emit one signed envelope.
+    export LOA_BUDGET_DRIFT_THRESHOLD="1000"
+    export LOA_BUDGET_TEST_NOW="2026-05-04T15:00:00.000000Z"
+
+    # shellcheck source=/dev/null
+    source "$AUDIT_ENVELOPE"
+    # shellcheck source=/dev/null
+    source "$L2_LIB"
+}
+
+teardown() {
+    if declare -f signing_fixtures_teardown >/dev/null 2>&1; then
+        signing_fixtures_teardown
+    fi
+    unset LOA_BUDGET_LOG LOA_BUDGET_OBSERVER_CMD LOA_BUDGET_DAILY_CAP_USD \
+          LOA_BUDGET_FRESHNESS_SECONDS LOA_BUDGET_STALE_HALT_PCT \
+          LOA_BUDGET_CLOCK_TOLERANCE LOA_BUDGET_LAG_HALT_SECONDS \
+          LOA_BUDGET_TEST_NOW OBSERVER_OUT
+}
+
+# -----------------------------------------------------------------------------
+# Sign-on-emit
+# -----------------------------------------------------------------------------
+
+@test "L2 signed-mode: budget_verdict emits SIGNED envelope" {
+    run budget_verdict "1.50"
+    [ "$status" -eq 0 ]
+    [ -f "$BUDGET_LOG" ]
+    run jq -sr '.[] | select(.event_type == "budget.allow") | .signature' "$BUDGET_LOG"
+    [ -n "$output" ]
+    [ "$output" != "null" ]
+    [[ "$output" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]
+    run jq -sr '.[] | select(.event_type == "budget.allow") | .signing_key_id' "$BUDGET_LOG"
+    [ "$output" = "test-budget-writer" ]
+}
+
+@test "L2 signed-mode: budget_record_call emits SIGNED envelope" {
+    run budget_record_call "0.75" --provider "anthropic"
+    [ "$status" -eq 0 ]
+    run jq -sr '.[] | select(.event_type == "budget.record_call") | .signature' "$BUDGET_LOG"
+    [ -n "$output" ]
+    [ "$output" != "null" ]
+    run jq -sr '.[] | select(.event_type == "budget.record_call") | .signing_key_id' "$BUDGET_LOG"
+    [ "$output" = "test-budget-writer" ]
+}
+
+@test "L2 signed-mode: budget_reconcile emits SIGNED envelope" {
+    # Need at least one record_call so reconcile has counter state.
+    budget_record_call "5.00" --provider "anthropic"
+    run budget_reconcile --provider "anthropic"
+    [ "$status" -eq 0 ]
+    run jq -sr '.[] | select(.event_type == "budget.reconcile") | .signature' "$BUDGET_LOG"
+    [ -n "$output" ]
+    [ "$output" != "null" ]
+    run jq -sr '.[] | select(.event_type == "budget.reconcile") | .signing_key_id' "$BUDGET_LOG"
+    [ "$output" = "test-budget-writer" ]
+}
+
+# -----------------------------------------------------------------------------
+# Multi-event chain validates
+# -----------------------------------------------------------------------------
+
+@test "L2 signed-mode: audit_verify_chain validates verdict + record_call + reconcile chain" {
+    budget_verdict "2.50"
+    budget_record_call "2.50" --provider "anthropic"
+    budget_verdict "1.00"
+    budget_record_call "1.00" --provider "openai"
+    budget_reconcile --provider "anthropic"
+    run audit_verify_chain "$BUDGET_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "L2 signed-mode: every L2 entry on chain carries signature + signing_key_id" {
+    budget_verdict "1.00"
+    budget_record_call "1.00"
+    budget_reconcile
+    local n_total n_signed
+    n_total="$(jq -sr '[.[] | select(.primitive_id == "L2")] | length' "$BUDGET_LOG")"
+    n_signed="$(jq -sr '[.[] | select(.primitive_id == "L2") | select(.signature != null and .signing_key_id != null)] | length' "$BUDGET_LOG")"
+    [ "$n_total" -eq "$n_signed" ]
+    [ "$n_signed" -ge 3 ]
+}
+
+# -----------------------------------------------------------------------------
+# Tamper detection
+# -----------------------------------------------------------------------------
+
+@test "L2 signed-mode: stripping signature from one entry → chain verification FAILS" {
+    budget_verdict "1.00"
+    budget_record_call "1.00"
+    budget_verdict "0.50"
+    # Strip signature from line 2 only.
+    local stripped tmp
+    tmp="${TEST_DIR}/tampered.jsonl"
+    {
+        sed -n '1p' "$BUDGET_LOG"
+        sed -n '2p' "$BUDGET_LOG" | jq -c 'del(.signature)'
+        sed -n '3p' "$BUDGET_LOG"
+    } > "$tmp"
+    run audit_verify_chain "$tmp"
+    [ "$status" -ne 0 ]
+}
+
+@test "L2 signed-mode: corrupting payload of one entry → chain verification FAILS" {
+    budget_verdict "1.00"
+    budget_record_call "1.00"
+    budget_verdict "0.50"
+    # Mutate payload of line 2 (preserve all other fields including signature).
+    local tmp
+    tmp="${TEST_DIR}/payload-tampered.jsonl"
+    {
+        sed -n '1p' "$BUDGET_LOG"
+        sed -n '2p' "$BUDGET_LOG" | jq -c '.payload.actual_usd = 999999'
+        sed -n '3p' "$BUDGET_LOG"
+    } > "$tmp"
+    run audit_verify_chain "$tmp"
+    [ "$status" -ne 0 ]
+}

--- a/tests/integration/cost-budget-enforcer-signed-mode.bats
+++ b/tests/integration/cost-budget-enforcer-signed-mode.bats
@@ -51,11 +51,17 @@ EOF
     export LOA_BUDGET_STALE_HALT_PCT="75"
     export LOA_BUDGET_CLOCK_TOLERANCE="60"
     export LOA_BUDGET_LAG_HALT_SECONDS="300"
-    # Disable drift BLOCKER for these tests — they're about the signed-mode
-    # write path, not the reconciliation state machine. The drift-detection
-    # behavior is exhaustively covered by tests/unit/cost-budget-enforcer-*
-    # in unsigned mode; we only need reconcile to emit one signed envelope.
-    export LOA_BUDGET_DRIFT_THRESHOLD="1000"
+    # Disable drift BLOCKER for these tests. Reason: the legitimate per-
+    # provider drift between observer ($5.00 aggregate) and post-record_call
+    # counter (per-provider, partial) would otherwise fire as a BLOCKER and
+    # halt budget_reconcile before the test can verify the SIGNED envelope
+    # was emitted. The reconciliation state machine itself is exhaustively
+    # covered by tests/unit/cost-budget-enforcer-state-machine.bats in
+    # unsigned mode. Setting effectively-infinite (999999%) makes the intent
+    # unambiguous to future maintainers (vs the prior magic "1000").
+    # If LOA_BUDGET_DRIFT_THRESHOLD is removed, expect budget_reconcile to
+    # exit non-zero with a "drift_pct >>> threshold" BLOCKER.
+    export LOA_BUDGET_DRIFT_THRESHOLD="999999"
     export LOA_BUDGET_TEST_NOW="2026-05-04T15:00:00.000000Z"
 
     # shellcheck source=/dev/null
@@ -158,18 +164,23 @@ teardown() {
     [ "$status" -ne 0 ]
 }
 
-@test "L2 signed-mode: corrupting payload of one entry → chain verification FAILS" {
+@test "L2 signed-mode: payload tamper detected by SIGNATURE (chain-repaired test isolates the gate)" {
+    # Sprint H1 review HIGH-1: prior payload-tamper tests caught regressions
+    # via prev_hash chain-hash, NOT signature verification — they would pass
+    # against a buggy verifier that always returns 0. The chain-repair helper
+    # repairs prev_hashes after tampering so the chain-hash check passes;
+    # signature mismatch becomes the SOLE failure mode.
     budget_verdict "1.00"
     budget_record_call "1.00"
     budget_verdict "0.50"
-    # Mutate payload of line 2 (preserve all other fields including signature).
-    local tmp
-    tmp="${TEST_DIR}/payload-tampered.jsonl"
-    {
-        sed -n '1p' "$BUDGET_LOG"
-        sed -n '2p' "$BUDGET_LOG" | jq -c '.payload.actual_usd = 999999'
-        sed -n '3p' "$BUDGET_LOG"
-    } > "$tmp"
-    run audit_verify_chain "$tmp"
+    local tmp="${TEST_DIR}/payload-chain-repaired.jsonl"
+    signing_fixtures_tamper_with_chain_repair \
+        "$BUDGET_LOG" 2 '.payload.actual_usd = 999999' "$tmp"
+    # VERIFY_SIGS=0: chain hashes were repaired → verify SUCCEEDS (proves the
+    # chain-hash check is satisfied; signature is now the only gate).
+    LOA_AUDIT_VERIFY_SIGS=0 run audit_verify_chain "$tmp"
+    [ "$status" -eq 0 ]
+    # VERIFY_SIGS=1: signature on line 2 mismatches the new payload → FAILS.
+    LOA_AUDIT_VERIFY_SIGS=1 run audit_verify_chain "$tmp"
     [ "$status" -ne 0 ]
 }

--- a/tests/integration/hitl-jury-panel-signed-mode.bats
+++ b/tests/integration/hitl-jury-panel-signed-mode.bats
@@ -107,15 +107,16 @@ _views_payload() {
     [ "$status" -ne 0 ]
 }
 
-@test "L1 signed-mode: corrupting payload → chain FAILS" {
+@test "L1 signed-mode: payload tamper detected by SIGNATURE (chain-repaired)" {
+    # Sprint H1 review HIGH-1: chain-repair isolates signature as the gate.
     panel_log_views "dec-1" "$(_views_payload)" "$PANEL_LOG"
     panel_log_views "dec-2" "$(_views_payload)" "$PANEL_LOG"
-    local tmp
-    tmp="${TEST_DIR}/payload-tampered.jsonl"
-    {
-        sed -n '1p' "$PANEL_LOG"
-        sed -n '2p' "$PANEL_LOG" | jq -c '.payload.decision_id = "fraudulent-id"'
-    } > "$tmp"
-    run audit_verify_chain "$tmp"
+    panel_log_views "dec-3" "$(_views_payload)" "$PANEL_LOG"
+    local tmp="${TEST_DIR}/payload-chain-repaired.jsonl"
+    signing_fixtures_tamper_with_chain_repair \
+        "$PANEL_LOG" 2 '.payload.decision_id = "fraudulent-id"' "$tmp"
+    LOA_AUDIT_VERIFY_SIGS=0 run audit_verify_chain "$tmp"
+    [ "$status" -eq 0 ]
+    LOA_AUDIT_VERIFY_SIGS=1 run audit_verify_chain "$tmp"
     [ "$status" -ne 0 ]
 }

--- a/tests/integration/hitl-jury-panel-signed-mode.bats
+++ b/tests/integration/hitl-jury-panel-signed-mode.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/hitl-jury-panel-signed-mode.bats
+#
+# cycle-098 Sprint H1 — L1 trailing-gap closure. tests/unit/panel-audit-
+# envelope.bats covers the SIGN-ON-EMIT path for L1 (one entry, signature
+# present); this file adds the multi-event CHAIN-VALIDATES path that the L2
+# and L3 H1 files exercise — so L1 has the same end-to-end coverage shape.
+#
+# Coverage:
+#   - panel_log_views + panel_log_bind sign every envelope
+#   - audit_verify_chain validates a 3-decision chain
+#   - Tampering one envelope → chain fails
+# =============================================================================
+
+load_fixtures() {
+    # shellcheck source=../lib/signing-fixtures.sh
+    source "${BATS_TEST_DIRNAME}/../lib/signing-fixtures.sh"
+}
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    PANEL_LIB="${REPO_ROOT}/.claude/scripts/lib/hitl-jury-panel-lib.sh"
+    AUDIT_ENVELOPE="${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    [[ -f "$PANEL_LIB" ]] || skip "hitl-jury-panel-lib.sh not present"
+    [[ -f "$AUDIT_ENVELOPE" ]] || skip "audit-envelope.sh not present"
+
+    load_fixtures
+    signing_fixtures_setup --strict --key-id "test-panel-writer"
+
+    PANEL_LOG="${TEST_DIR}/panel-decisions.jsonl"
+
+    # shellcheck source=/dev/null
+    source "$AUDIT_ENVELOPE"
+    # shellcheck source=/dev/null
+    source "$PANEL_LIB"
+}
+
+teardown() {
+    if declare -f signing_fixtures_teardown >/dev/null 2>&1; then
+        signing_fixtures_teardown
+    fi
+}
+
+# Helper: a 3-panelist views payload.
+_views_payload() {
+    jq -nc '[
+        {id:"alpha",model:"claude-opus-4-7",persona_path:"a.md",view:"v1",reasoning_summary:"r1"},
+        {id:"beta",model:"claude-opus-4-7",persona_path:"b.md",view:"v2",reasoning_summary:"r2"},
+        {id:"gamma",model:"claude-opus-4-7",persona_path:"c.md",view:"v3",reasoning_summary:"r3"}
+    ]'
+}
+
+# -----------------------------------------------------------------------------
+# Sign-on-emit
+# -----------------------------------------------------------------------------
+
+@test "L1 signed-mode: panel_log_views emits SIGNED envelope" {
+    panel_log_views "dec-1" "$(_views_payload)" "$PANEL_LOG"
+    [ -f "$PANEL_LOG" ]
+    run jq -sr '.[] | select(.event_type == "panel.solicit") | .signature' "$PANEL_LOG"
+    [ -n "$output" ]
+    [ "$output" != "null" ]
+    run jq -sr '.[] | select(.event_type == "panel.solicit") | .signing_key_id' "$PANEL_LOG"
+    [ "$output" = "test-panel-writer" ]
+}
+
+# -----------------------------------------------------------------------------
+# Chain validates across multiple panel decisions
+# -----------------------------------------------------------------------------
+
+@test "L1 signed-mode: chain validates across 3 successive panel decisions" {
+    panel_log_views "dec-1" "$(_views_payload)" "$PANEL_LOG"
+    panel_log_views "dec-2" "$(_views_payload)" "$PANEL_LOG"
+    panel_log_views "dec-3" "$(_views_payload)" "$PANEL_LOG"
+    run audit_verify_chain "$PANEL_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "L1 signed-mode: every L1 entry on chain carries signature + signing_key_id" {
+    panel_log_views "dec-1" "$(_views_payload)" "$PANEL_LOG"
+    panel_log_views "dec-2" "$(_views_payload)" "$PANEL_LOG"
+    local n_total n_signed
+    n_total="$(jq -sr '[.[] | select(.primitive_id == "L1")] | length' "$PANEL_LOG")"
+    n_signed="$(jq -sr '[.[] | select(.primitive_id == "L1") | select(.signature != null and .signing_key_id != null)] | length' "$PANEL_LOG")"
+    [ "$n_total" -eq "$n_signed" ]
+    [ "$n_signed" -ge 2 ]
+}
+
+# -----------------------------------------------------------------------------
+# Tamper detection
+# -----------------------------------------------------------------------------
+
+@test "L1 signed-mode: stripping signature → chain FAILS" {
+    panel_log_views "dec-1" "$(_views_payload)" "$PANEL_LOG"
+    panel_log_views "dec-2" "$(_views_payload)" "$PANEL_LOG"
+    panel_log_views "dec-3" "$(_views_payload)" "$PANEL_LOG"
+    local tmp
+    tmp="${TEST_DIR}/strip-tampered.jsonl"
+    {
+        sed -n '1p' "$PANEL_LOG"
+        sed -n '2p' "$PANEL_LOG" | jq -c 'del(.signature)'
+        sed -n '3p' "$PANEL_LOG"
+    } > "$tmp"
+    run audit_verify_chain "$tmp"
+    [ "$status" -ne 0 ]
+}
+
+@test "L1 signed-mode: corrupting payload → chain FAILS" {
+    panel_log_views "dec-1" "$(_views_payload)" "$PANEL_LOG"
+    panel_log_views "dec-2" "$(_views_payload)" "$PANEL_LOG"
+    local tmp
+    tmp="${TEST_DIR}/payload-tampered.jsonl"
+    {
+        sed -n '1p' "$PANEL_LOG"
+        sed -n '2p' "$PANEL_LOG" | jq -c '.payload.decision_id = "fraudulent-id"'
+    } > "$tmp"
+    run audit_verify_chain "$tmp"
+    [ "$status" -ne 0 ]
+}

--- a/tests/integration/scheduled-cycle-lib-signed-mode.bats
+++ b/tests/integration/scheduled-cycle-lib-signed-mode.bats
@@ -144,17 +144,16 @@ teardown() {
     [ "$status" -ne 0 ]
 }
 
-@test "L3 signed-mode: corrupting cycle.phase payload → chain FAILS" {
+@test "L3 signed-mode: cycle.phase payload tamper detected by SIGNATURE (chain-repaired)" {
+    # Sprint H1 review HIGH-1: chain-repair isolates signature as the gate.
     cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-payload-tamper"
-    # Tamper line 3 (cycle.phase, decider) — change duration_seconds.
-    local tmp
-    tmp="${TEST_DIR}/payload-tampered.jsonl"
-    {
-        sed -n '1,2p' "$LOG_FILE"
-        sed -n '3p' "$LOG_FILE" | jq -c '.payload.duration_seconds = 9999'
-        sed -n '4,7p' "$LOG_FILE"
-    } > "$tmp"
-    run audit_verify_chain "$tmp"
+    local tmp="${TEST_DIR}/payload-chain-repaired.jsonl"
+    # Line 3 is cycle.phase (decider) per the cycle_invoke event ordering.
+    signing_fixtures_tamper_with_chain_repair \
+        "$LOG_FILE" 3 '.payload.duration_seconds = 9999' "$tmp"
+    LOA_AUDIT_VERIFY_SIGS=0 run audit_verify_chain "$tmp"
+    [ "$status" -eq 0 ]
+    LOA_AUDIT_VERIFY_SIGS=1 run audit_verify_chain "$tmp"
     [ "$status" -ne 0 ]
 }
 

--- a/tests/integration/scheduled-cycle-lib-signed-mode.bats
+++ b/tests/integration/scheduled-cycle-lib-signed-mode.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/scheduled-cycle-lib-signed-mode.bats
+#
+# cycle-098 Sprint H1 (closes #713). End-to-end happy path for L3 with
+# Ed25519 signing enabled. Sprint 3 BATS suites all run with
+# LOA_AUDIT_VERIFY_SIGS=0 + unset LOA_AUDIT_SIGNING_KEY_ID; this file
+# exercises the signed code path so a regression that drops signing
+# propagation through cycle_invoke ships red.
+#
+# Coverage:
+#   - cycle.start signed
+#   - cycle.phase × 5 all signed
+#   - cycle.complete signed
+#   - audit_verify_chain validates the full multi-event chain
+#   - Tampered chain fails verification
+#   - cycle.error path also signs
+# =============================================================================
+
+load_fixtures() {
+    # shellcheck source=../lib/signing-fixtures.sh
+    source "${BATS_TEST_DIRNAME}/../lib/signing-fixtures.sh"
+}
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    L3_LIB="${REPO_ROOT}/.claude/scripts/lib/scheduled-cycle-lib.sh"
+    AUDIT_ENVELOPE="${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    [[ -f "$L3_LIB" ]] || skip "scheduled-cycle-lib.sh not present"
+    [[ -f "$AUDIT_ENVELOPE" ]] || skip "audit-envelope.sh not present"
+
+    load_fixtures
+    signing_fixtures_setup --strict --key-id "test-cycle-writer"
+
+    LOG_FILE="${TEST_DIR}/cycles.jsonl"
+    LOCK_DIR="${TEST_DIR}/.run/cycles"
+    SCHEDULE_YAML="${TEST_DIR}/schedule.yaml"
+    mkdir -p "$LOCK_DIR"
+
+    for phase in reader decider dispatcher awaiter logger; do
+        cat > "${TEST_DIR}/${phase}.sh" <<EOF
+#!/usr/bin/env bash
+echo "{\"phase\":\"${phase}\"}"
+exit 0
+EOF
+        chmod +x "${TEST_DIR}/${phase}.sh"
+    done
+
+    cat > "$SCHEDULE_YAML" <<EOF
+schedule_id: test-h1-signed
+schedule: "*/5 * * * *"
+dispatch_contract:
+  reader: "${TEST_DIR}/reader.sh"
+  decider: "${TEST_DIR}/decider.sh"
+  dispatcher: "${TEST_DIR}/dispatcher.sh"
+  awaiter: "${TEST_DIR}/awaiter.sh"
+  logger: "${TEST_DIR}/logger.sh"
+  budget_estimate_usd: 0
+  timeout_seconds: 60
+EOF
+
+    export LOA_CYCLES_LOG="$LOG_FILE"
+    export LOA_L3_LOCK_DIR="$LOCK_DIR"
+    export LOA_L3_LOCK_TIMEOUT_SECONDS=2
+    export LOA_L3_PHASE_PATH_ALLOWED_PREFIXES="$TEST_DIR"
+    export LOA_L3_TEST_NOW="2026-05-04T15:00:00.000000Z"
+
+    # shellcheck source=/dev/null
+    source "$AUDIT_ENVELOPE"
+    # shellcheck source=/dev/null
+    source "$L3_LIB"
+}
+
+teardown() {
+    if declare -f signing_fixtures_teardown >/dev/null 2>&1; then
+        signing_fixtures_teardown
+    fi
+    unset LOA_CYCLES_LOG LOA_L3_LOCK_DIR LOA_L3_LOCK_TIMEOUT_SECONDS \
+          LOA_L3_PHASE_PATH_ALLOWED_PREFIXES LOA_L3_TEST_NOW
+}
+
+# -----------------------------------------------------------------------------
+# All cycle events sign
+# -----------------------------------------------------------------------------
+
+@test "L3 signed-mode: cycle_invoke emits 7 signed envelopes (start + 5 phase + complete)" {
+    run cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-signed-1"
+    [ "$status" -eq 0 ]
+    [ -f "$LOG_FILE" ]
+    local n_total n_signed
+    n_total="$(jq -sr '. | length' "$LOG_FILE")"
+    n_signed="$(jq -sr '[.[] | select(.signature != null and .signing_key_id != null)] | length' "$LOG_FILE")"
+    [ "$n_total" -eq 7 ]
+    [ "$n_signed" -eq 7 ]
+}
+
+@test "L3 signed-mode: each event_type carries the test signing_key_id" {
+    cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-signed-2"
+    local distinct
+    distinct="$(jq -sr '[.[] | .signing_key_id] | unique | join(",")' "$LOG_FILE")"
+    [ "$distinct" = "test-cycle-writer" ]
+}
+
+@test "L3 signed-mode: signatures are base64-formatted" {
+    cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-signed-3"
+    while IFS= read -r sig; do
+        [[ "$sig" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]
+    done < <(jq -sr '.[] | .signature' "$LOG_FILE")
+}
+
+# -----------------------------------------------------------------------------
+# Chain validates
+# -----------------------------------------------------------------------------
+
+@test "L3 signed-mode: audit_verify_chain validates the full cycle chain" {
+    cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-signed-4"
+    run audit_verify_chain "$LOG_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "L3 signed-mode: chain still validates across multiple cycles" {
+    cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-multi-1"
+    cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-multi-2"
+    cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-multi-3"
+    run audit_verify_chain "$LOG_FILE"
+    [ "$status" -eq 0 ]
+}
+
+# -----------------------------------------------------------------------------
+# Tamper detection
+# -----------------------------------------------------------------------------
+
+@test "L3 signed-mode: stripping signature from cycle.complete → chain FAILS" {
+    cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-strip-1"
+    # Strip signature from the final cycle.complete line (line 7).
+    local tmp
+    tmp="${TEST_DIR}/strip-tampered.jsonl"
+    {
+        sed -n '1,6p' "$LOG_FILE"
+        sed -n '7p' "$LOG_FILE" | jq -c 'del(.signature)'
+    } > "$tmp"
+    run audit_verify_chain "$tmp"
+    [ "$status" -ne 0 ]
+}
+
+@test "L3 signed-mode: corrupting cycle.phase payload → chain FAILS" {
+    cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-payload-tamper"
+    # Tamper line 3 (cycle.phase, decider) — change duration_seconds.
+    local tmp
+    tmp="${TEST_DIR}/payload-tampered.jsonl"
+    {
+        sed -n '1,2p' "$LOG_FILE"
+        sed -n '3p' "$LOG_FILE" | jq -c '.payload.duration_seconds = 9999'
+        sed -n '4,7p' "$LOG_FILE"
+    } > "$tmp"
+    run audit_verify_chain "$tmp"
+    [ "$status" -ne 0 ]
+}
+
+# -----------------------------------------------------------------------------
+# Error-path also signs
+# -----------------------------------------------------------------------------
+
+@test "L3 signed-mode: cycle.error event is also signed" {
+    cat > "${TEST_DIR}/dispatcher.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 13
+EOF
+    chmod +x "${TEST_DIR}/dispatcher.sh"
+    run cycle_invoke "$SCHEDULE_YAML" --cycle-id "h1-signed-error"
+    [ "$status" -eq 1 ]
+    run jq -sr '.[] | select(.event_type == "cycle.error") | .signature' "$LOG_FILE"
+    [ -n "$output" ]
+    [ "$output" != "null" ]
+    run audit_verify_chain "$LOG_FILE"
+    [ "$status" -eq 0 ]
+}

--- a/tests/integration/signing-fixtures-smoke.bats
+++ b/tests/integration/signing-fixtures-smoke.bats
@@ -151,12 +151,41 @@ teardown() {
     [[ "$has_pem" = "true" ]]
 }
 
+@test "fixtures: --update-trust-store cache-invalidation actually flips audit-envelope state" {
+    # Sprint H1 review MEDIUM (H1-cache-invalidation-private-state):
+    # signing_fixtures_register_extra_key clears the audit-envelope private
+    # cache vars by direct assignment. If those vars are ever renamed in
+    # audit-envelope.sh, our invalidation silently no-ops. This test catches
+    # the drift by ASSERTING the trust-store status genuinely flips from
+    # BOOTSTRAP-PENDING to a non-BOOTSTRAP state after --update-trust-store.
+    load_fixtures
+    signing_fixtures_setup --strict
+    # shellcheck source=/dev/null
+    source "$AUDIT_ENVELOPE"
+    # Pre-state: BOOTSTRAP-PENDING.
+    local pre
+    pre="$(_audit_trust_store_status)"
+    [[ "$pre" = "BOOTSTRAP-PENDING" ]]
+    # Register with trust-store update.
+    signing_fixtures_register_extra_key "extra-cache-test" --update-trust-store >/dev/null
+    # Post-state: audit-envelope must have observed the change. Either VERIFIED
+    # (won't happen — no signed root_sig) or INVALID (expected) — both prove
+    # the cache invalidation actually flipped status away from
+    # BOOTSTRAP-PENDING. If our private-var clear silently no-ops, this test
+    # would still see BOOTSTRAP-PENDING and fail.
+    local post
+    post="$(_audit_trust_store_status)"
+    [[ "$post" != "BOOTSTRAP-PENDING" ]]
+}
+
 @test "fixtures: teardown removes TEST_DIR and unsets env" {
     load_fixtures
     signing_fixtures_setup --strict
     local td="$TEST_DIR"
     signing_fixtures_teardown
-    [[ ! -d "$td" ]] || [[ -z "$(ls -A "$td" 2>/dev/null)" ]]
+    # rm -rf cleanup → dir must be gone (was weakened with `|| ls -A` before;
+    # that hid teardown gaps per review iter-1 H1-teardown-find-vs-rm).
+    [[ ! -d "$td" ]]
     [[ -z "${LOA_AUDIT_KEY_DIR:-}" ]]
     [[ -z "${LOA_AUDIT_SIGNING_KEY_ID:-}" ]]
     [[ -z "${LOA_TRUST_STORE_FILE:-}" ]]
@@ -210,11 +239,18 @@ teardown() {
     [ "$status" -ne 0 ]
 }
 
-@test "fixtures: --cutoff in future suppresses post-cutoff strip-attack gate" {
-    # Sprint H1 review MEDIUM (smoke #7 expansion): observed effect of cutoff.
-    # With cutoff in 2099, an unsigned entry written after VERIFY_SIGS=1 set
-    # is still pre-cutoff (any real-world ts_utc < 2099) — strip-attack gate
-    # does NOT fire. Confirms the cutoff plumbing actually wires through.
+@test "fixtures: --cutoff in future pins current pre-cutoff behavior (CHANGE-DETECTOR)" {
+    # Sprint H1 review MEDIUM (H1-strict-cutoff-future-cutoff-naming):
+    # **This test PINS current audit-envelope.sh behavior, not a security
+    # invariant.** Currently, a pre-cutoff entry can have signature stripped
+    # and audit_verify_chain still returns 0. If audit-envelope.sh is ever
+    # hardened to require signatures REGARDLESS of cutoff (a defensible
+    # security improvement), this test goes RED — and the correct response
+    # is to UPDATE the test, not to revert the hardening.
+    #
+    # The test ALSO confirms the --cutoff plumbing wires through (smoke #7
+    # only checked that the yaml field was updated; this verifies the
+    # behavioral effect).
     load_fixtures
     signing_fixtures_setup --strict --cutoff "2099-01-01T00:00:00Z"
     # shellcheck source=/dev/null
@@ -224,7 +260,8 @@ teardown() {
     # Strip the signature to simulate the strip attack.
     local stripped="${TEST_DIR}/stripped.jsonl"
     jq -c 'del(.signature, .signing_key_id)' "$log" > "$stripped"
-    # With cutoff in future, the strip-attack gate is dormant — chain validates.
+    # CURRENT BEHAVIOR: cutoff in future → strip-attack gate dormant.
+    # Update this test if audit-envelope.sh hardens to require sigs always.
     LOA_AUDIT_VERIFY_SIGS=1 run audit_verify_chain "$stripped"
     [ "$status" -eq 0 ]
 }

--- a/tests/integration/signing-fixtures-smoke.bats
+++ b/tests/integration/signing-fixtures-smoke.bats
@@ -107,6 +107,50 @@ teardown() {
     [[ "$n_distinct" = "2" ]]
 }
 
+@test "fixtures: register_extra_key (default) writes KEY_DIR only — trust-store untouched" {
+    # Sprint H1 review HIGH-2 fix: default behavior is honest about what it
+    # does — only generates keypair files in KEY_DIR. The pubkey resolution
+    # fallback in audit-envelope.sh handles multi-writer chains via KEY_DIR.
+    load_fixtures
+    signing_fixtures_setup --strict
+    if command -v yq >/dev/null 2>&1; then
+        local pre_count post_count
+        pre_count="$(yq -r '.keys | length' "$LOA_TRUST_STORE_FILE")"
+        [[ "$pre_count" = "0" ]]
+        signing_fixtures_register_extra_key "extra-writer-default" >/dev/null
+        post_count="$(yq -r '.keys | length' "$LOA_TRUST_STORE_FILE")"
+        # Trust-store keys[] still empty (default mode).
+        [[ "$post_count" = "0" ]]
+    else
+        signing_fixtures_register_extra_key "extra-writer-default" >/dev/null
+    fi
+    # KEY_DIR file present.
+    [[ -f "$KEY_DIR/extra-writer-default.priv" ]]
+    [[ -f "$KEY_DIR/extra-writer-default.pub" ]]
+}
+
+@test "fixtures: register_extra_key --update-trust-store appends to .keys[] (BOOTSTRAP-PENDING transition)" {
+    # Opt-in flag: appends to trust-store keys[]. Trips BOOTSTRAP-PENDING →
+    # NEEDS_VERIFY. Without a properly-signed root_signature this makes
+    # subsequent audit_emit calls fail with [TRUST-STORE-INVALID] — caller's
+    # responsibility to handle. Smoke just verifies the registration write.
+    load_fixtures
+    signing_fixtures_setup --strict
+    if ! command -v yq >/dev/null 2>&1; then skip "yq not present"; fi
+    local pre_count post_count
+    pre_count="$(yq -r '.keys | length' "$LOA_TRUST_STORE_FILE")"
+    [[ "$pre_count" = "0" ]]
+    signing_fixtures_register_extra_key "extra-writer-trusted" --update-trust-store >/dev/null
+    post_count="$(yq -r '.keys | length' "$LOA_TRUST_STORE_FILE")"
+    [[ "$post_count" = "1" ]]
+    local writer_id
+    writer_id="$(yq -r '.keys[0].writer_id' "$LOA_TRUST_STORE_FILE")"
+    [[ "$writer_id" = "extra-writer-trusted" ]]
+    local has_pem
+    has_pem="$(yq -r '.keys[0].pubkey_pem | test("BEGIN PUBLIC KEY")' "$LOA_TRUST_STORE_FILE")"
+    [[ "$has_pem" = "true" ]]
+}
+
 @test "fixtures: teardown removes TEST_DIR and unsets env" {
     load_fixtures
     signing_fixtures_setup --strict
@@ -129,4 +173,58 @@ teardown() {
         cutoff="$(yq -r '.trust_cutoff.default_strict_after' "$LOA_TRUST_STORE_FILE")"
         [[ "$cutoff" = "2025-06-15T00:00:00Z" ]]
     fi
+}
+
+@test "fixtures: chain-repair tamper helper makes signature the SOLE failure mode" {
+    # Sprint H1 review HIGH-1: prior payload-tamper tests caught regressions
+    # via prev_hash chain-hash, NOT via signature verification — they would
+    # pass against a buggy verifier. This smoke test proves the chain-repair
+    # helper isolates signature as the gate: VERIFY_SIGS=1 fails, VERIFY_SIGS=0
+    # passes.
+    load_fixtures
+    signing_fixtures_setup --strict
+    # shellcheck source=/dev/null
+    source "$AUDIT_ENVELOPE"
+    local log="${TEST_DIR}/sig-only.jsonl"
+    audit_emit L1 panel.bind '{"decision_id":"d-1"}' "$log"
+    audit_emit L1 panel.bind '{"decision_id":"d-2"}' "$log"
+    audit_emit L1 panel.bind '{"decision_id":"d-3"}' "$log"
+
+    # Baseline: chain valid in both modes.
+    LOA_AUDIT_VERIFY_SIGS=1 run audit_verify_chain "$log"
+    [ "$status" -eq 0 ]
+    LOA_AUDIT_VERIFY_SIGS=0 run audit_verify_chain "$log"
+    [ "$status" -eq 0 ]
+
+    # Tamper line 2 payload + repair chain.
+    local tampered="${TEST_DIR}/tampered-chain-repaired.jsonl"
+    signing_fixtures_tamper_with_chain_repair \
+        "$log" 2 '.payload.decision_id = "tampered-id"' "$tampered"
+
+    # VERIFY_SIGS=0 should PASS (chain hashes were repaired; signature ignored).
+    LOA_AUDIT_VERIFY_SIGS=0 run audit_verify_chain "$tampered"
+    [ "$status" -eq 0 ]
+
+    # VERIFY_SIGS=1 should FAIL (signature on line 2 mismatches the new payload).
+    LOA_AUDIT_VERIFY_SIGS=1 run audit_verify_chain "$tampered"
+    [ "$status" -ne 0 ]
+}
+
+@test "fixtures: --cutoff in future suppresses post-cutoff strip-attack gate" {
+    # Sprint H1 review MEDIUM (smoke #7 expansion): observed effect of cutoff.
+    # With cutoff in 2099, an unsigned entry written after VERIFY_SIGS=1 set
+    # is still pre-cutoff (any real-world ts_utc < 2099) — strip-attack gate
+    # does NOT fire. Confirms the cutoff plumbing actually wires through.
+    load_fixtures
+    signing_fixtures_setup --strict --cutoff "2099-01-01T00:00:00Z"
+    # shellcheck source=/dev/null
+    source "$AUDIT_ENVELOPE"
+    local log="${TEST_DIR}/precutoff.jsonl"
+    audit_emit L1 panel.bind '{"decision_id":"d-pre"}' "$log"
+    # Strip the signature to simulate the strip attack.
+    local stripped="${TEST_DIR}/stripped.jsonl"
+    jq -c 'del(.signature, .signing_key_id)' "$log" > "$stripped"
+    # With cutoff in future, the strip-attack gate is dormant — chain validates.
+    LOA_AUDIT_VERIFY_SIGS=1 run audit_verify_chain "$stripped"
+    [ "$status" -eq 0 ]
 }

--- a/tests/integration/signing-fixtures-smoke.bats
+++ b/tests/integration/signing-fixtures-smoke.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/signing-fixtures-smoke.bats
+#
+# Smoke-tests for tests/lib/signing-fixtures.sh — confirms the shared helper
+# emits a working trust-store + key-pair such that audit_emit can sign and
+# audit_verify_chain accepts the result.
+# =============================================================================
+
+load_fixtures() {
+    # shellcheck source=../lib/signing-fixtures.sh
+    source "${BATS_TEST_DIRNAME}/../lib/signing-fixtures.sh"
+}
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    AUDIT_ENVELOPE="${REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+    [[ -f "$AUDIT_ENVELOPE" ]] || skip "audit-envelope.sh not present"
+}
+
+teardown() {
+    if declare -f signing_fixtures_teardown >/dev/null 2>&1; then
+        signing_fixtures_teardown
+    fi
+}
+
+@test "fixtures: --strict mode generates keypair + trust-store + exports env" {
+    load_fixtures
+    signing_fixtures_setup --strict
+    [[ -d "$TEST_DIR" ]]
+    [[ -d "$KEY_DIR" ]]
+    [[ -f "$KEY_DIR/test-writer.priv" ]]
+    [[ -f "$KEY_DIR/test-writer.pub" ]]
+    [[ -f "$LOA_TRUST_STORE_FILE" ]]
+    [[ "$LOA_AUDIT_SIGNING_KEY_ID" = "test-writer" ]]
+    [[ "$LOA_AUDIT_VERIFY_SIGS" = "1" ]]
+    # priv key mode 0600
+    local priv_mode
+    priv_mode="$(stat -c '%a' "$KEY_DIR/test-writer.priv" 2>/dev/null || stat -f '%A' "$KEY_DIR/test-writer.priv")"
+    [[ "$priv_mode" = "600" || "$priv_mode" = "0600" ]]
+}
+
+@test "fixtures: --strict mode trust-store yaml is parseable + has cutoff" {
+    load_fixtures
+    signing_fixtures_setup --strict
+    if command -v yq >/dev/null 2>&1; then
+        local cutoff
+        cutoff="$(yq -r '.trust_cutoff.default_strict_after' "$LOA_TRUST_STORE_FILE")"
+        [[ "$cutoff" = "2020-01-01T00:00:00Z" ]]
+        # Trust-store stays BOOTSTRAP-PENDING (empty keys[]); pubkey resolution
+        # falls through to KEY_DIR (the documented test path).
+        local n_keys
+        n_keys="$(yq -r '.keys | length' "$LOA_TRUST_STORE_FILE")"
+        [[ "$n_keys" = "0" ]]
+    else
+        skip "yq not present"
+    fi
+}
+
+@test "fixtures: --strict mode end-to-end audit_emit + audit_verify_chain happy path" {
+    load_fixtures
+    signing_fixtures_setup --strict
+    # shellcheck source=/dev/null
+    source "$AUDIT_ENVELOPE"
+    local log="${TEST_DIR}/sign-smoke.jsonl"
+    audit_emit L1 panel.bind '{"decision_id":"smoke-1"}' "$log"
+    audit_emit L1 panel.bind '{"decision_id":"smoke-2"}' "$log"
+    audit_emit L1 panel.bind '{"decision_id":"smoke-3"}' "$log"
+    [[ -f "$log" ]]
+    # All 3 envelopes must carry signature + signing_key_id
+    local n_signed
+    n_signed="$(jq -sr '[.[] | select(.signature != null and .signing_key_id != null)] | length' "$log")"
+    [[ "$n_signed" = "3" ]]
+    # Chain verifies
+    run audit_verify_chain "$log"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "fixtures: --bootstrap mode permits unsigned writes" {
+    load_fixtures
+    signing_fixtures_setup --bootstrap
+    [[ -z "${LOA_AUDIT_VERIFY_SIGS:-}" ]]
+    if command -v yq >/dev/null 2>&1; then
+        local n_keys
+        n_keys="$(yq -r '.keys | length' "$LOA_TRUST_STORE_FILE")"
+        [[ "$n_keys" = "0" ]]
+    fi
+}
+
+@test "fixtures: register_extra_key adds a second key + works for second writer" {
+    load_fixtures
+    signing_fixtures_setup --strict
+    # shellcheck source=/dev/null
+    source "$AUDIT_ENVELOPE"
+    local log="${TEST_DIR}/multi-writer.jsonl"
+    audit_emit L1 panel.bind '{"decision_id":"alice-1"}' "$log"
+    # Register and switch to a second key.
+    signing_fixtures_register_extra_key "writer-bob" >/dev/null
+    LOA_AUDIT_SIGNING_KEY_ID="writer-bob" audit_emit L1 panel.bind '{"decision_id":"bob-1"}' "$log"
+    # Both entries verify.
+    run audit_verify_chain "$log"
+    [[ "$status" -eq 0 ]]
+    # Verify the writer_ids differ.
+    local n_distinct
+    n_distinct="$(jq -sr '[.[] | .signing_key_id] | unique | length' "$log")"
+    [[ "$n_distinct" = "2" ]]
+}
+
+@test "fixtures: teardown removes TEST_DIR and unsets env" {
+    load_fixtures
+    signing_fixtures_setup --strict
+    local td="$TEST_DIR"
+    signing_fixtures_teardown
+    [[ ! -d "$td" ]] || [[ -z "$(ls -A "$td" 2>/dev/null)" ]]
+    [[ -z "${LOA_AUDIT_KEY_DIR:-}" ]]
+    [[ -z "${LOA_AUDIT_SIGNING_KEY_ID:-}" ]]
+    [[ -z "${LOA_TRUST_STORE_FILE:-}" ]]
+    [[ -z "${LOA_AUDIT_VERIFY_SIGS:-}" ]]
+}
+
+@test "fixtures: custom --key-id and --cutoff honored" {
+    load_fixtures
+    signing_fixtures_setup --strict --key-id "custom-writer" --cutoff "2025-06-15T00:00:00Z"
+    [[ "$LOA_AUDIT_SIGNING_KEY_ID" = "custom-writer" ]]
+    [[ -f "$KEY_DIR/custom-writer.priv" ]]
+    if command -v yq >/dev/null 2>&1; then
+        local cutoff
+        cutoff="$(yq -r '.trust_cutoff.default_strict_after' "$LOA_TRUST_STORE_FILE")"
+        [[ "$cutoff" = "2025-06-15T00:00:00Z" ]]
+    fi
+}

--- a/tests/integration/signing-fixtures-smoke.bats
+++ b/tests/integration/signing-fixtures-smoke.bats
@@ -239,29 +239,11 @@ teardown() {
     [ "$status" -ne 0 ]
 }
 
-@test "fixtures: --cutoff in future pins current pre-cutoff behavior (CHANGE-DETECTOR)" {
-    # Sprint H1 review MEDIUM (H1-strict-cutoff-future-cutoff-naming):
-    # **This test PINS current audit-envelope.sh behavior, not a security
-    # invariant.** Currently, a pre-cutoff entry can have signature stripped
-    # and audit_verify_chain still returns 0. If audit-envelope.sh is ever
-    # hardened to require signatures REGARDLESS of cutoff (a defensible
-    # security improvement), this test goes RED — and the correct response
-    # is to UPDATE the test, not to revert the hardening.
-    #
-    # The test ALSO confirms the --cutoff plumbing wires through (smoke #7
-    # only checked that the yaml field was updated; this verifies the
-    # behavioral effect).
-    load_fixtures
-    signing_fixtures_setup --strict --cutoff "2099-01-01T00:00:00Z"
-    # shellcheck source=/dev/null
-    source "$AUDIT_ENVELOPE"
-    local log="${TEST_DIR}/precutoff.jsonl"
-    audit_emit L1 panel.bind '{"decision_id":"d-pre"}' "$log"
-    # Strip the signature to simulate the strip attack.
-    local stripped="${TEST_DIR}/stripped.jsonl"
-    jq -c 'del(.signature, .signing_key_id)' "$log" > "$stripped"
-    # CURRENT BEHAVIOR: cutoff in future → strip-attack gate dormant.
-    # Update this test if audit-envelope.sh hardens to require sigs always.
-    LOA_AUDIT_VERIFY_SIGS=1 run audit_verify_chain "$stripped"
-    [ "$status" -eq 0 ]
-}
+# NOTE: The "--cutoff in future pins pre-cutoff behavior" test was REMOVED
+# in iter-2 review remediation (REFRAME). Reasoning: the test pinned
+# audit-envelope.sh behavior (pre-cutoff strip-attack tolerance) that the
+# review itself flagged as questionable security policy. Pinning that
+# behavior in the FIXTURE-LIB smoke is the wrong owner — if it's worth
+# pinning, it belongs in tests/integration/audit-envelope-* where the
+# hardening logic lives. The cutoff yaml-field write is already covered by
+# smoke #2 ("trust-store yaml is parseable + has cutoff").

--- a/tests/lib/signing-fixtures.sh
+++ b/tests/lib/signing-fixtures.sh
@@ -35,7 +35,10 @@
 #   - audit-envelope.sh
 #   - python3 with cryptography module
 #
-# Idempotent: calling setup twice in a single test (or after teardown) is fine.
+# Re-call safety: calling `signing_fixtures_setup` AFTER `_teardown` is safe
+# (cleans up first via mktemp re-creation). Back-to-back setup without
+# teardown will orphan the prior TEST_DIR — call teardown between setups if
+# you need pristine state.
 # =============================================================================
 
 if [[ "${_LOA_SIGNING_FIXTURES_SOURCED:-0}" == "1" ]]; then
@@ -63,12 +66,23 @@ _sign_fix_repo_root() {
 # -----------------------------------------------------------------------------
 signing_fixtures_setup() {
     local mode="strict"
+    local mode_explicit=0
     local key_id="test-writer"
     local cutoff="2020-01-01T00:00:00Z"
     while (( "$#" )); do
         case "$1" in
-            --strict)    mode="strict"; shift ;;
-            --bootstrap) mode="bootstrap"; shift ;;
+            --strict)
+                if (( mode_explicit == 1 )) && [[ "$mode" != "strict" ]]; then
+                    echo "signing_fixtures_setup: --strict and --bootstrap are mutually exclusive" >&2
+                    return 1
+                fi
+                mode="strict"; mode_explicit=1; shift ;;
+            --bootstrap)
+                if (( mode_explicit == 1 )) && [[ "$mode" != "bootstrap" ]]; then
+                    echo "signing_fixtures_setup: --strict and --bootstrap are mutually exclusive" >&2
+                    return 1
+                fi
+                mode="bootstrap"; mode_explicit=1; shift ;;
             --key-id)    key_id="$2"; shift 2 ;;
             --cutoff)    cutoff="$2"; shift 2 ;;
             *) echo "signing_fixtures_setup: unknown arg $1" >&2; return 1 ;;
@@ -181,14 +195,43 @@ signing_fixtures_teardown() {
 }
 
 # -----------------------------------------------------------------------------
-# signing_fixtures_register_extra_key <key_id>
+# signing_fixtures_register_extra_key <key_id> [--update-trust-store]
 #
-# Generate a SECOND ephemeral key and register it in the trust-store. Used by
-# tests that need multiple writers (e.g., revocation, multi-writer chains).
+# Generate a SECOND ephemeral key and write its priv/pub PEM into KEY_DIR.
+# By default does NOT touch the trust-store — tests that just need to switch
+# `LOA_AUDIT_SIGNING_KEY_ID` between writers rely on the KEY_DIR fallback
+# (the documented path in audit-envelope.sh:311) for pubkey resolution.
+#
+# Pass `--update-trust-store` to ALSO append `{writer_id, pubkey_pem}` to the
+# trust-store's `keys[]`. WARNING: doing so trips the trust-store out of
+# BOOTSTRAP-PENDING state (empty keys + empty revocations + empty root_sig
+# is the BOOTSTRAP marker — adding a key flips it to NEEDS_VERIFY, which
+# fails without a properly-signed `root_signature`). Tests using this flag
+# are responsible for restoring trust-store validity (e.g., re-bootstrap
+# with a maintainer-root-pubkey fixture, out of scope for this lib).
+#
+# Sprint H1 review remediation (HIGH-2): prior version silently appended to
+# `keys[]` via a malformed yq invocation that always failed. The smoke test
+# passed because the audit-envelope KEY_DIR fallback resolved the pubkey
+# regardless of trust-store state. Function signature now matches actual
+# behavior; trust-store update is opt-in and dangerous.
+#
 # Returns the new pubkey PEM on stdout.
 # -----------------------------------------------------------------------------
 signing_fixtures_register_extra_key() {
-    local extra_id="$1"
+    local extra_id=""
+    local update_trust_store=0
+    while (( "$#" )); do
+        case "$1" in
+            --update-trust-store) update_trust_store=1; shift ;;
+            --*) echo "signing_fixtures_register_extra_key: unknown flag $1" >&2; return 1 ;;
+            *)
+                if [[ -z "$extra_id" ]]; then extra_id="$1"
+                else echo "signing_fixtures_register_extra_key: too many positional args" >&2; return 1
+                fi
+                shift ;;
+        esac
+    done
     [[ -n "$extra_id" ]] || { echo "signing_fixtures_register_extra_key: requires <key_id>" >&2; return 1; }
     [[ -d "${KEY_DIR:-}" ]] || { echo "signing_fixtures_register_extra_key: signing_fixtures_setup must run first" >&2; return 1; }
     python3 - "$KEY_DIR" "$extra_id" <<'PY'
@@ -211,23 +254,124 @@ priv = ed25519.Ed25519PrivateKey.generate()
 PY
     local pem
     pem="$(cat "${KEY_DIR}/${extra_id}.pub")"
-    # Append to trust-store keys[].
-    if [[ -f "${LOA_TRUST_STORE_FILE:-}" ]]; then
-        local pem_indented
-        pem_indented="$(printf '%s\n' "$pem" | sed 's/^/      /')"
-        # Use yq if available for safe in-place edit; fall back to Python.
-        if command -v yq >/dev/null 2>&1; then
-            yq -i '.keys += [{"writer_id": strenv(EXTRA_ID), "pubkey_pem": strenv(EXTRA_PEM)}]' \
-                EXTRA_ID="$extra_id" EXTRA_PEM="$pem" "$LOA_TRUST_STORE_FILE" 2>/dev/null || true
-        else
-            python3 - "$LOA_TRUST_STORE_FILE" "$extra_id" "$pem" <<'PY'
+    if (( update_trust_store == 1 )) && [[ -f "${LOA_TRUST_STORE_FILE:-}" ]]; then
+        # Caller acknowledged the BOOTSTRAP-PENDING transition risk via the
+        # explicit flag. Use python+PyYAML adapter (the previous yq-via-env
+        # form was malformed and silently failed — HIGH-2 finding).
+        if ! python3 - "$LOA_TRUST_STORE_FILE" "$extra_id" "$pem" <<'PY'
 import sys, yaml
 path, kid, pem = sys.argv[1], sys.argv[2], sys.argv[3]
-with open(path) as f: doc = yaml.safe_load(f)
+with open(path) as f: doc = yaml.safe_load(f) or {}
 doc.setdefault("keys", []).append({"writer_id": kid, "pubkey_pem": pem})
-with open(path, "w") as f: yaml.safe_dump(doc, f, default_style="|")
+with open(path, "w") as f: yaml.safe_dump(doc, f, default_flow_style=False)
 PY
+        then
+            echo "signing_fixtures_register_extra_key: failed to update trust-store $LOA_TRUST_STORE_FILE" >&2
+            return 1
         fi
+        # Invalidate the audit-envelope trust-store status cache so the
+        # next audit_emit re-checks. Prevents stale BOOTSTRAP-PENDING cache
+        # from masking a now-INVALID trust-store.
+        _LOA_AUDIT_TS_CACHE_PATH=""
+        _LOA_AUDIT_TS_CACHE_KEY=""
+        _LOA_AUDIT_TS_CACHE_STATUS=""
     fi
     printf '%s' "$pem"
+}
+
+# -----------------------------------------------------------------------------
+# signing_fixtures_tamper_with_chain_repair <log> <line_n> <jq_filter>
+#
+# Rigorous payload-tampering helper for signed-mode tests (Sprint H1 review
+# HIGH-1). The naive pattern `jq -c '.payload.x = "tampered"'` followed by
+# audit_verify_chain catches the tamper via prev_hash chain validation alone
+# — the test would pass even against a buggy signature verifier that always
+# returns 0. To rigorously test SIGNATURE verification, we must repair the
+# chain after tampering: recompute prev_hash of subsequent lines so the
+# chain-hash check slides by, leaving signature mismatch as the ONLY failure
+# mode. This makes the test signed-mode-specific.
+#
+# Args:
+#   $1 — input log path (untouched)
+#   $2 — 1-indexed line number to tamper
+#   $3 — jq filter to apply to that line (e.g., '.payload.usd_used = 999')
+#   $4 — output log path (where to write the chain-repaired tampered log)
+#
+# After this helper:
+#   - audit_verify_chain $4 with LOA_AUDIT_VERIFY_SIGS=0 → SUCCESS
+#     (chain hashes match because prev_hashes were repaired)
+#   - audit_verify_chain $4 with LOA_AUDIT_VERIFY_SIGS=1 → FAIL
+#     (signature on line $2 is invalid because payload changed but
+#      signature was computed over the pre-tamper payload)
+# -----------------------------------------------------------------------------
+signing_fixtures_tamper_with_chain_repair() {
+    local input_log="$1"
+    local line_n="$2"
+    local jq_filter="$3"
+    local output_log="$4"
+    [[ -f "$input_log" ]] || { echo "tamper_with_chain_repair: input log $input_log missing" >&2; return 1; }
+    [[ -n "$line_n" && "$line_n" =~ ^[0-9]+$ ]] || { echo "tamper_with_chain_repair: line_n must be a positive integer" >&2; return 1; }
+    [[ -n "$jq_filter" ]] || { echo "tamper_with_chain_repair: requires <jq_filter>" >&2; return 1; }
+    [[ -n "$output_log" ]] || { echo "tamper_with_chain_repair: requires <output_log>" >&2; return 1; }
+
+    # Source audit-envelope helpers if not already loaded.
+    if ! declare -f _audit_chain_input >/dev/null 2>&1; then
+        local repo_root
+        repo_root="$(_sign_fix_repo_root)"
+        # shellcheck source=/dev/null
+        source "${repo_root}/.claude/scripts/audit-envelope.sh"
+    fi
+
+    local repo_root
+    repo_root="$(_sign_fix_repo_root)"
+    local jcs_helper="${repo_root}/.claude/scripts/lib/jcs-helper.py"
+    [[ -f "$jcs_helper" ]] || { echo "tamper_with_chain_repair: jcs-helper.py not found at $jcs_helper" >&2; return 1; }
+
+    python3 - "$input_log" "$line_n" "$jq_filter" "$output_log" "$jcs_helper" <<'PY'
+import sys, hashlib, subprocess
+
+input_log, line_n_str, jq_filter, output_log, jcs_helper = sys.argv[1:6]
+line_n = int(line_n_str)
+
+with open(input_log) as f:
+    lines = [ln.rstrip("\n") for ln in f if ln.rstrip("\n")]
+
+if line_n < 1 or line_n > len(lines):
+    print(f"tamper_with_chain_repair: line {line_n} out of range (1..{len(lines)})", file=sys.stderr)
+    sys.exit(1)
+
+tamper_idx = line_n - 1
+tampered = subprocess.run(
+    ["jq", "-c", jq_filter],
+    input=lines[tamper_idx], capture_output=True, text=True, check=True,
+).stdout.strip()
+lines[tamper_idx] = tampered
+
+# chain-input bytes = JCS-canonical(envelope minus signature + signing_key_id).
+# Hash → sha256 hex. Matches audit-envelope.sh:_audit_chain_input + _audit_sha256.
+def chain_input_sha(env_json: str) -> str:
+    stripped = subprocess.run(
+        ["jq", "-c", "del(.signature, .signing_key_id)"],
+        input=env_json, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    canonical = subprocess.run(
+        ["python3", jcs_helper],
+        input=stripped, capture_output=True, text=True, check=True,
+    ).stdout
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+# Recompute prev_hash for line_n+1 onwards so the chain stays coherent.
+for i in range(tamper_idx + 1, len(lines)):
+    prev_idx = i - 1
+    new_prev_hash = chain_input_sha(lines[prev_idx])
+    repaired = subprocess.run(
+        ["jq", "-c", f'.prev_hash = "{new_prev_hash}"'],
+        input=lines[i], capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    lines[i] = repaired
+
+with open(output_log, "w") as f:
+    for ln in lines:
+        f.write(ln + "\n")
+PY
 }

--- a/tests/lib/signing-fixtures.sh
+++ b/tests/lib/signing-fixtures.sh
@@ -56,8 +56,20 @@ _sign_fix_repo_root() {
     elif [[ -n "${BATS_TEST_FILENAME:-}" ]]; then
         ( cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd )
     else
-        # Fallback: assume cwd is repo root (allowed when sourced manually).
-        pwd
+        # Fallback: walk up from cwd looking for the sentinel file (the very
+        # script audit-envelope.sh that the helpers are about). Avoids the
+        # pwd-resolves-wrong-dir failure mode iter-1 review flagged.
+        local d
+        d="$(pwd)"
+        while [[ "$d" != "/" ]]; do
+            if [[ -f "${d}/.claude/scripts/audit-envelope.sh" ]]; then
+                echo "$d"
+                return 0
+            fi
+            d="$(dirname "$d")"
+        done
+        echo "_sign_fix_repo_root: cannot locate repo root from $(pwd) (no .claude/scripts/audit-envelope.sh in any ancestor)" >&2
+        return 1
     fi
 }
 
@@ -185,9 +197,12 @@ EOF
 # signing_fixtures_teardown — clean up TEST_DIR + unset env. Idempotent.
 # -----------------------------------------------------------------------------
 signing_fixtures_teardown() {
+    # Use rm -rf for atomic cleanup — find -delete left behind any non-file
+    # entries (symlinks, sockets) and forced the smoke test to weaken its
+    # assertion (review iter-1 H1-teardown-find-vs-rm). For an mktemp dir we
+    # control entirely, rm -rf is the idiomatic choice.
     if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
-        find "$TEST_DIR" -type f -delete 2>/dev/null || true
-        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+        rm -rf -- "$TEST_DIR"
     fi
     unset LOA_AUDIT_KEY_DIR LOA_AUDIT_SIGNING_KEY_ID LOA_TRUST_STORE_FILE \
           LOA_AUDIT_VERIFY_SIGS TEST_DIR KEY_DIR \

--- a/tests/lib/signing-fixtures.sh
+++ b/tests/lib/signing-fixtures.sh
@@ -273,6 +273,12 @@ PY
         # Caller acknowledged the BOOTSTRAP-PENDING transition risk via the
         # explicit flag. Use python+PyYAML adapter (the previous yq-via-env
         # form was malformed and silently failed — HIGH-2 finding).
+        # Iter-2 review MEDIUM: explicit PyYAML availability check so the
+        # missing-dep error is clear rather than a generic "failed to update".
+        if ! python3 -c "import yaml" 2>/dev/null; then
+            echo "signing_fixtures_register_extra_key --update-trust-store: PyYAML not installed (pip install pyyaml)" >&2
+            return 1
+        fi
         if ! python3 - "$LOA_TRUST_STORE_FILE" "$extra_id" "$pem" <<'PY'
 import sys, yaml
 path, kid, pem = sys.argv[1], sys.argv[2], sys.argv[3]

--- a/tests/lib/signing-fixtures.sh
+++ b/tests/lib/signing-fixtures.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tests/lib/signing-fixtures.sh — shared signed-mode test setup
+#
+# cycle-098 Sprint H1 (closes #706 + #713 + similar follow-ups). Consolidates
+# the per-test ephemeral-Ed25519-keypair + trust-store + env-var dance that
+# was duplicated across audit-envelope-signing.bats, audit-envelope-strip-
+# attack.bats, audit-envelope-bootstrap.bats, panel-audit-envelope.bats.
+#
+# Public API (call inside `setup()` / `teardown()`):
+#   signing_fixtures_setup [--strict|--bootstrap] [--key-id <id>] [--cutoff <iso>]
+#   signing_fixtures_teardown
+#
+# Modes:
+#   --strict    (default) Trust-store cutoff in the past + pubkey REGISTERED
+#               in `keys[]`. Sets LOA_AUDIT_VERIFY_SIGS=1. The full happy
+#               path: audit_emit signs, audit_verify_chain validates.
+#   --bootstrap Trust-store empty `keys[]` (BOOTSTRAP-PENDING). audit_emit
+#               accepts unsigned writes. Used for tests that exercise the
+#               pre-bootstrap operator path.
+#
+# Variables exported to the test (via `export` so subshells inherit):
+#   TEST_DIR        — mktemp dir; teardown removes it
+#   KEY_DIR         — mode 0700; contains <key_id>.priv (0600) + <key_id>.pub
+#   LOA_AUDIT_KEY_DIR
+#   LOA_AUDIT_SIGNING_KEY_ID
+#   LOA_TRUST_STORE_FILE
+#   LOA_AUDIT_VERIFY_SIGS  (1 in --strict mode; unset in --bootstrap)
+#
+# Variables exposed (no export — caller can still use them inside its own
+# setup() and they will be set in the test's shell scope):
+#   _SIGN_FIX_KEY_ID, _SIGN_FIX_PUBKEY_PEM
+#
+# Skips the test (via `skip`) when prerequisites are missing:
+#   - audit-envelope.sh
+#   - python3 with cryptography module
+#
+# Idempotent: calling setup twice in a single test (or after teardown) is fine.
+# =============================================================================
+
+if [[ "${_LOA_SIGNING_FIXTURES_SOURCED:-0}" == "1" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_LOA_SIGNING_FIXTURES_SOURCED=1
+
+# -----------------------------------------------------------------------------
+# _sign_fix_repo_root — resolve the repo root from BATS_TEST_FILENAME or
+# BATS_TEST_DIRNAME so callers don't have to compute it themselves.
+# -----------------------------------------------------------------------------
+_sign_fix_repo_root() {
+    if [[ -n "${BATS_TEST_DIRNAME:-}" ]]; then
+        ( cd "${BATS_TEST_DIRNAME}/../.." && pwd )
+    elif [[ -n "${BATS_TEST_FILENAME:-}" ]]; then
+        ( cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd )
+    else
+        # Fallback: assume cwd is repo root (allowed when sourced manually).
+        pwd
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# signing_fixtures_setup [--strict|--bootstrap] [--key-id <id>] [--cutoff <iso>]
+# -----------------------------------------------------------------------------
+signing_fixtures_setup() {
+    local mode="strict"
+    local key_id="test-writer"
+    local cutoff="2020-01-01T00:00:00Z"
+    while (( "$#" )); do
+        case "$1" in
+            --strict)    mode="strict"; shift ;;
+            --bootstrap) mode="bootstrap"; shift ;;
+            --key-id)    key_id="$2"; shift 2 ;;
+            --cutoff)    cutoff="$2"; shift 2 ;;
+            *) echo "signing_fixtures_setup: unknown arg $1" >&2; return 1 ;;
+        esac
+    done
+
+    local repo_root
+    repo_root="$(_sign_fix_repo_root)"
+    local audit_envelope="${repo_root}/.claude/scripts/audit-envelope.sh"
+    if [[ ! -f "$audit_envelope" ]]; then
+        skip "audit-envelope.sh not present"
+    fi
+    if ! python3 -c "import cryptography" 2>/dev/null; then
+        skip "python cryptography not installed"
+    fi
+
+    TEST_DIR="$(mktemp -d)"
+    KEY_DIR="${TEST_DIR}/audit-keys"
+    mkdir -p "$KEY_DIR"
+    chmod 700 "$KEY_DIR"
+
+    # Generate ephemeral Ed25519 keypair via Python (matches Sprint 1B helper).
+    python3 - "$KEY_DIR" "$key_id" <<'PY'
+import sys
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+
+key_dir = Path(sys.argv[1])
+key_id  = sys.argv[2]
+priv = ed25519.Ed25519PrivateKey.generate()
+priv_bytes = priv.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+)
+pub_bytes = priv.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+)
+priv_path = key_dir / f"{key_id}.priv"
+pub_path  = key_dir / f"{key_id}.pub"
+priv_path.write_bytes(priv_bytes)
+priv_path.chmod(0o600)
+pub_path.write_bytes(pub_bytes)
+PY
+
+    _SIGN_FIX_KEY_ID="$key_id"
+    _SIGN_FIX_PUBKEY_PEM="$(cat "${KEY_DIR}/${key_id}.pub")"
+
+    # Build the trust-store. Both modes use BOOTSTRAP-PENDING shape (empty
+    # keys[] + revocations[] + root_signature) so _audit_check_trust_store
+    # permits writes without requiring a properly-signed root pubkey. Pubkey
+    # resolution for verification falls through to <KEY_DIR>/<key_id>.pub
+    # (the documented test path in audit-envelope.sh:311). The two modes
+    # differ only in the trust_cutoff + LOA_AUDIT_VERIFY_SIGS:
+    #   --strict   : cutoff in past, VERIFY_SIGS=1 → post-cutoff strip-attack
+    #                gate active (signature + signing_key_id REQUIRED on emit;
+    #                audit_verify_chain validates signatures on read).
+    #   --bootstrap: cutoff far in future, VERIFY_SIGS unset → unsigned writes
+    #                permitted (operator-bootstrap path).
+    LOA_TRUST_STORE_FILE="${TEST_DIR}/trust-store.yaml"
+    if [[ "$mode" == "strict" ]]; then
+        cat > "$LOA_TRUST_STORE_FILE" <<EOF
+schema_version: "1.0"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: ""
+  signed_at: ""
+  signature: ""
+keys: []
+revocations: []
+trust_cutoff:
+  default_strict_after: "$cutoff"
+EOF
+        export LOA_AUDIT_VERIFY_SIGS=1
+    else
+        cat > "$LOA_TRUST_STORE_FILE" <<EOF
+schema_version: "1.0"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: ""
+  signed_at: ""
+  signature: ""
+keys: []
+revocations: []
+trust_cutoff:
+  default_strict_after: "2099-01-01T00:00:00Z"
+EOF
+        unset LOA_AUDIT_VERIFY_SIGS
+    fi
+
+    export LOA_AUDIT_KEY_DIR="$KEY_DIR"
+    export LOA_AUDIT_SIGNING_KEY_ID="$key_id"
+    export LOA_TRUST_STORE_FILE
+    export TEST_DIR KEY_DIR
+}
+
+# -----------------------------------------------------------------------------
+# signing_fixtures_teardown — clean up TEST_DIR + unset env. Idempotent.
+# -----------------------------------------------------------------------------
+signing_fixtures_teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_AUDIT_KEY_DIR LOA_AUDIT_SIGNING_KEY_ID LOA_TRUST_STORE_FILE \
+          LOA_AUDIT_VERIFY_SIGS TEST_DIR KEY_DIR \
+          _SIGN_FIX_KEY_ID _SIGN_FIX_PUBKEY_PEM
+}
+
+# -----------------------------------------------------------------------------
+# signing_fixtures_register_extra_key <key_id>
+#
+# Generate a SECOND ephemeral key and register it in the trust-store. Used by
+# tests that need multiple writers (e.g., revocation, multi-writer chains).
+# Returns the new pubkey PEM on stdout.
+# -----------------------------------------------------------------------------
+signing_fixtures_register_extra_key() {
+    local extra_id="$1"
+    [[ -n "$extra_id" ]] || { echo "signing_fixtures_register_extra_key: requires <key_id>" >&2; return 1; }
+    [[ -d "${KEY_DIR:-}" ]] || { echo "signing_fixtures_register_extra_key: signing_fixtures_setup must run first" >&2; return 1; }
+    python3 - "$KEY_DIR" "$extra_id" <<'PY'
+import sys
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+key_dir = Path(sys.argv[1]); key_id = sys.argv[2]
+priv = ed25519.Ed25519PrivateKey.generate()
+(key_dir / f"{key_id}.priv").write_bytes(priv.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+))
+(key_dir / f"{key_id}.priv").chmod(0o600)
+(key_dir / f"{key_id}.pub").write_bytes(priv.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+))
+PY
+    local pem
+    pem="$(cat "${KEY_DIR}/${extra_id}.pub")"
+    # Append to trust-store keys[].
+    if [[ -f "${LOA_TRUST_STORE_FILE:-}" ]]; then
+        local pem_indented
+        pem_indented="$(printf '%s\n' "$pem" | sed 's/^/      /')"
+        # Use yq if available for safe in-place edit; fall back to Python.
+        if command -v yq >/dev/null 2>&1; then
+            yq -i '.keys += [{"writer_id": strenv(EXTRA_ID), "pubkey_pem": strenv(EXTRA_PEM)}]' \
+                EXTRA_ID="$extra_id" EXTRA_PEM="$pem" "$LOA_TRUST_STORE_FILE" 2>/dev/null || true
+        else
+            python3 - "$LOA_TRUST_STORE_FILE" "$extra_id" "$pem" <<'PY'
+import sys, yaml
+path, kid, pem = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as f: doc = yaml.safe_load(f)
+doc.setdefault("keys", []).append({"writer_id": kid, "pubkey_pem": pem})
+with open(path, "w") as f: yaml.safe_dump(doc, f, default_style="|")
+PY
+        fi
+    fi
+    printf '%s' "$pem"
+}


### PR DESCRIPTION
## Summary

Sprint H1 of the cycle-098 hardening wave. Closes the recurring "fidelity desert" finding raised across Sprint 1, 2, and 3 bridgebuilder iterations: all primitive-level BATS suites ran with `LOA_AUDIT_VERIFY_SIGS=0` + `unset LOA_AUDIT_SIGNING_KEY_ID`, so a regression that drops signing propagation through L1/L2/L3 would ship green. This PR introduces a shared signing fixture lib + 27 BATS tests exercising the strict-mode signed code path.

| Layer | New file | Tests |
|-------|----------|-------|
| Shared fixture | `tests/lib/signing-fixtures.sh` | (lib) |
| Smoke | `tests/integration/signing-fixtures-smoke.bats` | 7 |
| L2 (#706) | `tests/integration/cost-budget-enforcer-signed-mode.bats` | 7 |
| L3 (#713) | `tests/integration/scheduled-cycle-lib-signed-mode.bats` | 8 |
| L1 (trailing gap) | `tests/integration/hitl-jury-panel-signed-mode.bats` | 5 |
| **H1 total** | — | **27** |

Regression suite (Sprint 1+2+3 + audit-envelope + L1 panel): 129/129 PASS, 0 regressions.

## Closes

- [#706](https://github.com/0xHoneyJar/loa/issues/706) — Sprint 2 signed-mode happy-path coverage
- [#713](https://github.com/0xHoneyJar/loa/issues/713) — Sprint 3 signed-mode happy-path coverage

## Why a shared fixture

The Sprint 1B signing pattern (ephemeral Ed25519 keypair via Python `cryptography`, BOOTSTRAP-PENDING trust-store with the cutoff in the past, KEY_DIR pubkey fallback for verification) was duplicated across `audit-envelope-signing.bats`, `audit-envelope-strip-attack.bats`, `audit-envelope-bootstrap.bats`, and `panel-audit-envelope.bats`. Extracting it to `tests/lib/signing-fixtures.sh` consolidates the pattern, exposes `--strict` / `--bootstrap` toggles, and makes future primitive-level signed tests trivial to author (5 lines in `setup()`).

## Coverage shape (consistent across L1 + L2 + L3)

For each primitive:
1. Each public emit function writes a SIGNED envelope (signature + signing_key_id present, base64-formatted).
2. Multi-event chain validates via `audit_verify_chain`.
3. Stripping signature from one entry → `audit_verify_chain` returns non-zero.
4. Tampering payload of one entry → `audit_verify_chain` returns non-zero.

Plus, for L1: 5 tests; for L2: also reconcile path; for L3: also cycle.error path.

## Engineering note

`signing_fixtures_setup --strict` keeps the trust-store BOOTSTRAP-PENDING (empty `keys[]`) instead of populating it with the test pubkey. This avoids needing a properly-signed maintainer-root-pubkey fixture (which would trip `_audit_check_trust_store`'s INVALID branch). Pubkey resolution then falls through to the documented test path (`<KEY_DIR>/<key_id>.pub`), and the `LOA_AUDIT_VERIFY_SIGS=1` + `cutoff in past` combination still activates the post-cutoff strip-attack gate.

## Test plan

- [x] H1 BATS suite passes — 27/27
- [x] Sprint 1+2+3 regression — 129/129
- [ ] /review-sprint subagent
- [ ] /audit-sprint paranoid cypherpunk subagent
- [ ] Bridgebuilder kaironic inline
- [ ] Admin-squash merge after kaironic plateau

## Notes for reviewers

- Pure test surface (no production code change). Reduces blast radius.
- Sprint H2 (BB LOW-batch consolidation #694 + #708 + #714) follows.
- After H1+H2 land, the inbound /bugs for #711 (gpt-review hook recursion + gpt-5.2 fallback) ship before resuming Sprint 4 (L4 graduated-trust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)