### PR TITLE
feat(cycle-099-sprint-1C): codegen reproducibility matrix CI + toolchain runbook

### DIFF
--- a/.claude/scripts/generated-model-maps.sh
+++ b/.claude/scripts/generated-model-maps.sh
@@ -23,6 +23,7 @@ declare -A MODEL_PROVIDERS=(
     ["claude-opus-4-7"]="anthropic"
     ["claude-opus-4-6"]="anthropic"
     ["claude-sonnet-4-6"]="anthropic"
+    ["claude-sonnet-4-5-20250929"]="anthropic"
     ["claude-haiku-4-5-20251001"]="anthropic"
     ["us.anthropic.claude-opus-4-7"]="bedrock"
     ["us.anthropic.claude-sonnet-4-6"]="bedrock"
@@ -66,6 +67,7 @@ declare -A MODEL_IDS=(
     ["claude-opus-4-7"]="claude-opus-4-7"
     ["claude-opus-4-6"]="claude-opus-4-6"
     ["claude-sonnet-4-6"]="claude-sonnet-4-6"
+    ["claude-sonnet-4-5-20250929"]="claude-sonnet-4-5-20250929"
     ["claude-haiku-4-5-20251001"]="claude-haiku-4-5-20251001"
     ["us.anthropic.claude-opus-4-7"]="us.anthropic.claude-opus-4-7"
     ["us.anthropic.claude-sonnet-4-6"]="us.anthropic.claude-sonnet-4-6"
@@ -109,6 +111,7 @@ declare -A COST_INPUT=(
     ["claude-opus-4-7"]="0.005"
     ["claude-opus-4-6"]="0.005"
     ["claude-sonnet-4-6"]="0.003"
+    ["claude-sonnet-4-5-20250929"]="0.003"
     ["claude-haiku-4-5-20251001"]="0.001"
     ["us.anthropic.claude-opus-4-7"]="0.005"
     ["us.anthropic.claude-sonnet-4-6"]="0.003"
@@ -152,6 +155,7 @@ declare -A COST_OUTPUT=(
     ["claude-opus-4-7"]="0.025"
     ["claude-opus-4-6"]="0.025"
     ["claude-sonnet-4-6"]="0.015"
+    ["claude-sonnet-4-5-20250929"]="0.015"
     ["claude-haiku-4-5-20251001"]="0.005"
     ["us.anthropic.claude-opus-4-7"]="0.025"
     ["us.anthropic.claude-sonnet-4-6"]="0.015"
@@ -201,6 +205,7 @@ declare -a VALID_FLATLINE_MODELS=(
     claude-opus-4.6
     claude-opus-4-7
     claude-opus-4.7
+    claude-sonnet-4-5-20250929
     claude-sonnet-4-6
     deep-research-pro
     deep-thinker

--- a/.github/workflows/model-registry-drift.yml
+++ b/.github/workflows/model-registry-drift.yml
@@ -158,6 +158,13 @@ jobs:
         working-directory: .claude/skills/bridgebuilder-review
         run: npm ci
 
+      - name: Verify pinned codegen toolchain
+        # Closes BB iter-1 F7: the paths filter triggers this workflow when
+        # tools/check-codegen-toolchain.sh changes, but until this step was
+        # added, the script itself was never executed. Now a regression in
+        # the script's version-comparison logic surfaces in CI.
+        run: bash tools/check-codegen-toolchain.sh
+
       - name: Run gen-bb-registry --check
         working-directory: .claude/skills/bridgebuilder-review
         run: |

--- a/.github/workflows/model-registry-drift.yml
+++ b/.github/workflows/model-registry-drift.yml
@@ -30,6 +30,10 @@ on:
       - 'tests/integration/lockfile-checksum.bats'
       - 'tests/integration/legacy-adapter-still-works.bats'
       - 'tests/integration/model-registry-sync.bats'
+      # cycle-099 sprint-1C review fix: runbook bumps must re-run the gate
+      # so version drift across runbook + workflow surfaces in CI.
+      - 'grimoires/loa/runbooks/codegen-toolchain.md'
+      - 'tools/check-codegen-toolchain.sh'
       - '.claude/skills/bridgebuilder-review/scripts/gen-bb-registry.ts'
       - '.claude/skills/bridgebuilder-review/resources/core/truncation.generated.ts'
       - '.claude/skills/bridgebuilder-review/resources/config.generated.ts'
@@ -101,8 +105,16 @@ jobs:
           echo "generated-model-maps.sh in sync"
 
   ts-codegen-check:
-    name: TS codegen (gen-bb-registry)
-    runs-on: ubuntu-latest
+    name: TS codegen (gen-bb-registry, ${{ matrix.os }})
+    # cycle-099 sprint-1C (T1.7): matrix CI verifying the bridgebuilder codegen
+    # produces byte-identical output across linux + macos. Each runner runs
+    # `npm run gen-bb-registry:check` against the committed tree — if both
+    # pass, both platforms produce byte-equal output.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -111,17 +123,36 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install yq (pinned + sha256-verified)
+      - name: Install yq (pinned + sha256-verified, platform-aware)
         run: |
           set -euo pipefail
-          # Same install pattern as the lockfile-checksum job; sha256-verified
-          # against the published v4.52.4 binary (closes BB iter-1 HIGH).
+          # SHA256-pinned per-platform binary. Closes BB iter-1 HIGH (linux)
+          # + sprint-1C subagent review H1 (macos). Hashes verified 2026-05-04
+          # from official mikefarah/yq v4.52.4 release artifacts via:
+          #   curl -sL <url> | shasum -a 256
+          case "${{ matrix.os }}" in
+              ubuntu-latest)
+                  yq_url='https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64'
+                  expected_sha256='0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c'
+                  ;;
+              macos-latest)
+                  # GitHub macos-latest is arm64 (M1/M2/M3) since 2024-Q3.
+                  yq_url='https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_darwin_arm64'
+                  expected_sha256='6bfa43a439936644d63c70308832390c8838290d064970eaada216219c218a13'
+                  ;;
+              *)
+                  echo "::error::Unsupported runner os: ${{ matrix.os }}"
+                  exit 1
+                  ;;
+          esac
           local_yq=/tmp/yq-${{ github.run_id }}
-          expected_sha256='0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c'
-          wget -qO "$local_yq" https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
-          echo "$expected_sha256  $local_yq" | sha256sum -c -
+          curl -fsSL --retry 3 --max-time 60 -o "$local_yq" "$yq_url"
+          # Use shasum (POSIX-portable) instead of sha256sum (GNU only) so the
+          # same workflow lines work on macos without a coreutils detour.
+          echo "$expected_sha256  $local_yq" | shasum -a 256 -c -
           sudo install -m 0755 "$local_yq" /usr/local/bin/yq
           rm "$local_yq"
+          yq --version
 
       - name: Install BB skill devDeps (pinned tsx + typescript)
         working-directory: .claude/skills/bridgebuilder-review

--- a/grimoires/loa/runbooks/codegen-toolchain.md
+++ b/grimoires/loa/runbooks/codegen-toolchain.md
@@ -1,0 +1,168 @@
+# Codegen Toolchain — cycle-099 Sprint 1
+
+**Version:** 1.0 (sprint-1C T1.9)
+**Date:** 2026-05-04
+**Owner:** @janitooor
+**Scope:** the toolchain required to run the cycle-099 model-registry codegen scripts deterministically across linux and macos
+
+## Why this document exists
+
+Cycle-099 consolidates the model registry into a single source of truth at `.claude/defaults/model-config.yaml`. Two codegen scripts derive consumed artifacts from that yaml:
+
+| Script | Output | Sprint |
+|---|---|---|
+| `.claude/scripts/gen-adapter-maps.sh` | `.claude/scripts/generated-model-maps.sh` | cycle-095 (existing) |
+| `.claude/skills/bridgebuilder-review/scripts/gen-bb-registry.ts` | `resources/core/truncation.generated.ts` + `resources/config.generated.ts` | cycle-099 sprint-1A |
+
+**Determinism is load-bearing.** PRD G-3 ("zero drift") requires that two operators on different machines, or the same operator on different days, regenerate byte-identical artifacts from an unchanged yaml. The drift gate in `.github/workflows/model-registry-drift.yml` enforces this on every PR — if your local regen produces different bytes than CI's, your PR fails.
+
+This runbook documents the pinned tool versions and verification steps so a fresh checkout (or a CI runner) can install the toolchain reproducibly.
+
+## Pinned tool versions
+
+| Tool | Pinned version | Rationale |
+|---|---|---|
+| `bash` | ≥ 5.0 | Associative arrays via `declare -A` (used pervasively in `generated-model-maps.sh`); macOS ships bash 3.2 by default — install via `brew install bash` |
+| `jq` | ≥ 1.7 | Used by `gen-adapter-maps.sh` for JSON manipulation; 1.7 introduced new function semantics relied on by `flatline-orchestrator.sh` |
+| `yq` (mikefarah) | **v4.52.4 exact** (sha256: `0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c` for linux_amd64) | YAML→JSON via `yq -o=json`; cycle-099 standardizes on the version used by `bats-tests.yml` to avoid CI lane skew |
+| `node` | ≥ 20.0.0 | BB skill `package.json:engines.node`; required for `tsx` and `tsc` |
+| `tsx` | ^4.21.0 (pinned in BB skill devDependencies) | Runs `gen-bb-registry.ts` directly without a tsc compile step; supply-chain hardened by being in `package-lock.json` rather than fetched via `npx tsx` on every invocation |
+| `typescript` | ^5.9.3 (BB skill devDeps) | Compiles `dist/` from the BB skill's `resources/` |
+| `python` | ≥ 3.11 | Required by cheval (`.claude/adapters/loa_cheval/`); cycle-099 sprint-2 will add `model-overlay-hook.py` |
+
+### Future toolchain (sprint-1D forward — do not install yet)
+
+These pins are forward-looking. Operators on the cycle-099 sprint-1C codepath do **not** need to install them; they ship with the consumers in later sprints.
+
+| Tool | Version | When it arrives |
+|---|---|---|
+| `idna` (Python) | ≥ 3.6 | Sprint-1D centralized endpoint validator (T1.15) — added to install steps when T1.15 lands |
+| `bun` | 1.1.x | Optional alternate runtime; the gen-bb-registry.ts script already runs under `npx tsx` (which is what CI + the BB skill `package.json` uses today). Bun migration is a single-line swap when T1.9 toolchain is universally adopted |
+
+## Install on a fresh machine
+
+### macOS (Homebrew)
+
+```bash
+brew install bash jq yq node@20 python@3.11
+
+# Verify versions
+bash --version | head -1
+jq --version
+yq --version
+node --version
+python3 --version
+```
+
+Then in the BB skill directory:
+
+```bash
+cd .claude/skills/bridgebuilder-review
+npm ci
+```
+
+### Ubuntu (apt + curl)
+
+```bash
+sudo apt-get update
+sudo apt-get install -y bash jq python3
+
+# Node 20 via NodeSource
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# yq pinned (mikefarah v4.52.4)
+curl -fsSL --retry 3 --max-time 60 \
+    -o /tmp/yq \
+    https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /tmp/yq" \
+    | sha256sum -c -
+sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+rm /tmp/yq
+
+# Verify
+bash --version | head -1
+jq --version
+yq --version
+node --version
+python3 --version
+
+# BB skill devDeps
+cd .claude/skills/bridgebuilder-review
+npm ci
+```
+
+### CI (GitHub Actions)
+
+The workflows under `.github/workflows/` install the toolchain reproducibly:
+
+- `model-registry-drift.yml` — pinned yq v4.52.4 with SHA256 verification
+- `bats-tests.yml` — pinned yq v4.52.4 (same SHA256)
+
+If you bump a pinned version, update **all three** workflows (and this runbook) atomically. The `paths:` filter in `model-registry-drift.yml` re-triggers the gate when this runbook changes, so version-drift across the four files surfaces in CI.
+
+## Verification — run the codegen
+
+Once the toolchain is in place, regenerate from yaml:
+
+```bash
+# Bash codegen
+bash .claude/scripts/gen-adapter-maps.sh
+
+# TS codegen (from BB skill dir)
+cd .claude/skills/bridgebuilder-review
+npm run gen-bb-registry
+```
+
+If your working tree has any diff in the generated files post-regen, your toolchain is producing different output than the committed artifacts. Investigate:
+
+1. Tool version skew — compare your installed versions against the pinned values above
+2. Locale / line-ending — both codegen scripts canonicalize, but a system shimming `sort` to use a locale-specific collation could cause divergence
+3. Filesystem case sensitivity — irrelevant for content, but watch for it on macos APFS
+
+## `loa doctor`-style verification
+
+The framework's `loa doctor` (cycle-072) does NOT yet check codegen-toolchain versions. Sprint-1D follow-up may integrate this. For now, sprint-1C ships a standalone helper at `tools/check-codegen-toolchain.sh`:
+
+```bash
+bash tools/check-codegen-toolchain.sh
+```
+
+Output:
+
+```
+Cycle-099 codegen toolchain check
+=================================
+OK    bash         5.2.37(1)-release (need 5.x)
+OK    jq           1.7 (need 1.7+)
+OK    yq           4.52.4 (need v4.52.4)
+OK    node         v20.x (need v20+)
+OK    python       3.11.x (need 3.11+)
+=================================
+OK: all pinned tools present
+```
+
+The script exits 0 if all tools are present, 1 if any are missing. The CI workflow (`.github/workflows/model-registry-drift.yml`) re-runs the drift gate when this script changes, so version-drift across the pin sites (script + runbook + workflows) surfaces in CI.
+
+## Drift between this runbook and the workflows
+
+If you find that this runbook's pinned version differs from `.github/workflows/model-registry-drift.yml` or `.github/workflows/bats-tests.yml`, file a bug — the runbook is the operator-facing source of truth and the workflows must mirror it.
+
+## Refresh cadence
+
+Bump the pinned versions when a security patch lands in any of the listed tools. Coordinate the bump across all four pin sites in a single PR:
+
+1. This runbook
+2. `.github/workflows/model-registry-drift.yml`
+3. `.github/workflows/bats-tests.yml`
+4. `tools/check-codegen-toolchain.sh`
+
+The `model-registry-drift.yml` workflow's `paths:` filter triggers the drift gate when this runbook OR the check script changes, so the gate runs end-to-end and confirms the new toolchain still produces byte-equal output.
+
+## Cycle-099 references
+
+- **PRD G-3**: Zero drift (`grimoires/loa/cycles/cycle-099-model-registry/prd.md`)
+- **SDD §1.4.3**: Codegen design (`grimoires/loa/cycles/cycle-099-model-registry/sdd.md`)
+- **SDD §2.1**: Tech stack pinning rationale
+- **NFR-Op-5**: Codegen reproducibility matrix CI requirement
+- **Sprint plan T1.7 + T1.9**: Matrix CI + this runbook (sprint-1C)

--- a/tools/check-codegen-toolchain.sh
+++ b/tools/check-codegen-toolchain.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-codegen-toolchain.sh — verify pinned toolchain (cycle-099 sprint-1C)
+# =============================================================================
+# Verifies that the cycle-099 codegen toolchain is installed and at supported
+# versions. Source of truth: grimoires/loa/runbooks/codegen-toolchain.md
+#
+# Exit codes:
+#   0 — all pinned tools present and within supported version range
+#   1 — one or more tools missing or below pinned minimum
+#   2 — invocation error (no args expected)
+#
+# Usage:
+#   bash tools/check-codegen-toolchain.sh
+#
+# CI uses this from .github/workflows/model-registry-drift.yml when the
+# runbook or this script is touched, so version drift across the pin sites
+# surfaces in CI rather than at codegen-time.
+
+set -euo pipefail
+
+if [ "$#" -ne 0 ]; then
+    echo "[check-codegen-toolchain] error: no arguments expected" >&2
+    exit 2
+fi
+
+errors=0
+
+# Print one row of the verification table.
+check_version() {
+    local name="$1"      # display name
+    local cmd="$2"       # version-extracting shell expression
+    local min="$3"       # minimum required version label (informational)
+    local actual
+    actual="$(eval "$cmd" 2>/dev/null || true)"
+    if [ -z "$actual" ] || [ "$actual" = "MISSING" ]; then
+        printf 'FAIL  %-12s missing (need %s)\n' "$name" "$min"
+        errors=$((errors + 1))
+    else
+        printf 'OK    %-12s %s (need %s)\n' "$name" "$actual" "$min"
+    fi
+}
+
+echo "Cycle-099 codegen toolchain check"
+echo "================================="
+
+# bash >= 5.0 — associative arrays are load-bearing (declare -A in
+# generated-model-maps.sh). macOS ships bash 3.2 by default; install via brew.
+check_version 'bash' \
+    'bash --version | head -1 | awk "{print \$4}"' \
+    '5.x'
+
+# jq >= 1.7 — flatline-orchestrator.sh + gen-adapter-maps.sh
+check_version 'jq' \
+    'jq --version | sed "s/^jq-//"' \
+    '1.7+'
+
+# yq (mikefarah) v4.52.4 exact — pinned to match
+# .github/workflows/model-registry-drift.yml + bats-tests.yml
+check_version 'yq' \
+    'yq --version | awk "{print \$NF}" | tr -d "v"' \
+    'v4.52.4'
+
+# node >= 20 — required by BB skill package.json:engines.node
+check_version 'node' \
+    'node --version | tr -d v' \
+    'v20+'
+
+# python >= 3.11 — cheval requirement
+check_version 'python' \
+    'python3 --version | awk "{print \$2}"' \
+    '3.11+'
+
+echo "================================="
+if [ "$errors" -gt 0 ]; then
+    echo "FAIL: $errors tool(s) missing or below pinned minimum"
+    echo "See: grimoires/loa/runbooks/codegen-toolchain.md"
+    exit 1
+fi
+echo "OK: all pinned tools present"
+exit 0

--- a/tools/check-codegen-toolchain.sh
+++ b/tools/check-codegen-toolchain.sh
@@ -26,18 +26,37 @@ fi
 
 errors=0
 
-# Print one row of the verification table.
+# Compare two semver-ish version strings using `sort -V`.
+# Returns 0 when $1 >= $2, 1 when $1 < $2.
+# Both arguments must be normalized to digit-dot-digit-dot-digit form
+# (or compatible — sort -V tolerates suffixes like "5.2.37(1)-release").
+_version_ge() {
+    local current="$1" required="$2"
+    local lowest
+    lowest="$(printf '%s\n%s\n' "$current" "$required" | sort -V | head -1)"
+    [ "$lowest" = "$required" ]
+}
+
+# IMPORTANT: callers MUST pass static literals to check_version (eval is
+# scoped to hardcoded version-extraction expressions only — see BB iter-1
+# F4). Do not parameterize the cmd argument from env vars or argv.
 check_version() {
     local name="$1"      # display name
-    local cmd="$2"       # version-extracting shell expression
-    local min="$3"       # minimum required version label (informational)
+    local cmd="$2"       # version-extracting shell expression (LITERAL)
+    local min="$3"       # minimum required version (e.g., "5.0", "1.7", "20.0")
     local actual
+    # shellcheck disable=SC2086
     actual="$(eval "$cmd" 2>/dev/null || true)"
     if [ -z "$actual" ] || [ "$actual" = "MISSING" ]; then
-        printf 'FAIL  %-12s missing (need %s)\n' "$name" "$min"
+        printf 'FAIL  %-12s missing (need %s+)\n' "$name" "$min"
         errors=$((errors + 1))
+        return
+    fi
+    if _version_ge "$actual" "$min"; then
+        printf 'OK    %-12s %s (need %s+)\n' "$name" "$actual" "$min"
     else
-        printf 'OK    %-12s %s (need %s)\n' "$name" "$actual" "$min"
+        printf 'FAIL  %-12s %s is below %s+\n' "$name" "$actual" "$min"
+        errors=$((errors + 1))
     fi
 }
 
@@ -46,30 +65,34 @@ echo "================================="
 
 # bash >= 5.0 — associative arrays are load-bearing (declare -A in
 # generated-model-maps.sh). macOS ships bash 3.2 by default; install via brew.
+# Strip the "(N)-release" suffix bash --version emits on some distros so
+# sort -V handles the digit-dot-digit form.
 check_version 'bash' \
-    'bash --version | head -1 | awk "{print \$4}"' \
-    '5.x'
+    'bash --version | head -1 | awk "{print \$4}" | grep -oE "^[0-9]+(\.[0-9]+)+"' \
+    '5.0'
 
 # jq >= 1.7 — flatline-orchestrator.sh + gen-adapter-maps.sh
 check_version 'jq' \
     'jq --version | sed "s/^jq-//"' \
-    '1.7+'
+    '1.7'
 
-# yq (mikefarah) v4.52.4 exact — pinned to match
-# .github/workflows/model-registry-drift.yml + bats-tests.yml
+# yq (mikefarah) v4.52.4 minimum (pinned to match workflows). BB iter-1 F6
+# noted yq's --version format has shifted across versions; use a targeted
+# grep for the digit-dot-digit-dot-digit pattern instead of trusting the
+# last whitespace-separated field.
 check_version 'yq' \
-    'yq --version | awk "{print \$NF}" | tr -d "v"' \
-    'v4.52.4'
+    'yq --version 2>&1 | grep -oE "v?[0-9]+\.[0-9]+\.[0-9]+" | head -1 | tr -d v' \
+    '4.52.4'
 
 # node >= 20 — required by BB skill package.json:engines.node
 check_version 'node' \
     'node --version | tr -d v' \
-    'v20+'
+    '20.0.0'
 
 # python >= 3.11 — cheval requirement
 check_version 'python' \
     'python3 --version | awk "{print \$2}"' \
-    '3.11+'
+    '3.11.0'
 
 echo "================================="
 if [ "$errors" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Sprint-1C of [cycle-099](https://github.com/0xHoneyJar/loa/issues/710) — **T1.7 + T1.9**. Matrix CI for cross-platform codegen byte-equality, the operator-facing toolchain runbook, and a latent-drift fix for sprint-1A's bash codegen output.

## Files (4 files, +293 / −8)

| File | Change |
|------|--------|
| `.github/workflows/model-registry-drift.yml` | MOD — ts-codegen-check now matrix `[ubuntu-latest, macos-latest]` with platform-aware SHA256-pinned yq install |
| `grimoires/loa/runbooks/codegen-toolchain.md` | NEW — 168 lines, operator-facing toolchain documentation |
| `tools/check-codegen-toolchain.sh` | NEW — operator-runnable pinned-tool verification script |
| `.claude/scripts/generated-model-maps.sh` | MOD (+5 lines) — latent-drift fix; sprint-1A added `claude-sonnet-4-5-20250929` to yaml without regenerating this output |

## Latent drift fix

Sprint-1A's PR added `claude-sonnet-4-5-20250929` to `.claude/defaults/model-config.yaml` but never regenerated `generated-model-maps.sh`. The drift went undetected because:

1. Sprint-1A predated the drift-gate workflow
2. Sprint-1B introduced the gate but couldn't run it against its own introducing PR (`pull_request:` scope; the workflow file didn't yet exist on main when the PR was evaluated)

Sprint-1C surfaces it via `bats tests/integration/model-registry-sync.bats` (which runs locally on the cycle-099 sprint-1c branch). The 5-line diff is mechanically derived via `bash .claude/scripts/gen-adapter-maps.sh` against the current yaml. **No semantic change** — the resulting map agrees with the existing TS codegen output and the model-config.yaml entry.

This is the **SDD R-5 "drift-gate cannot catch its own introducing PR"** race in the wild. Sprint-1D could mitigate via:
- `workflow_dispatch` trigger that runs the gate against post-merge main
- `pre-commit` hook mirror invoking `gen-adapter-maps --check` locally

## Quality gates (subagent review)

Combined review (smaller surface than 1A/1B — single pass instead of parallel review+audit). **Verdict**: APPROVE WITH FOLLOWUPS. All 5 substantive findings addressed inline:

| # | Finding | Source | Fix |
|---|---|---|---|
| H1 | macOS yq SHA256 originally skipped (CI-side supply-chain hole) | review HIGH | ✅ Computed `6bfa43a4...` for `yq_darwin_arm64` v4.52.4 + pinned in workflow |
| M2 | `idna ≥3.6` pinned in runbook but unused anywhere | review MEDIUM | ✅ Moved to "Future toolchain" section; removed from install steps |
| M3 | `bun 1.1.x` speculative entry | review MEDIUM | ✅ Same section relocation |
| L1 | Comment claims "hashes verified" but only linux was pinned | review LOW | ✅ Tightened comment |
| L2 | `tools/check-codegen-toolchain.sh` referenced but didn't exist | review LOW | ✅ Created the file (smoke-tested locally: 5/5 pins present) |

## Test plan (post-merge)

- [ ] CI green on **both** `ubuntu-latest` AND `macos-latest` for the ts-codegen-check matrix
- [ ] `bash tools/check-codegen-toolchain.sh` returns 0 on both platforms
- [ ] `bats tests/integration/model-registry-sync.bats` — 13/13 PASS (drift fix verified)

## --no-verify rationale (per cycle-099 sprint plan §`--no-verify` Safety Policy)

Beads is `UNHEALTHY/MIGRATION_NEEDED` ([#661](https://github.com/0xHoneyJar/loa/issues/661)). Manual pre-commit-equivalent:

- [x] `python3 -c yaml.safe_load` — workflow yaml VALID
- [x] `bash tools/check-codegen-toolchain.sh` — exit 0
- [x] `bats tests/integration/{lockfile-checksum,legacy-adapter-still-works,model-registry-sync}.bats` — 44/44 PASS
- [x] `gen-adapter-maps.sh --check` — clean (no drift after fix)
- [x] `[NO-VERIFY-RATIONALE: ...]` tag in commit body

Refs: #710 (cycle-099), cycle-099 sprint.md §1 Sprint 1, NFR-Op-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)