### PR TITLE
feat(cycle-099-sprint-1E.a): log-redactor + migrate-model-config CLI (T1.13 + T1.14)

### DIFF
--- a/.claude/data/schemas/model-config-v2.schema.json
+++ b/.claude/data/schemas/model-config-v2.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://loa.dev/schemas/model-config-v2.schema.json",
+  "title": "Loa model-config.yaml v2",
+  "description": "cycle-099 Sprint 1 v2 schema. Sprint 1 ships the structural shape (schema_version=2, archived/unknown namespaces, per-model permissions block per DD-1 Option B). Strict at every level: additionalProperties:false everywhere; operator-injected unknown keys MUST be swept into _unknown_v1_fields by the migrator (or rejected). Sprint 2/3 will tighten provider/alias/tier_groups vocabulary as those features land.",
+  "type": "object",
+  "required": ["schema_version", "providers"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": 2,
+      "description": "Locked to integer 2 in cycle-099. Older configs go through loa-migrate-model-config.py first."
+    },
+    "providers": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/providerEntry"}
+    },
+    "aliases": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "backward_compat_aliases": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "agents": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/agentBinding"}
+    },
+    "tier_groups": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mappings": {"type": "object"},
+        "denylist": {"type": "array", "items": {"type": "string"}},
+        "max_cost_per_session_micro_usd": {"type": ["integer", "null"], "minimum": 0}
+      }
+    },
+    "routing": {"type": "object"},
+    "retry": {"type": "object"},
+    "metering": {"type": "object"},
+    "defaults": {"type": "object"},
+    "_archived_v1_fields": {
+      "type": "object",
+      "description": "Top-level namespace for fields removed in v2 but preserved verbatim by loa-migrate-model-config. Operators MAY review and delete; loader ignores."
+    },
+    "_unknown_v1_fields": {
+      "type": "object",
+      "description": "Top-level namespace for v1 keys not recognized by the migrator (e.g., operator experimental fields). Loader ignores; operator should re-place into v2 schema if still needed."
+    }
+  },
+  "$defs": {
+    "providerEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Cycle-095 production field surface enumerated explicitly. Operator extensions go through .loa.config.yaml::model_aliases_extra, not by extending this schema.",
+      "properties": {
+        "type": {"type": "string"},
+        "endpoint": {"type": "string"},
+        "auth": {"type": "string"},
+        "auth_modes": {"type": "array", "items": {"type": "string"}},
+        "compliance_profile": {"type": ["string", "null"]},
+        "connect_timeout": {"type": "number"},
+        "read_timeout": {"type": "number"},
+        "region_default": {"type": "string"},
+        "models": {
+          "type": "object",
+          "additionalProperties": {"$ref": "#/$defs/modelEntry"}
+        }
+      }
+    },
+    "modelEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "capabilities": {"type": "array", "items": {"type": "string"}},
+        "context_window": {
+          "type": "integer",
+          "minimum": 1024,
+          "description": "v2 minimum 1024 (SDD §3.1.1.1 unit test corpus). v1 entries below this fail post-migration validation with [MIGRATION-PRODUCED-INVALID-V2]."
+        },
+        "token_param": {"type": "string"},
+        "endpoint_family": {
+          "type": "string",
+          "enum": ["chat", "responses"],
+          "description": "cycle-095 Sprint 1 (SDD §3.4): REQUIRED on every OpenAI registry entry. Carried forward verbatim from v1."
+        },
+        "api_format": {
+          "description": "String shorthand or per-capability mapping (cycle-095 bedrock pattern: {chat: converse, tools: converse, ...}).",
+          "type": ["string", "object"]
+        },
+        "api_mode": {"type": "string"},
+        "params": {"type": "object"},
+        "extra": {"type": "object"},
+        "pricing": {"type": "object"},
+        "permissions": {"$ref": "#/$defs/permissionsBlock"},
+        "fallback_to": {"type": "string"},
+        "fallback_mapping_version": {"type": "integer"},
+        "fallback_chain": {"type": "array", "items": {"type": "string"}},
+        "available_until": {"type": "string"},
+        "deprecated_since": {"type": "string"},
+        "notes": {"type": "string"},
+        "_archived_v1_fields": {
+          "type": "object",
+          "description": "Per-model namespace where loa-migrate-model-config archives legacy keys when both legacy + renamed forms coexist (e.g., endpoint_class + endpoint_family)."
+        }
+      }
+    },
+    "permissionsBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "DD-1 Option B per-model permissions block. Optional in cycle-099 v2 (Sprint 3 lands the migration that populates it from cycle-026 model-permissions.yaml). Becomes required in cycle-100+. Field-level vocabulary (`trust_level` enum, `trust_scopes` shape) is intentionally permissive in Sprint 1; Sprint 3 tightens once DD-1 Option B's authoritative vocabulary is locked.",
+      "properties": {
+        "trust_level": {"type": "string"},
+        "trust_scopes": {"type": "object"},
+        "execution_mode": {"type": "string"},
+        "capabilities": {"type": "object"},
+        "notes": {"type": "string"}
+      }
+    },
+    "agentBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "type": "string",
+          "not": {"enum": ["max", "cheap", "mid", "tiny"]},
+          "description": "Custom alias name (resolves via aliases / backward_compat_aliases). Tier-tag values (max/cheap/mid/tiny) belong under default_tier; the migrator renames them automatically. A v2 file with model:<tier-tag> fails validation."
+        },
+        "default_tier": {
+          "type": "string",
+          "enum": ["max", "cheap", "mid", "tiny"],
+          "description": "v2 tier-tag binding. The migrator renames v1 `agents.<skill>.model: <tier>` → `agents.<skill>.default_tier: <tier>` when the value is one of {max, cheap, mid, tiny}."
+        },
+        "temperature": {"type": "number"},
+        "requires": {"type": "object"}
+      },
+      "not": {
+        "required": ["model", "default_tier"],
+        "description": "An agent binding may have `model:` OR `default_tier:` but not both. Sprint 2 loader resolves either via tier_groups.mappings."
+      }
+    }
+  }
+}

--- a/.claude/scripts/lib/log-redactor.py
+++ b/.claude/scripts/lib/log-redactor.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Log redactor — canonical Python implementation per cycle-099 SDD §5.6.
+
+Masks URL userinfo (`://[REDACTED]@`) and 6 query-string secret patterns
+(`key`, `token`, `secret`, `password`, `api_key`, `auth`) case-insensitively
+while preserving structural identity (separator + parameter-name case).
+
+Stdlib-only. Cross-runtime parity with `.claude/scripts/lib/log-redactor.sh`
+asserted by `tests/integration/log-redactor-cross-runtime.bats`.
+
+Caller contract — IN-SCOPE redactions
+=====================================
+The redactor handles URL-shaped secrets ONLY. The patterns require a leading
+`?` or `&` (query-string separator) before the secret-bearing parameter name
+or `://` before the userinfo segment. Any caller emitting `key=value` log
+lines WITHOUT URL framing is responsible for either:
+
+  1. Reformatting their log emission to use URL-style framing, e.g.
+     `[MODEL-RESOLVE] endpoint=https://host/?api_key=<value>` rather than
+     `[MODEL-RESOLVE] api_key=<value>`. The redactor catches the former.
+
+  2. Redacting the secret VALUE in isolation BEFORE log emission, then
+     emitting the bare key=value pair safely.
+
+This is in-contract per SDD §5.6.2 — the redactor's stop-character set
+intentionally tracks URL grammar (`&`, `\\n`, end-of-string). Extending it
+to bare `\\s` would over-match in non-log contexts (file paths, JSON, etc.)
+and break the structural-identity guarantee that operators rely on for
+log-grep workflows.
+
+Usage:
+  As library:  from log_redactor import redact; redact(text)
+  As filter:   cat input | python3 log-redactor.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+# Order in the alternation does not affect correctness because no name in this
+# set is a prefix of another that the engine would silently match; however we
+# keep a single combined pattern for performance (one pass through the string).
+_QUERY_PARAMS = ("key", "token", "secret", "password", "api_key", "auth")
+
+_USERINFO_RE = re.compile(r"://[^/@\n]*@")
+
+_QUERY_RE = re.compile(
+    r"([?&])(" + "|".join(_QUERY_PARAMS) + r")=[^&\n]*",
+    re.IGNORECASE,
+)
+
+
+def _query_repl(match: re.Match) -> str:
+    # Preserve original separator (group 1) and original-case parameter name
+    # (group 2). The replacement value is the literal sentinel.
+    return f"{match.group(1)}{match.group(2)}=[REDACTED]"
+
+
+def redact(text: str) -> str:
+    """Return `text` with URL userinfo and known-secret query params masked.
+
+    Pure function, no I/O. Idempotent: redact(redact(x)) == redact(x).
+    Newlines act as natural boundaries — a redaction never spans a `\\n`,
+    matching the line-by-line semantics of the bash twin's `sed` pipeline.
+    """
+    text = _USERINFO_RE.sub("://[REDACTED]@", text)
+    text = _QUERY_RE.sub(_query_repl, text)
+    return text
+
+
+def _main() -> int:
+    sys.stdout.write(redact(sys.stdin.read()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/.claude/scripts/lib/log-redactor.sh
+++ b/.claude/scripts/lib/log-redactor.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# =============================================================================
+# log-redactor.sh — bash twin per cycle-099 SDD §5.6.
+#
+# Masks URL userinfo (`://[REDACTED]@`) and 6 query-string secret patterns
+# (key, token, secret, password, api_key, auth) case-insensitively while
+# preserving the original separator (`?`/`&`) and parameter-name case.
+#
+# Cross-runtime parity with `.claude/scripts/lib/log-redactor.py` asserted by
+# `tests/integration/log-redactor.bats`.
+#
+# POSIX BRE only — no GNU sed extensions, no `I` flag. Case-insensitivity is
+# expressed via explicit `[Aa]`-style character classes per name letter.
+#
+# Usage:
+#   As library:  source log-redactor.sh; printf '%s' "$text" | _redact
+#   As filter:   cat input | bash log-redactor.sh
+# =============================================================================
+
+# Apply redactor to stdin → stdout. Newlines are natural boundaries because
+# sed processes line-by-line and the negated character class `[^&]` / `[^/@]`
+# never sees `\n` inside its pattern space. Result: byte-equal to the Python
+# canonical for any UTF-8 / ASCII input.
+_redact() {
+    sed \
+        -e 's|://[^/@]*@|://[REDACTED]@|g' \
+        -e 's|\([?&][Kk][Ee][Yy]\)=[^&]*|\1=[REDACTED]|g' \
+        -e 's|\([?&][Tt][Oo][Kk][Ee][Nn]\)=[^&]*|\1=[REDACTED]|g' \
+        -e 's|\([?&][Ss][Ee][Cc][Rr][Ee][Tt]\)=[^&]*|\1=[REDACTED]|g' \
+        -e 's|\([?&][Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]\)=[^&]*|\1=[REDACTED]|g' \
+        -e 's|\([?&][Aa][Pp][Ii]_[Kk][Ee][Yy]\)=[^&]*|\1=[REDACTED]|g' \
+        -e 's|\([?&][Aa][Uu][Tt][Hh]\)=[^&]*|\1=[REDACTED]|g'
+}
+
+# Allow direct invocation as a script (filter mode).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    _redact
+fi

--- a/.claude/scripts/lib/model-config-migrate.py
+++ b/.claude/scripts/lib/model-config-migrate.py
@@ -1,0 +1,433 @@
+"""model-config-migrate — pure v1→v2 migration logic per cycle-099 SDD §3.1.1.1.
+
+This module is the contract surface; the CLI driver
+.claude/scripts/loa-migrate-model-config.py wraps it with file I/O + report
+formatting + exit-code handling.
+
+The single public function `migrate_v1_to_v2` is pure: takes a parsed v1 dict
+(plus optional cycle-026 model-permissions dict), returns a parsed v2 dict
+and a structured change report. No I/O. Idempotent on v2 input.
+
+Schema version detection:
+  - missing `schema_version` key  → treated as v1 (cycle-095 vintage)
+  - `schema_version: 1`           → v1
+  - `schema_version: 2`           → v2 (idempotent no-op + WARN)
+  - `schema_version: ≥3`          → unsupported (caller raises exit 78)
+
+Field-level migration table (SDD §3.1.1.1):
+  Pass-through (silent):
+    providers.<p>.models.<id>.{capabilities, context_window, …}
+    aliases.<name>
+  Populated with §3.1.2 defaults (INFO each):
+    tier_groups.mappings.<tier>.<provider>     (cycle-095 empty maps)
+  Auto-rename when value is a tier-tag (INFO):
+    agents.<skill>.model: <tier>  →  agents.<skill>.default_tier: <tier>
+  Merged from cycle-026 standalone file (INFO each):
+    model-permissions.yaml entries → providers.<p>.models.<id>.permissions
+  Renamed at model level (INFO each):
+    endpoint_class                 →  endpoint_family
+  Archived (WARN each):
+    fields removed in v2 → top-level _archived_v1_fields:
+  Preserved with namespace (WARN each):
+    operator-added top-level keys → top-level _unknown_v1_fields:
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+# Tier-tags whose presence in `agents.<skill>.model:` triggers rename to
+# `agents.<skill>.default_tier:`. Custom aliases (e.g., 'opus', 'reviewer')
+# stay under `model:` — they are not formal tiers per SDD §3.1.2.
+TIER_TAGS = frozenset({"max", "cheap", "mid", "tiny"})
+
+# Top-level keys recognized as v1 schema. Any other top-level key in a v1
+# input is treated as operator-added "unknown" and namespaced into
+# _unknown_v1_fields:.
+KNOWN_V1_TOP_KEYS = frozenset(
+    {
+        "schema_version",
+        "providers",
+        "aliases",
+        "backward_compat_aliases",
+        "agents",
+        "tier_groups",
+        "routing",
+        "retry",
+        "metering",
+        "defaults",
+    }
+)
+
+# Within a model entry, v1→v2 renames. Add new entries here as the v2 schema
+# evolves; the migrator emits one INFO per renamed instance.
+MODEL_FIELD_RENAMES: dict[str, str] = {
+    "endpoint_class": "endpoint_family",
+}
+
+# Top-level fields that v1 had but v2 explicitly removes. Currently empty;
+# any future deletion would land in _archived_v1_fields:.
+REMOVED_V1_TOP_KEYS: frozenset[str] = frozenset()
+
+# §3.1.2 default tier_groups.mappings populated when v1's mappings are empty.
+# These are the cycle-099 v2 defaults; operators can override in their own
+# .loa.config.yaml::tier_groups.mappings during Sprint 2 rollout.
+TIER_GROUPS_DEFAULTS: dict[str, dict[str, str]] = {
+    "max": {
+        "anthropic": "opus",
+        "openai": "gpt-5.5-pro",
+        "google": "gemini-3.1-pro",
+    },
+    "cheap": {
+        "anthropic": "cheap",
+        "openai": "gpt-5.3-codex",
+        "google": "gemini-3-flash",
+    },
+    "mid": {
+        "anthropic": "cheap",
+        "openai": "gpt-5.5",
+        "google": "gemini-2.5-pro",
+    },
+    "tiny": {
+        "anthropic": "tiny",
+        "openai": "gpt-5.3-codex",
+        "google": "gemini-3-flash",
+    },
+}
+
+
+class MigrationError(Exception):
+    """Raised when migration cannot proceed (schema version unsupported, etc.)."""
+
+    def __init__(self, code: str, detail: str):
+        super().__init__(f"[{code}] {detail}")
+        self.code = code
+        self.detail = detail
+
+
+def detect_schema_version(data: dict[str, Any]) -> int:
+    """Return the integer schema_version. Missing key → 1 (cycle-095 vintage).
+
+    Raises MigrationError if the value is present but not a positive integer.
+    """
+    raw = data.get("schema_version")
+    if raw is None:
+        return 1
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 1:
+        raise MigrationError(
+            "CONFIG-SCHEMA-VERSION-INVALID",
+            f"schema_version must be a positive integer; got {raw!r}",
+        )
+    return raw
+
+
+def migrate_v1_to_v2(
+    v1: dict[str, Any],
+    model_permissions: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Pure migration. Returns (v2_dict, report).
+
+    `report` is a list of `{kind: str, path: str, detail: str, severity: str}`.
+    `kind` ∈ {pass_through, rename, populate, merge_permissions, archive,
+              preserve_unknown, agent_default_tier, idempotent_noop}.
+    `severity` ∈ {INFO, WARN, ERROR}.
+
+    No file I/O. The caller (CLI) handles reading, writing, validation, and
+    structured error emission.
+
+    `model_permissions` is the optional cycle-026 standalone permissions
+    dict (parsed from model-permissions.yaml, top-level shape:
+    `model_permissions: { "<provider>:<model_id>": {...trust_scopes...} }`).
+    When provided, each entry is merged into the corresponding model's
+    `permissions` block per DD-1 Option B.
+
+    Defensive copy: the function deep-copies the inputs before mutating so the
+    caller's v1 dict (and its nested children — providers, models, agents)
+    survive untouched. This matches the SDD's "pure function" claim.
+    """
+    version = detect_schema_version(v1)
+    if version >= 3:
+        raise MigrationError(
+            "CONFIG-SCHEMA-VERSION-UNSUPPORTED",
+            f"schema_version {version} is newer than the migrator's target (v2). "
+            "Use a cycle-{N+1}+ migrator.",
+        )
+    if version == 2:
+        # Idempotent: return a defensive copy so caller-side post-migration
+        # mutations cannot retroactively change the input doc.
+        return copy.deepcopy(v1), [
+            {
+                "kind": "idempotent_noop",
+                "path": "schema_version",
+                "detail": "input is already v2; no migration applied",
+                "severity": "WARN",
+                "code": "MIGRATION-NOOP-V2-INPUT",
+            }
+        ]
+
+    # version == 1 (or absent — same path)
+    v1 = copy.deepcopy(v1)
+    if model_permissions is not None:
+        model_permissions = copy.deepcopy(model_permissions)
+    report: list[dict[str, Any]] = []
+    v2: dict[str, Any] = {"schema_version": 2}
+    # G-M2 (review remediation): emit an explicit version_bump entry so the
+    # CLI's text report doesn't print "(no changes)" on a v1→v2 migration that
+    # happened to have no field-level rewrites. The structural change (adding
+    # schema_version) is itself worth surfacing.
+    report.append(
+        {
+            "kind": "version_bump",
+            "path": "schema_version",
+            "detail": "added schema_version: 2 (v1 → v2)",
+            "severity": "INFO",
+        }
+    )
+
+    # Carry forward known top-level v1 keys; collect unknowns + removed.
+    unknown: dict[str, Any] = {}
+    archived: dict[str, Any] = {}
+
+    for key, value in v1.items():
+        if key == "schema_version":
+            continue
+        if key in REMOVED_V1_TOP_KEYS:
+            archived[key] = value
+            report.append(
+                {
+                    "kind": "archive",
+                    "path": key,
+                    "detail": f"archived field {key} (deprecated in v2)",
+                    "severity": "WARN",
+                }
+            )
+            continue
+        if key not in KNOWN_V1_TOP_KEYS:
+            unknown[key] = value
+            report.append(
+                {
+                    "kind": "preserve_unknown",
+                    "path": key,
+                    "detail": (
+                        f"preserved unknown v1 field {key} under "
+                        f"_unknown_v1_fields/{key}; review and re-place in v2 schema if needed"
+                    ),
+                    "severity": "WARN",
+                }
+            )
+            continue
+        v2[key] = value
+
+    # Per-model field renames (e.g., endpoint_class → endpoint_family).
+    if "providers" in v2:
+        v2["providers"] = _migrate_providers(v2["providers"], report)
+
+    # Agent-binding rename when value is a tier-tag.
+    if "agents" in v2:
+        v2["agents"] = _migrate_agents(v2["agents"], report)
+
+    # Populate tier_groups.mappings per SDD §3.1.1.1 row 3. Three cases per
+    # review remediation (G-H2 + G-H3):
+    #   1. v1 had no `tier_groups:` at all      → create the section + populate
+    #   2. v1 had empty `mappings: {}`          → populate all 4 tiers
+    #   3. v1 had partial mappings (cycle-095   → fill in missing (tier, provider)
+    #      operator started populating)            pairs without overwriting
+    v2["tier_groups"] = _migrate_tier_groups(v2.get("tier_groups", {}), report)
+
+    # Merge cycle-026 model-permissions.yaml entries.
+    if model_permissions is not None:
+        _merge_model_permissions(v2.get("providers", {}), model_permissions, report)
+
+    if archived:
+        v2["_archived_v1_fields"] = archived
+    if unknown:
+        v2["_unknown_v1_fields"] = unknown
+
+    return v2, report
+
+
+def _migrate_providers(
+    providers: dict[str, Any], report: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Walk providers.<p>.models.<id> and apply MODEL_FIELD_RENAMES."""
+    if not isinstance(providers, dict):
+        return providers
+    for provider_id, provider in providers.items():
+        if not isinstance(provider, dict):
+            continue
+        models = provider.get("models")
+        if not isinstance(models, dict):
+            continue
+        for model_id, model in models.items():
+            if not isinstance(model, dict):
+                continue
+            for old_name, new_name in MODEL_FIELD_RENAMES.items():
+                if old_name in model and new_name not in model:
+                    model[new_name] = model.pop(old_name)
+                    report.append(
+                        {
+                            "kind": "rename",
+                            "path": f"providers.{provider_id}.models.{model_id}.{old_name}",
+                            "detail": (
+                                f"renamed providers.{provider_id}.models.{model_id}."
+                                f"{old_name} -> .{new_name}"
+                            ),
+                            "severity": "INFO",
+                        }
+                    )
+                elif old_name in model and new_name in model:
+                    # Both present — operator already migrated the field; archive
+                    # the legacy key into the model entry under a per-model
+                    # _archived_v1_fields namespace to surface the conflict.
+                    legacy_value = model.pop(old_name)
+                    archived = model.setdefault("_archived_v1_fields", {})
+                    archived[old_name] = legacy_value
+                    report.append(
+                        {
+                            "kind": "archive",
+                            "path": f"providers.{provider_id}.models.{model_id}.{old_name}",
+                            "detail": (
+                                f"both {old_name} and {new_name} present; archived "
+                                f"legacy {old_name}={legacy_value!r} in favor of "
+                                f"{new_name}={model[new_name]!r}"
+                            ),
+                            "severity": "WARN",
+                        }
+                    )
+    return providers
+
+
+def _migrate_agents(
+    agents: dict[str, Any], report: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Rename agents.<skill>.model: <tier> → agents.<skill>.default_tier: <tier>.
+
+    Sprint 1E uses string-match against TIER_TAGS (literal value comparison).
+    SDD §3.1.1.1 row 4 wording ("IF the resolved model maps to a known tier")
+    implies alias resolution should run first; that requires the Sprint 2
+    resolver, which Sprint 1E doesn't ship. The string-match yields the same
+    answer for every cycle-095 vintage config in practice (operator naming
+    convention is to use the literal tier-tag), but a future operator who
+    aliases a tier-name to a model id (e.g., `aliases.cheap: openai:gpt-...`)
+    and uses `agents.x.model: <some-model-resolving-to-cheap>` will not get
+    renamed here. Sprint 2 will replace this with resolver-aware rename.
+    """
+    if not isinstance(agents, dict):
+        return agents
+    for skill_name, binding in agents.items():
+        if not isinstance(binding, dict):
+            continue
+        model_value = binding.get("model")
+        if isinstance(model_value, str) and model_value in TIER_TAGS:
+            binding["default_tier"] = model_value
+            del binding["model"]
+            report.append(
+                {
+                    "kind": "agent_default_tier",
+                    "path": f"agents.{skill_name}.model",
+                    "detail": (
+                        f"renamed agents.{skill_name}.model -> "
+                        f"agents.{skill_name}.default_tier (value '{model_value}' is a tier-tag)"
+                    ),
+                    "severity": "INFO",
+                }
+            )
+    return agents
+
+
+def _migrate_tier_groups(
+    tier_groups: dict[str, Any], report: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Populate tier_groups.mappings with SDD §3.1.2 defaults.
+
+    Handles three input shapes (review remediation G-H2/G-H3):
+      - tier_groups absent (we received {} as fallback)         → full populate
+      - tier_groups present, mappings absent or {}              → full populate
+      - tier_groups present, mappings has some (tier,provider)  → fill missing
+        pairs only; never overwrite operator-supplied entries
+    """
+    if not isinstance(tier_groups, dict):
+        return tier_groups
+    mappings = tier_groups.get("mappings")
+    if not isinstance(mappings, dict):
+        mappings = {}
+        tier_groups["mappings"] = mappings
+    for tier, provider_map in TIER_GROUPS_DEFAULTS.items():
+        tier_dict = mappings.setdefault(tier, {})
+        if not isinstance(tier_dict, dict):
+            # Operator wrote a non-dict at this tier; leave as-is and skip.
+            continue
+        for provider, value in provider_map.items():
+            if provider in tier_dict:
+                continue  # operator-supplied; preserve verbatim
+            tier_dict[provider] = value
+            report.append(
+                {
+                    "kind": "populate",
+                    "path": f"tier_groups.mappings.{tier}.{provider}",
+                    "detail": (
+                        f"populated tier_groups.mappings.{tier}.{provider} = {value} "
+                        "(SDD §3.1.2 default)"
+                    ),
+                    "severity": "INFO",
+                }
+            )
+    # Sprint 2 will own the denylist + max_cost defaults; Sprint 1E only
+    # ensures the section exists so the loader has a stable shape.
+    tier_groups.setdefault("denylist", [])
+    tier_groups.setdefault("max_cost_per_session_micro_usd", None)
+    return tier_groups
+
+
+def _merge_model_permissions(
+    providers: dict[str, Any],
+    model_permissions_doc: dict[str, Any],
+    report: list[dict[str, Any]],
+) -> None:
+    """Merge cycle-026 model_permissions block into providers.<p>.models.<id>.permissions."""
+    permissions_map = model_permissions_doc.get("model_permissions", {})
+    if not isinstance(permissions_map, dict):
+        return
+    for combined_key, perms in permissions_map.items():
+        if not isinstance(combined_key, str) or ":" not in combined_key:
+            continue
+        provider_id, model_id = combined_key.split(":", 1)
+        provider = providers.get(provider_id)
+        if not isinstance(provider, dict):
+            continue
+        models = provider.get("models")
+        if not isinstance(models, dict):
+            continue
+        model = models.get(model_id)
+        if not isinstance(model, dict):
+            continue
+        # DD-1 Option B: merge as a `permissions` block per-model.
+        if "permissions" in model:
+            # Operator-supplied permissions take precedence; legacy stash.
+            archived = model.setdefault("_archived_v1_fields", {})
+            archived.setdefault("legacy_model_permissions", perms)
+            report.append(
+                {
+                    "kind": "archive",
+                    "path": f"providers.{provider_id}.models.{model_id}.permissions",
+                    "detail": (
+                        f"existing permissions block on {provider_id}:{model_id}; "
+                        "legacy cycle-026 entry archived under _archived_v1_fields"
+                    ),
+                    "severity": "WARN",
+                }
+            )
+            continue
+        model["permissions"] = perms
+        report.append(
+            {
+                "kind": "merge_permissions",
+                "path": f"providers.{provider_id}.models.{model_id}.permissions",
+                "detail": (
+                    f"merged model-permissions {provider_id}:{model_id} -> "
+                    "permissions block (DD-1 Option B)"
+                ),
+                "severity": "INFO",
+            }
+        )

--- a/.claude/scripts/loa-migrate-model-config.py
+++ b/.claude/scripts/loa-migrate-model-config.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""loa migrate-model-config — operator-explicit v1 → v2 migration CLI.
+
+cycle-099 Sprint 1E (T1.14). Implements SDD §3.1.1.1 contract:
+  - Reads input YAML with ruamel.yaml (round-trip mode)
+  - Detects schema_version (absent → v1; explicit 1/2/≥3)
+  - Dispatches to pure migrate_v1_to_v2 (lib/model-config-migrate.py)
+  - Validates output against the v2 JSON Schema
+  - Reports field-level changes (text or JSON)
+  - Exits 0 on success, 78 on validation failure or unsupported schema_version
+
+Usage:
+  loa-migrate-model-config.py INPUT.yaml -o OUTPUT.yaml
+  loa-migrate-model-config.py INPUT.yaml -o OUT.yaml --model-permissions cycle-026.yaml
+  loa-migrate-model-config.py INPUT.yaml -o OUT.yaml --report-format json
+  loa-migrate-model-config.py INPUT.yaml -o OUT.yaml --dry-run
+
+The CLI is non-destructive: it never overwrites the input file. Operators
+should review the structured report and the diff between input and output
+before adopting the v2 file as their authoritative config.
+
+Limitation: in-line YAML comments and blank-line formatting are NOT preserved
+across migration in this Sprint 1E shipment. The transformation is structural
+(key order, nesting). Operators with heavily-commented configs should review
+the v2 output and re-add comments. A future cycle may add a
+--preserve-comments flag using ruamel's full round-trip mutation API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+EXIT_SUCCESS = 0
+EXIT_VALIDATION_FAIL = 78  # EX_CONFIG (sysexits.h convention)
+EXIT_USAGE = 64  # EX_USAGE
+
+# Mode 0600: the migrated v2 file may carry merged trust_scopes from the
+# cycle-026 model-permissions.yaml — operator-sensitive. Keep it owner-only
+# regardless of the operator's umask.
+_OUTPUT_FILE_MODE = 0o600
+
+
+def _load_migrate_module():
+    """Import the sibling lib/model-config-migrate.py via importlib.
+
+    The module name has dashes (per cycle-099 file-naming convention), which
+    makes plain `import` impossible — we use a spec loader instead.
+    """
+    here = Path(__file__).resolve().parent
+    target = here / "lib" / "model-config-migrate.py"
+    spec = importlib.util.spec_from_file_location("model_config_migrate", target)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {target}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_yaml(path: Path) -> Any:
+    from ruamel.yaml import YAML
+
+    yaml = YAML(typ="rt")
+    with path.open("r") as f:
+        return yaml.load(f)
+
+
+def _dump_yaml(data: Any, path: Path) -> None:
+    """Write `data` to `path` as YAML.
+
+    Symlink-safe: refuses to write through an existing symlink (review
+    remediation C-H2; prevents clobbering symlink targets like
+    ~/.aws/credentials, sensitive configs, or git-tracked paths the operator
+    forgot were symlinked). If the target exists as a regular file we
+    overwrite via O_TRUNC; if it does not exist we create with mode 0600
+    (owner-only — review remediation C-L1).
+    """
+    from ruamel.yaml import YAML
+
+    if path.is_symlink():
+        raise SymlinkRefusedError(
+            f"output path {path} is a symlink; refusing to follow. "
+            "Remove the symlink and re-run, or pick a different --output."
+        )
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    fd = os.open(path, flags, _OUTPUT_FILE_MODE)
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml = YAML(typ="rt")
+            yaml.indent(mapping=2, sequence=4, offset=2)
+            yaml.dump(data, f)
+    except BaseException:
+        # If yaml.dump raised after fdopen took ownership, fdopen's close runs
+        # via context-manager. If the os.open succeeded but fdopen didn't,
+        # close manually.
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+
+
+class SymlinkRefusedError(OSError):
+    """Raised when --output points at an existing symlink."""
+
+
+def _to_plain_dict(data: Any) -> Any:
+    """Convert ruamel CommentedMap/CommentedSeq → plain dict/list recursively.
+
+    The pure migrate function operates on plain Python dicts; passing ruamel's
+    round-trip types in directly works most of the time, but post-mutation
+    serialization via `yaml.dump` on a ruamel-typed dict that has had keys
+    inserted in arbitrary order can produce surprising output. Round-tripping
+    through plain types simplifies the contract.
+    """
+    if isinstance(data, dict):
+        return {k: _to_plain_dict(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_to_plain_dict(v) for v in data]
+    return data
+
+
+def _validate_v2(
+    data: dict[str, Any],
+    schema_path: Path,
+    *,
+    error_code: str = "MIGRATION-PRODUCED-INVALID-V2",
+) -> list[dict[str, Any]]:
+    """Run jsonschema validation against the v2 schema. Returns list of error dicts.
+
+    `error_code` lets the caller distinguish failures the migrator is
+    responsible for (default `MIGRATION-PRODUCED-INVALID-V2`) from failures
+    where the input was already v2 and didn't pass schema (operator handed
+    us a corrupt v2 file → `CONFIG-V2-INVALID`). Review remediation G-M4.
+    """
+    import jsonschema
+
+    with schema_path.open("r") as f:
+        schema = json.load(f)
+    validator = jsonschema.Draft202012Validator(schema)
+    errors: list[dict[str, Any]] = []
+    for err in validator.iter_errors(data):
+        errors.append(
+            {
+                "code": error_code,
+                "field": ".".join(str(p) for p in err.absolute_path) or "<root>",
+                "detail": err.message,
+            }
+        )
+    return errors
+
+
+def _emit_text_report(report: list[dict[str, Any]]) -> str:
+    if not report:
+        # Review remediation G-M2: this branch is now reachable only when the
+        # migrator returns an empty report — which our v1→v2 path no longer
+        # does (it always emits at least the version_bump entry). Leaving the
+        # message defensive in case future edits change that contract.
+        return "(no changes — input may be malformed)\n"
+    lines = []
+    for entry in report:
+        sev = entry.get("severity", "INFO")
+        code = entry.get("code")
+        prefix = f"[{sev}]"
+        if code:
+            prefix = f"[{sev}] [{code}]"
+        lines.append(f"{prefix} {entry.get('detail', '')}")
+    return "\n".join(lines) + "\n"
+
+
+def _emit_json_report(report: list[dict[str, Any]]) -> str:
+    return json.dumps({"changes": report}, indent=2, sort_keys=True)
+
+
+def _emit_validation_errors(errors: list[dict[str, Any]], fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(
+            {"exit_code": EXIT_VALIDATION_FAIL, "errors": errors},
+            indent=2,
+            sort_keys=True,
+        )
+    lines = []
+    for err in errors:
+        code = err.get("code", "MIGRATION-PRODUCED-INVALID-V2")
+        field = err.get("field", "<root>")
+        detail = err.get("detail", "")
+        lines.append(f"[{code}] field={field}\n  detail: {detail}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="loa migrate-model-config",
+        description="Migrate model-config.yaml from v1 (cycle-095 vintage) to v2 (cycle-099).",
+    )
+    parser.add_argument("input", help="Path to v1 model-config.yaml")
+    parser.add_argument(
+        "-o", "--output", required=True, help="Path to write v2 model-config.yaml"
+    )
+    parser.add_argument(
+        "--model-permissions",
+        help=(
+            "Optional path to cycle-026 standalone model-permissions.yaml; "
+            "entries merged into per-model `permissions` block per DD-1 Option B."
+        ),
+    )
+    parser.add_argument(
+        "--schema",
+        help=(
+            "Optional v2 JSON Schema path (default: "
+            ".claude/data/schemas/model-config-v2.schema.json relative to repo root)."
+        ),
+    )
+    parser.add_argument(
+        "--report-format",
+        choices=("text", "json"),
+        default="text",
+        help="Format for change report (default: text).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run migration + validation but do not write the output file.",
+    )
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help=(
+            "Skip post-migration v2 schema validation. Escape hatch — operator "
+            "assumes responsibility for v2 conformance. Default is to validate."
+        ),
+    )
+
+    args = parser.parse_args(argv)
+
+    input_path = Path(args.input)
+    if not input_path.is_file():
+        print(f"[INPUT-NOT-FOUND] {input_path}", file=sys.stderr)
+        return EXIT_USAGE
+
+    output_path = Path(args.output)
+
+    # Resolve the v2 schema path (CLI override or repo default).
+    if args.schema:
+        schema_path = Path(args.schema)
+    else:
+        repo_root = Path(__file__).resolve().parents[2]
+        schema_path = (
+            repo_root / ".claude" / "data" / "schemas" / "model-config-v2.schema.json"
+        )
+    if not args.no_validate and not schema_path.is_file():
+        print(f"[SCHEMA-NOT-FOUND] {schema_path}", file=sys.stderr)
+        return EXIT_USAGE
+
+    # Load input (and optional cycle-026 model-permissions doc).
+    try:
+        v1 = _load_yaml(input_path)
+    except Exception as exc:
+        print(f"[INPUT-PARSE-ERROR] {input_path}: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    if v1 is None:
+        print(f"[INPUT-EMPTY] {input_path}", file=sys.stderr)
+        return EXIT_USAGE
+    if not isinstance(v1, dict):
+        print(
+            f"[INPUT-NOT-MAPPING] {input_path}: top-level must be a mapping",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
+    permissions_doc: dict[str, Any] | None = None
+    if args.model_permissions:
+        perm_path = Path(args.model_permissions)
+        if not perm_path.is_file():
+            print(f"[PERMISSIONS-NOT-FOUND] {perm_path}", file=sys.stderr)
+            return EXIT_USAGE
+        try:
+            permissions_doc = _load_yaml(perm_path)
+        except Exception as exc:
+            print(f"[PERMISSIONS-PARSE-ERROR] {perm_path}: {exc}", file=sys.stderr)
+            return EXIT_USAGE
+
+    v1_plain = _to_plain_dict(v1)
+    permissions_plain = (
+        _to_plain_dict(permissions_doc) if permissions_doc is not None else None
+    )
+
+    # Run migration.
+    migrate_mod = _load_migrate_module()
+    try:
+        v2_dict, report = migrate_mod.migrate_v1_to_v2(v1_plain, permissions_plain)
+    except migrate_mod.MigrationError as exc:
+        print(str(exc), file=sys.stderr)
+        return EXIT_VALIDATION_FAIL
+
+    # Distinguish "operator-supplied invalid v2" from "migrator-produced invalid v2"
+    # so the operator can route the fix correctly (review remediation G-M4).
+    input_was_v2 = any(entry.get("kind") == "idempotent_noop" for entry in report)
+    error_code = "CONFIG-V2-INVALID" if input_was_v2 else "MIGRATION-PRODUCED-INVALID-V2"
+
+    # Post-migration validation (default on).
+    if not args.no_validate:
+        errors = _validate_v2(v2_dict, schema_path, error_code=error_code)
+        if errors:
+            sys.stderr.write(_emit_validation_errors(errors, args.report_format))
+            sys.stderr.write("\n")
+            return EXIT_VALIDATION_FAIL
+
+    # Emit report (stdout — operator-readable summary of what changed).
+    if args.report_format == "json":
+        sys.stdout.write(_emit_json_report(report))
+    else:
+        sys.stdout.write(_emit_text_report(report))
+
+    # Write v2 unless --dry-run.
+    if not args.dry_run:
+        try:
+            _dump_yaml(v2_dict, output_path)
+        except SymlinkRefusedError as exc:
+            print(f"[OUTPUT-IS-SYMLINK] {exc}", file=sys.stderr)
+            return EXIT_USAGE
+        except Exception as exc:
+            print(f"[OUTPUT-WRITE-ERROR] {output_path}: {exc}", file=sys.stderr)
+            return EXIT_USAGE
+
+    return EXIT_SUCCESS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cycle099-sprint-1e-tests.yml
+++ b/.github/workflows/cycle099-sprint-1e-tests.yml
@@ -1,0 +1,109 @@
+name: cycle-099 Sprint 1E hardening primitives
+
+# cycle-099 Sprint 1E (T1.13 + T1.14) — runs the bats integration tests for
+# the log-redactor (Python + bash twin) and the migrate-model-config CLI.
+# Both tests need Python deps that aren't on the default GitHub runner image:
+#   - ruamel.yaml (round-trip YAML for the migration CLI)
+#   - jsonschema  (post-migration v2 schema validation)
+
+on:
+  pull_request:
+    paths:
+      - '.claude/scripts/lib/log-redactor.py'
+      - '.claude/scripts/lib/log-redactor.sh'
+      - '.claude/scripts/lib/model-config-migrate.py'
+      - '.claude/scripts/loa-migrate-model-config.py'
+      - '.claude/data/schemas/model-config-v2.schema.json'
+      - 'tests/integration/log-redactor-cross-runtime.bats'
+      - 'tests/integration/migrate-model-config.bats'
+      - 'tests/fixtures/model-config-migrate/**'
+      - '.github/workflows/cycle099-sprint-1e-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/scripts/lib/log-redactor.py'
+      - '.claude/scripts/lib/log-redactor.sh'
+      - '.claude/scripts/lib/model-config-migrate.py'
+      - '.claude/scripts/loa-migrate-model-config.py'
+      - '.claude/data/schemas/model-config-v2.schema.json'
+      - 'tests/integration/log-redactor-cross-runtime.bats'
+      - 'tests/integration/migrate-model-config.bats'
+      - 'tests/fixtures/model-config-migrate/**'
+      - '.github/workflows/cycle099-sprint-1e-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cycle099-sprint-1e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hardening-primitives:
+    name: T1.13 log-redactor + T1.14 migrate-model-config CLI
+    runs-on: ubuntu-latest
+    steps:
+      # PINNING: SHA verified against actions/checkout v4.3.1 tag
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # PINNING: SHA matches the actions/setup-python v5.3.0 pin used by
+      # jcs-conformance.yml and bedrock-contract-smoke.yml. Rotate together.
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.13'
+
+      - name: Install Python deps (ruamel.yaml + jsonschema)
+        run: |
+          python -m pip install --upgrade pip
+          # Pinned versions match what's in .venv on the maintainer workstation.
+          # ruamel.yaml is the migrate CLI's structure-preserving YAML lib;
+          # jsonschema runs post-migration v2 validation per AC-S1.11.
+          pip install 'ruamel.yaml==0.18.17' 'jsonschema==4.26.0'
+
+      # PINNING: bats-core v1.13.0 — commit SHA verified after clone (mirrors
+      # bats-tests.yml). Keep these two pin sites in sync when rotating.
+      - name: Install bats-core v1.13.0
+        run: |
+          git clone --branch v1.13.0 --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          cd /tmp/bats-core
+          expected="3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87"
+          actual=$(git rev-parse HEAD)
+          if [ "$actual" != "$expected" ]; then
+            echo "ERROR: bats-core commit SHA mismatch — expected $expected, got $actual"
+            exit 1
+          fi
+          sudo ./install.sh /usr/local
+          bats --version
+
+      - name: Run log-redactor cross-runtime parity tests (T1.13)
+        run: bats tests/integration/log-redactor-cross-runtime.bats
+
+      - name: Run migrate-model-config CLI tests (T1.14)
+        run: bats tests/integration/migrate-model-config.bats
+
+      - name: Smoke test — migrate the production cycle-095 yaml
+        run: |
+          # Defense in depth: even if the unit/integration tests pass on
+          # synthetic fixtures, the migrator MUST handle the real cycle-095
+          # SoT without rejecting valid v1 input. AC-S1.11 verification.
+          python .claude/scripts/loa-migrate-model-config.py \
+              .claude/defaults/model-config.yaml \
+              -o /tmp/migrated.yaml \
+              --model-permissions .claude/data/model-permissions.yaml \
+              --report-format json
+          # Independent post-migration v2 schema validation
+          python - <<'PY'
+          import json, sys
+          import jsonschema
+          from ruamel.yaml import YAML
+          y = YAML(typ='safe')
+          with open('/tmp/migrated.yaml') as f:
+              data = y.load(f)
+          with open('.claude/data/schemas/model-config-v2.schema.json') as f:
+              schema = json.load(f)
+          jsonschema.Draft202012Validator(schema).validate(data)
+          if data.get('schema_version') != 2:
+              print('ERROR: migrated file missing schema_version: 2', file=sys.stderr)
+              sys.exit(1)
+          print('Smoke test: migrated production yaml passes v2 schema validation')
+          PY

--- a/tests/fixtures/model-config-migrate/cycle026-permissions.yaml
+++ b/tests/fixtures/model-config-migrate/cycle026-permissions.yaml
@@ -1,0 +1,24 @@
+# Mini cycle-026 model-permissions.yaml fixture — used by T1.14 test to
+# verify the merge-into-permissions-block migration path.
+model_permissions:
+  "openai:gpt-5.5":
+    trust_level: medium
+    trust_scopes:
+      data_access: medium
+      financial: none
+      delegation: limited
+      model_selection: medium
+      governance: none
+      external_communication: medium
+      context_access:
+        architecture: summary
+        business_logic: summary
+        security: redacted
+        lore: summary
+    execution_mode: api_call
+    capabilities:
+      file_read: false
+      file_write: false
+      command_execution: false
+      network_access: true
+    notes: "Test fixture — minimal cycle-026 entry."

--- a/tests/fixtures/model-config-migrate/v1-happy-path.yaml
+++ b/tests/fixtures/model-config-migrate/v1-happy-path.yaml
@@ -1,0 +1,60 @@
+# v1 cycle-095-vintage config — happy-path migration fixture for T1.14.
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    auth: "{env:OPENAI_API_KEY}"
+    models:
+      gpt-5.5:
+        capabilities: [chat, tools]
+        context_window: 200000
+        token_param: max_completion_tokens
+        endpoint_family: chat
+        pricing:
+          input_per_mtok: 1500000
+          output_per_mtok: 15000000
+  anthropic:
+    type: anthropic
+    endpoint: "https://api.anthropic.com/v1"
+    auth: "{env:ANTHROPIC_API_KEY}"
+    models:
+      claude-opus-4-7:
+        capabilities: [chat, tools]
+        context_window: 200000
+        pricing:
+          input_per_mtok: 15000000
+          output_per_mtok: 75000000
+
+aliases:
+  cheap: "anthropic:claude-sonnet-4-6"
+  opus: "anthropic:claude-opus-4-7"
+
+backward_compat_aliases:
+  "claude-opus-4-6": "anthropic:claude-opus-4-7"
+
+agents:
+  reviewer:
+    model: cheap
+    temperature: 0.3
+  designing-architecture:
+    model: opus
+    requires:
+      thinking_traces: preferred
+
+tier_groups:
+  mappings: {}
+  denylist: []
+  max_cost_per_session_micro_usd: null
+
+routing:
+  fallback:
+    openai: [anthropic]
+
+retry:
+  max_retries: 3
+
+metering:
+  enabled: true
+
+defaults:
+  connect_timeout: 10

--- a/tests/fixtures/model-config-migrate/v1-invalid-context-window.yaml
+++ b/tests/fixtures/model-config-migrate/v1-invalid-context-window.yaml
@@ -1,0 +1,12 @@
+# v1 with context_window below v2 schema minimum (1024). Migration should
+# transform without error, then post-migration v2 schema validation should
+# REJECT with [MIGRATION-PRODUCED-INVALID-V2] (exit 78) per SDD §3.1.1.1.
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      tiny-toy-model:
+        capabilities: [chat]
+        context_window: 500       # below v2 minimum 1024 — invalid
+        endpoint_family: chat

--- a/tests/fixtures/model-config-migrate/v1-malicious-python-tag.yaml
+++ b/tests/fixtures/model-config-migrate/v1-malicious-python-tag.yaml
@@ -1,0 +1,12 @@
+# Adversarial fixture: a YAML payload that would execute arbitrary code under
+# PyYAML's `Loader.full_load` or ruamel's `typ='unsafe'`. Confirms the migrate
+# CLI's `YAML(typ='rt')` rejects (or refuses to deserialize) the tag.
+#
+# The exploitation vector documented at https://pyyaml.org/wiki/PyYAMLDocumentation
+# (full/unsafe loaders execute python tags). Our migrator must NOT execute or
+# deserialize this payload — review remediation C-M2.
+providers:
+  openai:
+    type: !!python/object/apply:os.system ["echo PWNED >/tmp/loa-rce-test"]
+    endpoint: "https://api.openai.com/v1"
+    models: {}

--- a/tests/fixtures/model-config-migrate/v1-with-rename.yaml
+++ b/tests/fixtures/model-config-migrate/v1-with-rename.yaml
@@ -1,0 +1,10 @@
+# v1 with deprecated `endpoint_class` field — should be renamed to `endpoint_family`.
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-old:
+        capabilities: [chat]
+        context_window: 16000
+        endpoint_class: chat

--- a/tests/fixtures/model-config-migrate/v1-with-unknown.yaml
+++ b/tests/fixtures/model-config-migrate/v1-with-unknown.yaml
@@ -1,0 +1,15 @@
+# v1 with operator-added experimental top-level field — should be archived under
+# `_unknown_v1_fields:` for operator review.
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-5.5:
+        capabilities: [chat]
+        context_window: 200000
+        endpoint_family: chat
+
+experimental_routing:
+  strategy: round_robin
+  shadow_mode: true

--- a/tests/fixtures/model-config-migrate/v2-already.yaml
+++ b/tests/fixtures/model-config-migrate/v2-already.yaml
@@ -1,0 +1,25 @@
+# v2 input — migration should be idempotent (no-op + WARN).
+schema_version: 2
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-5.5:
+        capabilities: [chat, tools]
+        context_window: 200000
+        endpoint_family: chat
+aliases:
+  cheap: "anthropic:claude-sonnet-4-6"
+agents:
+  reviewer:
+    default_tier: cheap
+    temperature: 0.3
+tier_groups:
+  mappings:
+    cheap:
+      anthropic: cheap
+      openai: gpt-5.3-codex
+      google: gemini-3-flash
+  denylist: []
+  max_cost_per_session_micro_usd: null

--- a/tests/fixtures/model-config-migrate/v3-future.yaml
+++ b/tests/fixtures/model-config-migrate/v3-future.yaml
@@ -1,0 +1,8 @@
+# Future-version input — migration should reject with
+# [CONFIG-SCHEMA-VERSION-UNSUPPORTED] (exit 78) per SDD §3.1.1.1.
+schema_version: 3
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models: {}

--- a/tests/integration/log-redactor-cross-runtime.bats
+++ b/tests/integration/log-redactor-cross-runtime.bats
@@ -1,0 +1,399 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/log-redactor.bats
+#
+# cycle-099 Sprint 1E — T1.13 log-redactor cross-runtime parity test.
+#
+# Per SDD §5.6 the redactor masks URL userinfo + 6 query-string secret
+# patterns (key, token, secret, password, api_key, auth) case-insensitively
+# while preserving structural identity (separators + parameter-name case).
+#
+# The bats test runs both the Python canonical (.claude/scripts/lib/log-redactor.py)
+# and the bash twin (.claude/scripts/lib/log-redactor.sh) against the SDD §5.6.4
+# fixture corpus and asserts byte-equal output. Divergence indicates a runtime
+# missed a pattern.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    PY_REDACTOR="$PROJECT_ROOT/.claude/scripts/lib/log-redactor.py"
+    BASH_REDACTOR="$PROJECT_ROOT/.claude/scripts/lib/log-redactor.sh"
+
+    [[ -f "$PY_REDACTOR" ]] || skip "log-redactor.py not present"
+    [[ -f "$BASH_REDACTOR" ]] || skip "log-redactor.sh not present"
+
+    # Choose a Python interpreter. The redactor is stdlib-only so any python3
+    # works; .venv is preferred for reproducibility but fall through to system.
+    if [[ -x "$PROJECT_ROOT/.venv/bin/python" ]]; then
+        PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+    else
+        PYTHON_BIN="${PYTHON_BIN:-python3}"
+    fi
+
+    WORK_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+# Helper: run both redactors on $1 and compare byte-equality.
+# Sets $py_out, $sh_out for downstream assertions.
+_redact_both() {
+    local input="$1"
+    py_out="$(printf '%s' "$input" | "$PYTHON_BIN" "$PY_REDACTOR")"
+    # shellcheck disable=SC1090
+    sh_out="$(printf '%s' "$input" | bash "$BASH_REDACTOR")"
+}
+
+# Helper: assert byte-equal output between python + bash for the given input.
+_assert_parity() {
+    local input="$1"
+    _redact_both "$input"
+    if [[ "$py_out" != "$sh_out" ]]; then
+        printf '\n--- PARITY VIOLATION ---\n' >&2
+        printf 'INPUT:  %q\n' "$input" >&2
+        printf 'PYTHON: %q\n' "$py_out" >&2
+        printf 'BASH:   %q\n' "$sh_out" >&2
+        return 1
+    fi
+}
+
+# Tighter helper (review remediation G-M3): runs both redactors and asserts
+# BOTH match the expected literal. Single source of truth for the literal
+# eliminates the vacuous-green failure mode where one runtime silently
+# matches a relaxed value while the other still pins the literal.
+_assert_redacts_to() {
+    local input="$1"
+    local expected="$2"
+    _redact_both "$input"
+    if [[ "$py_out" != "$expected" ]]; then
+        printf '\n--- PYTHON OUTPUT MISMATCH ---\n' >&2
+        printf 'INPUT:    %q\n' "$input" >&2
+        printf 'EXPECTED: %q\n' "$expected" >&2
+        printf 'GOT:      %q\n' "$py_out" >&2
+        return 1
+    fi
+    if [[ "$sh_out" != "$expected" ]]; then
+        printf '\n--- BASH OUTPUT MISMATCH ---\n' >&2
+        printf 'INPUT:    %q\n' "$input" >&2
+        printf 'EXPECTED: %q\n' "$expected" >&2
+        printf 'GOT:      %q\n' "$sh_out" >&2
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# T1 — URL userinfo redaction (SDD §5.6.4 case 1)
+# ---------------------------------------------------------------------------
+
+@test "T1.1 url userinfo: simple user:pass@host" {
+    _assert_redacts_to \
+        'https://user:pass@api.example.com/v1' \
+        'https://[REDACTED]@api.example.com/v1'
+}
+
+@test "T1.2 url userinfo: token-form (no colon)" {
+    _redact_both 'https://abctok123@api.example.com/v1'
+    [[ "$py_out" = 'https://[REDACTED]@api.example.com/v1' ]]
+    _assert_parity 'https://abctok123@api.example.com/v1'
+}
+
+@test "T1.3 url userinfo: scheme variations http/ws/postgres" {
+    _assert_parity 'http://u:p@host/'
+    _assert_parity 'ws://u:p@host:8080/'
+    _assert_parity 'postgres://app:secret@db.internal:5432/main'
+}
+
+@test "T1.4 url userinfo: no userinfo passes through" {
+    _assert_redacts_to 'https://api.example.com/v1' 'https://api.example.com/v1'
+}
+
+@test "T1.5 url userinfo with empty userinfo (just '@')" {
+    _assert_redacts_to 'https://@api.example.com/' 'https://[REDACTED]@api.example.com/'
+}
+
+# ---------------------------------------------------------------------------
+# T2 — Query parameter redaction (mixed redacted + non-redacted)
+# ---------------------------------------------------------------------------
+
+@test "T2.1 query: key, token, foo - foo unchanged" {
+    _redact_both 'https://h/v1?key=abc&token=def&foo=bar'
+    [[ "$py_out" = 'https://h/v1?key=[REDACTED]&token=[REDACTED]&foo=bar' ]]
+    _assert_parity 'https://h/v1?key=abc&token=def&foo=bar'
+}
+
+@test "T2.2 query: all six secret types in one URL" {
+    _assert_redacts_to \
+        'https://h/?key=K&token=T&secret=S&password=P&api_key=A&auth=AU' \
+        'https://h/?key=[REDACTED]&token=[REDACTED]&secret=[REDACTED]&password=[REDACTED]&api_key=[REDACTED]&auth=[REDACTED]'
+}
+
+@test "T2.3 query: param at end of URL (no trailing &)" {
+    _redact_both 'https://h/?token=trailing'
+    [[ "$py_out" = 'https://h/?token=[REDACTED]' ]]
+    _assert_parity 'https://h/?token=trailing'
+}
+
+@test "T2.4 query: param value containing equals sign" {
+    _redact_both 'https://h/?token=a=b=c&foo=bar'
+    [[ "$py_out" = 'https://h/?token=[REDACTED]&foo=bar' ]]
+    _assert_parity 'https://h/?token=a=b=c&foo=bar'
+}
+
+# ---------------------------------------------------------------------------
+# T3 — Multiline (SDD §5.6.4 case 3)
+# ---------------------------------------------------------------------------
+
+@test "T3.1 multiline: each line redacted independently" {
+    local input
+    input=$'url1: https://u1:p1@a/v1\nurl2: https://u2:p2@b/v2'
+    local expected
+    expected=$'url1: https://[REDACTED]@a/v1\nurl2: https://[REDACTED]@b/v2'
+    _redact_both "$input"
+    [[ "$py_out" = "$expected" ]]
+    _assert_parity "$input"
+}
+
+@test "T3.2 multiline: redaction does not span newlines" {
+    # URL on line 1 has no userinfo; URL on line 2 has @ — must not greedy-match across newlines
+    local input
+    input=$'first: https://no-userinfo.example.com/path\nsecond: https://u:p@host/'
+    local expected
+    expected=$'first: https://no-userinfo.example.com/path\nsecond: https://[REDACTED]@host/'
+    _redact_both "$input"
+    [[ "$py_out" = "$expected" ]]
+    _assert_parity "$input"
+}
+
+@test "T3.3 multiline: query params split by newline" {
+    local input
+    input=$'?token=abc\n&key=def'
+    local expected
+    expected=$'?token=[REDACTED]\n&key=[REDACTED]'
+    _redact_both "$input"
+    [[ "$py_out" = "$expected" ]]
+    _assert_parity "$input"
+}
+
+# ---------------------------------------------------------------------------
+# T4 — URL-encoded chars (SDD §5.6.4 case 4)
+# ---------------------------------------------------------------------------
+
+@test "T4.1 encoded: percent-encoded value redacted as one unit" {
+    _redact_both 'https://h/?token=abc%20def'
+    [[ "$py_out" = 'https://h/?token=[REDACTED]' ]]
+    _assert_parity 'https://h/?token=abc%20def'
+}
+
+@test "T4.2 encoded: special chars in value (no premature termination)" {
+    _redact_both 'https://h/?secret=a:b@c/d?e'
+    [[ "$py_out" = 'https://h/?secret=[REDACTED]' ]]
+    _assert_parity 'https://h/?secret=a:b@c/d?e'
+}
+
+# ---------------------------------------------------------------------------
+# T5 — Empty values (SDD §5.6.4 case 5)
+# ---------------------------------------------------------------------------
+
+@test "T5.1 empty value: ?token=&key=foo" {
+    _redact_both 'https://h/?token=&key=foo'
+    [[ "$py_out" = 'https://h/?token=[REDACTED]&key=[REDACTED]' ]]
+    _assert_parity 'https://h/?token=&key=foo'
+}
+
+@test "T5.2 empty value at end: ?token=" {
+    _redact_both 'https://h/?token='
+    [[ "$py_out" = 'https://h/?token=[REDACTED]' ]]
+    _assert_parity 'https://h/?token='
+}
+
+# ---------------------------------------------------------------------------
+# T6 — Case-insensitive parameter name + case preservation (SDD §5.6.4 case 6)
+# ---------------------------------------------------------------------------
+
+@test "T6.1 case: ?Token preserves capital T" {
+    _redact_both 'https://h/?Token=abc'
+    [[ "$py_out" = 'https://h/?Token=[REDACTED]' ]]
+    _assert_parity 'https://h/?Token=abc'
+}
+
+@test "T6.2 case: ?TOKEN all-caps preserved" {
+    _redact_both 'https://h/?TOKEN=abc'
+    [[ "$py_out" = 'https://h/?TOKEN=[REDACTED]' ]]
+    _assert_parity 'https://h/?TOKEN=abc'
+}
+
+@test "T6.3 case: mixed Api_Key preserved" {
+    _redact_both 'https://h/?Api_Key=abc'
+    [[ "$py_out" = 'https://h/?Api_Key=[REDACTED]' ]]
+    _assert_parity 'https://h/?Api_Key=abc'
+}
+
+@test "T6.4 case: each name in mixed-case URL" {
+    _assert_redacts_to \
+        'https://h/?Key=1&TOKEN=2&Secret=3&PASSWORD=4&Api_Key=5&AUTH=6' \
+        'https://h/?Key=[REDACTED]&TOKEN=[REDACTED]&Secret=[REDACTED]&PASSWORD=[REDACTED]&Api_Key=[REDACTED]&AUTH=[REDACTED]'
+}
+
+# ---------------------------------------------------------------------------
+# T7 — No URL / passthrough (SDD §5.6.4 case 7)
+# ---------------------------------------------------------------------------
+
+@test "T7.1 passthrough: plain text unchanged" {
+    _assert_redacts_to 'this is plain text with no URL' 'this is plain text with no URL'
+}
+
+@test "T7.2 passthrough: empty input" {
+    _assert_redacts_to '' ''
+}
+
+@test "T7.3 passthrough: special chars without URL" {
+    _redact_both 'foo & bar | baz # quux $ @ at-sign'
+    [[ "$py_out" = 'foo & bar | baz # quux $ @ at-sign' ]]
+    _assert_parity 'foo & bar | baz # quux $ @ at-sign'
+}
+
+@test "T7.4 passthrough: similar but non-secret param names" {
+    # 'keyword' and 'token_count' don't end immediately after the param name
+    # with '=', so they should NOT be redacted. 'api_key_2' likewise has '_2'
+    # before '='. 'authentic' is not 'auth'.
+    _assert_redacts_to \
+        'https://h/?keyword=fine&token_count=5&secret_chamber=ok&authentic=yes&api_key_2=4' \
+        'https://h/?keyword=fine&token_count=5&secret_chamber=ok&authentic=yes&api_key_2=4'
+}
+
+# ---------------------------------------------------------------------------
+# T8 — Mixed (SDD §5.6.4 case 8)
+# ---------------------------------------------------------------------------
+
+@test "T8.1 mixed: MODEL-RESOLVE log line with userinfo + api_key" {
+    _assert_redacts_to \
+        '[MODEL-RESOLVE] skill=flatline endpoint=https://user:pass@api.example.com/v1?api_key=secret' \
+        '[MODEL-RESOLVE] skill=flatline endpoint=https://[REDACTED]@api.example.com/v1?api_key=[REDACTED]'
+}
+
+@test "T8.2 mixed: redactor is line-level, not JSON-aware" {
+    # SDD §5.6.2 defines `[^&]*` as the only query-value stop-char (with `\n`
+    # added implicitly because sed is line-based and the Python regex excludes
+    # `\n`). A JSON `"` is NOT a boundary; redacting an entire JSON string
+    # consumes the trailing `"}`. Application code is expected to redact URL
+    # fragments BEFORE JSON encoding, not after. This test pins that contract.
+    local input='{"endpoint":"https://u:p@api.example.com/v1?token=xyz"}'
+    local expected='{"endpoint":"https://[REDACTED]@api.example.com/v1?token=[REDACTED]'
+    _redact_both "$input"
+    [[ "$py_out" = "$expected" ]]
+    [[ "$sh_out" = "$expected" ]]
+    _assert_parity "$input"
+}
+
+@test "T8.3 mixed: structured key=value log line (recommended caller shape)" {
+    # `&` is NOT in the input, so api_key=[REDACTED] consumes everything until
+    # next `\n` or EOF — including the trailing ` status=resolved`. To prevent
+    # this, callers should redact endpoint VALUE in isolation OR ensure the
+    # log format uses `&` between fields when value-after-secret is needed.
+    # This test pins that expectation. (Caller contract is documented in
+    # log-redactor.py module docstring.)
+    _assert_redacts_to \
+        '[MODEL-RESOLVE] endpoint=https://u:p@host/v1?api_key=secret status=resolved' \
+        '[MODEL-RESOLVE] endpoint=https://[REDACTED]@host/v1?api_key=[REDACTED]'
+}
+
+@test "T8.4 caller-contract: bare key=val without URL framing is NOT redacted (in-contract)" {
+    # SDD §5.6.2 requires `[?&]` separator before the secret-bearing param
+    # name. A bare `api_key=secret` without URL framing falls outside the
+    # redactor's scope. Callers must reformat their log emission OR redact
+    # the value in isolation (see log-redactor.py docstring).
+    _assert_redacts_to \
+        '[MODEL-RESOLVE] api_key=should-not-be-redacted' \
+        '[MODEL-RESOLVE] api_key=should-not-be-redacted'
+}
+
+# ---------------------------------------------------------------------------
+# T9 — Idempotency (redact-twice == redact-once)
+# ---------------------------------------------------------------------------
+
+@test "T9.1 idempotency: python redact-twice equals once" {
+    local input='https://u:p@h/?token=secret'
+    local once
+    once="$(printf '%s' "$input" | "$PYTHON_BIN" "$PY_REDACTOR")"
+    local twice
+    twice="$(printf '%s' "$once" | "$PYTHON_BIN" "$PY_REDACTOR")"
+    [[ "$once" = "$twice" ]]
+}
+
+@test "T9.2 idempotency: bash redact-twice equals once" {
+    local input='https://u:p@h/?token=secret'
+    local once
+    once="$(printf '%s' "$input" | bash "$BASH_REDACTOR")"
+    local twice
+    twice="$(printf '%s' "$once" | bash "$BASH_REDACTOR")"
+    [[ "$once" = "$twice" ]]
+}
+
+# ---------------------------------------------------------------------------
+# T10 — Pathological / safety inputs
+# ---------------------------------------------------------------------------
+
+@test "T10.1 safety: very long input does not hang or crash" {
+    local long_input
+    long_input="$(printf 'https://u:p@h/?token=%s' "$(printf 'a%.0s' {1..1000})")"
+    timeout 5 bash -c "printf '%s' \"\$1\" | \"$PYTHON_BIN\" \"$PY_REDACTOR\" > /dev/null" _ "$long_input"
+    [[ $? -eq 0 ]]
+    timeout 5 bash -c "printf '%s' \"\$1\" | bash \"$BASH_REDACTOR\" > /dev/null" _ "$long_input"
+    [[ $? -eq 0 ]]
+}
+
+@test "T10.2 safety: nested @ chars in userinfo" {
+    # https://user@with-at@host/ — only first '@' terminates userinfo per RFC,
+    # so first segment 'user' is the userinfo. Both runtimes should agree.
+    _assert_parity 'https://user@with-at@host/'
+}
+
+@test "T10.3 safety: regex metachars in non-secret values" {
+    _redact_both 'https://h/?token=.*\\$^&foo=ok'
+    [[ "$py_out" = 'https://h/?token=[REDACTED]&foo=ok' ]]
+    _assert_parity 'https://h/?token=.*\\$^&foo=ok'
+}
+
+# ---------------------------------------------------------------------------
+# T11 — Module surface (CLI invocation contract)
+# ---------------------------------------------------------------------------
+
+@test "T11.1 module: python prints exit-0 on stdin redaction" {
+    run bash -c "printf 'plain\n' | \"$PYTHON_BIN\" \"$PY_REDACTOR\""
+    [[ "$status" -eq 0 ]]
+    [[ "$output" = "plain" ]]
+}
+
+@test "T11.2 module: bash sourceable + _redact callable" {
+    # shellcheck disable=SC1090
+    source "$BASH_REDACTOR"
+    run bash -c "source \"$BASH_REDACTOR\" && printf '?token=x' | _redact"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" = '?token=[REDACTED]' ]]
+}
+
+@test "T11.3 module: bash direct invocation (script as filter)" {
+    run bash -c "printf '?key=v' | bash \"$BASH_REDACTOR\""
+    [[ "$status" -eq 0 ]]
+    [[ "$output" = '?key=[REDACTED]' ]]
+}
+
+# ---------------------------------------------------------------------------
+# T12 — NUL byte safety (defense-in-depth; debug logs should be ASCII text)
+# ---------------------------------------------------------------------------
+
+@test "T12.1 nul: input without NUL passes through both runtimes" {
+    # Byte-level sanity: ensure non-NUL multi-byte input round-trips identically.
+    # NUL bytes are out-of-scope for both runtimes (sed truncates at NUL on many
+    # systems; Python depends on stdin decoding); we don't assert NUL behavior
+    # but DO assert that all printable ASCII passes through cleanly.
+    local input
+    input="$(printf '%s' '!"#$%&'"'"'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_\`abcdefghijklmnopqrstuvwxyz{|}~')"
+    _assert_redacts_to "$input" "$input"
+}

--- a/tests/integration/migrate-model-config.bats
+++ b/tests/integration/migrate-model-config.bats
@@ -311,17 +311,19 @@ EOF
 @test "M10.4 report: --report-format json produces valid JSON" {
     # Stream stdout into a file so apostrophes / quotes in the JSON cannot
     # break the python -c string interpolation (review remediation G-M1).
+    # BB iter-2 F2 follow-up: even the file path is passed via env var so a
+    # mktemp-d output containing shell metachars cannot inject into Python.
     run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-rename.yaml" -o "$OUT" --report-format json
     [[ "$status" -eq 0 ]]
     local payload="$WORK_DIR/report.json"
     printf '%s' "$output" > "$payload"
-    "$PYTHON_BIN" -c "
-import json
-with open('$payload') as f:
+    PAYLOAD="$payload" "$PYTHON_BIN" -c '
+import json, os
+with open(os.environ["PAYLOAD"]) as f:
     data = json.load(f)
-assert 'changes' in data, f'expected changes field; got {data}'
-assert any(c['kind'] == 'rename' for c in data['changes']), f'expected at least one rename; got {data}'
-"
+assert "changes" in data, f"expected changes field; got {data}"
+assert any(c["kind"] == "rename" for c in data["changes"]), f"expected at least one rename; got {data}"
+'
 }
 
 @test "M10.5 report: dry-run mode does not write output file" {
@@ -385,13 +387,17 @@ EOF
 # ---------------------------------------------------------------------------
 
 @test "M13.1 hardening: !!python/object tag does not execute (typ='rt' safe)" {
-    # C-M2: confirm ruamel's round-trip loader does not execute python tags.
-    # Regardless of exit code, the side-effect file must not appear.
-    rm -f /tmp/loa-rce-test
-    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-malicious-python-tag.yaml" -o "$OUT"
+    # C-M2 + BB iter-2 F1: confirm ruamel's round-trip loader does not execute
+    # python tags. Use a per-test sentinel under WORK_DIR (mktemp-d) so
+    # parallel bats runs don't race on a shared /tmp path.
+    local rce_sentinel="$WORK_DIR/rce-canary"
+    local fixture="$WORK_DIR/malicious.yaml"
+    sed "s|/tmp/loa-rce-test|$rce_sentinel|g" \
+        "$FIXTURES/v1-malicious-python-tag.yaml" > "$fixture"
+    run "$PYTHON_BIN" "$CLI" "$fixture" -o "$OUT"
     # We don't assert exit code (ruamel rt may either reject the tag or store
     # it as opaque); we DO assert the malicious side effect did not happen.
-    [[ ! -f /tmp/loa-rce-test ]]
+    [[ ! -f "$rce_sentinel" ]]
 }
 
 @test "M13.2 hardening: --output refuses to follow an existing symlink" {
@@ -589,17 +595,19 @@ EOF
     # F6 review remediation: assert version_bump kind appears in the report,
     # not the more general 'schema_version: 2' string (which leaked from the
     # original tautological OR — passed for the wrong reason on any input).
+    # BB iter-2 F2 follow-up: pass the payload path via env var to avoid
+    # interpolating it into the python -c source string.
     run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-rename.yaml" -o "$OUT" --report-format json
     [[ "$status" -eq 0 ]]
     local payload="$WORK_DIR/v17-report.json"
     printf '%s' "$output" > "$payload"
-    "$PYTHON_BIN" -c "
-import json
-with open('$payload') as f:
+    PAYLOAD="$payload" "$PYTHON_BIN" -c '
+import json, os
+with open(os.environ["PAYLOAD"]) as f:
     data = json.load(f)
-assert any(c.get('kind') == 'version_bump' for c in data.get('changes', [])), \
-    f'expected at least one version_bump entry; got {data}'
-"
+assert any(c.get("kind") == "version_bump" for c in data.get("changes", [])), \
+    f"expected at least one version_bump entry; got {data}"
+'
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/migrate-model-config.bats
+++ b/tests/integration/migrate-model-config.bats
@@ -1,0 +1,619 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/migrate-model-config.bats
+#
+# cycle-099 Sprint 1E — T1.14 loa migrate-model-config CLI tests.
+#
+# Per SDD §3.1.1.1 the v1→v2 migration is a pure function inside
+# .claude/scripts/lib/model-config-migrate.py; the operator-facing CLI at
+# .claude/scripts/loa-migrate-model-config.py drives I/O + reporting.
+#
+# Acceptance per AC-S1.11: v1 input → valid v2 file (full v2 schema validation
+# passes); idempotent on v2 input; exits 78 on validation failure; field-level
+# CLI report per SDD §3.1.1.1 table.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    CLI="$PROJECT_ROOT/.claude/scripts/loa-migrate-model-config.py"
+    LIB="$PROJECT_ROOT/.claude/scripts/lib/model-config-migrate.py"
+    SCHEMA="$PROJECT_ROOT/.claude/data/schemas/model-config-v2.schema.json"
+    FIXTURES="$PROJECT_ROOT/tests/fixtures/model-config-migrate"
+
+    [[ -f "$CLI" ]] || skip "loa-migrate-model-config.py not present"
+    [[ -f "$LIB" ]] || skip "model-config-migrate.py not present"
+    [[ -f "$SCHEMA" ]] || skip "model-config-v2.schema.json not present"
+
+    # Pinned interpreter — .venv has the ruamel.yaml + jsonschema deps.
+    if [[ -x "$PROJECT_ROOT/.venv/bin/python" ]]; then
+        PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+    else
+        PYTHON_BIN="${PYTHON_BIN:-python3}"
+    fi
+
+    # Verify deps; otherwise skip with a clear marker.
+    "$PYTHON_BIN" -c "import ruamel.yaml, jsonschema" 2>/dev/null \
+        || skip "ruamel.yaml or jsonschema not available in $PYTHON_BIN"
+
+    WORK_DIR="$(mktemp -d)"
+    OUT="$WORK_DIR/out.yaml"
+    REPORT="$WORK_DIR/report.json"
+}
+
+teardown() {
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# M1 — v1 → v2 happy path (cycle-095-vintage)
+# ---------------------------------------------------------------------------
+
+@test "M1.1 happy path: cycle-095 v1 migrates to valid v2" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    [[ -f "$OUT" ]]
+    # schema_version: 2 must appear
+    grep -q '^schema_version: 2$' "$OUT"
+    # Original cycle-095 fields preserved verbatim
+    grep -q 'gpt-5.5' "$OUT"
+    grep -q 'claude-opus-4-7' "$OUT"
+}
+
+@test "M1.2 happy path: validates against v2 schema after migration" {
+    "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    # Independent schema check (sanity)
+    "$PYTHON_BIN" - <<EOF
+import json, sys
+import jsonschema
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open("$OUT") as f:
+    data = y.load(f)
+with open("$SCHEMA") as f:
+    schema = json.load(f)
+jsonschema.Draft202012Validator(schema).validate(data)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# M2 — schema_version detection
+# ---------------------------------------------------------------------------
+
+@test "M2.1 detection: v1 absent (cycle-095 vintage) treated as v1" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    grep -q '^schema_version: 2$' "$OUT"
+}
+
+@test "M2.2 detection: v3+ input rejected with structured error" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v3-future.yaml" -o "$OUT"
+    [[ "$status" -eq 78 ]]
+    [[ "$output" == *"CONFIG-SCHEMA-VERSION-UNSUPPORTED"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# M3 — Field rename (endpoint_class → endpoint_family)
+# ---------------------------------------------------------------------------
+
+@test "M3.1 rename: endpoint_class becomes endpoint_family in v2" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-rename.yaml" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    # endpoint_class gone, endpoint_family present
+    ! grep -q 'endpoint_class' "$OUT"
+    grep -q 'endpoint_family: chat' "$OUT"
+}
+
+@test "M3.2 rename: report contains INFO for renamed field" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-rename.yaml" -o "$OUT" --report-format text
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"renamed"* ]]
+    [[ "$output" == *"endpoint_class"* ]]
+    [[ "$output" == *"endpoint_family"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# M4 — Unknown field preservation
+# ---------------------------------------------------------------------------
+
+@test "M4.1 unknown: experimental_routing archived under _unknown_v1_fields" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-unknown.yaml" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    grep -q '^_unknown_v1_fields:' "$OUT"
+    grep -q 'experimental_routing' "$OUT"
+    # The original top-level key must NOT remain at the root
+    ! grep -q '^experimental_routing:' "$OUT"
+}
+
+@test "M4.2 unknown: report contains WARN for preserved unknown field" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-unknown.yaml" -o "$OUT" --report-format text
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"WARN"* ]]
+    [[ "$output" == *"experimental_routing"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# M5 — Invalid v2 rejection (context_window < 1024)
+# ---------------------------------------------------------------------------
+
+@test "M5.1 invalid: context_window=500 fails post-migration v2 schema" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-invalid-context-window.yaml" -o "$OUT"
+    [[ "$status" -eq 78 ]]
+    [[ "$output" == *"MIGRATION-PRODUCED-INVALID-V2"* ]]
+    # Output should reference the offending field path
+    [[ "$output" == *"context_window"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# M6 — Idempotency on v2 input
+# ---------------------------------------------------------------------------
+
+@test "M6.1 idempotency: v2 input emits MIGRATION-NOOP-V2-INPUT and exits 0" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v2-already.yaml" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"MIGRATION-NOOP-V2-INPUT"* ]]
+}
+
+@test "M6.2 idempotency: round-trip v2 → v2 produces structurally-equivalent output" {
+    "$PYTHON_BIN" "$CLI" "$FIXTURES/v2-already.yaml" -o "$OUT"
+    # Both inputs parse to the same dict structure (using safe yaml load)
+    "$PYTHON_BIN" - <<EOF
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open("$FIXTURES/v2-already.yaml") as f:
+    a = y.load(f)
+with open("$OUT") as f:
+    b = y.load(f)
+assert a == b, f"v2 round-trip not idempotent.\nin:  {a}\nout: {b}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# M7 — agents.<skill>.model rename to default_tier (tier-tag values only)
+# ---------------------------------------------------------------------------
+
+@test "M7.1 agent rename: model: cheap becomes default_tier: cheap" {
+    "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    # reviewer was 'model: cheap' in v1 → should be 'default_tier: cheap' in v2
+    "$PYTHON_BIN" - <<EOF
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open("$OUT") as f:
+    data = y.load(f)
+reviewer = data["agents"]["reviewer"]
+assert "default_tier" in reviewer, f"expected default_tier; got {reviewer}"
+assert reviewer["default_tier"] == "cheap", f"expected cheap; got {reviewer.get('default_tier')}"
+assert "model" not in reviewer, f"v1 model: key should be removed after rename; got {reviewer}"
+EOF
+}
+
+@test "M7.2 agent rename: model: opus stays as model: (opus not a tier)" {
+    "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    "$PYTHON_BIN" - <<EOF
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open("$OUT") as f:
+    data = y.load(f)
+arch = data["agents"]["designing-architecture"]
+# 'opus' is a custom alias, not one of {max, cheap, mid, tiny}, so the
+# migrator MUST keep model: rather than rename to default_tier:
+assert arch.get("model") == "opus", f"expected model: opus; got {arch}"
+assert "default_tier" not in arch, f"opus is not a tier; should NOT rename. got {arch}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# M8 — tier_groups.mappings empty → populated per §3.1.2
+# ---------------------------------------------------------------------------
+
+@test "M8.1 tier_groups: empty mappings populated to §3.1.2 defaults" {
+    "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    "$PYTHON_BIN" - <<EOF
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open("$OUT") as f:
+    data = y.load(f)
+mappings = data["tier_groups"]["mappings"]
+# §3.1.2 specifies max/cheap/mid/tiny each with 3 providers
+for tier in ("max", "cheap", "mid", "tiny"):
+    assert tier in mappings, f"missing tier {tier} in {mappings}"
+    for provider in ("anthropic", "openai", "google"):
+        assert provider in mappings[tier], f"missing {tier}.{provider}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# M9 — model-permissions merging (DD-1 Option B)
+# ---------------------------------------------------------------------------
+
+@test "M9.1 permissions: cycle-026 entries merged into providers.<p>.models.<id>.permissions" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" \
+        -o "$OUT" \
+        --model-permissions "$FIXTURES/cycle026-permissions.yaml"
+    [[ "$status" -eq 0 ]]
+    "$PYTHON_BIN" - <<EOF
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open("$OUT") as f:
+    data = y.load(f)
+gpt = data["providers"]["openai"]["models"]["gpt-5.5"]
+assert "permissions" in gpt, f"expected permissions block; got {gpt}"
+ts = gpt["permissions"]["trust_scopes"]
+assert ts["data_access"] == "medium"
+assert ts["financial"] == "none"
+EOF
+}
+
+@test "M9.2 permissions: missing permissions arg leaves models without permissions block" {
+    "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    "$PYTHON_BIN" - <<EOF
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open("$OUT") as f:
+    data = y.load(f)
+gpt = data["providers"]["openai"]["models"]["gpt-5.5"]
+# permissions block is optional in cycle-099 v2; absent without --model-permissions
+assert "permissions" not in gpt, f"unexpected permissions block; got {gpt}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# M10 — CLI exit codes + report
+# ---------------------------------------------------------------------------
+
+@test "M10.1 exit: 0 on successful migration" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "M10.2 exit: 78 on post-migration validation failure" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-invalid-context-window.yaml" -o "$OUT"
+    [[ "$status" -eq 78 ]]
+}
+
+@test "M10.3 exit: 78 on unsupported schema_version" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v3-future.yaml" -o "$OUT"
+    [[ "$status" -eq 78 ]]
+}
+
+@test "M10.4 report: --report-format json produces valid JSON" {
+    # Stream stdout into a file so apostrophes / quotes in the JSON cannot
+    # break the python -c string interpolation (review remediation G-M1).
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-rename.yaml" -o "$OUT" --report-format json
+    [[ "$status" -eq 0 ]]
+    local payload="$WORK_DIR/report.json"
+    printf '%s' "$output" > "$payload"
+    "$PYTHON_BIN" -c "
+import json
+with open('$payload') as f:
+    data = json.load(f)
+assert 'changes' in data, f'expected changes field; got {data}'
+assert any(c['kind'] == 'rename' for c in data['changes']), f'expected at least one rename; got {data}'
+"
+}
+
+@test "M10.5 report: dry-run mode does not write output file" {
+    rm -f "$OUT"
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT" --dry-run
+    [[ "$status" -eq 0 ]]
+    [[ ! -f "$OUT" ]]
+}
+
+# ---------------------------------------------------------------------------
+# M11 — YAML structure preservation (ruamel round-trip)
+# ---------------------------------------------------------------------------
+
+@test "M11.1 structure: ruamel round-trip preserves key ordering" {
+    "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    # The first non-comment, non-empty line must be schema_version: 2 (we
+    # prepend it). Subsequent top-level keys appear in v1 order: providers,
+    # aliases, ..., defaults.
+    local first_key
+    first_key="$(grep -E '^[a-z_]+:' "$OUT" | head -1 | cut -d: -f1)"
+    [[ "$first_key" = "schema_version" ]]
+}
+
+@test "M11.2 structure: pure function migrate_v1_to_v2 is library-callable" {
+    # The lib filename has dashes (cycle-099 file-naming convention) so we
+    # load it via importlib.util.spec_from_file_location, mirroring the CLI.
+    "$PYTHON_BIN" - <<EOF
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location(
+    "mcm", "$PROJECT_ROOT/.claude/scripts/lib/model-config-migrate.py")
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+assert callable(m.migrate_v1_to_v2)
+assert callable(m.detect_schema_version)
+assert hasattr(m, "TIER_TAGS")
+assert hasattr(m, "TIER_GROUPS_DEFAULTS")
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# M12 — CLI safety: missing input, write-failure
+# ---------------------------------------------------------------------------
+
+@test "M12.1 safety: missing input file errors out" {
+    run "$PYTHON_BIN" "$CLI" "$WORK_DIR/does-not-exist.yaml" -o "$OUT"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "M12.2 safety: input file is malformed YAML" {
+    local bad="$WORK_DIR/bad.yaml"
+    printf 'providers:\n  - this is\n    : malformed yaml: [\n' > "$bad"
+    run "$PYTHON_BIN" "$CLI" "$bad" -o "$OUT"
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# M13 — Security hardening (review remediation)
+# ---------------------------------------------------------------------------
+
+@test "M13.1 hardening: !!python/object tag does not execute (typ='rt' safe)" {
+    # C-M2: confirm ruamel's round-trip loader does not execute python tags.
+    # Regardless of exit code, the side-effect file must not appear.
+    rm -f /tmp/loa-rce-test
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-malicious-python-tag.yaml" -o "$OUT"
+    # We don't assert exit code (ruamel rt may either reject the tag or store
+    # it as opaque); we DO assert the malicious side effect did not happen.
+    [[ ! -f /tmp/loa-rce-test ]]
+}
+
+@test "M13.2 hardening: --output refuses to follow an existing symlink" {
+    # C-H2: ensure the migrator rejects a symlink target rather than clobbering
+    # the symlink's destination.
+    local victim="$WORK_DIR/victim.yaml"
+    local link="$WORK_DIR/link.yaml"
+    printf 'sentinel: untouched\n' > "$victim"
+    ln -s "$victim" "$link"
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$link"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"OUTPUT-IS-SYMLINK"* ]]
+    # Sentinel intact: the migrator did NOT write through the symlink.
+    grep -q '^sentinel: untouched$' "$victim"
+}
+
+@test "M13.3 hardening: output file mode is 0600 (owner-only)" {
+    # C-L1: even on a permissive umask, the output should be owner-only.
+    local prior_umask
+    prior_umask="$(umask)"
+    umask 0022
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
+    umask "$prior_umask"
+    [[ "$status" -eq 0 ]]
+    local mode
+    mode="$(stat -c '%a' "$OUT" 2>/dev/null || stat -f '%A' "$OUT")"
+    [[ "$mode" = "600" ]]
+}
+
+# ---------------------------------------------------------------------------
+# M14 — tier_groups population edge cases (review remediation G-H2 + G-H3)
+# ---------------------------------------------------------------------------
+
+@test "M14.1 tier_groups: absent v1 section produces fully-populated v2" {
+    local minimal="$WORK_DIR/minimal-v1.yaml"
+    cat > "$minimal" <<'EOF'
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-5.5:
+        capabilities: [chat]
+        context_window: 200000
+        endpoint_family: chat
+EOF
+    run "$PYTHON_BIN" "$CLI" "$minimal" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    "$PYTHON_BIN" - <<EOF
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open("$OUT") as f:
+    data = y.load(f)
+mappings = data["tier_groups"]["mappings"]
+for tier in ("max", "cheap", "mid", "tiny"):
+    assert tier in mappings, f"missing tier {tier}; got {mappings}"
+    for provider in ("anthropic", "openai", "google"):
+        assert provider in mappings[tier], f"missing {tier}.{provider}; got {mappings}"
+EOF
+}
+
+@test "M14.2 tier_groups: partial v1 mappings get filled (operator entries preserved)" {
+    local partial="$WORK_DIR/partial-v1.yaml"
+    cat > "$partial" <<'EOF'
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-5.5:
+        capabilities: [chat]
+        context_window: 200000
+        endpoint_family: chat
+tier_groups:
+  mappings:
+    max:
+      anthropic: my-custom-opus
+  denylist: [some-alias]
+  max_cost_per_session_micro_usd: 1000000
+EOF
+    run "$PYTHON_BIN" "$CLI" "$partial" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    "$PYTHON_BIN" - <<EOF
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open("$OUT") as f:
+    data = y.load(f)
+m = data["tier_groups"]["mappings"]
+# Operator-supplied entry preserved verbatim
+assert m["max"]["anthropic"] == "my-custom-opus", f"operator entry overwritten; got {m}"
+# Missing tiers filled
+assert "openai" in m["max"], f"missing max.openai default; got {m}"
+assert "cheap" in m, f"missing cheap tier; got {m}"
+# Operator's other fields preserved
+assert data["tier_groups"]["denylist"] == ["some-alias"]
+assert data["tier_groups"]["max_cost_per_session_micro_usd"] == 1000000
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# M15 — Pure-function semantics (review remediation G-H1)
+# ---------------------------------------------------------------------------
+
+@test "M15.1 lib: migrate_v1_to_v2 does not mutate caller's dict" {
+    "$PYTHON_BIN" - <<EOF
+import importlib.util
+spec = importlib.util.spec_from_file_location(
+    "mcm", "$PROJECT_ROOT/.claude/scripts/lib/model-config-migrate.py")
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+# A v1 dict with nested mutable children
+v1 = {
+    "providers": {
+        "openai": {
+            "type": "openai",
+            "endpoint": "https://api.openai.com/v1",
+            "models": {
+                "gpt-5.5": {
+                    "capabilities": ["chat"],
+                    "context_window": 200000,
+                    "endpoint_family": "chat",
+                    "endpoint_class": "chat",  # legacy -- migrator should pop
+                }
+            },
+        }
+    },
+    "agents": {
+        "x": {"model": "cheap"}  # tier-tag -- migrator should rename to default_tier
+    },
+}
+import copy
+v1_before = copy.deepcopy(v1)
+v2, _report = m.migrate_v1_to_v2(v1)
+
+# Caller's dict survives untouched: endpoint_class still present, model: cheap still present
+assert v1 == v1_before, f"input dict was mutated.\nbefore: {v1_before}\nafter:  {v1}"
+# But the v2 output has the migrations applied
+gpt = v2["providers"]["openai"]["models"]["gpt-5.5"]
+assert "endpoint_class" not in gpt, f"v2 should have endpoint_class popped; got {gpt}"
+agent = v2["agents"]["x"]
+assert "default_tier" in agent and agent["default_tier"] == "cheap"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# M16 — Distinct error code for operator-supplied invalid v2 (G-M4)
+# ---------------------------------------------------------------------------
+
+@test "M16.1 errors: invalid-v2 input emits CONFIG-V2-INVALID, not MIGRATION-PRODUCED" {
+    local bad_v2="$WORK_DIR/bad-v2.yaml"
+    cat > "$bad_v2" <<'EOF'
+schema_version: 2
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      tiny-toy:
+        capabilities: [chat]
+        context_window: 500
+        endpoint_family: chat
+EOF
+    run "$PYTHON_BIN" "$CLI" "$bad_v2" -o "$OUT"
+    [[ "$status" -eq 78 ]]
+    [[ "$output" == *"CONFIG-V2-INVALID"* ]]
+    [[ "$output" != *"MIGRATION-PRODUCED-INVALID-V2"* ]]
+}
+
+@test "M16.2 errors: invalid v1 → invalid v2 emits MIGRATION-PRODUCED-INVALID-V2" {
+    # Re-affirm the original error code is unchanged when the migrator IS
+    # responsible for producing the bad v2.
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-invalid-context-window.yaml" -o "$OUT"
+    [[ "$status" -eq 78 ]]
+    [[ "$output" == *"MIGRATION-PRODUCED-INVALID-V2"* ]]
+    [[ "$output" != *"CONFIG-V2-INVALID"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# M17 — version_bump emitted on v1→v2 (review remediation G-M2)
+# ---------------------------------------------------------------------------
+
+@test "M17.1 report: v1→v2 always emits a version_bump entry" {
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-rename.yaml" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"version_bump"* || "$output" == *"schema_version: 2"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# M18 — Strict additionalProperties (review remediation C-H1)
+# ---------------------------------------------------------------------------
+
+@test "M18.1 strict-mode: top-level operator-injected key triggers MIGRATION-PRODUCED-INVALID-V2" {
+    # The migrator sweeps unknown top-level keys to _unknown_v1_fields, so a
+    # v1 input with an unknown key migrates cleanly. To exercise the schema's
+    # additionalProperties:false at root we hand it a v2 file with an
+    # unknown top-level key.
+    local bad_v2="$WORK_DIR/bad-extra-top.yaml"
+    cat > "$bad_v2" <<'EOF'
+schema_version: 2
+operator_injected_top: PWNED
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-5.5:
+        capabilities: [chat]
+        context_window: 200000
+        endpoint_family: chat
+EOF
+    run "$PYTHON_BIN" "$CLI" "$bad_v2" -o "$OUT"
+    [[ "$status" -eq 78 ]]
+    [[ "$output" == *"CONFIG-V2-INVALID"* ]]
+    [[ "$output" == *"operator_injected_top"* ]]
+}
+
+@test "M18.2 strict-mode: model-level operator-injected key rejected" {
+    local bad_v2="$WORK_DIR/bad-extra-model.yaml"
+    cat > "$bad_v2" <<'EOF'
+schema_version: 2
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-5.5:
+        capabilities: [chat]
+        context_window: 200000
+        endpoint_family: chat
+        injected_field: PWNED
+EOF
+    run "$PYTHON_BIN" "$CLI" "$bad_v2" -o "$OUT"
+    [[ "$status" -eq 78 ]]
+    [[ "$output" == *"injected_field"* ]]
+}
+
+@test "M18.3 strict-mode: agentBinding rejects tier-tag in model: field" {
+    local bad_v2="$WORK_DIR/bad-tier-in-model.yaml"
+    cat > "$bad_v2" <<'EOF'
+schema_version: 2
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-5.5:
+        capabilities: [chat]
+        context_window: 200000
+        endpoint_family: chat
+agents:
+  test_skill:
+    model: tiny
+EOF
+    run "$PYTHON_BIN" "$CLI" "$bad_v2" -o "$OUT"
+    [[ "$status" -eq 78 ]]
+}

--- a/tests/integration/migrate-model-config.bats
+++ b/tests/integration/migrate-model-config.bats
@@ -48,6 +48,29 @@ teardown() {
     return 0
 }
 
+# Helper: run an inline Python script with paths exposed via os.environ
+# rather than shell interpolation. Closes BB iter-1 F2 — a quoted-EOF heredoc
+# eliminates the shell-injection-into-Python-source surface that unquoted
+# heredocs leave open when paths contain quotes/$/\.
+#
+# Usage:
+#     _python_assert <<'EOF'
+#     import os
+#     from ruamel.yaml import YAML
+#     y = YAML(typ='safe')
+#     with open(os.environ["OUT"]) as f:
+#         data = y.load(f)
+#     ...
+#     EOF
+_python_assert() {
+    OUT="$OUT" \
+    FIXTURES="$FIXTURES" \
+    PROJECT_ROOT="$PROJECT_ROOT" \
+    SCHEMA="$SCHEMA" \
+    WORK_DIR="$WORK_DIR" \
+    "$PYTHON_BIN" -
+}
+
 # ---------------------------------------------------------------------------
 # M1 — v1 → v2 happy path (cycle-095-vintage)
 # ---------------------------------------------------------------------------
@@ -66,14 +89,14 @@ teardown() {
 @test "M1.2 happy path: validates against v2 schema after migration" {
     "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
     # Independent schema check (sanity)
-    "$PYTHON_BIN" - <<EOF
-import json, sys
+    _python_assert <<'EOF'
+import json, os
 import jsonschema
 from ruamel.yaml import YAML
 y = YAML(typ='safe')
-with open("$OUT") as f:
+with open(os.environ["OUT"]) as f:
     data = y.load(f)
-with open("$SCHEMA") as f:
+with open(os.environ["SCHEMA"]) as f:
     schema = json.load(f)
 jsonschema.Draft202012Validator(schema).validate(data)
 EOF
@@ -160,12 +183,13 @@ EOF
 @test "M6.2 idempotency: round-trip v2 → v2 produces structurally-equivalent output" {
     "$PYTHON_BIN" "$CLI" "$FIXTURES/v2-already.yaml" -o "$OUT"
     # Both inputs parse to the same dict structure (using safe yaml load)
-    "$PYTHON_BIN" - <<EOF
+    _python_assert <<'EOF'
+import os
 from ruamel.yaml import YAML
 y = YAML(typ='safe')
-with open("$FIXTURES/v2-already.yaml") as f:
+with open(os.path.join(os.environ["FIXTURES"], "v2-already.yaml")) as f:
     a = y.load(f)
-with open("$OUT") as f:
+with open(os.environ["OUT"]) as f:
     b = y.load(f)
 assert a == b, f"v2 round-trip not idempotent.\nin:  {a}\nout: {b}"
 EOF
@@ -178,10 +202,11 @@ EOF
 @test "M7.1 agent rename: model: cheap becomes default_tier: cheap" {
     "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
     # reviewer was 'model: cheap' in v1 → should be 'default_tier: cheap' in v2
-    "$PYTHON_BIN" - <<EOF
+    _python_assert <<'EOF'
+import os
 from ruamel.yaml import YAML
 y = YAML(typ='safe')
-with open("$OUT") as f:
+with open(os.environ["OUT"]) as f:
     data = y.load(f)
 reviewer = data["agents"]["reviewer"]
 assert "default_tier" in reviewer, f"expected default_tier; got {reviewer}"
@@ -192,10 +217,11 @@ EOF
 
 @test "M7.2 agent rename: model: opus stays as model: (opus not a tier)" {
     "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
-    "$PYTHON_BIN" - <<EOF
+    _python_assert <<'EOF'
+import os
 from ruamel.yaml import YAML
 y = YAML(typ='safe')
-with open("$OUT") as f:
+with open(os.environ["OUT"]) as f:
     data = y.load(f)
 arch = data["agents"]["designing-architecture"]
 # 'opus' is a custom alias, not one of {max, cheap, mid, tiny}, so the
@@ -211,10 +237,11 @@ EOF
 
 @test "M8.1 tier_groups: empty mappings populated to §3.1.2 defaults" {
     "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
-    "$PYTHON_BIN" - <<EOF
+    _python_assert <<'EOF'
+import os
 from ruamel.yaml import YAML
 y = YAML(typ='safe')
-with open("$OUT") as f:
+with open(os.environ["OUT"]) as f:
     data = y.load(f)
 mappings = data["tier_groups"]["mappings"]
 # §3.1.2 specifies max/cheap/mid/tiny each with 3 providers
@@ -234,10 +261,11 @@ EOF
         -o "$OUT" \
         --model-permissions "$FIXTURES/cycle026-permissions.yaml"
     [[ "$status" -eq 0 ]]
-    "$PYTHON_BIN" - <<EOF
+    _python_assert <<'EOF'
+import os
 from ruamel.yaml import YAML
 y = YAML(typ='safe')
-with open("$OUT") as f:
+with open(os.environ["OUT"]) as f:
     data = y.load(f)
 gpt = data["providers"]["openai"]["models"]["gpt-5.5"]
 assert "permissions" in gpt, f"expected permissions block; got {gpt}"
@@ -249,10 +277,11 @@ EOF
 
 @test "M9.2 permissions: missing permissions arg leaves models without permissions block" {
     "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-happy-path.yaml" -o "$OUT"
-    "$PYTHON_BIN" - <<EOF
+    _python_assert <<'EOF'
+import os
 from ruamel.yaml import YAML
 y = YAML(typ='safe')
-with open("$OUT") as f:
+with open(os.environ["OUT"]) as f:
     data = y.load(f)
 gpt = data["providers"]["openai"]["models"]["gpt-5.5"]
 # permissions block is optional in cycle-099 v2; absent without --model-permissions
@@ -319,10 +348,13 @@ assert any(c['kind'] == 'rename' for c in data['changes']), f'expected at least 
 @test "M11.2 structure: pure function migrate_v1_to_v2 is library-callable" {
     # The lib filename has dashes (cycle-099 file-naming convention) so we
     # load it via importlib.util.spec_from_file_location, mirroring the CLI.
-    "$PYTHON_BIN" - <<EOF
-import importlib.util, sys
-spec = importlib.util.spec_from_file_location(
-    "mcm", "$PROJECT_ROOT/.claude/scripts/lib/model-config-migrate.py")
+    _python_assert <<'EOF'
+import importlib.util, os
+lib = os.path.join(
+    os.environ["PROJECT_ROOT"],
+    ".claude/scripts/lib/model-config-migrate.py",
+)
+spec = importlib.util.spec_from_file_location("mcm", lib)
 m = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(m)
 assert callable(m.migrate_v1_to_v2)
@@ -378,6 +410,8 @@ EOF
 
 @test "M13.3 hardening: output file mode is 0600 (owner-only)" {
     # C-L1: even on a permissive umask, the output should be owner-only.
+    # F5 review remediation: BSD stat returns full mode like '100600'; trim
+    # to the trailing 3 octal digits so this test passes on macOS too.
     local prior_umask
     prior_umask="$(umask)"
     umask 0022
@@ -385,7 +419,11 @@ EOF
     umask "$prior_umask"
     [[ "$status" -eq 0 ]]
     local mode
-    mode="$(stat -c '%a' "$OUT" 2>/dev/null || stat -f '%A' "$OUT")"
+    if mode="$(stat -c '%a' "$OUT" 2>/dev/null)"; then
+        :  # Linux: %a returns octal mode without leading bits
+    else
+        mode="$(stat -f '%Lp' "$OUT")"  # BSD/macOS: %Lp returns lower 12 bits as octal
+    fi
     [[ "$mode" = "600" ]]
 }
 
@@ -408,10 +446,11 @@ providers:
 EOF
     run "$PYTHON_BIN" "$CLI" "$minimal" -o "$OUT"
     [[ "$status" -eq 0 ]]
-    "$PYTHON_BIN" - <<EOF
+    _python_assert <<'EOF'
+import os
 from ruamel.yaml import YAML
 y = YAML(typ='safe')
-with open("$OUT") as f:
+with open(os.environ["OUT"]) as f:
     data = y.load(f)
 mappings = data["tier_groups"]["mappings"]
 for tier in ("max", "cheap", "mid", "tiny"):
@@ -442,10 +481,11 @@ tier_groups:
 EOF
     run "$PYTHON_BIN" "$CLI" "$partial" -o "$OUT"
     [[ "$status" -eq 0 ]]
-    "$PYTHON_BIN" - <<EOF
+    _python_assert <<'EOF'
+import os
 from ruamel.yaml import YAML
 y = YAML(typ='safe')
-with open("$OUT") as f:
+with open(os.environ["OUT"]) as f:
     data = y.load(f)
 m = data["tier_groups"]["mappings"]
 # Operator-supplied entry preserved verbatim
@@ -464,10 +504,13 @@ EOF
 # ---------------------------------------------------------------------------
 
 @test "M15.1 lib: migrate_v1_to_v2 does not mutate caller's dict" {
-    "$PYTHON_BIN" - <<EOF
-import importlib.util
-spec = importlib.util.spec_from_file_location(
-    "mcm", "$PROJECT_ROOT/.claude/scripts/lib/model-config-migrate.py")
+    _python_assert <<'EOF'
+import importlib.util, os
+lib = os.path.join(
+    os.environ["PROJECT_ROOT"],
+    ".claude/scripts/lib/model-config-migrate.py",
+)
+spec = importlib.util.spec_from_file_location("mcm", lib)
 m = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(m)
 
@@ -543,9 +586,20 @@ EOF
 # ---------------------------------------------------------------------------
 
 @test "M17.1 report: v1→v2 always emits a version_bump entry" {
-    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-rename.yaml" -o "$OUT"
+    # F6 review remediation: assert version_bump kind appears in the report,
+    # not the more general 'schema_version: 2' string (which leaked from the
+    # original tautological OR — passed for the wrong reason on any input).
+    run "$PYTHON_BIN" "$CLI" "$FIXTURES/v1-with-rename.yaml" -o "$OUT" --report-format json
     [[ "$status" -eq 0 ]]
-    [[ "$output" == *"version_bump"* || "$output" == *"schema_version: 2"* ]]
+    local payload="$WORK_DIR/v17-report.json"
+    printf '%s' "$output" > "$payload"
+    "$PYTHON_BIN" -c "
+import json
+with open('$payload') as f:
+    data = json.load(f)
+assert any(c.get('kind') == 'version_bump' for c in data.get('changes', [])), \
+    f'expected at least one version_bump entry; got {data}'
+"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Cycle-099 Sprint 1E.a hardening primitives per SDD §5.6 (T1.13) and §3.1.1.1 (T1.14). Resumes the cycle-099 sprint chain after sprints 1A + 1B + 1C (PRs #722, #723, #724).

- **T1.13** — Debug Trace + JSON Output Secret Redactor: Python canonical (stdlib-only) + bash twin (POSIX BRE). Masks URL userinfo + 6 query-string secret patterns case-insensitively. Cross-runtime parity asserted at byte level. Resolves Flatline SDD pass #1 IMP-002 HIGH_CONSENSUS 860.
- **T1.14** — `loa migrate-model-config` CLI: operator-explicit v1→v2 migration via `ruamel.yaml`. Pure migration logic in lib + driver in CLI. Strict v2 JSON Schema with `additionalProperties: false` at every level. Field-level reporting. Resolves Flatline SDD pass #2 SKP-001 CRITICAL 910 + IMP-004 HIGH_CONSENSUS 835.

**Test count**: 74 tests, 0 failures, 0 skips. Production smoke verified — full cycle-095 model-config.yaml + cycle-026 model-permissions.yaml migrate cleanly to valid v2.

**Quality gate**: subagent dual-review (general-purpose + paranoid cypherpunk in parallel) surfaced 17 findings across 0 CRIT / 6 HIGH / 7 MEDIUM / 4 LOW. All HIGH and load-bearing MEDIUM remediated before commit. Remediation table in commit message.

## Acceptance criteria

- AC-S1.10 (T1.13): `tests/integration/log-redactor-cross-runtime.bats` PASSES — Python and bash log-redactor produce identical redacted output for SDD §5.6 corpus ✓
- AC-S1.11 (T1.14): `loa migrate-model-config` CLI invoked on v1 fixture produces valid v2 file (post-migration full v2 schema validation passes); idempotent on v2 input; exits 78 on validation failure with structured error per SDD §3.1.1.1 ✓

## Sprint 1 progress

- Sprint 1A ✓ codegen foundation (#722)
- Sprint 1B ✓ adapter migrations + drift gate (#723)
- Sprint 1C ✓ matrix CI + toolchain runbook (#724)
- **Sprint 1E.a ← this PR** — log-redactor + migrate CLI (T1.13 + T1.14)
- Sprint 1E.b deferred — endpoint validator (T1.15)
- Sprint 1D deferred — cross-runtime golden corpus (T1.11 + T1.12)

## Test plan

- [x] `bats tests/integration/log-redactor-cross-runtime.bats` — 37 tests pass locally
- [x] `bats tests/integration/migrate-model-config.bats` — 37 tests pass locally
- [x] Production smoke against `.claude/defaults/model-config.yaml` + `.claude/data/model-permissions.yaml` produces valid v2
- [x] Symlink-clobber rejection test (M13.2) confirms `--output` refuses symlink targets
- [x] `!!python/object` adversarial fixture confirms `typ='rt'` does not execute (M13.1)
- [x] CI workflow `.github/workflows/cycle099-sprint-1e-tests.yml` runs all of the above on PR

## --no-verify rationale

Per cycle-099 sprint plan policy: beads UNHEALTHY/MIGRATION_NEEDED (#661) blocks pre-commit hooks. Commit message carries `[NO-VERIFY-RATIONALE: ...]` audit-trail tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)