### PR TITLE
feat(cycle-099-sprint-1E.b): centralized endpoint validator (T1.15 partial)

### DIFF
--- a/.claude/scripts/lib/endpoint-validator.py
+++ b/.claude/scripts/lib/endpoint-validator.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""endpoint-validator — canonical Python implementation per cycle-099 SDD §1.9.1.
+
+The cycle-099 SDD §6.5 specifies an 8-step URL canonicalization pipeline that
+ALL HTTP callers funneling through Loa MUST share. This module is the SOLE
+implementation; bash callers wrap it via subprocess (`endpoint-validator.sh`),
+and the Bridgebuilder TS port (Sprint 1E.c follow-up) will be Jinja2-codegen'd
+from this canonical source so the validation logic lives in exactly one place.
+
+Sprint 1E.b first PR scope: 8-step URL canonicalization (offline string logic,
+no network). Deferred to 1E.c follow-up: TS port via Jinja2 codegen, DNS
+re-resolution + IP-range allowlist (NFR-Sec-1 v1.2), HTTP redirect same-host
+enforcement.
+
+Pipeline (each step has a distinct rejection code per SDD §6.5):
+  1. urlsplit()        → ENDPOINT-PARSE-FAILED
+  2. scheme == https   → ENDPOINT-INSECURE-SCHEME
+  3. netloc present    → ENDPOINT-RELATIVE
+  4. IPv6 ranges       → ENDPOINT-IPV6-BLOCKED
+  5. IDN allowlist     → ENDPOINT-IDN-NOT-ALLOWED
+  6. port allowlist    → ENDPOINT-PORT-NOT-ALLOWED
+  7. path normalization→ ENDPOINT-PATH-INVALID
+  8. host allowlist    → ENDPOINT-NOT-ALLOWED
+
+Stdlib + idna only. The bash twin invokes this module via subprocess; the
+Bridgebuilder TS port is Jinja2-generated from this Python source so all three
+runtimes share the same validation contract.
+
+CLI:
+    endpoint-validator.py --json --allowlist <path> <url>
+    Exit 0 if valid; non-zero otherwise. JSON shape:
+      {"valid": true, "url": "...", "scheme": "https", "host": "...", "port": 443}
+      {"valid": false, "code": "ENDPOINT-...", "detail": "...", "url": "..."}
+
+Library:
+    from endpoint_validator import validate, ValidationResult, load_allowlist
+    result = validate(url, allowlist)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import re
+import sys
+import urllib.parse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import idna  # ≥ 3.6, RFC 5891
+
+EXIT_VALID = 0
+EXIT_REJECTED = 78  # EX_CONFIG (sysexits.h)
+EXIT_USAGE = 64  # EX_USAGE
+
+# Per SDD §6.5 step 4: IPv6 ranges that must be blocked. We use ipaddress
+# module's network containment check rather than literal string match so all
+# representations of these ranges (compressed, expanded) are caught uniformly.
+_BLOCKED_IPV6_NETWORKS: tuple[ipaddress.IPv6Network, ...] = (
+    ipaddress.IPv6Network("::1/128"),       # loopback
+    ipaddress.IPv6Network("fe80::/10"),     # link-local
+    ipaddress.IPv6Network("fc00::/7"),      # unique-local (RFC 4193)
+    ipaddress.IPv6Network("ff00::/8"),      # multicast
+    ipaddress.IPv6Network("::/128"),        # unspecified
+    ipaddress.IPv6Network("::ffff:0:0/96"), # IPv4-mapped (might decode to private v4)
+    ipaddress.IPv6Network("64:ff9b::/96"),  # NAT64 well-known
+)
+
+# Defense-in-depth beyond SDD §6.5 step 4 (which is IPv6-only). The general-
+# purpose review (Sprint 1E.b correctness pass) flagged that an IPv4 literal
+# like https://127.0.0.1/v1, https://169.254.169.254/ (AWS IMDS), or
+# https://10.0.0.1/v1 falls through step 4 and is rejected only as
+# ENDPOINT-NOT-ALLOWED at step 8. The risk: a future allowlist that mixes
+# hostnames + IP literals (e.g., an internal Bedrock VPC endpoint) could
+# accidentally allowlist an IP literal that happens to match a private range.
+# We add an explicit `[ENDPOINT-IP-BLOCKED]` rejection that fires regardless
+# of allowlist contents — the cycle-099 SDD §1.9.1 mitigation rationale ("any
+# caller bypassing canonicalization/rebinding/redirect checks lets attacker-
+# controlled endpoints reach the wire despite policy intent") applies equally
+# to v4 and v6.
+def _is_ip_literal_blocked(host: str) -> tuple[bool, str | None]:
+    """If `host` is an IP literal (v4 or v6 unbracketed), return (blocked, reason).
+
+    `host` is the IPv4-form string OR the IPv6-form WITHOUT brackets.
+    Bracketed-form IPv6 must be unwrapped by the caller before invoking.
+    Returns (False, None) when host is not an IP literal at all.
+    """
+    try:
+        addr = ipaddress.ip_address(host)
+    except (ValueError, ipaddress.AddressValueError):
+        return False, None
+    if addr.is_loopback:
+        return True, f"IP {host} is loopback"
+    if addr.is_private:
+        return True, f"IP {host} is in a private range"
+    if addr.is_link_local:
+        return True, f"IP {host} is link-local"
+    if addr.is_multicast:
+        return True, f"IP {host} is multicast"
+    if addr.is_unspecified:
+        return True, f"IP {host} is unspecified (0.0.0.0 / ::)"
+    if addr.is_reserved:
+        return True, f"IP {host} is reserved"
+    # AWS IMDS — explicitly named here even though it falls under is_link_local.
+    if isinstance(addr, ipaddress.IPv4Address) and str(addr) == "169.254.169.254":
+        return True, "IP 169.254.169.254 is the AWS IMDS metadata endpoint"
+    return False, None
+
+
+def _coerce_ipv4_obfuscation(host: str) -> str | None:
+    """Convert obfuscated IPv4 forms (decimal / octal / hex int) to dotted-quad
+    string, if possible. Returns None if `host` doesn't look like a coerced
+    integer form. Examples:
+        '2130706433'   → '127.0.0.1'   (decimal)
+        '0x7f000001'   → '127.0.0.1'   (hex)
+        '017700000001' → '127.0.0.1'   (legacy-octal, leading 0)
+
+    cypherpunk MEDIUM 1 vector — getaddrinfo on most HTTP clients accepts
+    these forms but urllib.parse keeps them as opaque strings, so the
+    blocked-IP check needs explicit coercion to fire.
+    """
+    if not host or "." in host or ":" in host:
+        # Dotted-quad already, IPv6, or not an integer form.
+        return None
+    s = host.lower()
+    try:
+        if s.startswith("0x"):
+            n = int(s, 16)
+        elif s.startswith("0") and len(s) > 1 and s[1].isdigit():
+            n = int(s, 8)
+        elif s.isdigit():
+            n = int(s, 10)
+        else:
+            return None
+    except ValueError:
+        return None
+    if n < 0 or n > 0xFFFFFFFF:
+        return None
+    try:
+        return str(ipaddress.IPv4Address(n))
+    except (ValueError, ipaddress.AddressValueError):
+        return None
+
+
+# Per SDD §6.5 step 7: path-traversal + RTL-override rejection. We reject
+# raw `..`, leading `./`, repeated `//`, fully or partially percent-encoded
+# `%2e` (one or both dots encoded; case-insensitive), encoded forward slash
+# `%2[fF]` (legitimate paths shouldn't carry encoded `/`), and bidi-control
+# characters (U+202E RTL OVERRIDE etc.). Reviews — general-purpose H3 +
+# cypherpunk HIGH 1 — noted that the original regex missed `.%2e` and `%2e.`
+# and the cypherpunk pass added `%00`/`%2f`/CRLF/TAB defense.
+_PATH_TRAVERSAL_RE = re.compile(
+    r"(?:\.\.)"                      # raw ..
+    r"|(?:^|/)\.(?:/|$)"             # ./ at any path boundary
+    r"|(?://)"                       # repeated slash
+    r"|(?:%2[eE]%2[eE])"             # both dots encoded
+    r"|(?:\.%2[eE])"                 # one literal + one encoded
+    r"|(?:%2[eE]\.)"                 # one encoded + one literal
+    r"|(?:%2[fF])"                   # encoded forward slash
+    r"|(?:%00)"                      # encoded NUL
+)
+
+# Raw control bytes that must never appear in a URL path. CR/LF would split
+# HTTP requests in some clients; NUL truncates strings on the C side; TAB is
+# used in some smuggling vectors. (cypherpunk HIGH 2)
+_PATH_FORBIDDEN_BYTES = ("\x00", "\r", "\n", "\t")
+
+# Visible/invisible Unicode controls in the path that we treat as injection.
+_PATH_CONTROL_CHARS = (
+    "‪",  # LRE
+    "‫",  # RLE
+    "‬",  # PDF
+    "‭",  # LRO
+    "‮",  # RLO
+    "‎",  # LRM
+    "‏",  # RLM
+    "⁦",  # LRI
+    "⁧",  # RLI
+    "⁨",  # FSI
+    "⁩",  # PDI
+)
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of validating one URL.
+
+    `valid` True → all 8 steps passed; the canonicalized fields are populated.
+    `valid` False → `code` carries the SDD §6.5 rejection code; `detail` has
+    a single-line operator-readable description.
+    """
+
+    valid: bool
+    url: str
+    code: str | None = None
+    detail: str | None = None
+    scheme: str | None = None
+    host: str | None = None
+    port: int | None = None
+    path: str | None = None
+    matched_provider: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"valid": self.valid, "url": self.url}
+        for key in ("code", "detail", "scheme", "host", "port", "path", "matched_provider"):
+            value = getattr(self, key)
+            if value is not None:
+                d[key] = value
+        if self.extra:
+            d["extra"] = self.extra
+        return d
+
+
+def _reject(url: str, code: str, detail: str) -> ValidationResult:
+    return ValidationResult(valid=False, url=url, code=code, detail=detail)
+
+
+_ALLOWLIST_MAX_BYTES = 65536  # 64 KiB — see cypherpunk LOW 1
+
+
+def load_allowlist(path: str | Path) -> dict[str, list[dict[str, Any]]]:
+    """Read a JSON allowlist file. Top-level shape:
+
+        {"providers": {"<id>": [{"host": "<lowercased>", "ports": [<int>...]}, ...]}}
+
+    Hardening (cypherpunk LOW 1 + LOW 2):
+      - Reject non-regular files (FIFO, /dev/stdin, /dev/zero) — those can hang.
+      - Reject files > 64 KiB — defends against deep-nest JSON DoS.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise ValueError(f"allowlist {p}: not a regular file")
+    size = p.stat().st_size
+    if size > _ALLOWLIST_MAX_BYTES:
+        raise ValueError(
+            f"allowlist {p}: {size} bytes exceeds {_ALLOWLIST_MAX_BYTES} byte cap"
+        )
+    with p.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    providers = data.get("providers", {})
+    if not isinstance(providers, dict):
+        raise ValueError(
+            f"allowlist {p}: top-level `providers` must be a mapping, got {type(providers).__name__}"
+        )
+    return providers
+
+
+def _is_ipv6_blocked(host: str) -> bool:
+    """Strip the brackets from an RFC-3986 IPv6 literal, parse it, return True
+    if the address falls in any blocked range. False if the host is not an
+    IPv6 literal (caller falls through to other checks)."""
+    if not (host.startswith("[") and host.endswith("]")):
+        return False
+    try:
+        addr = ipaddress.IPv6Address(host[1:-1])
+    except (ValueError, ipaddress.AddressValueError):
+        # Malformed IPv6 inside brackets — treat as blocked since we can't
+        # safely match against allowlist (the allowlist holds hostnames).
+        return True
+    return any(addr in net for net in _BLOCKED_IPV6_NETWORKS)
+
+
+def _validate_path(path: str) -> tuple[bool, str]:
+    """Return (ok, detail). False means path-injection vector detected."""
+    if not path:
+        return True, ""
+    for ch in _PATH_FORBIDDEN_BYTES:
+        if ch in path:
+            return False, f"path contains forbidden control byte (0x{ord(ch):02X})"
+    for ch in _PATH_CONTROL_CHARS:
+        if ch in path:
+            return False, f"path contains bidi/RTL control char (U+{ord(ch):04X})"
+    if _PATH_TRAVERSAL_RE.search(path):
+        return False, (
+            "path contains traversal pattern "
+            "(.., ./, //, %2e%2e, .%2e, %2e., %2f, or %00)"
+        )
+    return True, ""
+
+
+def _idna_normalize(host: str) -> str:
+    """Return the IDNA-normalized + lowercased host. Falls back to lowercase
+    when the host is pure ASCII (no encoding needed). Strips a single trailing
+    dot (FQDN form) so `api.openai.com.` and `api.openai.com` match the same
+    allowlist entry (cypherpunk HIGH 3)."""
+    if host.endswith("."):
+        host = host[:-1]
+    if all(ord(c) < 128 for c in host) and "xn--" not in host.lower():
+        return host.lower()
+    try:
+        encoded = idna.encode(host, uts46=False, transitional=False).decode("ascii")
+        return encoded.lower()
+    except idna.core.IDNAError:
+        # Caller treats failure as ENDPOINT-IDN-NOT-ALLOWED — the encoded form
+        # is undefined, so it can't match any allowlist entry verbatim.
+        return host.lower()
+
+
+def _coerce_port(p: Any) -> int | None:
+    """Strict port coercion. Reject booleans (which `isinstance(p, int)` would
+    otherwise accept), reject out-of-range ints, reject string-form. Returns
+    None for invalid inputs so the caller can drop them silently. Per gp M3."""
+    if isinstance(p, bool):
+        return None
+    if not isinstance(p, int):
+        return None
+    if p < 1 or p > 65535:
+        return None
+    return p
+
+
+def _provider_for_host(
+    host: str, port: int, allowlist: dict[str, list[dict[str, Any]]]
+) -> tuple[str | None, list[int] | None]:
+    """Return (provider_id, allowed_ports) if the host is allowlisted under any
+    provider; else (None, None). The host must match VERBATIM (lowercased)."""
+    for provider_id, entries in allowlist.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            entry_host = str(entry.get("host", "")).lower()
+            if entry_host == host:
+                raw_ports = entry.get("ports", [])
+                if not isinstance(raw_ports, list):
+                    return provider_id, []
+                # Filter out booleans (which `isinstance(p, int)` would accept),
+                # out-of-range ints, and non-int values; gp M3.
+                valid_ports = [
+                    coerced for p in raw_ports
+                    if (coerced := _coerce_port(p)) is not None
+                ]
+                return provider_id, valid_ports
+    return None, None
+
+
+def validate(url: str, allowlist: dict[str, list[dict[str, Any]]]) -> ValidationResult:
+    """Run the SDD §6.5 8-step canonicalization pipeline against `url`.
+
+    Returns a ValidationResult; pure function, no I/O, no network.
+    """
+    if not isinstance(url, str):
+        return _reject(str(url), "ENDPOINT-PARSE-FAILED", "url must be a string")
+
+    # Step 0 (cypherpunk HIGH 2): Python 3.6+ urlsplit silently STRIPS ASCII
+    # control bytes (\r, \n, \t) from the URL before parsing — meaning the
+    # downstream path-validator never sees them. But the original URL string
+    # is preserved in `result.url`, and a downstream caller that re-emits it
+    # would pass the smuggling payload to a less-defensive HTTP client. Reject
+    # these at entry so the validator and the original URL agree.
+    for ch in _PATH_FORBIDDEN_BYTES:
+        if ch in url:
+            return _reject(
+                url,
+                "ENDPOINT-PATH-INVALID",
+                f"URL contains forbidden control byte (0x{ord(ch):02X}); "
+                "CR/LF/TAB/NUL trigger HTTP smuggling in some clients",
+            )
+
+    # Step 1: parse
+    try:
+        parts = urllib.parse.urlsplit(url)
+    except (ValueError, UnicodeError) as exc:
+        return _reject(url, "ENDPOINT-PARSE-FAILED", f"urlsplit raised: {exc}")
+    # urlsplit doesn't raise on most malformed URLs — it returns an empty
+    # netloc instead. We keep the explicit check; empty-netloc is a Step 3
+    # concern but we surface the parse-failed flavor when scheme is unknown.
+    if not parts.scheme and not parts.netloc:
+        return _reject(url, "ENDPOINT-RELATIVE", "missing scheme + netloc")
+    # An invalid bracketed IPv6 (e.g., 'http://[invalid-bracket') gives a
+    # parse warning on stdlib that depends on Python version; check explicitly.
+    if "[" in url and url.count("[") != url.count("]"):
+        return _reject(url, "ENDPOINT-PARSE-FAILED", "unmatched IPv6 brackets")
+
+    # Step 2: scheme
+    if parts.scheme.lower() != "https":
+        return _reject(
+            url,
+            "ENDPOINT-INSECURE-SCHEME",
+            f"scheme {parts.scheme!r} not allowed; only https",
+        )
+
+    # Step 2.5 (general-purpose review HIGH 1): userinfo segments are not part
+    # of the SDD §6.5 pipeline but allowing them silently has two failure
+    # modes: (a) `https://user:pass@api.openai.com/` lets credentials reach
+    # the wire if a downstream caller re-emits the original URL string, and
+    # (b) phishing-style `https://api.openai.com@evil.com/` is rejected only
+    # at step 8, with the misleading code ENDPOINT-NOT-ALLOWED. Reject both
+    # forms with a dedicated code so operator diagnostics are unambiguous.
+    if parts.username is not None or parts.password is not None:
+        return _reject(
+            url,
+            "ENDPOINT-USERINFO-PRESENT",
+            "URL contains userinfo segment; credentials must travel via env vars, not URLs",
+        )
+
+    # Step 3: netloc
+    if not parts.netloc:
+        return _reject(url, "ENDPOINT-RELATIVE", "URL has no netloc (host)")
+
+    # Extract host + port. We have to handle bracketed IPv6 carefully because
+    # urllib's `.hostname` strips brackets but `.netloc` retains them.
+    raw_host = parts.hostname or ""
+    if not raw_host:
+        return _reject(url, "ENDPOINT-RELATIVE", "URL has no parseable hostname")
+
+    # Step 4: IP-literal blocking (per SDD §6.5 step 4 for IPv6, plus general-
+    # purpose CRIT defense-in-depth for IPv4 — incl. AWS IMDS 169.254.169.254
+    # and RFC 1918 private ranges). The cypherpunk pass also flagged decimal/
+    # octal/hex IPv4 literals (e.g., 2130706433 == 127.0.0.1) as a vector;
+    # `ipaddress.ip_address` only parses dotted-quad form, so we additionally
+    # try integer coercion before falling through.
+    if "[" in parts.netloc:
+        bracketed = "[" + raw_host + "]"
+        if _is_ipv6_blocked(bracketed):
+            return _reject(
+                url,
+                "ENDPOINT-IPV6-BLOCKED",
+                f"IPv6 literal {raw_host} falls in a blocked range",
+            )
+        # Public IPv6 falls through here. We fail-closed at step 8 below
+        # because Sprint 1E.b's allowlist is hostname-only; the dedicated
+        # rejection happens at step 8 with ENDPOINT-IPV6-NOT-ALLOWED so
+        # operators see a clear diagnostic.
+    elif ":" in raw_host:
+        # IPv6-shaped hostname without brackets — RFC 3986 forbids.
+        try:
+            addr6 = ipaddress.IPv6Address(raw_host)
+            if any(addr6 in net for net in _BLOCKED_IPV6_NETWORKS):
+                return _reject(
+                    url, "ENDPOINT-IPV6-BLOCKED",
+                    f"IPv6 literal {raw_host} falls in a blocked range",
+                )
+            return _reject(
+                url, "ENDPOINT-PARSE-FAILED",
+                "IPv6 literal must be RFC 3986 bracketed (e.g., https://[::1]/)",
+            )
+        except (ValueError, ipaddress.AddressValueError):
+            pass  # not actually IPv6; fall through
+
+    # IPv4 literal blocking — explicit. SDD §6.5 step 4 wording is IPv6-only,
+    # so this is defense-in-depth named ENDPOINT-IP-BLOCKED.
+    blocked, reason = _is_ip_literal_blocked(raw_host)
+    if blocked:
+        return _reject(url, "ENDPOINT-IP-BLOCKED", reason or f"IP {raw_host} is blocked")
+    # Decimal / octal / hex coercion for "2130706433"-style obfuscated IPv4.
+    # An attacker URL `https://2130706433/` resolves via getaddrinfo on most
+    # HTTP clients but urllib.parse keeps the literal as a string. Try int
+    # coercion (decimal + 0x hex + 0o octal) and re-check.
+    coerced = _coerce_ipv4_obfuscation(raw_host)
+    if coerced is not None:
+        blocked, reason = _is_ip_literal_blocked(coerced)
+        if blocked:
+            return _reject(
+                url,
+                "ENDPOINT-IP-BLOCKED",
+                f"obfuscated IPv4 literal {raw_host!r} resolves to {coerced} ({reason})",
+            )
+        # Even a public-IPv4-decimal-form is a misuse; per SDD §6.5 step 4
+        # spirit, only standard dotted-quad host strings should be accepted.
+        # Reject all obfuscated forms — no legitimate provider URL uses them.
+        return _reject(
+            url,
+            "ENDPOINT-IP-BLOCKED",
+            f"obfuscated IPv4 form {raw_host!r} not allowed; use dotted-quad",
+        )
+
+    # Step 5: IDN normalization + allowlist match (allowlist match happens at
+    # step 8; here we just ensure the encoded form exists / fail closed).
+    try:
+        normalized_host = _idna_normalize(raw_host)
+    except UnicodeError as exc:
+        return _reject(url, "ENDPOINT-IDN-NOT-ALLOWED", f"IDN encode failed: {exc}")
+
+    # Step 6: port — extract from URL, default to 443 if absent.
+    try:
+        port = parts.port if parts.port is not None else 443
+    except ValueError:
+        return _reject(url, "ENDPOINT-PARSE-FAILED", "port is not a valid integer")
+
+    # Step 7: path normalization
+    path_ok, path_detail = _validate_path(parts.path)
+    if not path_ok:
+        return _reject(url, "ENDPOINT-PATH-INVALID", path_detail)
+
+    # Step 8: explicit host + port allowlist match.
+    provider_id, allowed_ports = _provider_for_host(normalized_host, port, allowlist)
+    if provider_id is None:
+        # IPv6 literal that wasn't blocked at step 4 falls through here. Use
+        # a dedicated code so operators see "the host is an IP, not a
+        # hostname allowlist entry" rather than misleading them into thinking
+        # the host string is just typo'd (general-purpose review HIGH 2).
+        if "[" in parts.netloc:
+            return _reject(
+                url,
+                "ENDPOINT-IPV6-NOT-ALLOWED",
+                f"IPv6 literal {raw_host} not in any provider's allowlist; "
+                "Sprint 1E.b allowlist is hostname-only",
+            )
+        if any(ord(c) >= 128 for c in raw_host) or raw_host.lower().startswith("xn--"):
+            return _reject(
+                url,
+                "ENDPOINT-IDN-NOT-ALLOWED",
+                f"IDN-encoded host {normalized_host!r} not in any provider's allowlist",
+            )
+        return _reject(
+            url,
+            "ENDPOINT-NOT-ALLOWED",
+            f"host {normalized_host!r} not in any provider's allowlist",
+        )
+    # Port allowlist: fail-closed when the provider entry has no valid ports
+    # (gp M3). An empty allowed_ports list is a CONFIG bug, not "any port OK".
+    if not allowed_ports:
+        return _reject(
+            url,
+            "ENDPOINT-PORT-NOT-ALLOWED",
+            f"provider {provider_id!r} has no valid ports configured (allowlist bug?)",
+        )
+    if port not in allowed_ports:
+        return _reject(
+            url,
+            "ENDPOINT-PORT-NOT-ALLOWED",
+            f"port {port} not in allowlist {allowed_ports} for provider {provider_id!r}",
+        )
+
+    return ValidationResult(
+        valid=True,
+        url=url,
+        scheme="https",
+        host=normalized_host,
+        port=port,
+        path=parts.path,
+        matched_provider=provider_id,
+    )
+
+
+def _emit(result: ValidationResult, *, json_mode: bool) -> str:
+    if json_mode:
+        return json.dumps(result.as_dict(), indent=2, sort_keys=True)
+    if result.valid:
+        return f"VALID host={result.host} port={result.port} provider={result.matched_provider}"
+    return f"[{result.code}] {result.detail}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="endpoint-validator",
+        description="Validate a URL against the cycle-099 endpoint allowlist (SDD §1.9.1).",
+    )
+    parser.add_argument("url", help="URL to validate")
+    parser.add_argument(
+        "--allowlist",
+        required=True,
+        help=(
+            "Path to JSON allowlist with shape "
+            '{"providers": {"<id>": [{"host": "...", "ports": [...]}]}}'
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of a human-readable line.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        allowlist = load_allowlist(args.allowlist)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"[ALLOWLIST-LOAD-FAILED] {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    result = validate(args.url, allowlist)
+    out = _emit(result, json_mode=args.json)
+    if result.valid:
+        # Acceptance always to stdout (operator-visible canonicalized JSON).
+        print(out)
+        return EXIT_VALID
+    # Rejection always to stderr per SDD §6.2 ("All errors emitted via stderr
+    # in the structured shape"). gp M1 + cypherpunk LOW 3: tests had merged
+    # 2>&1 streams and could not detect a stream-placement regression.
+    print(out, file=sys.stderr)
+    return EXIT_REJECTED
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/scripts/lib/endpoint-validator.sh
+++ b/.claude/scripts/lib/endpoint-validator.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# =============================================================================
+# endpoint-validator.sh — bash wrapper per cycle-099 SDD §1.9.1.
+#
+# The Python canonical at .claude/scripts/lib/endpoint-validator.py is the
+# sole implementation of the SDD §6.5 8-step URL canonicalization pipeline.
+# This wrapper delegates to it via subprocess so bash callers (red-team
+# adapter, model-adapter.sh) get byte-identical validation outcomes.
+#
+# Rationale: a pure-bash port of urllib.parse + idna + ipaddress is brittle
+# (locale-sensitive regex, missing edge cases, BSD/GNU divergence). Using
+# Python via subprocess delegates to the canonical with one fork+exec per
+# validation; that's cheap enough for config-load-time validation, and the
+# cross-runtime parity test asserts byte-equal output between Python direct
+# and bash wrapper.
+#
+# Usage:
+#   As library:
+#     source .claude/scripts/lib/endpoint-validator.sh
+#     endpoint_validator__check --json --allowlist <path> <url>
+#   As filter:
+#     bash .claude/scripts/lib/endpoint-validator.sh --json --allowlist X URL
+#
+# Hardening (cypherpunk MEDIUM 3 + 4):
+#   - argv smuggling: any argument that LOOKS like a flag but follows the
+#     designated URL slot is treated as opaque positional data via the
+#     argparse `--` separator. Without this, an attacker URL value of
+#     `--allowlist=/dev/stdin` would clobber the operator's allowlist arg.
+#   - symlink swap: BASH_SOURCE-relative path resolution follows symlinks
+#     by default, letting an attacker who controls a symlink target
+#     redirect to a fake validator. We resolve with `realpath -e` and
+#     bail if the resolved path is outside the project's lib directory.
+# =============================================================================
+
+set -euo pipefail
+
+# Resolve the Python interpreter. Prefer the project's .venv (which has idna
+# pinned at the version the canonical was tested against), else fall back to
+# system python3. Operators should run `python3 -m pip install idna>=3.6`
+# in their .venv before relying on this wrapper.
+_endpoint_validator__python() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+    local repo_root
+    repo_root="$(cd "$script_dir/../../.." && pwd -P)"
+    if [[ -x "$repo_root/.venv/bin/python" ]]; then
+        printf '%s' "$repo_root/.venv/bin/python"
+    elif command -v python3 >/dev/null 2>&1; then
+        command -v python3
+    else
+        printf ''
+    fi
+}
+
+# Resolve the canonical Python script path. Refuses symlinks: the resolved
+# path MUST live under .claude/scripts/lib/ inside the same repo as this
+# wrapper. Returns 0 + stdout on success, 1 on tamper detection.
+_endpoint_validator__resolve_canonical() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+    local resolved
+    if command -v realpath >/dev/null 2>&1; then
+        resolved="$(realpath -e "$script_dir/endpoint-validator.py" 2>/dev/null || true)"
+    else
+        resolved="$script_dir/endpoint-validator.py"
+    fi
+    if [[ -z "$resolved" ]] || [[ ! -f "$resolved" ]]; then
+        printf '[ENDPOINT-VALIDATOR-MISSING] %s/endpoint-validator.py not found\n' \
+            "$script_dir" >&2
+        return 1
+    fi
+    # Guard: the resolved path MUST live under script_dir (same physical lib/).
+    case "$resolved" in
+        "$script_dir"/*) ;;
+        *)
+            printf '[ENDPOINT-VALIDATOR-SYMLINK-OUT-OF-TREE] %s\n' "$resolved" >&2
+            return 1
+            ;;
+    esac
+    printf '%s' "$resolved"
+}
+
+# Library entrypoint. Forwards argv to the Python canonical; preserves stdout,
+# stderr, and exit code so callers see identical behavior to invoking the
+# Python module directly.
+#
+# argv contract: callers MUST pass flags first and the URL last, e.g.
+#   endpoint_validator__check --json --allowlist X URL
+# We force a `--` separator before the URL so argparse can't be smuggled by
+# an attacker URL that starts with `-`.
+endpoint_validator__check() {
+    local py
+    py="$(_endpoint_validator__python)"
+    if [[ -z "$py" ]]; then
+        printf '[ENDPOINT-VALIDATOR-NO-PYTHON] python3 not found on PATH\n' >&2
+        return 64  # EX_USAGE
+    fi
+    local validator
+    if ! validator="$(_endpoint_validator__resolve_canonical)"; then
+        return 64
+    fi
+    if [[ $# -lt 1 ]]; then
+        # No argv at all → forward to Python so argparse emits its usage line.
+        "$py" -I "$validator"
+        return $?
+    fi
+    # Split argv: everything except the LAST argument is forwarded as flags,
+    # the last argument is the URL slot and goes after `--` so argparse can
+    # never reinterpret it as an option (cypherpunk M3).
+    local last_idx=$(( $# - 1 ))
+    local url="${!#}"
+    local flags=("${@:1:$last_idx}")
+    # `python -I` enables isolated mode (ignore PYTHON* env vars + user site-
+    # packages) — defends against PYTHONPATH-injected interpreter modules.
+    "$py" -I "$validator" "${flags[@]}" -- "$url"
+}
+
+# When invoked as a script (not sourced), forward all argv to the library
+# entry. This lets `bash endpoint-validator.sh --json --allowlist X URL` work
+# the same as `source endpoint-validator.sh; endpoint_validator__check ...`.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    endpoint_validator__check "$@"
+fi

--- a/.github/workflows/cycle099-sprint-1e-b-tests.yml
+++ b/.github/workflows/cycle099-sprint-1e-b-tests.yml
@@ -1,0 +1,148 @@
+name: cycle-099 Sprint 1E.b endpoint-validator
+
+# cycle-099 Sprint 1E.b (T1.15) — runs the cross-runtime parity test for the
+# centralized endpoint validator AND the PR-level CI guard that asserts no
+# caller bypasses the validator by importing urllib.parse / running curl/wget
+# / using fetch() outside the canonical module.
+
+on:
+  pull_request:
+    paths:
+      - '.claude/scripts/lib/endpoint-validator.py'
+      - '.claude/scripts/lib/endpoint-validator.sh'
+      - 'tests/integration/endpoint-validator-cross-runtime.bats'
+      - 'tests/fixtures/endpoint-validator/**'
+      - '.github/workflows/cycle099-sprint-1e-b-tests.yml'
+      # The CI-guard step inspects all .py / .sh / .ts files anywhere in
+      # .claude/, so any change to those files re-runs the gate.
+      - '.claude/**/*.py'
+      - '.claude/**/*.sh'
+      - '.claude/**/*.ts'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/scripts/lib/endpoint-validator.py'
+      - '.claude/scripts/lib/endpoint-validator.sh'
+      - 'tests/integration/endpoint-validator-cross-runtime.bats'
+      - 'tests/fixtures/endpoint-validator/**'
+      - '.github/workflows/cycle099-sprint-1e-b-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cycle099-sprint-1e-b-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  endpoint-validator-parity:
+    name: T1.15 endpoint-validator parity tests
+    runs-on: ubuntu-latest
+    steps:
+      # PINNING: SHA verified against actions/checkout v4.3.1 tag
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # PINNING: SHA matches actions/setup-python v5.3.0 used elsewhere in repo.
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.13'
+
+      - name: Install Python deps (idna)
+        run: |
+          python -m pip install --upgrade pip
+          # idna 3.6+ per SDD §6.5 step 5 (RFC 5891).
+          pip install 'idna==3.13'
+
+      # PINNING: bats-core v1.13.0 — commit SHA verified after clone.
+      - name: Install bats-core v1.13.0
+        run: |
+          git clone --branch v1.13.0 --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          cd /tmp/bats-core
+          expected="3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87"
+          actual=$(git rev-parse HEAD)
+          if [ "$actual" != "$expected" ]; then
+            echo "ERROR: bats-core commit SHA mismatch — expected $expected, got $actual"
+            exit 1
+          fi
+          sudo ./install.sh /usr/local
+          bats --version
+
+      - name: Run endpoint-validator cross-runtime parity tests
+        run: bats tests/integration/endpoint-validator-cross-runtime.bats
+
+  endpoint-validator-import-guard:
+    name: T1.15 import-guard (no urllib.parse / curl / fetch outside validator)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Python — only endpoint-validator.py imports urllib.parse
+        run: |
+          set -euo pipefail
+          # SDD §1.9.1: "endpoint validation must go through endpoint-validator
+          # module". The PR-level guard catches any new caller importing
+          # urllib.parse — directly OR via the parent `import urllib` + later
+          # `urllib.parse.<X>(...)` pattern (gp M2). The gp review also flagged
+          # `__import__("urllib.parse")` and `importlib.import_module("urllib.parse")`
+          # as bypasses. We catch all four forms with one regex.
+          # Scope: .claude/adapters/, .claude/scripts/, tests/, scripts/
+          # (gp M2 — scope expansion). The pre-existing baseline file tracks
+          # files that pre-date Sprint 1E.b for cycle-by-cycle migration.
+          allowed_path='.claude/scripts/lib/endpoint-validator.py'
+          # Search dirs we care about. `--include='*.py'` confines to Python
+          # source; the regex catches:
+          #   - urllib.parse (attribute access)
+          #   - from urllib import parse
+          #   - import urllib (NOT followed by a dot — the bare-import form)
+          #   - __import__("urllib.parse")
+          #   - import_module("urllib.parse")
+          violations=$(
+              grep -rEln \
+                  '(urllib\.parse|from urllib import parse|^import urllib($|[^.])|__import__\(.urllib\.parse|import_module\(.urllib\.parse)' \
+                  .claude/adapters/ .claude/scripts/ tests/ scripts/ \
+                  --include='*.py' 2>/dev/null \
+                  | { grep -vF "$allowed_path" || true; } \
+                  | { grep -vFx -f .github/workflows/lint-pre-existing-urllib.txt 2>/dev/null || cat; }
+          )
+          if [[ -n "$violations" ]]; then
+            echo "::error::endpoint validation must go through endpoint-validator module; see SDD §1.9.1"
+            echo "$violations"
+            exit 1
+          fi
+          echo "OK — urllib.parse confined to endpoint-validator.py"
+
+      - name: Bash — informational scan for curl/wget usage (Sprint 1E.c migrates)
+        run: |
+          set -euo pipefail
+          # Sprint 1E.b ships the Python canonical + bash wrapper; Sprint 1E.c
+          # will migrate the existing bash callers (model-health-probe.sh,
+          # flatline-*.sh, anthropic-oracle.sh, gpt-review-api.sh, etc.) to
+          # funnel through endpoint_validator__check before invoking curl.
+          # For now, surface the inventory as a workflow annotation so operators
+          # see the migration surface area; do not fail the build.
+          callers=$(
+              grep -rln 'curl\|wget' .claude/scripts/ --include='*.sh' \
+                  | grep -vF '.claude/scripts/lib/endpoint-validator.sh' \
+                  | sort -u || true
+          )
+          if [[ -n "$callers" ]]; then
+              echo "::warning::Sprint 1E.c will migrate these bash callers through endpoint_validator__check:"
+              printf '  - %s\n' $callers
+          else
+              echo "OK — no bash curl/wget callers."
+          fi
+
+      - name: TS — informational scan for fetch / http.request (Sprint 1E.c codegen)
+        run: |
+          set -euo pipefail
+          # Sprint 1E.c will ship the TS port (Jinja2 codegen from the Python
+          # canonical) and a stricter TS guard. For 1E.b we report any direct
+          # fetch()/http.request usage as INFO so operators see the future
+          # surface area but the build does not fail.
+          if grep -rEln 'fetch\(|http\.request' \
+                .claude/skills/bridgebuilder-review/resources/ \
+                --include='*.ts' 2>/dev/null; then
+              echo "::warning::TS fetch()/http.request usage detected; Sprint 1E.c will gate via codegen."
+          else
+              echo "OK — no TS fetch()/http.request usage."
+          fi

--- a/.github/workflows/cycle099-sprint-1e-b-tests.yml
+++ b/.github/workflows/cycle099-sprint-1e-b-tests.yml
@@ -96,10 +96,14 @@ jobs:
           #   - import urllib (NOT followed by a dot — the bare-import form)
           #   - __import__("urllib.parse")
           #   - import_module("urllib.parse")
+          # BB iter-1 F2: extend scope to .claude/skills/ + .claude/commands/.
+          # Skills (e.g., bridgebuilder-review) ship Python helpers; commands
+          # (e.g., constructs-loader) likewise. Future Python additions there
+          # need to go through the validator too.
           violations=$(
               grep -rEln \
                   '(urllib\.parse|from urllib import parse|^import urllib($|[^.])|__import__\(.urllib\.parse|import_module\(.urllib\.parse)' \
-                  .claude/adapters/ .claude/scripts/ tests/ scripts/ \
+                  .claude/adapters/ .claude/scripts/ .claude/skills/ .claude/commands/ tests/ scripts/ \
                   --include='*.py' 2>/dev/null \
                   | { grep -vF "$allowed_path" || true; } \
                   | { grep -vFx -f .github/workflows/lint-pre-existing-urllib.txt 2>/dev/null || cat; }
@@ -120,8 +124,13 @@ jobs:
           # funnel through endpoint_validator__check before invoking curl.
           # For now, surface the inventory as a workflow annotation so operators
           # see the migration surface area; do not fail the build.
+          # BB iter-1 F4: tighter regex — match curl/wget only when they
+          # appear as command words, not embedded in other identifiers like
+          # `nocurl_helper` or `_curl_inner`. POSIX `[[:space:]]` boundary
+          # before, optional flags after.
           callers=$(
-              grep -rln 'curl\|wget' .claude/scripts/ --include='*.sh' \
+              grep -rEln '(^|[[:space:]])(curl|wget)([[:space:]]|$)' \
+                  .claude/scripts/ --include='*.sh' \
                   | grep -vF '.claude/scripts/lib/endpoint-validator.sh' \
                   | sort -u || true
           )

--- a/.github/workflows/cycle099-sprint-1e-b-tests.yml
+++ b/.github/workflows/cycle099-sprint-1e-b-tests.yml
@@ -103,7 +103,7 @@ jobs:
           violations=$(
               grep -rEln \
                   '(urllib\.parse|from urllib import parse|^import urllib($|[^.])|__import__\(.urllib\.parse|import_module\(.urllib\.parse)' \
-                  .claude/adapters/ .claude/scripts/ .claude/skills/ .claude/commands/ tests/ scripts/ \
+                  .claude/adapters/ .claude/scripts/ .claude/skills/ .claude/commands/ .claude/hooks/ tests/ scripts/ \
                   --include='*.py' 2>/dev/null \
                   | { grep -vF "$allowed_path" || true; } \
                   | { grep -vFx -f .github/workflows/lint-pre-existing-urllib.txt 2>/dev/null || cat; }

--- a/.github/workflows/cycle099-sprint-1e-b-tests.yml
+++ b/.github/workflows/cycle099-sprint-1e-b-tests.yml
@@ -100,10 +100,18 @@ jobs:
           # Skills (e.g., bridgebuilder-review) ship Python helpers; commands
           # (e.g., constructs-loader) likewise. Future Python additions there
           # need to go through the validator too.
+          # Pre-filter to only dirs that exist — `grep -rE` on a missing
+          # directory returns exit 2, which `set -e` (workflow default) treats
+          # as fatal. The repo has no top-level `scripts/` today; future
+          # additions to this list should not require workflow edits.
+          scope=()
+          for d in .claude/adapters .claude/scripts .claude/skills .claude/commands .claude/hooks tests scripts; do
+              [[ -d "$d" ]] && scope+=("$d")
+          done
           violations=$(
               grep -rEln \
                   '(urllib\.parse|from urllib import parse|^import urllib($|[^.])|__import__\(.urllib\.parse|import_module\(.urllib\.parse)' \
-                  .claude/adapters/ .claude/scripts/ .claude/skills/ .claude/commands/ .claude/hooks/ tests/ scripts/ \
+                  "${scope[@]}" \
                   --include='*.py' 2>/dev/null \
                   | { grep -vF "$allowed_path" || true; } \
                   | { grep -vFx -f .github/workflows/lint-pre-existing-urllib.txt 2>/dev/null || cat; }

--- a/.github/workflows/lint-pre-existing-urllib.txt
+++ b/.github/workflows/lint-pre-existing-urllib.txt
@@ -1,0 +1,3 @@
+.claude/adapters/loa_cheval/providers/bedrock_adapter.py
+.claude/adapters/tests/test_bedrock_redaction_adversarial.py
+tests/fixtures/mock_server.py

--- a/.github/workflows/lint-pre-existing-urllib.txt
+++ b/.github/workflows/lint-pre-existing-urllib.txt
@@ -1,3 +1,13 @@
+# Sprint 1E.b baseline — files importing urllib.parse that pre-date the
+# centralized endpoint-validator. Each entry should be migrated through
+# `endpoint-validator.py` in a follow-up cycle (Sprint 1E.c migrates the
+# bash callers; the Python migration is tracked separately).
+#
+# To remove an entry: rewrite the file to call `endpoint-validator` instead,
+# then delete the line below. CI will fail loudly if removal is incomplete.
+#
+# Owners: tracked via .github/CODEOWNERS for each path.
+# Expiry target: cycle-100 (operator review of the migration debt).
 .claude/adapters/loa_cheval/providers/bedrock_adapter.py
 .claude/adapters/tests/test_bedrock_redaction_adversarial.py
 tests/fixtures/mock_server.py

--- a/tests/fixtures/endpoint-validator/allowlist.json
+++ b/tests/fixtures/endpoint-validator/allowlist.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Test fixture allowlist for endpoint-validator parity tests. Mirrors the cycle-099 production providers' canonical endpoints. Sprint 2 will wire this through loa.defaults.yaml; Sprint 1E.b uses a caller-supplied allowlist as input parameter.",
+  "providers": {
+    "openai": [
+      {"host": "api.openai.com", "ports": [443]}
+    ],
+    "anthropic": [
+      {"host": "api.anthropic.com", "ports": [443]}
+    ],
+    "google": [
+      {"host": "generativelanguage.googleapis.com", "ports": [443]}
+    ],
+    "bedrock": [
+      {"host": "bedrock-runtime.us-east-1.amazonaws.com", "ports": [443]},
+      {"host": "bedrock-runtime.us-west-2.amazonaws.com", "ports": [443]},
+      {"host": "bedrock-runtime.eu-central-1.amazonaws.com", "ports": [443]}
+    ]
+  }
+}

--- a/tests/integration/endpoint-validator-cross-runtime.bats
+++ b/tests/integration/endpoint-validator-cross-runtime.bats
@@ -1,0 +1,535 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/endpoint-validator-cross-runtime.bats
+#
+# cycle-099 Sprint 1E.b — T1.15 endpoint-validator cross-runtime parity test.
+#
+# Per SDD §1.9.1 the validator is a centralized URL canonicalization gate that
+# all HTTP callers MUST funnel through. Per §6.5 the canonicalization pipeline
+# has 8 steps, each with a distinct rejection code:
+#
+#   1. ENDPOINT-PARSE-FAILED      — urlsplit raises
+#   2. ENDPOINT-INSECURE-SCHEME   — non-https
+#   3. ENDPOINT-RELATIVE          — empty netloc
+#   4. ENDPOINT-IPV6-BLOCKED      — IPv6 literal in blocked range
+#   5. ENDPOINT-IDN-NOT-ALLOWED   — IDN hostname not in allowlist
+#   6. ENDPOINT-PORT-NOT-ALLOWED  — non-default port not allowlisted
+#   7. ENDPOINT-PATH-INVALID      — path traversal / RTL / repeated slashes
+#   8. ENDPOINT-NOT-ALLOWED       — host not in allowlist
+#
+# Sprint 1E.b first PR scope: 8-step URL canonicalization (offline string
+# logic, no network). Deferred to 1E.c: TS port via Jinja2 codegen, DNS
+# rebinding, redirect-chain enforcement.
+#
+# Cross-runtime parity (Python canonical + bash wrapper) verified by running
+# the same fixture through both and asserting byte-equal JSON output.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    PY_VALIDATOR="$PROJECT_ROOT/.claude/scripts/lib/endpoint-validator.py"
+    SH_VALIDATOR="$PROJECT_ROOT/.claude/scripts/lib/endpoint-validator.sh"
+    ALLOWLIST="$PROJECT_ROOT/tests/fixtures/endpoint-validator/allowlist.json"
+
+    [[ -f "$PY_VALIDATOR" ]] || skip "endpoint-validator.py not present"
+    [[ -f "$SH_VALIDATOR" ]] || skip "endpoint-validator.sh not present"
+    [[ -f "$ALLOWLIST" ]] || skip "allowlist fixture not present"
+
+    if [[ -x "$PROJECT_ROOT/.venv/bin/python" ]]; then
+        PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+    else
+        PYTHON_BIN="${PYTHON_BIN:-python3}"
+    fi
+    "$PYTHON_BIN" -c "import idna" 2>/dev/null \
+        || skip "idna not available in $PYTHON_BIN"
+
+    WORK_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+# Helper: validate $1 via Python canonical → JSON; also via bash wrapper → JSON;
+# assert byte-equal. Sets py_out, sh_out for downstream literal assertions.
+# Allowlist + caller scope come from $ALLOWLIST + a default test scope.
+_validate_both() {
+    local url="$1"
+    py_out="$(URL="$url" ALLOWLIST_PATH="$ALLOWLIST" \
+        "$PYTHON_BIN" "$PY_VALIDATOR" --json --allowlist "$ALLOWLIST" "$url" 2>&1 || true)"
+    sh_out="$(URL="$url" ALLOWLIST_PATH="$ALLOWLIST" \
+        bash "$SH_VALIDATOR" --json --allowlist "$ALLOWLIST" "$url" 2>&1 || true)"
+}
+
+_assert_parity() {
+    local url="$1"
+    _validate_both "$url"
+    if [[ "$py_out" != "$sh_out" ]]; then
+        printf '\n--- PARITY VIOLATION ---\n' >&2
+        printf 'INPUT:  %q\n' "$url" >&2
+        printf 'PYTHON: %q\n' "$py_out" >&2
+        printf 'BASH:   %q\n' "$sh_out" >&2
+        return 1
+    fi
+}
+
+_assert_rejected_with() {
+    local url="$1"
+    local code="$2"
+    _validate_both "$url"
+    [[ "$py_out" == *"$code"* ]] || {
+        printf 'PYTHON did not reject %q with %s; got: %s\n' "$url" "$code" "$py_out" >&2
+        return 1
+    }
+    [[ "$sh_out" == *"$code"* ]] || {
+        printf 'BASH did not reject %q with %s; got: %s\n' "$url" "$code" "$sh_out" >&2
+        return 1
+    }
+}
+
+_assert_accepted() {
+    local url="$1"
+    _validate_both "$url"
+    # Acceptance is signaled by JSON `"valid": true` in the output.
+    [[ "$py_out" == *'"valid": true'* ]] || {
+        printf 'PYTHON did not accept %q; got: %s\n' "$url" "$py_out" >&2
+        return 1
+    }
+    [[ "$sh_out" == *'"valid": true'* ]] || {
+        printf 'BASH did not accept %q; got: %s\n' "$url" "$sh_out" >&2
+        return 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# E1 — Step 1: parse failures (ENDPOINT-PARSE-FAILED)
+# ---------------------------------------------------------------------------
+
+@test "E1.1 parse-failed: utterly malformed URL" {
+    _assert_rejected_with 'http://[invalid-bracket' 'ENDPOINT-PARSE-FAILED'
+}
+
+@test "E1.2 parse-failed: empty string" {
+    _assert_rejected_with '' 'ENDPOINT-RELATIVE'
+}
+
+# ---------------------------------------------------------------------------
+# E2 — Step 2: insecure-scheme rejection (ENDPOINT-INSECURE-SCHEME)
+# ---------------------------------------------------------------------------
+
+@test "E2.1 scheme: http rejected" {
+    _assert_rejected_with 'http://api.openai.com/v1' 'ENDPOINT-INSECURE-SCHEME'
+}
+
+@test "E2.2 scheme: ws rejected" {
+    _assert_rejected_with 'ws://api.openai.com/v1' 'ENDPOINT-INSECURE-SCHEME'
+}
+
+@test "E2.3 scheme: custom rejected" {
+    _assert_rejected_with 'gopher://api.openai.com/v1' 'ENDPOINT-INSECURE-SCHEME'
+}
+
+@test "E2.4 scheme: file:// rejected" {
+    _assert_rejected_with 'file:///etc/passwd' 'ENDPOINT-INSECURE-SCHEME'
+}
+
+# ---------------------------------------------------------------------------
+# E3 — Step 3: relative URL rejection (ENDPOINT-RELATIVE)
+# ---------------------------------------------------------------------------
+
+@test "E3.1 relative: missing netloc" {
+    _assert_rejected_with '/v1/chat/completions' 'ENDPOINT-RELATIVE'
+}
+
+@test "E3.2 relative: scheme-only" {
+    _assert_rejected_with 'https:///v1' 'ENDPOINT-RELATIVE'
+}
+
+# ---------------------------------------------------------------------------
+# E4 — Step 4: IPv6 blocked-range rejection (ENDPOINT-IPV6-BLOCKED)
+# ---------------------------------------------------------------------------
+
+@test "E4.1 ipv6: loopback ::1 rejected" {
+    _assert_rejected_with 'https://[::1]:443/v1' 'ENDPOINT-IPV6-BLOCKED'
+}
+
+@test "E4.2 ipv6: link-local fe80:: rejected" {
+    _assert_rejected_with 'https://[fe80::1]:443/v1' 'ENDPOINT-IPV6-BLOCKED'
+}
+
+@test "E4.3 ipv6: ULA fc00:: rejected" {
+    _assert_rejected_with 'https://[fc00::1]:443/v1' 'ENDPOINT-IPV6-BLOCKED'
+}
+
+@test "E4.4 ipv6: ULA fd00:: rejected" {
+    _assert_rejected_with 'https://[fd00::1]:443/v1' 'ENDPOINT-IPV6-BLOCKED'
+}
+
+@test "E4.5 ipv6: multicast ff00:: rejected" {
+    _assert_rejected_with 'https://[ff00::1]:443/v1' 'ENDPOINT-IPV6-BLOCKED'
+}
+
+# ---------------------------------------------------------------------------
+# E5 — Step 5: IDN/punycode allowlist rejection (ENDPOINT-IDN-NOT-ALLOWED)
+# ---------------------------------------------------------------------------
+
+@test "E5.1 idn: cyrillic homograph rejected (gооgle.com with Cyrillic 'o')" {
+    _assert_rejected_with 'https://gооgle.com/v1' 'ENDPOINT-IDN-NOT-ALLOWED'
+}
+
+@test "E5.2 idn: punycode form of homograph rejected" {
+    _assert_rejected_with 'https://xn--ggle-vqa.com/v1' 'ENDPOINT-IDN-NOT-ALLOWED'
+}
+
+@test "E5.3 idn: legitimate punycode for unallowed host rejected" {
+    _assert_rejected_with 'https://xn--fsq.com/v1' 'ENDPOINT-IDN-NOT-ALLOWED'
+}
+
+# ---------------------------------------------------------------------------
+# E6 — Step 6: port allowlist rejection (ENDPOINT-PORT-NOT-ALLOWED)
+# ---------------------------------------------------------------------------
+
+@test "E6.1 port: openai on :8443 rejected" {
+    _assert_rejected_with 'https://api.openai.com:8443/v1' 'ENDPOINT-PORT-NOT-ALLOWED'
+}
+
+@test "E6.2 port: anthropic on :80 rejected" {
+    _assert_rejected_with 'https://api.anthropic.com:80/v1' 'ENDPOINT-PORT-NOT-ALLOWED'
+}
+
+@test "E6.3 port: google on :8080 rejected" {
+    _assert_rejected_with 'https://generativelanguage.googleapis.com:8080/v1' 'ENDPOINT-PORT-NOT-ALLOWED'
+}
+
+# ---------------------------------------------------------------------------
+# E7 — Step 7: path normalization rejection (ENDPOINT-PATH-INVALID)
+# ---------------------------------------------------------------------------
+
+@test "E7.1 path: .. traversal rejected" {
+    _assert_rejected_with 'https://api.openai.com/v1/../admin' 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.2 path: ./ rejected" {
+    _assert_rejected_with 'https://api.openai.com/./v1' 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.3 path: repeated slashes rejected" {
+    _assert_rejected_with 'https://api.openai.com//v1' 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.4 path: percent-encoded traversal %2e%2e rejected" {
+    _assert_rejected_with 'https://api.openai.com/v1/%2e%2e/admin' 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.5 path: RTL override (U+202E) in path rejected" {
+    _assert_rejected_with $'https://api.openai.com/v1/admin‮' 'ENDPOINT-PATH-INVALID'
+}
+
+# ---------------------------------------------------------------------------
+# E8 — Step 8: explicit-allowlist rejection (ENDPOINT-NOT-ALLOWED)
+# ---------------------------------------------------------------------------
+
+@test "E8.1 allowlist: unknown host rejected" {
+    _assert_rejected_with 'https://attacker.example.com/v1' 'ENDPOINT-NOT-ALLOWED'
+}
+
+@test "E8.2 allowlist: subdomain typo rejected" {
+    _assert_rejected_with 'https://api2.openai.com/v1' 'ENDPOINT-NOT-ALLOWED'
+}
+
+@test "E8.3 allowlist: api.openai.co (wrong TLD) rejected" {
+    _assert_rejected_with 'https://api.openai.co/v1' 'ENDPOINT-NOT-ALLOWED'
+}
+
+# ---------------------------------------------------------------------------
+# A — Acceptance cases (the production endpoints in our allowlist)
+# ---------------------------------------------------------------------------
+
+@test "A1 accept: openai canonical" {
+    _assert_accepted 'https://api.openai.com/v1'
+}
+
+@test "A2 accept: anthropic canonical" {
+    _assert_accepted 'https://api.anthropic.com/v1'
+}
+
+@test "A3 accept: google canonical" {
+    _assert_accepted 'https://generativelanguage.googleapis.com/v1beta'
+}
+
+@test "A4 accept: bedrock us-east-1 canonical" {
+    _assert_accepted 'https://bedrock-runtime.us-east-1.amazonaws.com'
+}
+
+@test "A5 accept: bedrock us-west-2 canonical" {
+    _assert_accepted 'https://bedrock-runtime.us-west-2.amazonaws.com'
+}
+
+@test "A6 accept: openai with explicit :443 port" {
+    _assert_accepted 'https://api.openai.com:443/v1'
+}
+
+@test "A7 accept: openai uppercase host normalized" {
+    _assert_accepted 'https://API.OPENAI.COM/v1'
+}
+
+# ---------------------------------------------------------------------------
+# P — Cross-runtime parity (every test case round-trips byte-equal)
+# ---------------------------------------------------------------------------
+
+@test "P1 parity: rejection messages identical across runtimes" {
+    _assert_parity 'http://api.openai.com/v1'
+    _assert_parity 'https://[::1]:443/v1'
+    _assert_parity 'https://attacker.example.com/v1'
+    _assert_parity 'https://api.openai.com/v1/../admin'
+}
+
+@test "P2 parity: acceptance JSON identical across runtimes" {
+    _assert_parity 'https://api.openai.com/v1'
+    _assert_parity 'https://api.anthropic.com/v1'
+}
+
+# ---------------------------------------------------------------------------
+# C — CLI contract
+# ---------------------------------------------------------------------------
+
+@test "C1 cli: python --json mode produces valid JSON" {
+    "$PYTHON_BIN" "$PY_VALIDATOR" --json --allowlist "$ALLOWLIST" 'https://api.openai.com/v1' \
+        | "$PYTHON_BIN" -c 'import json, sys; json.load(sys.stdin)'
+}
+
+@test "C2 cli: bash --json mode produces valid JSON" {
+    bash "$SH_VALIDATOR" --json --allowlist "$ALLOWLIST" 'https://api.openai.com/v1' \
+        | "$PYTHON_BIN" -c 'import json, sys; json.load(sys.stdin)'
+}
+
+@test "C3 cli: rejection exits non-zero" {
+    run "$PYTHON_BIN" "$PY_VALIDATOR" --json --allowlist "$ALLOWLIST" 'http://api.openai.com/v1'
+    [[ "$status" -ne 0 ]]
+}
+
+@test "C4 cli: acceptance exits 0" {
+    run "$PYTHON_BIN" "$PY_VALIDATOR" --json --allowlist "$ALLOWLIST" 'https://api.openai.com/v1'
+    [[ "$status" -eq 0 ]]
+}
+
+@test "C5 cli: missing allowlist arg errors out" {
+    run "$PYTHON_BIN" "$PY_VALIDATOR" --json 'https://api.openai.com/v1'
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# C — Stream contract (gp M1 + cypherpunk LOW 3): rejection JSON to STDERR,
+# acceptance JSON to STDOUT, both modes byte-identical across runtimes
+# ---------------------------------------------------------------------------
+
+@test "C6 stream: --json acceptance lands on STDOUT (not stderr)" {
+    local out err
+    out="$("$PYTHON_BIN" "$PY_VALIDATOR" --json --allowlist "$ALLOWLIST" 'https://api.openai.com/v1' 2>"$WORK_DIR/err")"
+    err="$(cat "$WORK_DIR/err")"
+    [[ -n "$out" ]]
+    [[ -z "$err" ]]
+    [[ "$out" == *'"valid": true'* ]]
+}
+
+@test "C7 stream: --json rejection lands on STDERR (not stdout)" {
+    local out err
+    out="$("$PYTHON_BIN" "$PY_VALIDATOR" --json --allowlist "$ALLOWLIST" 'http://attacker.example.com/v1' 2>"$WORK_DIR/err" || true)"
+    err="$(cat "$WORK_DIR/err")"
+    [[ -z "$out" ]]
+    [[ -n "$err" ]]
+    [[ "$err" == *'"valid": false'* ]]
+}
+
+@test "C8 stream: bash wrapper preserves the same stream contract" {
+    local out err
+    out="$(bash "$SH_VALIDATOR" --json --allowlist "$ALLOWLIST" 'http://attacker.example.com/v1' 2>"$WORK_DIR/err" || true)"
+    err="$(cat "$WORK_DIR/err")"
+    [[ -z "$out" ]]
+    [[ -n "$err" ]]
+    [[ "$err" == *'"valid": false'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# E0 — Userinfo rejection (general-purpose review HIGH 1)
+# ---------------------------------------------------------------------------
+
+@test "E0.1 userinfo: user:pass@ rejected" {
+    _assert_rejected_with 'https://user:pass@api.openai.com/v1' 'ENDPOINT-USERINFO-PRESENT'
+}
+
+@test "E0.2 userinfo: user@ alone rejected" {
+    _assert_rejected_with 'https://user@api.openai.com/v1' 'ENDPOINT-USERINFO-PRESENT'
+}
+
+@test "E0.3 userinfo: confusable api.openai.com@evil.com rejected as userinfo" {
+    # urllib parses `api.openai.com@evil.com` — host=evil.com, userinfo=
+    # api.openai.com. With the userinfo-reject in place the rejection reason
+    # is the userinfo presence, not the host-not-allowed; clearer diagnostic
+    # for the operator.
+    _assert_rejected_with 'https://api.openai.com@evil.com/v1' 'ENDPOINT-USERINFO-PRESENT'
+}
+
+# ---------------------------------------------------------------------------
+# E4 — IPv4 literal blocking + decimal/hex obfuscation (CRITICAL gp finding)
+# ---------------------------------------------------------------------------
+
+@test "E4.6 ipv4: 127.0.0.1 loopback rejected" {
+    _assert_rejected_with 'https://127.0.0.1/v1' 'ENDPOINT-IP-BLOCKED'
+}
+
+@test "E4.7 ipv4: 169.254.169.254 AWS IMDS rejected" {
+    _assert_rejected_with 'https://169.254.169.254/latest/meta-data/' 'ENDPOINT-IP-BLOCKED'
+}
+
+@test "E4.8 ipv4: 10.0.0.1 RFC 1918 private rejected" {
+    _assert_rejected_with 'https://10.0.0.1/v1' 'ENDPOINT-IP-BLOCKED'
+}
+
+@test "E4.9 ipv4: 172.16.0.1 RFC 1918 private rejected" {
+    _assert_rejected_with 'https://172.16.0.1/v1' 'ENDPOINT-IP-BLOCKED'
+}
+
+@test "E4.10 ipv4: 192.168.1.1 RFC 1918 private rejected" {
+    _assert_rejected_with 'https://192.168.1.1/v1' 'ENDPOINT-IP-BLOCKED'
+}
+
+@test "E4.11 ipv4: 0.0.0.0 unspecified rejected" {
+    _assert_rejected_with 'https://0.0.0.0/v1' 'ENDPOINT-IP-BLOCKED'
+}
+
+@test "E4.12 ipv4 obfuscation: decimal 2130706433 == 127.0.0.1 rejected" {
+    _assert_rejected_with 'https://2130706433/v1' 'ENDPOINT-IP-BLOCKED'
+}
+
+@test "E4.13 ipv4 obfuscation: hex 0x7f000001 == 127.0.0.1 rejected" {
+    _assert_rejected_with 'https://0x7f000001/v1' 'ENDPOINT-IP-BLOCKED'
+}
+
+@test "E4.14 ipv4 obfuscation: octal 017700000001 == 127.0.0.1 rejected" {
+    _assert_rejected_with 'https://017700000001/v1' 'ENDPOINT-IP-BLOCKED'
+}
+
+# ---------------------------------------------------------------------------
+# E4-extended — IPv4 obfuscation public form rejected (defense-in-depth):
+# even non-private decimal IPs are rejected because no legitimate provider
+# URL uses the form
+# ---------------------------------------------------------------------------
+
+@test "E4.15 ipv4 obfuscation: decimal 134744072 (8.8.8.8) rejected" {
+    _assert_rejected_with 'https://134744072/v1' 'ENDPOINT-IP-BLOCKED'
+}
+
+# ---------------------------------------------------------------------------
+# E4-IPv6 — public IPv6 fail-closed when allowlist is hostname-only (gp H2)
+# ---------------------------------------------------------------------------
+
+@test "E4.16 ipv6: public 2001:4860:4860::8888 rejected as IPV6-NOT-ALLOWED" {
+    _assert_rejected_with 'https://[2001:4860:4860::8888]/v1' 'ENDPOINT-IPV6-NOT-ALLOWED'
+}
+
+# ---------------------------------------------------------------------------
+# E5 — IDN trailing-dot FQDN normalization (cypherpunk HIGH 3)
+# ---------------------------------------------------------------------------
+
+@test "E5.4 idn: trailing-dot FQDN api.openai.com. accepted via normalization" {
+    _assert_accepted 'https://api.openai.com./v1'
+}
+
+# ---------------------------------------------------------------------------
+# E7 — Path-traversal regex extensions (gp H3 + cypherpunk HIGH 1 + HIGH 2)
+# ---------------------------------------------------------------------------
+
+@test "E7.6 path: half-encoded %2e./ rejected" {
+    _assert_rejected_with 'https://api.openai.com/v1/%2e./admin' 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.7 path: half-encoded .%2e/ rejected" {
+    _assert_rejected_with 'https://api.openai.com/v1/.%2e/admin' 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.8 path: uppercase %2E%2E rejected" {
+    _assert_rejected_with 'https://api.openai.com/v1/%2E%2E/admin' 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.9 path: encoded slash %2f rejected" {
+    _assert_rejected_with 'https://api.openai.com/v1/..%2fadmin' 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.10 path: NUL byte %00 rejected" {
+    _assert_rejected_with 'https://api.openai.com/v1/foo%00bar' 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.11 path: literal CR rejected (CRLF smuggling)" {
+    # urllib normalizes some control chars; we assert the validator catches what
+    # urllib hands us. Use printf to embed a literal CR.
+    local url
+    url="$(printf 'https://api.openai.com/v1\rfoo')"
+    _assert_rejected_with "$url" 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.12 path: literal LF rejected" {
+    local url
+    url="$(printf 'https://api.openai.com/v1\nfoo')"
+    _assert_rejected_with "$url" 'ENDPOINT-PATH-INVALID'
+}
+
+@test "E7.13 path: literal TAB rejected" {
+    local url
+    url="$(printf 'https://api.openai.com/v1\tfoo')"
+    _assert_rejected_with "$url" 'ENDPOINT-PATH-INVALID'
+}
+
+# ---------------------------------------------------------------------------
+# A — Acceptance: empty / root / canonical paths (general-purpose review HIGH 4)
+# ---------------------------------------------------------------------------
+
+@test "A8 accept: bare host (no path) https://api.openai.com" {
+    _assert_accepted 'https://api.openai.com'
+}
+
+@test "A9 accept: root path https://api.openai.com/" {
+    _assert_accepted 'https://api.openai.com/'
+}
+
+# ---------------------------------------------------------------------------
+# B — Bash wrapper hardening (cypherpunk MEDIUM 3 — argv smuggling)
+# ---------------------------------------------------------------------------
+
+@test "B1 bash: argv smuggling — URL starting with -- treated as positional" {
+    # An attacker URL that begins with `--allowlist=/dev/stdin` MUST NOT be
+    # parsed by argparse as a `--allowlist` flag value. The wrapper inserts a
+    # `--` separator before the URL slot to enforce this.
+    local fake_allowlist="$WORK_DIR/fake-allowlist.json"
+    printf '{"providers": {"hijack": [{"host": "evil.com", "ports": [443]}]}}' > "$fake_allowlist"
+    run bash "$SH_VALIDATOR" --json --allowlist "$ALLOWLIST" "--allowlist=$fake_allowlist"
+    # The URL is the literal string `--allowlist=...`. Because of `--` the
+    # validator parses it as a URL (urlsplit returns no scheme), step 1/3
+    # rejects with parse-failed or relative — anything BUT
+    # ENDPOINT-NOT-ALLOWED on `evil.com` (which would prove the smuggle worked).
+    [[ "$status" -ne 0 ]]
+    [[ "$output" != *'evil.com'* ]]
+}
+
+@test "B2 bash: missing python interpreter errors with clear code" {
+    # Force the wrapper to fail by overriding PATH to nothing AND removing
+    # .venv access. We do this by running through env -i.
+    run env -i HOME="$HOME" PATH="/nonexistent" bash "$SH_VALIDATOR" --json --allowlist "$ALLOWLIST" 'https://api.openai.com/v1'
+    # Either python3 isn't found (ENDPOINT-VALIDATOR-NO-PYTHON), or .venv path
+    # is unreachable. Either way the wrapper exits non-zero with our prefix.
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# E4-zone — IPv6 zone-id regression (cypherpunk MEDIUM 2)
+# ---------------------------------------------------------------------------
+
+@test "E4.17 ipv6 zone-id: [fe80::1%25eth0] still rejected as link-local" {
+    # Per RFC 6874 IPv6 zone IDs in URLs are %-encoded (% → %25). The link-
+    # local range fe80::/10 must reject regardless of zone suffix.
+    _assert_rejected_with 'https://[fe80::1%25eth0]/v1' 'ENDPOINT-IPV6-BLOCKED'
+}


### PR DESCRIPTION
## Summary

Cycle-099 Sprint 1E.b first PR — implements SDD §1.9.1 centralized endpoint validator's 8-step URL canonicalization pipeline (offline string logic, no network). Resolves Flatline SDD pass #2 SKP-006 CRITICAL 870.

- **Python canonical** at `.claude/scripts/lib/endpoint-validator.py` (~370 LOC, stdlib + idna)
- **Bash wrapper** at `.claude/scripts/lib/endpoint-validator.sh` (subprocess delegate, hardened against argv smuggling + symlink swap)
- **CI guard** with STRICT `urllib.parse` import-gate (5 patterns, expanded scope to `tests/` + `scripts/`)
- **72 cross-runtime parity tests** (E1-E8 step rejection, E0 userinfo, E4-IPv4-literal incl. AWS IMDS, A1-A9 acceptance, B1-B2 wrapper hardening, C1-C8 CLI + stream contract)

**Test count**: 72 tests, 0 failures, 0 regressions. Production smoke verified against all four cycle-099 providers.

## Quality gate trail

Subagent dual-review (general-purpose + paranoid cypherpunk in parallel) surfaced 19 findings:

| Severity | Reviewer | Title | Status |
|----------|----------|-------|--------|
| CRITICAL | gp | IPv4 literals incl. AWS IMDS not blocked | ✅ fixed (step 4b) |
| HIGH | gp | userinfo URLs accepted | ✅ fixed (ENDPOINT-USERINFO-PRESENT) |
| HIGH | gp | public IPv6 misleading code | ✅ fixed (ENDPOINT-IPV6-NOT-ALLOWED) |
| HIGH | gp+cypherpunk | half-encoded `%2e` + encoded slash bypass | ✅ fixed (regex extended) |
| HIGH | gp | empty/root path acceptance untested | ✅ fixed (A8/A9) |
| HIGH | cypherpunk | NUL/CR/LF/TAB smuggling | ✅ fixed (raw-URL gate at step 0) |
| HIGH | cypherpunk | trailing-dot FQDN | ✅ fixed (`_idna_normalize`) |
| MEDIUM | gp | JSON stream contract not enforced | ✅ fixed (rejection→stderr; C6/C7/C8) |
| MEDIUM | gp | CI guard regex too narrow | ✅ fixed (5 patterns + expanded scope) |
| MEDIUM | gp | port type filter (bools + fail-open) | ✅ fixed (`_coerce_port` + fail-closed) |
| MEDIUM | cypherpunk | bash argv smuggling via `--allowlist=...` | ✅ fixed (`--` separator + `python -I`) |
| MEDIUM | cypherpunk | BASH_SOURCE symlink swap | ✅ fixed (`realpath -e` + tree-confinement) |
| MEDIUM | cypherpunk | IPv6 zone-id regression | ✅ fixed (E4.17 test) |
| LOW | cypherpunk | allowlist size cap + non-regular-file | ✅ fixed (64 KiB + `is_file`) |
| LOW | gp | dead variable | ✅ removed |

**0 CRITICAL findings remaining**. Cypherpunk's overall verdict: "the verbatim allowlist match is the saving grace — every parser-confusion vector tested ends with the attacker host being canonicalized and missing the allowlist."

## Acceptance criteria

- AC-S1.12 (T1.15): centralized endpoint validator + cross-runtime parity test + CI guard ✅
- SDD §6.5 8-step pipeline: implemented, tested, parity-verified ✅
- SDD §1.9.1 PR-level CI guard for urllib.parse: STRICT, with negative-test self-validation ✅

## Sprint 1E.b deferred (Sprint 1E.c follow-up)

Per SDD §1.9.1, the full T1.15 scope includes:
- TS port via Python+Jinja2 codegen — adds Python jinja2 dep + emit script + parity test
- DNS rebinding defense (resolve + lock IP) — runtime, not offline
- HTTP redirect same-host enforcement — runtime
- Migration of existing bash callers (`flatline-*.sh`, `model-health-probe.sh`, `anthropic-oracle.sh`, `gpt-review-api.sh`, `mount-loa.sh`, etc.) to funnel through `endpoint_validator__check`

Sprint 1E.b first PR ships the SDD-mandated security primitive (Python + bash) so downstream callers have a stable target. Sprint 1E.c continues from `feat/cycle-099-sprint-1e-c` cut from this PR's merge commit.

## Sprint 1 progress

- 1A ✅ codegen foundation (#722)
- 1B ✅ adapter migrations + drift gate (#723)
- 1C ✅ matrix CI + toolchain runbook (#724)
- 1E.a ✅ log-redactor + migrate CLI (#728)
- **1E.b ← this PR** — endpoint validator (T1.15 partial)
- 1E.c deferred — TS codegen + DNS rebinding + bash caller migration
- 1D deferred — cross-runtime golden corpus (T1.11+T1.12)

## Test plan

- [x] `bats tests/integration/endpoint-validator-cross-runtime.bats` — 72 tests pass locally
- [x] Production smoke against `https://api.openai.com/v1`, `https://api.anthropic.com/v1`, `https://generativelanguage.googleapis.com/v1beta`, `https://bedrock-runtime.us-east-1.amazonaws.com` → all VALID
- [x] CI guard: positive (current tree passes) + negative (synthetic urllib.parse caller correctly flagged)
- [x] Argv-smuggling defense: `bash endpoint-validator.sh --json --allowlist GOOD '--allowlist=EVIL'` does NOT match `evil.com`
- [x] Symlink swap: `realpath -e` + tree-confinement check verified
- [x] CI workflow runs the bats + import-guard on PR

## --no-verify rationale

Per cycle-099 sprint plan policy: beads UNHEALTHY/MIGRATION_NEEDED (#661) blocks pre-commit hooks. Commit message carries `[NO-VERIFY-RATIONALE: ...]` audit-trail tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)