### PR TITLE
feat(cycle-099-sprint-1E.c.2): DNS rebinding + redirect enforcement (T1.15 cont.)

### DIFF
--- a/.claude/scripts/lib/endpoint-validator.py
+++ b/.claude/scripts/lib/endpoint-validator.py
@@ -43,6 +43,7 @@ import argparse
 import ipaddress
 import json
 import re
+import socket
 import sys
 import urllib.parse
 from dataclasses import dataclass, field
@@ -336,7 +337,396 @@ def _reject(url: str, code: str, detail: str) -> ValidationResult:
     return ValidationResult(valid=False, url=url, code=code, detail=detail)
 
 
+# =============================================================================
+# DNS rebinding + redirect enforcement (cycle-099 SDD §1.9.1 NFR-Sec-1 v1.2,
+# Sprint 1E.c.2). The validator's offline string-validation (steps 1-8) catches
+# attacker-supplied URL forms; the runtime DNS rebinding check catches the
+# OPERATOR-supplied URL whose hostname resolves to an attacker IP at a later
+# point. The pattern:
+#
+#   1. Operator config-load time: validate(url) → resolve host once (lock_ip).
+#   2. Each subsequent request: verify_locked_ip(locked) → re-resolve, refuse
+#      if a different IP is returned (DNS rebinding).
+#   3. HTTP redirect: validate_redirect(orig_locked, new_url, allowlist) →
+#      re-runs the 8-step pipeline AND requires the redirect-target to
+#      resolve to the ORIGINAL locked IP (same-host + same-IP).
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class LockedIP:
+    """Immutable record of a host-IP binding established at validate-time.
+
+    Subsequent requests against the same host are required to resolve to the
+    SAME IP (or any IP in the same multi-record set captured at lock time);
+    a different IP triggers DNS-rebinding rejection.
+
+    Hardening (sprint-1E.c.2 cypherpunk LOW): __post_init__ normalizes the
+    host (lowercase + strip trailing FQDN dot) so deserialized LockedIPs
+    don't drift from the form the validator emits. Also validates that
+    `ip` and every entry in `initial_ips` parse cleanly — a forged LockedIP
+    constructed with garbage fields fails fast at construction time.
+
+    KNOWN LIMITATION (TOCTOU): the lock-then-verify pattern has an inherent
+    race window between `verify_locked_ip()` returning OK and the actual
+    `socket.connect()`. The validator cannot close this; callers needing
+    transport-level pinning should use `LockedIP.ip` for direct connect
+    with `Host:` header set to `LockedIP.host`. This is per NFR-Sec-1 v1.2
+    contract — DNS rebinding defense is best-effort, not transport-level.
+    """
+
+    host: str
+    ip: str
+    family: int  # socket.AF_INET / AF_INET6
+    port: int
+    # All IPs returned by the initial getaddrinfo. We accept any of them on
+    # re-resolve so legitimate CDN round-robin doesn't trip the gate.
+    initial_ips: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        # Normalize host: lowercase + strip trailing FQDN dot. Mirrors the
+        # canonical-form treatment in `_idna_normalize`.
+        normalized = self.host.lower().rstrip(".")
+        if normalized != self.host:
+            object.__setattr__(self, "host", normalized)
+        # Validate ip + initial_ips parse cleanly so a forged LockedIP from
+        # JSON deserialization can't carry "169.254.169.254" past type-check.
+        try:
+            ipaddress.ip_address(self.ip)
+        except (ValueError, ipaddress.AddressValueError) as exc:
+            raise ValueError(f"LockedIP.ip {self.ip!r} is not a valid IP: {exc}") from exc
+        # Guard against accidental empty initial_ips after deserialization.
+        if not self.initial_ips:
+            object.__setattr__(self, "initial_ips", (self.ip,))
+        for entry in self.initial_ips:
+            try:
+                ipaddress.ip_address(entry)
+            except (ValueError, ipaddress.AddressValueError) as exc:
+                raise ValueError(
+                    f"LockedIP.initial_ips contains invalid {entry!r}: {exc}"
+                ) from exc
+
+
+class EndpointDnsError(Exception):
+    """Common base for DNS-related validator failures (gp MEDIUM remediation).
+
+    A loader catching ``except EndpointDnsError`` will catch resolution
+    failures AND rebinding rejections without enumerating every subclass.
+    """
+
+
+class DnsResolutionError(EndpointDnsError):
+    """Raised when getaddrinfo fails for a host the validator was asked to lock."""
+
+    def __init__(self, host: str, detail: str):
+        super().__init__(
+            f"[ENDPOINT-DNS-RESOLUTION-FAILED] host={host!r} detail={detail}"
+        )
+        self.host = host
+        self.detail = detail
+
+
+class DnsRebindingError(EndpointDnsError):
+    """Raised when DNS resolution returns a different IP than initially locked,
+    OR when the resolved IP falls in a blocked range AND no
+    `cdn_cidr_exemptions` covers it (per SDD §1.9)."""
+
+    def __init__(self, code: str, detail: str):
+        super().__init__(f"[{code}] {detail}")
+        self.code = code
+        self.detail = detail
+
+
+def _resolve_addrinfo(host: str, port: int = 443) -> list[tuple[int, str]]:
+    """Wrap socket.getaddrinfo, returning a list of (family, ip-string) pairs.
+
+    Raises DnsResolutionError on failure. Filters out non-INET/INET6 entries
+    (no Bluetooth, no Unix sockets reaching this code path).
+    """
+    try:
+        records = socket.getaddrinfo(
+            host, port, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP
+        )
+    except (socket.gaierror, OSError) as exc:
+        raise DnsResolutionError(host, str(exc)) from exc
+    out: list[tuple[int, str]] = []
+    for family, _socktype, _proto, _canon, sockaddr in records:
+        if family not in (socket.AF_INET, socket.AF_INET6):
+            continue
+        ip = sockaddr[0]
+        # Strip IPv6 zone-id from the resolved form (RFC 6874).
+        if family == socket.AF_INET6 and "%" in ip:
+            ip = ip.split("%", 1)[0]
+        out.append((family, ip))
+    if not out:
+        raise DnsResolutionError(host, "no usable INET/INET6 records returned")
+    return out
+
+
+def _is_resolved_ip_blocked(ip: str) -> tuple[bool, str]:
+    """Defense-in-depth at resolve time. The 8-step canonicalization pipeline
+    already rejects IP-literal hostnames, but a HOSTNAME that resolves to a
+    blocked range is the DNS rebinding scenario this function exists to
+    catch. Returns (blocked, reason).
+
+    Diagnostic readability (gp HIGH 2): the IPv6 IMDS / link-local /
+    NAT64 /  ULA ranges all fall in `fc00::/7` or `fe80::/10`; the bare
+    "falls in blocked range" message obscures the threat identity. We
+    add a more specific reason for well-known operational endpoints.
+    """
+    try:
+        addr = ipaddress.ip_address(ip)
+    except (ValueError, ipaddress.AddressValueError):
+        return False, ""
+    if isinstance(addr, ipaddress.IPv6Address):
+        # Well-known IPv6 endpoints — surface their identity in diagnostics.
+        if str(addr) == "fd00:ec2::254":
+            return True, f"resolved IPv6 {ip} is the AWS IPv6 IMDS metadata endpoint"
+        for net in _BLOCKED_IPV6_NETWORKS:
+            if addr in net:
+                # Attach a more specific reason when the range is well-known.
+                if net == ipaddress.IPv6Network("fe80::/10"):
+                    return True, f"resolved IPv6 {ip} is link-local (fe80::/10)"
+                if net == ipaddress.IPv6Network("64:ff9b::/96"):
+                    return True, f"resolved IPv6 {ip} is NAT64 well-known (64:ff9b::/96)"
+                if net == ipaddress.IPv6Network("::1/128"):
+                    return True, f"resolved IPv6 {ip} is loopback (::1/128)"
+                return True, f"resolved IPv6 {ip} falls in blocked range {net}"
+    if isinstance(addr, ipaddress.IPv4Address):
+        # Reuse the literal-IPv4 blocked-set logic via _is_ip_literal_blocked.
+        blocked, reason = _is_ip_literal_blocked(ip)
+        if blocked:
+            return True, reason or f"resolved IPv4 {ip} falls in blocked range"
+    return False, ""
+
+
+def _ip_in_cidrs(ip: str, cidrs: list[str]) -> bool:
+    """True iff `ip` falls in any of the configured CIDR ranges."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except (ValueError, ipaddress.AddressValueError):
+        return False
+    for cidr in cidrs:
+        try:
+            net = ipaddress.ip_network(cidr, strict=False)
+        except (ValueError, ipaddress.AddressValueError):
+            continue
+        if addr.version != net.version:
+            continue
+        if addr in net:
+            return True
+    return False
+
+
+def lock_resolved_ip(
+    host: str,
+    *,
+    port: int = 443,
+    allowlist: dict[str, list[dict[str, Any]]] | None = None,
+    provider_id: str | None = None,
+) -> LockedIP:
+    """Resolve `host` once via getaddrinfo and lock the (host, IP) pair.
+
+    Per SDD §1.9 (cycle-099 SKP-005 reconciliation): if `allowlist` and
+    `provider_id` are supplied AND the matching provider entry has a
+    `cdn_cidr_exemptions` list, a resolved IP that falls in one of those
+    CIDRs SKIPS the RFC-1918/loopback/IMDS rebinding check — accepting the
+    legitimate CDN-fronted provider behavior (e.g., anthropic.com via
+    Cloudflare resolving to a CF range that's "public" but the CF range
+    has been vetted at cycle-level System Zone review).
+
+    Without the exemption, any resolution to a blocked range raises
+    DnsRebindingError. The exemption ONLY relaxes the blocked-range trip;
+    the per-request rebinding check (verify_locked_ip) still applies on
+    subsequent calls.
+
+    Raises:
+        DnsResolutionError: if getaddrinfo fails.
+        DnsRebindingError:  if the resolved IP is in a blocked range
+                            AND no cdn_cidr_exemption applies.
+    """
+    records = _resolve_addrinfo(host, port=port)
+    family, ip = records[0]
+    # Determine the CDN-CIDR exemption set (if any) for this provider+host.
+    exemption_cidrs: list[str] = []
+    if allowlist is not None and provider_id is not None:
+        for entry in allowlist.get(provider_id, []):
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("host", "").lower() != host.lower():
+                continue
+            cidrs = entry.get("cdn_cidr_exemptions") or []
+            extras = entry.get("cdn_cidr_exemptions_extra") or []
+            if isinstance(cidrs, list):
+                exemption_cidrs.extend(str(c) for c in cidrs)
+            if isinstance(extras, list):
+                exemption_cidrs.extend(str(c) for c in extras)
+            break
+    # Apply the relaxing-semantics check to EVERY record (cypherpunk MEDIUM —
+    # Happy Eyeballs defense). If TCP connect picks records[1] over
+    # records[0], the validator must have already rejected blocked IPs
+    # anywhere in the dual-stack record set.
+    for _fam, candidate_ip in records:
+        if exemption_cidrs and _ip_in_cidrs(candidate_ip, exemption_cidrs):
+            continue  # explicitly exempted; do not run blocked-range check
+        blocked, reason = _is_resolved_ip_blocked(candidate_ip)
+        if blocked:
+            raise DnsRebindingError(
+                "ENDPOINT-IP-BLOCKED",
+                f"host {host!r} resolved to a blocked IP: {reason}",
+            )
+    return LockedIP(
+        host=host,
+        ip=ip,
+        family=family,
+        port=port,
+        initial_ips=tuple(r[1] for r in records),
+    )
+
+
+def verify_locked_ip(locked: LockedIP) -> bool:
+    """Re-resolve the locked host and verify the IP set still includes the
+    locked IP. Returns True on match. Raises DnsRebindingError on mismatch
+    (the actual rebinding scenario) or DnsResolutionError if re-resolution
+    fails entirely.
+
+    Acceptance rule: any IP in the FRESH record set may match the LOCKED IP
+    OR be in the locked initial_ips set. This tolerates legitimate CDN
+    round-robin while still catching the case where ALL fresh records
+    differ from the locked set.
+    """
+    fresh = _resolve_addrinfo(locked.host, port=locked.port)
+    fresh_ips = {r[1] for r in fresh}
+    if locked.ip in fresh_ips:
+        return True
+    # Tolerate CDN/round-robin: if any of our INITIAL_IPS appears in fresh, OK.
+    if any(ip in fresh_ips for ip in locked.initial_ips):
+        return True
+    # Re-check blocked ranges in the fresh set — even if this isn't the
+    # locked IP, an attacker-rebound resolution could now land on a private
+    # range, which we want to surface clearly.
+    for ip in fresh_ips:
+        blocked, reason = _is_resolved_ip_blocked(ip)
+        if blocked:
+            raise DnsRebindingError(
+                "ENDPOINT-DNS-REBOUND",
+                f"host {locked.host!r} re-resolved to blocked IP: {reason}",
+            )
+    raise DnsRebindingError(
+        "ENDPOINT-DNS-REBOUND",
+        f"host {locked.host!r} re-resolved to {sorted(fresh_ips)!r}; "
+        f"none match locked initial_ips {sorted(locked.initial_ips)!r}",
+    )
+
+
+def validate_redirect(
+    original_locked: LockedIP,
+    new_url: str,
+    allowlist: dict[str, list[dict[str, Any]]],
+) -> ValidationResult:
+    """Validate an HTTP 3xx redirect target.
+
+    Steps:
+      1. Run the full 8-step `validate()` pipeline on `new_url`.
+      2. Same-host check: redirect target must resolve to the SAME host as
+         the locked endpoint (exact lowercased hostname match).
+      3. Same-IP check: re-resolve the host and confirm the locked IP is
+         still in the resulting record set (verify_locked_ip).
+
+    Returns a ValidationResult; never raises (callers can route on the
+    structured rejection code).
+    """
+    new_result = validate(new_url, allowlist)
+    if not new_result.valid:
+        return new_result
+    # LockedIP.__post_init__ already normalized; new_result.host is also
+    # IDNA-normalized + lowercased per step 5.
+    if new_result.host != original_locked.host:
+        return _reject(
+            new_url,
+            "ENDPOINT-REDIRECT-DENIED",
+            f"redirect target host {new_result.host!r} differs from locked host "
+            f"{original_locked.host!r}; same-host policy refuses cross-host redirects",
+        )
+    # gp MEDIUM remediation: same-port enforcement. A redirect from :443 to
+    # an alternate port (even if allowlisted at the provider) lets attacker
+    # pivot to a different service if the operator allowlists multiple ports
+    # per host. The lock contract was made at a specific port; honor it.
+    if new_result.port != original_locked.port:
+        return _reject(
+            new_url,
+            "ENDPOINT-REDIRECT-DENIED",
+            f"redirect port {new_result.port} differs from locked port "
+            f"{original_locked.port}; same-port policy refuses port pivots",
+        )
+    try:
+        verify_locked_ip(original_locked)
+    except DnsRebindingError as exc:
+        return _reject(new_url, exc.code, exc.detail)
+    except DnsResolutionError as exc:
+        return _reject(
+            new_url,
+            "ENDPOINT-DNS-RESOLUTION-FAILED",
+            f"redirect target re-resolution failed: {exc.detail}",
+        )
+    return new_result
+
+
+def validate_redirect_chain(
+    original_locked: LockedIP,
+    redirect_urls: list[str],
+    allowlist: dict[str, list[dict[str, Any]]],
+) -> ValidationResult:
+    """Validate a multi-hop HTTP redirect chain.
+
+    Cypherpunk MEDIUM remediation: `validate_redirect` is single-hop. An
+    attacker controlling a redirect chain (URL_a → URL_b → evil.com) could
+    pass URL_a (same-host as original) and slip URL_b past validation if the
+    caller doesn't re-invoke validate_redirect. This helper enforces per-hop
+    validation against the SAME `original_locked` — every hop must remain
+    same-host AND same-IP. Returns the final ValidationResult; rejects on
+    the first hop that fails.
+    """
+    if not redirect_urls:
+        return ValidationResult(valid=True, url="", scheme="", host="", port=0)
+    result = ValidationResult(valid=False, url="", code="ENDPOINT-RELATIVE", detail="empty chain")
+    for url in redirect_urls:
+        result = validate_redirect(original_locked, url, allowlist)
+        if not result.valid:
+            return result
+    return result
+
+
 _ALLOWLIST_MAX_BYTES = 65536  # 64 KiB — see cypherpunk LOW 1
+
+
+def _warn_overly_permissive_cidr(allowlist: dict[str, list[dict[str, Any]]]) -> None:
+    """Cypherpunk MEDIUM remediation: scan cdn_cidr_exemptions for /0 (or
+    suspiciously-wide /1../4) entries and emit a stderr WARN per occurrence.
+    Operators copy-pasting `0.0.0.0/0` defeat the rebinding defense entirely
+    without realizing it; the warning surfaces the misconfig at load time."""
+    for provider_id, entries in allowlist.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            for field_name in ("cdn_cidr_exemptions", "cdn_cidr_exemptions_extra"):
+                cidrs = entry.get(field_name) or []
+                if not isinstance(cidrs, list):
+                    continue
+                for c in cidrs:
+                    try:
+                        net = ipaddress.ip_network(str(c), strict=False)
+                    except (ValueError, ipaddress.AddressValueError):
+                        continue
+                    if net.prefixlen <= 4:
+                        sys.stderr.write(
+                            f"[ALLOWLIST-OVERLY-PERMISSIVE] {field_name}={c!r} "
+                            f"(prefix /{net.prefixlen}) for provider {provider_id!r} "
+                            "disables the DNS-rebinding defense for matching IPs; "
+                            "tighten the CIDR or remove the entry\n"
+                        )
 
 
 def load_allowlist(path: str | Path) -> dict[str, list[dict[str, Any]]]:
@@ -363,6 +753,7 @@ def load_allowlist(path: str | Path) -> dict[str, list[dict[str, Any]]]:
         raise ValueError(
             f"allowlist {p}: top-level `providers` must be a mapping, got {type(providers).__name__}"
         )
+    _warn_overly_permissive_cidr(providers)
     return providers
 
 

--- a/.claude/scripts/lib/endpoint-validator.py
+++ b/.claude/scripts/lib/endpoint-validator.py
@@ -126,6 +126,11 @@ def _is_ip_literal_blocked(host: str) -> tuple[bool, str | None]:
         addr = ipaddress.ip_address(host)
     except (ValueError, ipaddress.AddressValueError):
         return False, None
+    # AWS IMDS — surface its identity ahead of the generic is_link_local match
+    # so operator diagnostics name the threat (BB iter-1 F3 surfaced this dead
+    # code path; the more-specific message must run first).
+    if isinstance(addr, ipaddress.IPv4Address) and str(addr) == "169.254.169.254":
+        return True, "IP 169.254.169.254 is the AWS IMDS metadata endpoint"
     if addr.is_loopback:
         return True, f"IP {host} is loopback"
     if addr.is_private:
@@ -138,9 +143,6 @@ def _is_ip_literal_blocked(host: str) -> tuple[bool, str | None]:
         return True, f"IP {host} is unspecified (0.0.0.0 / ::)"
     if addr.is_reserved:
         return True, f"IP {host} is reserved"
-    # AWS IMDS — explicitly named here even though it falls under is_link_local.
-    if isinstance(addr, ipaddress.IPv4Address) and str(addr) == "169.254.169.254":
-        return True, "IP 169.254.169.254 is the AWS IMDS metadata endpoint"
     return False, None
 
 

--- a/.claude/scripts/lib/endpoint-validator.py
+++ b/.claude/scripts/lib/endpoint-validator.py
@@ -674,10 +674,15 @@ def validate_redirect(
     return new_result
 
 
+DEFAULT_MAX_REDIRECT_HOPS = 10
+
+
 def validate_redirect_chain(
     original_locked: LockedIP,
     redirect_urls: list[str],
     allowlist: dict[str, list[dict[str, Any]]],
+    *,
+    max_hops: int = DEFAULT_MAX_REDIRECT_HOPS,
 ) -> ValidationResult:
     """Validate a multi-hop HTTP redirect chain.
 
@@ -688,9 +693,21 @@ def validate_redirect_chain(
     validation against the SAME `original_locked` — every hop must remain
     same-host AND same-IP. Returns the final ValidationResult; rejects on
     the first hop that fails.
+
+    BB iter-2 F8: enforce a `max_hops` ceiling (default 10, mirroring the
+    HTTP RFC 7231 §6.4 recommendation for client-side limits). Chains
+    longer than the cap are rejected with ENDPOINT-REDIRECT-DENIED rather
+    than allowed to consume unbounded resources.
     """
     if not redirect_urls:
         return ValidationResult(valid=True, url="", scheme="", host="", port=0)
+    if len(redirect_urls) > max_hops:
+        return _reject(
+            redirect_urls[0],
+            "ENDPOINT-REDIRECT-DENIED",
+            f"redirect chain length {len(redirect_urls)} exceeds max_hops={max_hops}; "
+            "refuse to follow potentially unbounded redirect chains",
+        )
     result = ValidationResult(valid=False, url="", code="ENDPOINT-RELATIVE", detail="empty chain")
     for url in redirect_urls:
         result = validate_redirect(original_locked, url, allowlist)

--- a/.claude/skills/bridgebuilder-review/resources/lib/endpoint-validator.generated.ts
+++ b/.claude/skills/bridgebuilder-review/resources/lib/endpoint-validator.generated.ts
@@ -5,7 +5,7 @@
 // .claude/scripts/lib/codegen/endpoint-validator.ts.j2 + the canonical
 // .claude/scripts/lib/endpoint-validator.py source.
 //
-// Source content hash: cd478d4ea090fb6f5fd37cd2e3a03ce8b5bf6fcbffb1fe87aec687f761a8e9e7
+// Source content hash: 0b8fbc46d4f009c7755baa47dd67d99d36b632839e429619348be1ed6970cbb0
 // Generator version:   1.0
 // Generated at:        (deterministic — wall-clock excluded)
 //

--- a/.claude/skills/bridgebuilder-review/resources/lib/endpoint-validator.generated.ts
+++ b/.claude/skills/bridgebuilder-review/resources/lib/endpoint-validator.generated.ts
@@ -5,7 +5,7 @@
 // .claude/scripts/lib/codegen/endpoint-validator.ts.j2 + the canonical
 // .claude/scripts/lib/endpoint-validator.py source.
 //
-// Source content hash: 77348ea2463b9fbc9484d8d4b9e0a51165126b9cd78ae740839c822e1ab47d9d
+// Source content hash: afc6972433ecf5d93d7185ea0c08efe4cdf2451298a21b20c404bb1f000ea5e3
 // Generator version:   1.0
 // Generated at:        (deterministic — wall-clock excluded)
 //

--- a/.claude/skills/bridgebuilder-review/resources/lib/endpoint-validator.generated.ts
+++ b/.claude/skills/bridgebuilder-review/resources/lib/endpoint-validator.generated.ts
@@ -5,7 +5,7 @@
 // .claude/scripts/lib/codegen/endpoint-validator.ts.j2 + the canonical
 // .claude/scripts/lib/endpoint-validator.py source.
 //
-// Source content hash: 0b8fbc46d4f009c7755baa47dd67d99d36b632839e429619348be1ed6970cbb0
+// Source content hash: 77348ea2463b9fbc9484d8d4b9e0a51165126b9cd78ae740839c822e1ab47d9d
 // Generator version:   1.0
 // Generated at:        (deterministic — wall-clock excluded)
 //

--- a/.github/workflows/cycle099-sprint-1e-c2-dns-tests.yml
+++ b/.github/workflows/cycle099-sprint-1e-c2-dns-tests.yml
@@ -26,8 +26,10 @@ concurrency:
 
 jobs:
   dns-rebinding-tests:
-    name: T1.15 DNS rebinding + redirect tests (12 fixtures)
+    name: T1.15 DNS rebinding + redirect tests
     runs-on: ubuntu-latest
+    # F8 (BB iter-1): bound the job; DNS-mocked tests should complete in <1min.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/cycle099-sprint-1e-c2-dns-tests.yml
+++ b/.github/workflows/cycle099-sprint-1e-c2-dns-tests.yml
@@ -1,0 +1,62 @@
+name: cycle-099 Sprint 1E.c.2 DNS rebinding + redirect
+
+# cycle-099 Sprint 1E.c.2 — runtime SSRF defenses for the centralized
+# endpoint validator: DNS rebinding (lock + verify resolved IP) and HTTP
+# redirect same-host enforcement, per SDD §1.9.1 + NFR-Sec-1 v1.2.
+
+on:
+  pull_request:
+    paths:
+      - '.claude/scripts/lib/endpoint-validator.py'
+      - 'tests/integration/endpoint-validator-dns-rebinding.bats'
+      - '.github/workflows/cycle099-sprint-1e-c2-dns-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/scripts/lib/endpoint-validator.py'
+      - 'tests/integration/endpoint-validator-dns-rebinding.bats'
+      - '.github/workflows/cycle099-sprint-1e-c2-dns-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cycle099-sprint-1e-c2-dns-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dns-rebinding-tests:
+    name: T1.15 DNS rebinding + redirect tests (12 fixtures)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.13'
+
+      - name: Install Python deps (idna)
+        run: |
+          python -m pip install --upgrade pip
+          # Sprint-1E.c.2 uses only stdlib `socket` for DNS resolution; idna
+          # remains the only third-party dep for the canonical validator.
+          pip install 'idna==3.13'
+
+      - name: Install bats-core v1.13.0
+        run: |
+          git clone --branch v1.13.0 --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          cd /tmp/bats-core
+          expected="3bca150ec86275d6d9d5a4fd7d48ab8b6c6f3d87"
+          actual=$(git rev-parse HEAD)
+          if [ "$actual" != "$expected" ]; then
+            echo "ERROR: bats-core commit SHA mismatch — expected $expected, got $actual"
+            exit 1
+          fi
+          sudo ./install.sh /usr/local
+          bats --version
+
+      - name: Run DNS rebinding + redirect tests
+        # The tests monkeypatch socket.getaddrinfo so they run offline (no
+        # actual network I/O). 12 fixtures: lock × 3 + verify × 3 + redirect
+        # × 4 + cidr-allowlist × 2.
+        run: bats tests/integration/endpoint-validator-dns-rebinding.bats

--- a/tests/integration/endpoint-validator-dns-rebinding.bats
+++ b/tests/integration/endpoint-validator-dns-rebinding.bats
@@ -1,0 +1,631 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/endpoint-validator-dns-rebinding.bats
+#
+# cycle-099 Sprint 1E.c.2 — DNS rebinding + HTTP redirect enforcement.
+#
+# Per SDD §1.9.1 + NFR-Sec-1 v1.2, the validator exposes:
+#   - lock_resolved_ip(host) → LockedIP        (resolve once, lock the pair)
+#   - verify_locked_ip(locked, host) → bool    (re-resolve, check unchanged)
+#   - validate_redirect(orig_locked, new_url, allowlist) → ValidationResult
+#
+# DNS is mocked via monkeypatching `socket.getaddrinfo` at runtime so the
+# test corpus runs offline. Each test asserts the expected rejection code
+# (ENDPOINT-DNS-REBOUND, ENDPOINT-REDIRECT-DENIED, ENDPOINT-DNS-RESOLUTION-FAILED)
+# or the expected acceptance.
+#
+# Sprint-1E.c.2 ships Python-only — the TS port from 1E.c.1 doesn't include
+# DNS APIs (sync TS would need Promise<LockedIP> which doesn't fit the
+# codegen template's sync model). Bash wrapper delegates.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    PY_VALIDATOR="$PROJECT_ROOT/.claude/scripts/lib/endpoint-validator.py"
+    ALLOWLIST="$PROJECT_ROOT/tests/fixtures/endpoint-validator/allowlist.json"
+
+    [[ -f "$PY_VALIDATOR" ]] || skip "endpoint-validator.py not present"
+    [[ -f "$ALLOWLIST" ]] || skip "allowlist fixture not present"
+
+    if [[ -x "$PROJECT_ROOT/.venv/bin/python" ]]; then
+        PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+    else
+        PYTHON_BIN="${PYTHON_BIN:-python3}"
+    fi
+
+    WORK_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+# Helper: invoke a Python expression that imports the canonical via
+# spec_loader (same pattern as the codegen module) and runs the assertion.
+# Paths are passed via env vars to avoid heredoc shell-injection.
+_python_assert() {
+    PY_VALIDATOR="$PY_VALIDATOR" \
+    ALLOWLIST="$ALLOWLIST" \
+    WORK_DIR="$WORK_DIR" \
+    PROJECT_ROOT="$PROJECT_ROOT" \
+    "$PYTHON_BIN" -
+}
+
+# ---------------------------------------------------------------------------
+# L — lock_resolved_ip
+# ---------------------------------------------------------------------------
+
+@test "L1 lock: returns LockedIP for resolvable host" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+# Monkeypatch getaddrinfo to return a deterministic IPv4.
+def fake_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+m.socket.getaddrinfo = fake_getaddrinfo
+
+locked = m.lock_resolved_ip("api.openai.com")
+assert locked.host == "api.openai.com", f"host mismatch: {locked}"
+assert locked.ip == "8.8.8.8", f"ip mismatch: {locked}"
+assert locked.family in (socket.AF_INET, socket.AF_INET6)
+EOF
+}
+
+@test "L2 lock: raises DnsResolutionError on getaddrinfo failure" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def failing_getaddrinfo(*args, **kwargs):
+    raise socket.gaierror(-2, "Name or service not known")
+m.socket.getaddrinfo = failing_getaddrinfo
+
+try:
+    m.lock_resolved_ip("nonexistent.example.invalid")
+    raise AssertionError("expected DnsResolutionError")
+except m.DnsResolutionError as e:
+    assert "DNS-RESOLUTION-FAILED" in str(e), f"unexpected error: {e}"
+EOF
+}
+
+@test "L3 lock: rejects IPv4 in blocked range (private, loopback, IMDS)" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def imds_getaddrinfo(host, port, *args, **kwargs):
+    # Operator allowlists api.example.com but DNS resolves it to AWS IMDS.
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", port or 443))]
+m.socket.getaddrinfo = imds_getaddrinfo
+
+try:
+    m.lock_resolved_ip("api.example.com")
+    raise AssertionError("expected DnsRebindingError on IMDS resolution")
+except m.DnsRebindingError as e:
+    assert "ENDPOINT-IP-BLOCKED" in str(e) or "ENDPOINT-DNS-REBOUND" in str(e), f"unexpected: {e}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# V — verify_locked_ip
+# ---------------------------------------------------------------------------
+
+@test "V1 verify: stable resolution succeeds" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def stable_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+m.socket.getaddrinfo = stable_getaddrinfo
+
+locked = m.lock_resolved_ip("api.openai.com")
+# Re-resolve; same IP returned. Must succeed.
+assert m.verify_locked_ip(locked) is True
+EOF
+}
+
+@test "V2 verify: changed IP raises DnsRebindingError" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+# Phase 1: resolve to public IP. Lock.
+state = {"call": 0}
+def shifting_getaddrinfo(host, port, *args, **kwargs):
+    state["call"] += 1
+    if state["call"] == 1:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+    # Phase 2: re-resolve to attacker-controlled internal IP — DNS rebinding.
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", port or 443))]
+m.socket.getaddrinfo = shifting_getaddrinfo
+
+locked = m.lock_resolved_ip("api.openai.com")
+try:
+    m.verify_locked_ip(locked)
+    raise AssertionError("expected DnsRebindingError")
+except m.DnsRebindingError as e:
+    assert "ENDPOINT-DNS-REBOUND" in str(e), f"unexpected: {e}"
+EOF
+}
+
+@test "V3 verify: multi-record resolution accepts ANY record matching locked IP" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+# CDN-style: getaddrinfo returns multiple A records. Lock picks the first.
+# On re-resolve, the first record may differ (round-robin) but if any
+# record matches the locked IP, that's the same backend pool.
+state = {"call": 0}
+def cdn_getaddrinfo(host, port, *args, **kwargs):
+    state["call"] += 1
+    if state["call"] == 1:
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("1.1.1.1", port or 443)),
+        ]
+    return [
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("1.1.1.1", port or 443)),
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443)),
+    ]
+m.socket.getaddrinfo = cdn_getaddrinfo
+
+locked = m.lock_resolved_ip("api.openai.com")
+# Original locked IP was the first in phase-1 (8.8.8.8); phase-2 record
+# set still includes 8.8.8.8 — must accept.
+assert m.verify_locked_ip(locked) is True
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# R — validate_redirect
+# ---------------------------------------------------------------------------
+
+@test "R1 redirect: same-host same-IP redirect accepted" {
+    _python_assert <<'EOF'
+import importlib.util, json, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def stable_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+m.socket.getaddrinfo = stable_getaddrinfo
+
+with open(os.environ["ALLOWLIST"]) as f:
+    allowlist = json.load(f).get("providers", {})
+orig = m.validate("https://api.openai.com/v1", allowlist)
+assert orig.valid
+locked = m.lock_resolved_ip(orig.host)
+
+# Redirect to same host, different path — should accept.
+result = m.validate_redirect(locked, "https://api.openai.com/v1/redirected", allowlist)
+assert result.valid, f"expected accept; got {result.code}"
+EOF
+}
+
+@test "R2 redirect: cross-host redirect rejected with REDIRECT-DENIED" {
+    _python_assert <<'EOF'
+import importlib.util, json, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def stable_getaddrinfo(host, port, *args, **kwargs):
+    if host == "api.openai.com":
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("9.9.9.9", port or 443))]
+m.socket.getaddrinfo = stable_getaddrinfo
+
+with open(os.environ["ALLOWLIST"]) as f:
+    allowlist = json.load(f).get("providers", {})
+orig = m.validate("https://api.openai.com/v1", allowlist)
+locked = m.lock_resolved_ip(orig.host)
+
+result = m.validate_redirect(locked, "https://api.anthropic.com/v1", allowlist)
+assert not result.valid
+assert result.code == "ENDPOINT-REDIRECT-DENIED", f"unexpected: {result.code}"
+EOF
+}
+
+@test "R3 redirect: same-host with rebound IP rejected" {
+    _python_assert <<'EOF'
+import importlib.util, json, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+state = {"call": 0}
+def shifting_getaddrinfo(host, port, *args, **kwargs):
+    state["call"] += 1
+    if state["call"] <= 1:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", port or 443))]
+m.socket.getaddrinfo = shifting_getaddrinfo
+
+with open(os.environ["ALLOWLIST"]) as f:
+    allowlist = json.load(f).get("providers", {})
+orig = m.validate("https://api.openai.com/v1", allowlist)
+locked = m.lock_resolved_ip(orig.host)
+
+# Phase 2 returns rebinding-style internal IP. validate_redirect must reject
+# even when the URL host matches the locked host.
+result = m.validate_redirect(locked, "https://api.openai.com/v1/sub", allowlist)
+assert not result.valid
+assert result.code in ("ENDPOINT-DNS-REBOUND", "ENDPOINT-IP-BLOCKED"), f"unexpected: {result.code}"
+EOF
+}
+
+@test "R4 redirect: validation pipeline still applies (e.g., scheme rejected)" {
+    _python_assert <<'EOF'
+import importlib.util, json, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def stable_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+m.socket.getaddrinfo = stable_getaddrinfo
+
+with open(os.environ["ALLOWLIST"]) as f:
+    allowlist = json.load(f).get("providers", {})
+orig = m.validate("https://api.openai.com/v1", allowlist)
+locked = m.lock_resolved_ip(orig.host)
+
+# Redirect downgrade to http should fail at the canonicalization gate, not
+# the same-host gate — verify the code reflects scheme-rejection.
+result = m.validate_redirect(locked, "http://api.openai.com/v1", allowlist)
+assert not result.valid
+assert result.code == "ENDPOINT-INSECURE-SCHEME", f"unexpected: {result.code}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# C — cdn_cidr_exemptions (per SDD §1.9 — relaxing semantics for CDN-fronted
+# providers; matching IPs SKIP the blocked-range check)
+# ---------------------------------------------------------------------------
+
+@test "C1 cdn_exemption: in-CIDR private IP bypasses blocked-range check" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def cdn_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", port or 443))]
+m.socket.getaddrinfo = cdn_getaddrinfo
+
+# 10.0.0.0/8 is normally rejected as RFC 1918 private. Operator declares it
+# as a CDN exemption (legitimate for self-hosted CDN-fronted endpoints).
+allowlist = {
+    "openai": [
+        {"host": "api.openai.com", "ports": [443], "cdn_cidr_exemptions": ["10.0.0.0/8"]},
+    ],
+}
+locked = m.lock_resolved_ip("api.openai.com", allowlist=allowlist, provider_id="openai")
+assert locked.ip == "10.0.0.5", f"expected exempted private IP; got {locked.ip}"
+EOF
+}
+
+@test "C2 cdn_exemption: NOT in CIDR → standard blocked-range check fires" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def out_of_exemption_getaddrinfo(host, port, *args, **kwargs):
+    # Operator's exemption is 10.0.0.0/8 but resolution lands on 192.168.1.1
+    # (also private, but NOT in the configured exemption).
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.168.1.1", port or 443))]
+m.socket.getaddrinfo = out_of_exemption_getaddrinfo
+
+allowlist = {
+    "openai": [
+        {"host": "api.openai.com", "ports": [443], "cdn_cidr_exemptions": ["10.0.0.0/8"]},
+    ],
+}
+try:
+    m.lock_resolved_ip("api.openai.com", allowlist=allowlist, provider_id="openai")
+    raise AssertionError("expected DnsRebindingError on private IP outside exemption")
+except m.DnsRebindingError as e:
+    assert "ENDPOINT-IP-BLOCKED" in str(e), f"unexpected: {e}"
+EOF
+}
+
+@test "C3 cdn_exemption_extra: operator-side extension is honored" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def cdn_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", port or 443))]
+m.socket.getaddrinfo = cdn_getaddrinfo
+
+# Framework defaults are empty; operator extends with their own range. The
+# union of both sets should be honored per SDD §1.9.
+allowlist = {
+    "openai": [
+        {
+            "host": "api.openai.com",
+            "ports": [443],
+            "cdn_cidr_exemptions": [],
+            "cdn_cidr_exemptions_extra": ["10.0.0.0/8"],
+        },
+    ],
+}
+locked = m.lock_resolved_ip("api.openai.com", allowlist=allowlist, provider_id="openai")
+assert locked.ip == "10.0.0.5"
+EOF
+}
+
+@test "C4 cdn_exemption: missing field → standard blocked-range check applies" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def imds_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", port or 443))]
+m.socket.getaddrinfo = imds_getaddrinfo
+
+# Provider entry has no cdn_cidr_exemptions — standard check fires.
+allowlist = {
+    "openai": [{"host": "api.openai.com", "ports": [443]}],
+}
+try:
+    m.lock_resolved_ip("api.openai.com", allowlist=allowlist, provider_id="openai")
+    raise AssertionError("expected IMDS rejection")
+except m.DnsRebindingError as e:
+    assert "ENDPOINT-IP-BLOCKED" in str(e), f"unexpected: {e}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# H — Happy Eyeballs / dual-stack hardening (cypherpunk MEDIUM)
+# ---------------------------------------------------------------------------
+
+@test "H1 dual-stack: ALL records in set checked, not just records[0]" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+# Phase-1: getaddrinfo returns [public IPv4 8.8.8.8, IMDS 169.254.169.254].
+# Records[0] is benign but Happy Eyeballs / OS connect could pivot to
+# records[1]. The validator MUST reject when ANY record is blocked.
+def dual_stack_getaddrinfo(host, port, *args, **kwargs):
+    return [
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443)),
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", port or 443)),
+    ]
+m.socket.getaddrinfo = dual_stack_getaddrinfo
+
+try:
+    m.lock_resolved_ip("api.openai.com")
+    raise AssertionError("expected blocked-range rejection on records[1] IMDS")
+except m.DnsRebindingError as e:
+    assert "ENDPOINT-IP-BLOCKED" in str(e), f"unexpected: {e}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# N — LockedIP normalization + forge-defense (cypherpunk HIGH 2 + LOW)
+# ---------------------------------------------------------------------------
+
+@test "N1 normalize: trailing-dot FQDN + uppercase host normalized" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def stable_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+m.socket.getaddrinfo = stable_getaddrinfo
+
+locked = m.lock_resolved_ip("API.OpenAI.com.")
+# host normalized to lowercase + trailing-dot stripped at __post_init__.
+assert locked.host == "api.openai.com", f"unexpected host: {locked.host!r}"
+EOF
+}
+
+@test "N2 forge-defense: LockedIP construction with garbage IP fails fast" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+# Forged LockedIP from a JSON state file with garbage IP must reject at
+# __post_init__ rather than silently accepting.
+try:
+    m.LockedIP(host="api.openai.com", ip="not-an-ip", family=socket.AF_INET, port=443)
+    raise AssertionError("expected ValueError on invalid IP")
+except ValueError as e:
+    assert "not a valid IP" in str(e), f"unexpected: {e}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# P — Port-pivot defense in validate_redirect (gp MEDIUM)
+# ---------------------------------------------------------------------------
+
+@test "P1 redirect: same-host different-port rejected (port-pivot defense)" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def stable_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+m.socket.getaddrinfo = stable_getaddrinfo
+
+# Allowlist openai with two ports (operator allowed both 443 and 8443).
+allowlist = {
+    "openai": [{"host": "api.openai.com", "ports": [443, 8443]}],
+}
+orig = m.validate("https://api.openai.com/v1", allowlist)
+assert orig.valid
+locked = m.lock_resolved_ip(orig.host)
+
+# Redirect to the SAME host but on the alternate allowlisted port.
+# 8-step pipeline accepts (port allowlisted), but validate_redirect rejects
+# because the lock was made at port 443 — locking is per-port.
+result = m.validate_redirect(locked, "https://api.openai.com:8443/v1", allowlist)
+assert not result.valid
+assert result.code == "ENDPOINT-REDIRECT-DENIED", f"unexpected: {result.code}"
+assert "port" in result.detail.lower()
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# X — Multi-hop redirect chain helper (cypherpunk MEDIUM)
+# ---------------------------------------------------------------------------
+
+@test "X1 chain: per-hop validation rejects mid-chain bounce to new host" {
+    _python_assert <<'EOF'
+import importlib.util, json, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def stable_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+m.socket.getaddrinfo = stable_getaddrinfo
+
+with open(os.environ["ALLOWLIST"]) as f:
+    allowlist = json.load(f).get("providers", {})
+orig = m.validate("https://api.openai.com/v1", allowlist)
+locked = m.lock_resolved_ip(orig.host)
+
+# Chain: same-host → same-host → cross-host (attacker goal). Helper rejects
+# at the third hop, NOT silently accept-and-follow.
+chain = [
+    "https://api.openai.com/v1/step1",
+    "https://api.openai.com/v1/step2",
+    "https://api.anthropic.com/v1",
+]
+result = m.validate_redirect_chain(locked, chain, allowlist)
+assert not result.valid
+assert result.code == "ENDPOINT-REDIRECT-DENIED", f"unexpected: {result.code}"
+EOF
+}
+
+@test "X2 chain: empty chain returns valid (no redirect)" {
+    _python_assert <<'EOF'
+import importlib.util, json, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def stable_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+m.socket.getaddrinfo = stable_getaddrinfo
+
+with open(os.environ["ALLOWLIST"]) as f:
+    allowlist = json.load(f).get("providers", {})
+orig = m.validate("https://api.openai.com/v1", allowlist)
+locked = m.lock_resolved_ip(orig.host)
+
+result = m.validate_redirect_chain(locked, [], allowlist)
+assert result.valid, f"empty chain should be valid; got {result.code}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# B — Common error base + load-time CIDR warning (gp MEDIUM + cypherpunk MEDIUM)
+# ---------------------------------------------------------------------------
+
+@test "B1 errors: DnsResolutionError + DnsRebindingError share EndpointDnsError base" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+assert issubclass(m.DnsResolutionError, m.EndpointDnsError)
+assert issubclass(m.DnsRebindingError, m.EndpointDnsError)
+EOF
+}
+
+@test "B2 cidr-warn: 0.0.0.0/0 in cdn_cidr_exemptions emits stderr WARN" {
+    # Operator copy-pastes 0.0.0.0/0 thinking it means "match anything"; it
+    # actually disables the rebinding defense entirely. Warn loudly at load.
+    local bad_allowlist="$WORK_DIR/permissive.json"
+    cat > "$bad_allowlist" <<'JSON'
+{
+  "providers": {
+    "openai": [
+      {"host": "api.openai.com", "ports": [443], "cdn_cidr_exemptions": ["0.0.0.0/0"]}
+    ]
+  }
+}
+JSON
+    BAD_ALLOWLIST="$bad_allowlist" \
+    PY_VALIDATOR="$PY_VALIDATOR" \
+    "$PYTHON_BIN" - <<'EOF'
+import importlib.util, io, os, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+# Capture stderr around load_allowlist.
+buf = io.StringIO()
+real_stderr = sys.stderr
+sys.stderr = buf
+try:
+    m.load_allowlist(os.environ["BAD_ALLOWLIST"])
+finally:
+    sys.stderr = real_stderr
+warn = buf.getvalue()
+assert "ALLOWLIST-OVERLY-PERMISSIVE" in warn, f"expected warning; got {warn!r}"
+assert "0.0.0.0/0" in warn, f"expected CIDR in warning; got {warn!r}"
+EOF
+}

--- a/tests/integration/endpoint-validator-dns-rebinding.bats
+++ b/tests/integration/endpoint-validator-dns-rebinding.bats
@@ -558,6 +558,31 @@ assert result.code == "ENDPOINT-REDIRECT-DENIED", f"unexpected: {result.code}"
 EOF
 }
 
+@test "X3 chain: rejects chains longer than max_hops (default 10)" {
+    _python_assert <<'EOF'
+import importlib.util, json, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def stable_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port or 443))]
+m.socket.getaddrinfo = stable_getaddrinfo
+
+with open(os.environ["ALLOWLIST"]) as f:
+    allowlist = json.load(f).get("providers", {})
+locked = m.lock_resolved_ip("api.openai.com")
+
+# 11-hop chain (default max is 10) — must reject before validating any hop.
+chain = [f"https://api.openai.com/v1/step{i}" for i in range(11)]
+result = m.validate_redirect_chain(locked, chain, allowlist)
+assert not result.valid
+assert result.code == "ENDPOINT-REDIRECT-DENIED"
+assert "max_hops" in result.detail
+EOF
+}
+
 @test "X2 chain: empty chain returns valid (no redirect)" {
     _python_assert <<'EOF'
 import importlib.util, json, os, socket, sys

--- a/tests/integration/endpoint-validator-dns-rebinding.bats
+++ b/tests/integration/endpoint-validator-dns-rebinding.bats
@@ -116,7 +116,10 @@ try:
     m.lock_resolved_ip("api.example.com")
     raise AssertionError("expected DnsRebindingError on IMDS resolution")
 except m.DnsRebindingError as e:
-    assert "ENDPOINT-IP-BLOCKED" in str(e) or "ENDPOINT-DNS-REBOUND" in str(e), f"unexpected: {e}"
+    # F3 (BB iter-1): tightened to single specific code. ENDPOINT-IP-BLOCKED
+    # is the load-time check; DNS-REBOUND fires only on subsequent re-resolve.
+    assert "ENDPOINT-IP-BLOCKED" in str(e), f"unexpected: {e}"
+    assert "AWS IMDS" in str(e), f"expected IMDS-specific reason; got {e}"
 EOF
 }
 
@@ -591,6 +594,94 @@ spec.loader.exec_module(m)
 
 assert issubclass(m.DnsResolutionError, m.EndpointDnsError)
 assert issubclass(m.DnsRebindingError, m.EndpointDnsError)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# I — IPv6 lock + verify (BB iter-1 F11 — was IPv4-monoculture)
+# ---------------------------------------------------------------------------
+
+@test "I1 ipv6 lock: AF_INET6 record locked correctly" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def v6_getaddrinfo(host, port, *args, **kwargs):
+    # Cloudflare DNS public IPv6 — globally routable, not in any blocked range.
+    return [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("2606:4700:4700::1111", port or 443, 0, 0))]
+m.socket.getaddrinfo = v6_getaddrinfo
+
+locked = m.lock_resolved_ip("api.openai.com")
+assert locked.ip == "2606:4700:4700::1111"
+assert locked.family == socket.AF_INET6
+EOF
+}
+
+@test "I2 ipv6 lock: link-local fe80:: rejected with link-local reason" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def linklocal_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("fe80::1", port or 443, 0, 0))]
+m.socket.getaddrinfo = linklocal_getaddrinfo
+
+try:
+    m.lock_resolved_ip("api.openai.com")
+    raise AssertionError("expected IPv6 link-local rejection")
+except m.DnsRebindingError as e:
+    assert "ENDPOINT-IP-BLOCKED" in str(e)
+    assert "link-local" in str(e), f"expected link-local reason; got {e}"
+EOF
+}
+
+@test "I3 ipv6 lock: AWS IPv6 IMDS (fd00:ec2::254) rejected with IMDS reason" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def imds_v6_getaddrinfo(host, port, *args, **kwargs):
+    return [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("fd00:ec2::254", port or 443, 0, 0))]
+m.socket.getaddrinfo = imds_v6_getaddrinfo
+
+try:
+    m.lock_resolved_ip("api.openai.com")
+    raise AssertionError("expected IPv6 IMDS rejection")
+except m.DnsRebindingError as e:
+    assert "ENDPOINT-IP-BLOCKED" in str(e)
+    assert "IMDS" in str(e), f"expected IMDS reason; got {e}"
+EOF
+}
+
+@test "I4 ipv6 zone-id: stripped before blocked-range check" {
+    _python_assert <<'EOF'
+import importlib.util, os, socket, sys
+spec = importlib.util.spec_from_file_location("ev", os.environ["PY_VALIDATOR"])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ev"] = m
+spec.loader.exec_module(m)
+
+def zone_id_getaddrinfo(host, port, *args, **kwargs):
+    # getaddrinfo can include zone-id in sockaddr[0] (e.g., fe80::1%eth0).
+    # _resolve_addrinfo strips %... before the blocked-range check.
+    return [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("fe80::1%eth0", port or 443, 0, 0))]
+m.socket.getaddrinfo = zone_id_getaddrinfo
+
+try:
+    m.lock_resolved_ip("api.openai.com")
+    raise AssertionError("expected link-local rejection (zone-id stripped)")
+except m.DnsRebindingError as e:
+    assert "ENDPOINT-IP-BLOCKED" in str(e)
+    assert "link-local" in str(e)
 EOF
 }
 


### PR DESCRIPTION
## Summary

Per cycle-099 SDD §1.9.1 NFR-Sec-1 v1.2, ships runtime SSRF defenses for the centralized endpoint validator: DNS rebinding (lock + verify resolved IP) and HTTP redirect same-host + same-port enforcement.

- **Library API additions** to `.claude/scripts/lib/endpoint-validator.py`:
  - `LockedIP` dataclass (frozen; normalizes host + validates IPs in `__post_init__`)
  - `EndpointDnsError` base class with `DnsResolutionError` + `DnsRebindingError` subclasses
  - `lock_resolved_ip()` — resolve once, lock (host, IP) pair, validate ALL records (Happy Eyeballs defense), apply `cdn_cidr_exemptions` per SDD §1.9
  - `verify_locked_ip()` — re-resolve, accept if any initial IP appears in fresh records
  - `validate_redirect()` — same-host + same-port + same-IP enforcement
  - `validate_redirect_chain()` — per-hop validation for multi-hop redirects (SSRF chain defense)
- **22 cross-runtime tests** with DNS mocked via `socket.getaddrinfo` monkeypatch
- **Dedicated CI**: `.github/workflows/cycle099-sprint-1e-c2-dns-tests.yml`

**Test count**: 131/131 across all four validator suites (cross-runtime + TS parity + DNS rebinding + import-guard).

## Quality gate trail

Subagent dual-review (general-purpose + paranoid cypherpunk) surfaced 19 findings — 3 HIGH:

| Severity | Reviewer | Finding | Status |
|----------|----------|---------|--------|
| HIGH | gp+cypherpunk | `cidr_ranges` field-name + semantic inversion vs SDD §1.9 v1.3 (`cdn_cidr_exemptions` has RELAXING semantics for CDN reconciliation, not require-match) | ✅ renamed + inverted; added `cdn_cidr_exemptions_extra` union |
| HIGH | cypherpunk | Trailing-dot FQDN host carried raw in `LockedIP.host` | ✅ `__post_init__` normalizes lowercase + strips trailing dot |
| HIGH | gp | IPv6 IMDS / link-local / NAT64 diagnostic readability | ✅ well-known endpoints get specific reasons in `_is_resolved_ip_blocked` |
| MEDIUM | gp | Port-pivot via redirect when operator allowlists multiple ports | ✅ `validate_redirect` compares `new_result.port` to `original_locked.port` |
| MEDIUM | cypherpunk | Happy Eyeballs IPv4+IPv6 records[0] gambit | ✅ `lock_resolved_ip` checks ALL records; rejects if any blocked |
| MEDIUM | cypherpunk | `0.0.0.0/0` in `cdn_cidr_exemptions` silently disables defense | ✅ `_warn_overly_permissive_cidr` emits stderr WARN on /0../4 at load |
| MEDIUM | cypherpunk | Multi-hop redirect chain bypass | ✅ `validate_redirect_chain` enforces per-hop |
| MEDIUM | gp | DnsResolutionError/DnsRebindingError lacked common base | ✅ `EndpointDnsError` parent class |
| LOW | cypherpunk | `LockedIP` forgery via direct construction (deserialization) | ✅ `__post_init__` ipaddress parse-validates fields |

Remaining LOWs (test corpus IPv4 monoculture, CI matrix ubuntu-only, TOCTOU documentation) deferred to sprint-1E.c.3 follow-up.

## Acceptance criteria

- AC-S1.12 (T1.15 cont.): DNS rebinding + redirect enforcement APIs ✅
- SDD §1.9 cdn_cidr_exemptions semantics implemented per spec ✅
- NFR-Sec-1 v1.2 lock-then-verify pattern with documented TOCTOU limitation ✅

## Sprint 1E.c.2 scope ships Python-only

TS port doesn't include DNS APIs (sync TS / `Promise<LockedIP>` mismatch with the codegen template's sync model). TS port code unchanged from sprint-1E.c.1; only the embedded `Source content hash` in the generated header updates.

## Sprint 1 progress

- 1A ✅ codegen foundation (#722)
- 1B ✅ adapter migrations + drift gate (#723)
- 1C ✅ matrix CI + toolchain runbook (#724)
- 1E.a ✅ log-redactor + migrate CLI (#728)
- 1E.b ✅ endpoint-validator Python + bash (#729)
- 1E.c.1 ✅ TS port via Jinja2 codegen (#730)
- **1E.c.2 ← this PR** — DNS rebinding + redirect enforcement
- 1E.c.3 deferred — bash caller migration (~15 files)
- 1D deferred — cross-runtime golden corpus (T1.11+T1.12)

## Test plan

- [x] `bats tests/integration/endpoint-validator-dns-rebinding.bats` — 22 tests pass
- [x] All four validator suites combined: 131/131 pass
- [x] Drift gate green: TS source-hash matches regenerated content
- [x] B2 test asserts overly-permissive CIDR warning fires correctly

## --no-verify rationale

Per cycle-099 sprint plan policy: beads UNHEALTHY/MIGRATION_NEEDED (#661). Commit message carries `[NO-VERIFY-RATIONALE: ...]` audit-trail tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)