### PR TITLE
feat(cycle-099-sprint-1E.c.3.b): bash caller migration batch + smuggling-defense remediation (T1.15 cont.)

### DIFF
--- a/.claude/scripts/check-updates.sh
+++ b/.claude/scripts/check-updates.sh
@@ -57,6 +57,12 @@ NOTIFY_MODE=false
 # shellcheck source=bash-version-guard.sh
 source "$SCRIPT_DIR/bash-version-guard.sh"
 
+# cycle-099 sprint-1E.c.3.b: GitHub API release-version probe via endpoint
+# validator with the loa-github.json allowlist (api.github.com).
+# shellcheck source=lib/endpoint-validator.sh
+source "$SCRIPT_DIR/lib/endpoint-validator.sh"
+CHECK_UPDATES_ALLOWLIST="${LOA_CHECK_UPDATES_ALLOWLIST:-$SCRIPT_DIR/lib/allowlists/loa-github.json}"
+
 check_dependencies() {
     local missing=()
 
@@ -314,11 +320,14 @@ fetch_latest_release() {
     local api_url="https://api.github.com/repos/$owner/$repo/releases/latest"
 
     local response
-    # HIGH-002 FIX: Enforce HTTPS and TLS 1.2+
-    response=$(curl -sL --proto =https --tlsv1.2 \
+    # HIGH-002: --tlsv1.2 enforces minimum TLS version. cycle-099 sprint-1E.c.3.b:
+    # https-only + redirect-bound enforcement comes from the wrapper.
+    response=$(endpoint_validator__guarded_curl \
+        --allowlist "$CHECK_UPDATES_ALLOWLIST" \
+        --url "$api_url" \
+        -sL --tlsv1.2 \
         -H "Accept: application/vnd.github+json" \
-        --max-time 5 \
-        "$api_url" 2>/dev/null) || {
+        --max-time 5 2>/dev/null) || {
         # Network error - silent fail
         echo ""
         return 1

--- a/.claude/scripts/constructs-auth.sh
+++ b/.claude/scripts/constructs-auth.sh
@@ -37,6 +37,12 @@ if [[ -f "$SCRIPT_DIR/lib-security.sh" ]]; then
     source "$SCRIPT_DIR/lib-security.sh"
 fi
 
+# cycle-099 sprint-1E.c.3.b: route registry auth-validate through endpoint
+# validator with the constructs registry allowlist (api.constructs.network).
+# shellcheck source=lib/endpoint-validator.sh
+source "$SCRIPT_DIR/lib/endpoint-validator.sh"
+CONSTRUCTS_REGISTRY_ALLOWLIST="${LOA_CONSTRUCTS_REGISTRY_ALLOWLIST:-$SCRIPT_DIR/lib/allowlists/loa-registry.json}"
+
 # =============================================================================
 # Configuration
 # =============================================================================
@@ -157,16 +163,20 @@ cmd_validate() {
     local response
     local http_code
     
-    # SHELL-002: Use curl config file to avoid exposing API key in process list
+    # SHELL-002 + cycle-099 sprint-1E.c.3.b: keep API key out of process
+    # listings via auth tempfile, route through endpoint validator with
+    # registry allowlist. --config-auth content-gates the auth file.
     local curl_config
     curl_config=$(write_curl_auth_config "Authorization" "Bearer ${api_key}") || {
         echo "ERROR: Failed to create secure curl config" >&2
         return 3
     }
 
-    http_code=$(curl -s -o /dev/null -w "%{http_code}" \
-        --config "$curl_config" \
-        "${registry_url}/auth/validate" 2>/dev/null || echo "000")
+    http_code=$(endpoint_validator__guarded_curl \
+        --allowlist "$CONSTRUCTS_REGISTRY_ALLOWLIST" \
+        --config-auth "$curl_config" \
+        --url "${registry_url}/auth/validate" \
+        -s -o /dev/null -w "%{http_code}" 2>/dev/null || echo "000")
     rm -f "$curl_config"
     
     case "$http_code" in

--- a/.claude/scripts/constructs-browse.sh
+++ b/.claude/scripts/constructs-browse.sh
@@ -38,6 +38,13 @@ else
     exit 6
 fi
 
+# cycle-099 sprint-1E.c.3.b: registry GETs (with + without auth) funnel
+# through endpoint_validator__guarded_curl using the loa-registry.json
+# allowlist (api.constructs.network).
+# shellcheck source=lib/endpoint-validator.sh
+source "$SCRIPT_DIR/lib/endpoint-validator.sh"
+CONSTRUCTS_REGISTRY_ALLOWLIST="${LOA_CONSTRUCTS_REGISTRY_ALLOWLIST:-$SCRIPT_DIR/lib/allowlists/loa-registry.json}"
+
 # Source security library (for write_curl_auth_config)
 if [[ -f "$SCRIPT_DIR/lib-security.sh" ]]; then
     source "$SCRIPT_DIR/lib-security.sh"
@@ -114,20 +121,27 @@ fetch_packs() {
         return 0
     fi
 
-    # Fetch from API - use unified /constructs endpoint
-    # SHELL-003: Use curl config file to avoid exposing API key in process list
+    # Fetch from API - use unified /constructs endpoint.
+    # SHELL-003 + cycle-099 sprint-1E.c.3.b: API key in auth tempfile (out
+    # of process listings); auth tempfile passed via --config-auth (content-
+    # gated to header= lines only); URL gated by allowlist.
     local curl_args=(-s -f)
+    local config_auth_arg=()
     local curl_config=""
     if [[ -n "$api_key" ]]; then
         curl_config=$(write_curl_auth_config "Authorization" "Bearer ${api_key}") || true
         if [[ -n "$curl_config" ]]; then
-            curl_args+=(--config "$curl_config")
+            config_auth_arg=(--config-auth "$curl_config")
         fi
     fi
 
     local response http_code
     # Capture both response and HTTP code
-    response=$(curl "${curl_args[@]}" -w "\n%{http_code}" "${registry_url}/constructs?type=pack" 2>/dev/null) || true
+    response=$(endpoint_validator__guarded_curl \
+        --allowlist "$CONSTRUCTS_REGISTRY_ALLOWLIST" \
+        ${config_auth_arg[@]+"${config_auth_arg[@]}"} \
+        --url "${registry_url}/constructs?type=pack" \
+        "${curl_args[@]}" -w "\n%{http_code}" 2>/dev/null) || true
     [[ -n "$curl_config" ]] && rm -f "$curl_config"
     http_code=$(echo "$response" | tail -n1)
     response=$(echo "$response" | sed '$d')
@@ -149,7 +163,10 @@ fetch_packs() {
     # constructs list endpoint is public and doesn't require auth
     if [[ -n "$api_key" ]] && [[ "$http_code" =~ ^(401|403|502|000)$ || -z "$http_code" ]]; then
         echo "  Auth failed (HTTP $http_code), retrying without credentials..." >&2
-        response=$(curl -s -f -w "\n%{http_code}" "${registry_url}/constructs?type=pack" 2>/dev/null) || true
+        response=$(endpoint_validator__guarded_curl \
+            --allowlist "$CONSTRUCTS_REGISTRY_ALLOWLIST" \
+            --url "${registry_url}/constructs?type=pack" \
+            -s -f -w "\n%{http_code}" 2>/dev/null) || true
         http_code=$(echo "$response" | tail -n1)
         response=$(echo "$response" | sed '$d')
 
@@ -196,18 +213,23 @@ fetch_pack_info() {
     local api_key
     api_key=$(get_api_key 2>/dev/null || echo "")
 
-    # SHELL-003: Use curl config file to avoid exposing API key in process list
+    # SHELL-003 + cycle-099 sprint-1E.c.3.b: auth tempfile + endpoint validator.
     local curl_args=(-s -f)
+    local config_auth_arg=()
     local curl_config=""
     if [[ -n "$api_key" ]]; then
         curl_config=$(write_curl_auth_config "Authorization" "Bearer ${api_key}") || true
         if [[ -n "$curl_config" ]]; then
-            curl_args+=(--config "$curl_config")
+            config_auth_arg=(--config-auth "$curl_config")
         fi
     fi
 
     local response http_code
-    response=$(curl "${curl_args[@]}" -w "\n%{http_code}" "${registry_url}/constructs/${slug}" 2>/dev/null) || true
+    response=$(endpoint_validator__guarded_curl \
+        --allowlist "$CONSTRUCTS_REGISTRY_ALLOWLIST" \
+        ${config_auth_arg[@]+"${config_auth_arg[@]}"} \
+        --url "${registry_url}/constructs/${slug}" \
+        "${curl_args[@]}" -w "\n%{http_code}" 2>/dev/null) || true
     [[ -n "$curl_config" ]] && rm -f "$curl_config"
     http_code=$(echo "$response" | tail -n1)
     response=$(echo "$response" | sed '$d')
@@ -221,7 +243,10 @@ fetch_pack_info() {
     # The constructs detail endpoint is public and doesn't require auth
     if [[ -n "$api_key" ]] && [[ "$http_code" =~ ^(401|403|502|000)$ || -z "$http_code" ]]; then
         echo "  Auth failed (HTTP $http_code), retrying without credentials..." >&2
-        response=$(curl -s -f -w "\n%{http_code}" "${registry_url}/constructs/${slug}" 2>/dev/null) || true
+        response=$(endpoint_validator__guarded_curl \
+            --allowlist "$CONSTRUCTS_REGISTRY_ALLOWLIST" \
+            --url "${registry_url}/constructs/${slug}" \
+            -s -f -w "\n%{http_code}" 2>/dev/null) || true
         http_code=$(echo "$response" | tail -n1)
         response=$(echo "$response" | sed '$d')
 

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -51,6 +51,12 @@ if [[ -f "$SCRIPT_DIR/lib-security.sh" ]]; then
     source "$SCRIPT_DIR/lib-security.sh"
 fi
 
+# cycle-099 sprint-1E.c.3.b: pack + skill download via endpoint validator
+# with the constructs registry allowlist (api.constructs.network).
+# shellcheck source=lib/endpoint-validator.sh
+source "$SCRIPT_DIR/lib/endpoint-validator.sh"
+CONSTRUCTS_REGISTRY_ALLOWLIST="${LOA_CONSTRUCTS_REGISTRY_ALLOWLIST:-$SCRIPT_DIR/lib/allowlists/loa-registry.json}"
+
 # =============================================================================
 # Exit Codes
 # =============================================================================
@@ -508,18 +514,21 @@ do_install_pack() {
     # Disable command tracing during API call to prevent key leakage
     { set +x; } 2>/dev/null || true
 
-    # SHELL-002: Use write_curl_auth_config to prevent header injection
+    # SHELL-002 + cycle-099 sprint-1E.c.3.b: auth tempfile + endpoint validator.
     local auth_config
     auth_config=$(write_curl_auth_config "Authorization" "Bearer $api_key") || {
         rm -f "$tmp_file"
         print_error "ERROR: Failed to create secure auth config"
         return $EXIT_AUTH_ERROR
     }
-    # HIGH-002 FIX: Enforce HTTPS and TLS 1.2+
-    http_code=$(curl -s -w "%{http_code}" --proto =https --tlsv1.2 --max-time 300 \
-        --config "$auth_config" \
+    # HIGH-002: --tlsv1.2 enforces minimum TLS version. Wrapper supplies
+    # --proto =https / --proto-redir =https / --max-redirs 10 hardened defaults.
+    http_code=$(endpoint_validator__guarded_curl \
+        --allowlist "$CONSTRUCTS_REGISTRY_ALLOWLIST" \
+        --config-auth "$auth_config" \
+        --url "$registry_url/packs/$pack_slug/download" \
+        -s -w "%{http_code}" --tlsv1.2 --max-time 300 \
         -H "Accept: application/json" \
-        "$registry_url/packs/$pack_slug/download" \
         -o "$tmp_file" 2>/dev/null) || {
         rm -f "$auth_config" "$tmp_file"
         print_error "ERROR: Network error while downloading pack"
@@ -847,18 +856,21 @@ do_install_skill() {
     # Disable command tracing during API call to prevent key leakage
     { set +x; } 2>/dev/null || true
 
-    # SHELL-002: Use write_curl_auth_config to prevent header injection
+    # SHELL-002 + cycle-099 sprint-1E.c.3.b: auth tempfile + endpoint validator.
     local auth_config
     auth_config=$(write_curl_auth_config "Authorization" "Bearer $api_key") || {
         rm -f "$tmp_file"
         print_error "ERROR: Failed to create secure auth config"
         return $EXIT_AUTH_ERROR
     }
-    # HIGH-002 FIX: Enforce HTTPS and TLS 1.2+
-    http_code=$(curl -s -w "%{http_code}" --proto =https --tlsv1.2 --max-time 300 \
-        --config "$auth_config" \
+    # HIGH-002: --tlsv1.2 minimum TLS version. Wrapper supplies https-only
+    # + redirect-bound enforcement.
+    http_code=$(endpoint_validator__guarded_curl \
+        --allowlist "$CONSTRUCTS_REGISTRY_ALLOWLIST" \
+        --config-auth "$auth_config" \
+        --url "$registry_url/skills/$skill_slug/download" \
+        -s -w "%{http_code}" --tlsv1.2 --max-time 300 \
         -H "Accept: application/json" \
-        "$registry_url/skills/$skill_slug/download" \
         -o "$tmp_file" 2>/dev/null) || {
         rm -f "$auth_config" "$tmp_file"
         print_error "ERROR: Network error while downloading skill"

--- a/.claude/scripts/constructs-loader.sh
+++ b/.claude/scripts/constructs-loader.sh
@@ -47,6 +47,12 @@ if [[ -f "$SCRIPT_DIR/yq-safe.sh" ]]; then
     source "$SCRIPT_DIR/yq-safe.sh"
 fi
 
+# cycle-099 sprint-1E.c.3.b: route registry GET through endpoint validator
+# with the constructs registry allowlist (api.constructs.network).
+# shellcheck source=lib/endpoint-validator.sh
+source "$SCRIPT_DIR/lib/endpoint-validator.sh"
+CONSTRUCTS_REGISTRY_ALLOWLIST="${LOA_CONSTRUCTS_REGISTRY_ALLOWLIST:-$SCRIPT_DIR/lib/allowlists/loa-registry.json}"
+
 # =============================================================================
 # Constants
 # =============================================================================
@@ -1128,8 +1134,15 @@ query_skill_versions() {
 
     # Query the versions endpoint
     local url="${registry_url}/skills/${skill_slug}/versions"
-    # HIGH-002 FIX: Enforce HTTPS and TLS 1.2+
-    curl -s --proto =https --tlsv1.2 --connect-timeout 5 --max-time 10 "$url" 2>/dev/null
+    # HIGH-002: --tlsv1.2 enforces minimum TLS version.
+    # cycle-099 sprint-1E.c.3.b: https-only + redirect-bound enforcement now
+    # comes from endpoint_validator__guarded_curl. Allowlist gate also closes
+    # the SSRF surface where LOA_REGISTRY_URL env override could redirect at
+    # an attacker-controlled host.
+    endpoint_validator__guarded_curl \
+        --allowlist "$CONSTRUCTS_REGISTRY_ALLOWLIST" \
+        --url "$url" \
+        -s --tlsv1.2 --connect-timeout 5 --max-time 10 2>/dev/null
 }
 
 # Check for updates for all installed skills

--- a/.claude/scripts/flatline-learning-extractor.sh
+++ b/.claude/scripts/flatline-learning-extractor.sh
@@ -32,6 +32,14 @@ SCHEMA_DIR="$PROJECT_ROOT/.claude/schemas"
 TRAJECTORY_DIR="$PROJECT_ROOT/grimoires/loa/a2a/trajectory"
 COMPOUND_DIR="$PROJECT_ROOT/grimoires/loa/a2a/compound"
 
+# cycle-099 sprint-1E.c.3.b: source the centralized endpoint validator so the
+# fallback (non-api-resilience) curl path funnels through guarded_curl. The
+# api-resilience helper itself was migrated in the same sub-sprint and uses
+# the same allowlist by default.
+# shellcheck source=lib/endpoint-validator.sh
+source "$LIB_DIR/endpoint-validator.sh"
+FLATLINE_PROVIDERS_ALLOWLIST="${LOA_FLATLINE_PROVIDERS_ALLOWLIST:-$LIB_DIR/allowlists/loa-providers.json}"
+
 # Source utilities
 if [[ -f "$LIB_DIR/api-resilience.sh" ]]; then
     source "$LIB_DIR/api-resilience.sh"
@@ -307,16 +315,22 @@ EOF
                 max_tokens: 500
             }')" 30)
     else
-        # SEC-AUDIT SEC-HIGH-01: Use curl config to avoid exposing API key in process list
+        # SEC-AUDIT SEC-HIGH-01 + cycle-099 sprint-1E.c.3.b: keep API key out
+        # of process listings via curl auth-config tempfile, AND funnel
+        # through endpoint_validator__guarded_curl with the providers
+        # allowlist so a tampered OPENAI_API_BASE override is rejected.
         local _curl_cfg
         _curl_cfg=$(write_curl_auth_config "Authorization" "Bearer ${OPENAI_API_KEY:-}") || {
             log_error "Failed to create secure curl config"
             return 4
         }
         printf 'header = "Content-Type: application/json"\n' >> "$_curl_cfg"
-        response=$(curl -s --max-time 30 \
-            -X POST "${OPENAI_API_BASE:-https://api.openai.com}/v1/chat/completions" \
-            --config "$_curl_cfg" \
+        response=$(endpoint_validator__guarded_curl \
+            --allowlist "$FLATLINE_PROVIDERS_ALLOWLIST" \
+            --config-auth "$_curl_cfg" \
+            --url "${OPENAI_API_BASE:-https://api.openai.com}/v1/chat/completions" \
+            -s --max-time 30 \
+            -X POST \
             -d "$(jq -n --arg prompt "$prompt" '{
                 model: "gpt-4o-mini",
                 messages: [{role: "user", content: $prompt}],

--- a/.claude/scripts/flatline-proposal-review.sh
+++ b/.claude/scripts/flatline-proposal-review.sh
@@ -28,6 +28,13 @@ LIB_DIR="$SCRIPT_DIR/lib"
 SCHEMA_DIR="$PROJECT_ROOT/.claude/schemas"
 TRAJECTORY_DIR="$PROJECT_ROOT/grimoires/loa/a2a/trajectory"
 
+# cycle-099 sprint-1E.c.3.b: source the centralized endpoint validator so
+# both fallback curl paths (GPT + Opus reviewers) funnel through guarded_curl
+# with the providers allowlist.
+# shellcheck source=lib/endpoint-validator.sh
+source "$LIB_DIR/endpoint-validator.sh"
+FLATLINE_PROVIDERS_ALLOWLIST="${LOA_FLATLINE_PROVIDERS_ALLOWLIST:-$LIB_DIR/allowlists/loa-providers.json}"
+
 # Source utilities
 if [[ -f "$LIB_DIR/api-resilience.sh" ]]; then
     source "$LIB_DIR/api-resilience.sh"
@@ -169,16 +176,20 @@ call_gpt_review() {
                 max_tokens: 500
             }')" "$TIMEOUT_SECONDS")
     else
-        # SEC-AUDIT SEC-HIGH-01: Use curl config to avoid exposing API key in process list
+        # SEC-AUDIT SEC-HIGH-01 + cycle-099 sprint-1E.c.3.b: auth tempfile +
+        # endpoint_validator__guarded_curl for SSRF allowlist enforcement.
         local _curl_cfg
         _curl_cfg=$(write_curl_auth_config "Authorization" "Bearer ${OPENAI_API_KEY:-}") || {
             log_error "Failed to create secure curl config"
             return 4
         }
         printf 'header = "Content-Type: application/json"\n' >> "$_curl_cfg"
-        response=$(curl -s --max-time "$TIMEOUT_SECONDS" \
-            -X POST "${OPENAI_API_BASE:-https://api.openai.com}/v1/chat/completions" \
-            --config "$_curl_cfg" \
+        response=$(endpoint_validator__guarded_curl \
+            --allowlist "$FLATLINE_PROVIDERS_ALLOWLIST" \
+            --config-auth "$_curl_cfg" \
+            --url "${OPENAI_API_BASE:-https://api.openai.com}/v1/chat/completions" \
+            -s --max-time "$TIMEOUT_SECONDS" \
+            -X POST \
             -d "$(jq -n --arg prompt "$prompt" --arg model "$GPT_MODEL" '{
                 model: $model,
                 messages: [{role: "user", content: $prompt}],
@@ -235,7 +246,8 @@ call_opus_review() {
     fi
 
     local response
-    # SEC-AUDIT SEC-HIGH-01: Use curl config to avoid exposing API key in process list
+    # SEC-AUDIT SEC-HIGH-01 + cycle-099 sprint-1E.c.3.b: auth tempfile +
+    # endpoint_validator__guarded_curl for SSRF allowlist enforcement.
     local _curl_cfg
     _curl_cfg=$(write_curl_auth_config "x-api-key" "${ANTHROPIC_API_KEY:-}") || {
         log_error "Failed to create secure curl config"
@@ -243,9 +255,12 @@ call_opus_review() {
     }
     printf 'header = "Content-Type: application/json"\n' >> "$_curl_cfg"
     printf 'header = "anthropic-version: 2023-06-01"\n' >> "$_curl_cfg"
-    response=$(curl -s --max-time "$TIMEOUT_SECONDS" \
-        -X POST "https://api.anthropic.com/v1/messages" \
-        --config "$_curl_cfg" \
+    response=$(endpoint_validator__guarded_curl \
+        --allowlist "$FLATLINE_PROVIDERS_ALLOWLIST" \
+        --config-auth "$_curl_cfg" \
+        --url "https://api.anthropic.com/v1/messages" \
+        -s --max-time "$TIMEOUT_SECONDS" \
+        -X POST \
         -d "$(jq -n --arg prompt "$prompt" --arg model "$OPUS_MODEL" '{
             model: $model,
             max_tokens: 500,

--- a/.claude/scripts/flatline-semantic-similarity.sh
+++ b/.claude/scripts/flatline-semantic-similarity.sh
@@ -28,6 +28,13 @@ CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
 LIB_DIR="$SCRIPT_DIR/lib"
 TRAJECTORY_DIR="$PROJECT_ROOT/grimoires/loa/a2a/trajectory"
 
+# cycle-099 sprint-1E.c.3.b: route OpenAI embeddings call through the
+# centralized endpoint validator. Uses the shared loa-providers.json
+# allowlist (api.openai.com).
+# shellcheck source=lib/endpoint-validator.sh
+source "$LIB_DIR/endpoint-validator.sh"
+FLATLINE_PROVIDERS_ALLOWLIST="${LOA_FLATLINE_PROVIDERS_ALLOWLIST:-$LIB_DIR/allowlists/loa-providers.json}"
+
 # Default paths
 DEFAULT_INDEX_PATH="$PROJECT_ROOT/.claude/loa/learnings/index.json"
 DEFAULT_EMBEDDINGS_PATH="$PROJECT_ROOT/.claude/loa/learnings/embeddings.bin"
@@ -186,16 +193,22 @@ get_embedding() {
     truncated=$(echo "$text" | head -c 8000)
 
     local response
-    # SEC-AUDIT SEC-HIGH-01: Use curl config to avoid exposing API key in process list
+    # SEC-AUDIT SEC-HIGH-01: Use curl auth config to keep the API key out of
+    # process listings; SDD §1.9.1 (cycle-099 sprint-1E.c.3.b): the wrapper
+    # passes the auth tempfile via --config-auth (content-gated to header=
+    # lines only) so a tampered tempfile cannot smuggle url=/next= directives.
     local _curl_cfg
     _curl_cfg=$(write_curl_auth_config "Authorization" "Bearer ${OPENAI_API_KEY:-}") || {
         log_warning "Failed to create secure curl config"
         return 1
     }
     printf 'header = "Content-Type: application/json"\n' >> "$_curl_cfg"
-    response=$(curl -s --max-time 30 \
-        -X POST "https://api.openai.com/v1/embeddings" \
-        --config "$_curl_cfg" \
+    response=$(endpoint_validator__guarded_curl \
+        --allowlist "$FLATLINE_PROVIDERS_ALLOWLIST" \
+        --config-auth "$_curl_cfg" \
+        --url "https://api.openai.com/v1/embeddings" \
+        -s --max-time 30 \
+        -X POST \
         -d "$(jq -n --arg text "$truncated" --arg model "$EMBEDDING_MODEL" '{
             model: $model,
             input: $text,

--- a/.claude/scripts/flatline-validate-learning.sh
+++ b/.claude/scripts/flatline-validate-learning.sh
@@ -32,6 +32,12 @@ LIB_DIR="$SCRIPT_DIR/lib"
 SCHEMA_DIR="$PROJECT_ROOT/.claude/schemas"
 TRAJECTORY_DIR="$PROJECT_ROOT/grimoires/loa/a2a/trajectory"
 
+# cycle-099 sprint-1E.c.3.b: source the centralized endpoint validator so
+# both fallback curl paths (GPT + Opus validators) funnel through guarded_curl.
+# shellcheck source=lib/endpoint-validator.sh
+source "$LIB_DIR/endpoint-validator.sh"
+FLATLINE_PROVIDERS_ALLOWLIST="${LOA_FLATLINE_PROVIDERS_ALLOWLIST:-$LIB_DIR/allowlists/loa-providers.json}"
+
 # Source utilities
 if [[ -f "$LIB_DIR/api-resilience.sh" ]]; then
     source "$LIB_DIR/api-resilience.sh"
@@ -256,16 +262,20 @@ call_gpt_validation() {
                 max_tokens: 300
             }')" "$TIMEOUT_SECONDS")
     else
-        # SEC-AUDIT SEC-HIGH-01: Use curl config to avoid exposing API key in process list
+        # SEC-AUDIT SEC-HIGH-01 + cycle-099 sprint-1E.c.3.b: auth tempfile +
+        # endpoint_validator__guarded_curl for SSRF allowlist enforcement.
         local _curl_cfg
         _curl_cfg=$(write_curl_auth_config "Authorization" "Bearer ${OPENAI_API_KEY:-}") || {
             log_error "Failed to create secure curl config"
             return 4
         }
         printf 'header = "Content-Type: application/json"\n' >> "$_curl_cfg"
-        response=$(curl -s --max-time "$TIMEOUT_SECONDS" \
-            -X POST "${OPENAI_API_BASE:-https://api.openai.com}/v1/chat/completions" \
-            --config "$_curl_cfg" \
+        response=$(endpoint_validator__guarded_curl \
+            --allowlist "$FLATLINE_PROVIDERS_ALLOWLIST" \
+            --config-auth "$_curl_cfg" \
+            --url "${OPENAI_API_BASE:-https://api.openai.com}/v1/chat/completions" \
+            -s --max-time "$TIMEOUT_SECONDS" \
+            -X POST \
             -d "$(jq -n --arg prompt "$prompt" --arg model "$GPT_MODEL" '{
                 model: $model,
                 messages: [{role: "user", content: $prompt}],
@@ -324,7 +334,8 @@ call_opus_validation() {
     fi
 
     local response
-    # SEC-AUDIT SEC-HIGH-01: Use curl config to avoid exposing API key in process list
+    # SEC-AUDIT SEC-HIGH-01 + cycle-099 sprint-1E.c.3.b: auth tempfile +
+    # endpoint_validator__guarded_curl for SSRF allowlist enforcement.
     local _curl_cfg
     _curl_cfg=$(write_curl_auth_config "x-api-key" "${ANTHROPIC_API_KEY:-}") || {
         log_error "Failed to create secure curl config"
@@ -332,9 +343,12 @@ call_opus_validation() {
     }
     printf 'header = "Content-Type: application/json"\n' >> "$_curl_cfg"
     printf 'header = "anthropic-version: 2023-06-01"\n' >> "$_curl_cfg"
-    response=$(curl -s --max-time "$TIMEOUT_SECONDS" \
-        -X POST "https://api.anthropic.com/v1/messages" \
-        --config "$_curl_cfg" \
+    response=$(endpoint_validator__guarded_curl \
+        --allowlist "$FLATLINE_PROVIDERS_ALLOWLIST" \
+        --config-auth "$_curl_cfg" \
+        --url "https://api.anthropic.com/v1/messages" \
+        -s --max-time "$TIMEOUT_SECONDS" \
+        -X POST \
         -d "$(jq -n --arg prompt "$prompt" --arg model "$OPUS_MODEL" '{
             model: $model,
             max_tokens: 300,

--- a/.claude/scripts/lib/allowlists/loa-github.json
+++ b/.claude/scripts/lib/allowlists/loa-github.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Per-caller allowlist for check-updates.sh — GitHub framework version probes against the releases API. Currently the only consumer; mount-loa.sh is [ENDPOINT-VALIDATOR-EXEMPT] (bootstrap path) and does NOT route through this allowlist. Add raw.githubusercontent.com / objects.githubusercontent.com / github.com only when a NEW guarded_curl caller actually needs them — speculative entries widen the SSRF horizon for no benefit.",
+  "providers": {
+    "github_api": [
+      {"host": "api.github.com", "ports": [443]}
+    ]
+  }
+}

--- a/.claude/scripts/lib/allowlists/loa-registry.json
+++ b/.claude/scripts/lib/allowlists/loa-registry.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Per-caller allowlist for constructs-* + license-validator.sh — Loa constructs registry API + Cloudflare-fronted public-keys CDN. Default registry URL is https://api.constructs.network/v1 (per .claude/scripts/constructs-lib.sh::get_registry_url). Operators can override via LOA_REGISTRY_URL — but the override URL MUST resolve to a host in this allowlist or the wrapper rejects (closes the SSRF vector where a tampered .loa.config.yaml or env-var injection points the registry at attacker infra).",
+  "providers": {
+    "loa_registry": [
+      {"host": "api.constructs.network", "ports": [443]}
+    ]
+  }
+}

--- a/.claude/scripts/lib/api-resilience.sh
+++ b/.claude/scripts/lib/api-resilience.sh
@@ -29,6 +29,19 @@ if [[ -f "${_API_RESILIENCE_DIR}/common.sh" ]]; then
     source "${_API_RESILIENCE_DIR}/common.sh"
 fi
 
+# Source endpoint validator (cycle-099 sprint-1E.c.3.b). The retry+circuit
+# helper now funnels through endpoint_validator__guarded_curl. Callers MUST
+# either pass --allowlist <PATH> as the 5th positional arg, OR export
+# LOA_API_RESILIENCE_ALLOWLIST in the environment. The allowlist path MUST
+# live under .claude/scripts/lib/allowlists/ (tree-restricted by the wrapper).
+if ! declare -f endpoint_validator__guarded_curl &>/dev/null; then
+    if [[ -f "${_API_RESILIENCE_DIR}/endpoint-validator.sh" ]]; then
+        # shellcheck source=endpoint-validator.sh
+        source "${_API_RESILIENCE_DIR}/endpoint-validator.sh"
+    fi
+fi
+LOA_API_RESILIENCE_ALLOWLIST_DEFAULT="${_API_RESILIENCE_DIR}/allowlists/loa-providers.json"
+
 # Logging functions
 log_error() { echo "[ERROR] $(date -Iseconds) $*" >&2; }
 log_warning() { echo "[WARN] $(date -Iseconds) $*" >&2; }
@@ -331,13 +344,25 @@ calculate_backoff() {
 }
 
 # Make API call with retry and circuit breaker
-# Usage: call_api_with_retry <endpoint> <method> <data> [timeout]
+# Usage: call_api_with_retry <endpoint> <method> <data> [timeout] [allowlist]
 # Returns: Response body on success, empty on failure
+#
+# cycle-099 sprint-1E.c.3.b: every call now funnels through
+# endpoint_validator__guarded_curl. The 5th arg is the allowlist path; if
+# not supplied, falls back to $LOA_API_RESILIENCE_ALLOWLIST env var, then
+# to the loa-providers.json default (covers openai + anthropic + google +
+# bedrock — the multi-model surface this helper has historically served).
 call_api_with_retry() {
     local endpoint="$1"
     local method="${2:-POST}"
     local data="${3:-}"
     local timeout="${4:-$API_TIMEOUT_SECONDS}"
+    local allowlist="${5:-${LOA_API_RESILIENCE_ALLOWLIST:-$LOA_API_RESILIENCE_ALLOWLIST_DEFAULT}}"
+
+    if ! declare -f endpoint_validator__guarded_curl &>/dev/null; then
+        log_error "endpoint_validator__guarded_curl not available — call_api_with_retry refuses to run with raw curl (cycle-099 SDD §1.9.1)"
+        return 1
+    fi
 
     local endpoint_key
     endpoint_key=$(normalize_endpoint_key "$endpoint")
@@ -359,14 +384,32 @@ call_api_with_retry() {
 
         log_debug "API call attempt $attempt/$API_MAX_RETRIES to $endpoint"
 
-        # Make the request
-        local http_response
-        http_response=$(curl -s -w "\n%{http_code}" \
+        # Make the request via the SSRF-safe wrapper. Wrapper exit 78 = URL
+        # not in allowlist; 64 = wrapper usage error. Both are configuration
+        # bugs (NOT transients) — exit immediately, do NOT retry.
+        # Note: 2>&1 stderr-merge is DELIBERATE — preserves the pre-migration
+        # behavior where transient curl errors fold into $http_response so
+        # the parse path can surface them. On rejection (78/64) the wrapper
+        # has emitted structured stderr but we return BEFORE setting
+        # $http_response, so the merge doesn't pollute the parsed response.
+        local http_response curl_rc=0
+        http_response=$(endpoint_validator__guarded_curl \
+            --allowlist "$allowlist" \
+            --url "$endpoint" \
+            -s -w "\n%{http_code}" \
             --max-time "$timeout" \
             -X "$method" \
             -H "Content-Type: application/json" \
-            ${data:+-d "$data"} \
-            "$endpoint" 2>&1) || {
+            ${data:+-d "$data"} 2>&1) || curl_rc=$?
+        if (( curl_rc == 78 )); then
+            log_error "endpoint validator rejected $endpoint (SSRF allowlist enforcement; allowlist=$allowlist)"
+            return 1
+        fi
+        if (( curl_rc == 64 )); then
+            log_error "endpoint validator wrapper usage error (allowlist out-of-tree, --config-auth invalid, or smuggling flag in caller args)"
+            return 1
+        fi
+        if (( curl_rc != 0 )); then
             log_warning "curl failed (timeout or network error)"
             record_circuit_failure "$endpoint_key"
             if (( attempt < API_MAX_RETRIES )); then
@@ -376,8 +419,7 @@ call_api_with_retry() {
                 continue
             fi
             return 1
-        }
-
+        fi
         # Parse response
         response=$(echo "$http_response" | sed '$d')
         status_code=$(echo "$http_response" | tail -1)

--- a/.claude/scripts/license-validator.sh
+++ b/.claude/scripts/license-validator.sh
@@ -34,6 +34,12 @@ else
     exit 5
 fi
 
+# cycle-099 sprint-1E.c.3.b: public-key fetch via endpoint validator with
+# constructs registry allowlist (license registry shares the same host).
+# shellcheck source=lib/endpoint-validator.sh
+source "$SCRIPT_DIR/lib/endpoint-validator.sh"
+LICENSE_REGISTRY_ALLOWLIST="${LOA_LICENSE_REGISTRY_ALLOWLIST:-$SCRIPT_DIR/lib/allowlists/loa-registry.json}"
+
 # =============================================================================
 # Constants
 # =============================================================================
@@ -210,8 +216,12 @@ do_get_public_key() {
     fi
 
     local response
-    # HIGH-002 FIX: Enforce HTTPS and TLS 1.2+
-    response=$(curl -sf --proto =https --tlsv1.2 "${registry_url}/public-keys/${key_id}" 2>/dev/null) || {
+    # HIGH-002: --tlsv1.2 enforces minimum TLS version. cycle-099 sprint-1E.c.3.b:
+    # https-only + redirect-bound enforcement comes from the wrapper.
+    response=$(endpoint_validator__guarded_curl \
+        --allowlist "$LICENSE_REGISTRY_ALLOWLIST" \
+        --url "${registry_url}/public-keys/${key_id}" \
+        -sf --tlsv1.2 2>/dev/null) || {
         # Network error - try to use stale cache
         if [[ -f "$key_file" ]]; then
             echo "WARNING: Using stale cached key (network error)" >&2

--- a/.claude/scripts/mount-loa.sh
+++ b/.claude/scripts/mount-loa.sh
@@ -29,6 +29,27 @@ if [[ -z "${BASH_SOURCE[0]:-}" ]] && [[ -z "${_LOA_MOUNT_REEXEC:-}" ]]; then
   # Replaced by the script's normal traps after exec.
   trap 'rm -rf "$_loa_tmpdir" 2>/dev/null' EXIT INT TERM HUP
 
+  # [ENDPOINT-VALIDATOR-EXEMPT] cycle-099 sprint-1E.c.3.b: this is the
+  # bootstrap path — the endpoint validator + its allowlist files don't
+  # exist on disk YET (we're downloading them right now). Hardening in
+  # place: (1) validate _loa_ref against an alphanumeric+dotted pattern
+  # AND reject any `..` segment (GitHub raw.githubusercontent.com normalizes
+  # `..` per RFC 3986 §5.2.4, so `_loa_ref="../attacker/repo/refs/heads/main"`
+  # would otherwise resolve to a different repo); (2) hardcode the host
+  # (raw.githubusercontent.com) as a literal string so the URL composition
+  # is visible in source — not operator-overridable; (3) curl with
+  # --proto =https / --proto-redir =https / --max-redirs 10 hardened defaults
+  # that mirror the wrapper's defaults.
+  if [[ ! "$_loa_ref" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+    printf '\033[0;31m[loa]\033[0m ERROR: invalid ref '\''%s'\'' (must match [A-Za-z0-9._/-]+)\n' "$_loa_ref" >&2
+    rm -rf "$_loa_tmpdir"
+    exit 1
+  fi
+  if [[ "$_loa_ref" == *..* ]]; then
+    printf '\033[0;31m[loa]\033[0m ERROR: ref '\''%s'\'' contains `..` — repo-pivot via path traversal blocked\n' "$_loa_ref" >&2
+    rm -rf "$_loa_tmpdir"
+    exit 1
+  fi
   _loa_base="https://raw.githubusercontent.com/0xHoneyJar/loa/${_loa_ref}/.claude/scripts"
 
   # B1/S1: Use printf '%s' to avoid ANSI escape injection from _loa_ref
@@ -39,7 +60,8 @@ if [[ -z "${BASH_SOURCE[0]:-}" ]] && [[ -z "${_LOA_MOUNT_REEXEC:-}" ]]; then
   mkdir -p "$_loa_tmpdir/lib"
   _loa_ok=true
   for _f in mount-loa.sh mount-submodule.sh compat-lib.sh; do
-    if ! curl -fsSL -o "$_loa_tmpdir/$_f" -- "$_loa_base/$_f"; then
+    if ! curl --proto =https --proto-redir =https --max-redirs 10 \
+              -fsSL -o "$_loa_tmpdir/$_f" -- "$_loa_base/$_f"; then
       _loa_ok=false
     fi
   done
@@ -55,7 +77,8 @@ if [[ -z "${BASH_SOURCE[0]:-}" ]] && [[ -z "${_LOA_MOUNT_REEXEC:-}" ]]; then
 
   # Download auxiliary scripts (non-fatal if missing in older versions)
   for _f in bootstrap.sh bash-version-guard.sh lib/symlink-manifest.sh; do
-    curl -fsSL -o "$_loa_tmpdir/$_f" -- "$_loa_base/$_f" 2>/dev/null || true
+    curl --proto =https --proto-redir =https --max-redirs 10 \
+         -fsSL -o "$_loa_tmpdir/$_f" -- "$_loa_base/$_f" 2>/dev/null || true
   done
   chmod +x "$_loa_tmpdir"/*.sh "$_loa_tmpdir/lib"/*.sh 2>/dev/null || true
 
@@ -521,7 +544,16 @@ auto_install_deps() {
           *) warn "Unknown arch for yq download"; return 0 ;;
         esac
         local yq_url="https://github.com/mikefarah/yq/releases/download/${yq_version}/yq_linux_${yq_arch}"
-        if sudo curl -fsSL "$yq_url" -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq; then
+        # [ENDPOINT-VALIDATOR-EXEMPT] cycle-099 sprint-1E.c.3.b: yq install
+        # is a bootstrap-internal dependency that must run BEFORE the rest
+        # of the framework can use yq-driven config. The validator itself
+        # depends on Python+idna which may not be available yet at this
+        # stage of mount-loa. URL is composed from a hardcoded host
+        # (github.com), pinned version, and an allowlisted arch — no
+        # operator input flows into the URL. Hardening defaults below
+        # mirror what the wrapper would have applied.
+        if sudo curl --proto =https --proto-redir =https --max-redirs 10 \
+                     -fsSL "$yq_url" -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq; then
           log "yq installed ✓ (${yq_version})"
         else
           warn "yq auto-install failed ✗. Manual: https://github.com/mikefarah/yq#install"

--- a/tests/integration/cycle099-sprint-1ec3b-migration-smoke.bats
+++ b/tests/integration/cycle099-sprint-1ec3b-migration-smoke.bats
@@ -313,16 +313,54 @@ _assert_has_allowlist_decl() {
     # update this test.
     grep -qE '\[\[[[:space:]]*"\$_loa_ref"[[:space:]]*==[[:space:]]*\*\.\.\*' \
         "$PROJECT_ROOT/.claude/scripts/mount-loa.sh"
-    # Behavior-level pin: extract the bash branch into a sub-shell and run
-    # it standalone with a `..`-containing ref. We can't actually invoke
-    # mount-loa.sh end-to-end without massive setup, so verify the regex
-    # logic in isolation.
-    local ref="../attacker/repo"
-    bash -c "[[ ! \"$ref\" =~ ^[A-Za-z0-9._/-]+\$ ]] || [[ \"$ref\" == *..* ]]" \
-        && return 0 || {
-            printf 'expected ref %q to be rejected by either regex or ..-check; both passed\n' "$ref" >&2
-            return 1
-        }
+
+    # Behavior-level pin (BB iter-2 HIGH + MEDIUM remediation): mirror
+    # mount-loa.sh's actual reject condition explicitly. The reject logic
+    # is "if regex FAILS OR ref contains `..` → reject"; equivalently, a
+    # ref that PASSES validation must satisfy `(regex matches) AND (no
+    # ..)`. We test by constructing each ref and verifying the conjunction
+    # of acceptance conditions is FALSE for attack inputs and TRUE for a
+    # legitimate ref (positive control). No `bash -c` interpolation —
+    # use bats's [[ ... ]] directly to avoid shell-injection-shaped patterns
+    # in security tests.
+    _passes_validation() {
+        # Returns 0 iff $1 would be ACCEPTED by mount-loa.sh's checks.
+        local r="$1"
+        [[ "$r" =~ ^[A-Za-z0-9._/-]+$ ]] || return 1
+        [[ "$r" != *..* ]] || return 1
+        return 0
+    }
+
+    # Negative case: dot-dot path traversal MUST be rejected.
+    if _passes_validation "../attacker/repo/refs/heads/main"; then
+        printf 'M4 FAIL: ../attacker/repo/refs/heads/main passed validation; mount-loa would have allowed repo-pivot\n' >&2
+        return 1
+    fi
+
+    # Negative case: bare `..` segment MUST be rejected.
+    if _passes_validation ".."; then
+        printf 'M4 FAIL: bare `..` passed validation\n' >&2
+        return 1
+    fi
+
+    # Negative case: ref with embedded `..` mid-string MUST be rejected.
+    if _passes_validation "main/../foo"; then
+        printf 'M4 FAIL: main/../foo passed validation\n' >&2
+        return 1
+    fi
+
+    # Positive control: a legitimate ref MUST pass (otherwise the gate is
+    # too strict and mount-loa would reject normal usage).
+    if ! _passes_validation "refs/heads/main"; then
+        printf 'M4 FAIL: legitimate ref refs/heads/main was rejected; gate is too strict\n' >&2
+        return 1
+    fi
+
+    # Positive control: tagged release ref.
+    if ! _passes_validation "v1.30.0"; then
+        printf 'M4 FAIL: legitimate tag v1.30.0 was rejected\n' >&2
+        return 1
+    fi
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/cycle099-sprint-1ec3b-migration-smoke.bats
+++ b/tests/integration/cycle099-sprint-1ec3b-migration-smoke.bats
@@ -1,0 +1,375 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/cycle099-sprint-1ec3b-migration-smoke.bats
+#
+# cycle-099 Sprint 1E.c.3.b — bash caller migration smoke tests.
+#
+# Each migrated script MUST:
+#   - source .claude/scripts/lib/endpoint-validator.sh
+#   - declare a *_ALLOWLIST constant pointing under .claude/scripts/lib/allowlists/
+#   - reach endpoint_validator__guarded_curl from at least one call site
+#   - retain bash -n syntax cleanliness
+#
+# These are GREP-based contract tests, not behavioral E2E. The behavioral
+# coverage for the wrapper itself lives in endpoint-validator-guarded-curl.bats
+# (54 tests in 1E.c.3.a). This suite catches "did the migration land?" in CI.
+#
+# Mount-loa.sh has an explicit [ENDPOINT-VALIDATOR-EXEMPT] carve-out (bootstrap
+# script — validator isn't on disk yet). Tests confirm the exemption banner
+# AND the hardened defaults (--proto =https / --proto-redir =https /
+# --max-redirs 10) are in place.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+    # Sanity: 1E.c.3.a artifacts MUST exist (we depend on them)
+    [[ -f "$PROJECT_ROOT/.claude/scripts/lib/endpoint-validator.sh" ]] \
+        || skip "endpoint-validator.sh missing (1E.c.3.a not on disk)"
+    [[ -d "$PROJECT_ROOT/.claude/scripts/lib/allowlists" ]] \
+        || skip "allowlists dir missing"
+}
+
+# Helper: assert script $1 sources endpoint-validator.sh AND uses guarded_curl
+_assert_migrated() {
+    local script="$1"
+    local script_path="$PROJECT_ROOT/.claude/scripts/$script"
+    [[ -f "$script_path" ]] || {
+        printf 'script not found: %s\n' "$script_path" >&2
+        return 1
+    }
+    grep -qE 'source[[:space:]]+.*endpoint-validator\.sh' "$script_path" || {
+        printf '%s does NOT source endpoint-validator.sh\n' "$script" >&2
+        return 1
+    }
+    grep -qE 'endpoint_validator__guarded_curl' "$script_path" || {
+        printf '%s does NOT call endpoint_validator__guarded_curl\n' "$script" >&2
+        return 1
+    }
+    bash -n "$script_path" || {
+        printf '%s has bash -n syntax errors\n' "$script" >&2
+        return 1
+    }
+}
+
+# Helper: assert script $1 declares a *_ALLOWLIST constant pointing to a real file
+_assert_has_allowlist_decl() {
+    local script="$1"
+    local script_path="$PROJECT_ROOT/.claude/scripts/$script"
+    grep -qE '_ALLOWLIST="\$\{LOA_[A-Z_]+_ALLOWLIST:-' "$script_path" || {
+        printf '%s does NOT declare a *_ALLOWLIST="${LOA_*:-...}" constant\n' "$script" >&2
+        return 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# A — Allowlist fixture files exist and are valid JSON
+# ---------------------------------------------------------------------------
+
+@test "A1 loa-providers.json exists (sprint-1E.c.3.a artifact)" {
+    [[ -f "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-providers.json" ]]
+    jq -e '.providers' "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-providers.json" >/dev/null
+}
+
+@test "A2 loa-anthropic-docs.json exists (sprint-1E.c.3.a artifact)" {
+    [[ -f "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-anthropic-docs.json" ]]
+    jq -e '.providers' "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-anthropic-docs.json" >/dev/null
+}
+
+@test "A3 openai.json exists (sprint-1E.c.3.a artifact)" {
+    [[ -f "$PROJECT_ROOT/.claude/scripts/lib/allowlists/openai.json" ]]
+    jq -e '.providers' "$PROJECT_ROOT/.claude/scripts/lib/allowlists/openai.json" >/dev/null
+}
+
+@test "A4 loa-registry.json exists (sprint-1E.c.3.b new)" {
+    [[ -f "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-registry.json" ]]
+    jq -e '.providers.loa_registry' "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-registry.json" >/dev/null
+}
+
+@test "A5 loa-github.json exists (sprint-1E.c.3.b new)" {
+    [[ -f "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-github.json" ]]
+    jq -e '.providers.github_api' "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-github.json" >/dev/null
+}
+
+@test "A6 loa-registry.json allows api.constructs.network:443 only" {
+    local hosts
+    hosts=$(jq -r '.providers.loa_registry[].host' "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-registry.json")
+    [[ "$hosts" == "api.constructs.network" ]]
+}
+
+@test "A7 loa-github.json allows api.github.com (narrowest possible — bridgebuilder iter-1 LOW)" {
+    # BB iter-1 LOW: previously had raw.githubusercontent.com + objects.githubusercontent.com
+    # + github.com as speculative entries for future use. Removed because
+    # mount-loa.sh is EXEMPT (doesn't route through validator) and check-updates
+    # is the only consumer — only hits api.github.com. Future callers requiring
+    # raw.githubusercontent.com etc. should add the entry in the same PR.
+    local hosts
+    hosts=$(jq -r '.providers | to_entries[].value[].host' "$PROJECT_ROOT/.claude/scripts/lib/allowlists/loa-github.json" | sort -u | tr '\n' ',' )
+    [[ "$hosts" == *"api.github.com"* ]]
+    # Confirm the speculative entries are NOT present (regression guard for
+    # accidental re-widening)
+    [[ "$hosts" != *"raw.githubusercontent.com"* ]] || {
+        printf 'loa-github.json widened back to include raw.githubusercontent.com — review before adding\n' >&2
+        return 1
+    }
+    [[ "$hosts" != *"objects.githubusercontent.com"* ]] || return 1
+}
+
+# ---------------------------------------------------------------------------
+# F — Flatline batch migrations (4 scripts, ~9 sites)
+# ---------------------------------------------------------------------------
+
+@test "F1 flatline-semantic-similarity.sh sources validator + uses guarded_curl" {
+    _assert_migrated "flatline-semantic-similarity.sh"
+    _assert_has_allowlist_decl "flatline-semantic-similarity.sh"
+}
+
+@test "F2 flatline-learning-extractor.sh sources validator + uses guarded_curl" {
+    _assert_migrated "flatline-learning-extractor.sh"
+    _assert_has_allowlist_decl "flatline-learning-extractor.sh"
+}
+
+@test "F3 flatline-proposal-review.sh sources validator + uses guarded_curl (2 sites)" {
+    _assert_migrated "flatline-proposal-review.sh"
+    _assert_has_allowlist_decl "flatline-proposal-review.sh"
+    # Both GPT and Opus paths must use guarded_curl
+    local count
+    count=$(grep -cE 'endpoint_validator__guarded_curl' \
+        "$PROJECT_ROOT/.claude/scripts/flatline-proposal-review.sh")
+    [[ "$count" -ge 2 ]] || {
+        printf 'expected at least 2 guarded_curl calls (GPT + Opus); got %d\n' "$count" >&2
+        return 1
+    }
+}
+
+@test "F4 flatline-validate-learning.sh sources validator + uses guarded_curl (2 sites)" {
+    _assert_migrated "flatline-validate-learning.sh"
+    _assert_has_allowlist_decl "flatline-validate-learning.sh"
+    local count
+    count=$(grep -cE 'endpoint_validator__guarded_curl' \
+        "$PROJECT_ROOT/.claude/scripts/flatline-validate-learning.sh")
+    [[ "$count" -ge 2 ]] || return 1
+}
+
+@test "F5 flatline scripts use loa-providers.json allowlist (multi-model)" {
+    for script in flatline-semantic-similarity.sh flatline-learning-extractor.sh \
+                  flatline-proposal-review.sh flatline-validate-learning.sh; do
+        grep -qF 'loa-providers.json' "$PROJECT_ROOT/.claude/scripts/$script" || {
+            printf '%s missing loa-providers.json reference\n' "$script" >&2
+            return 1
+        }
+    done
+}
+
+# ---------------------------------------------------------------------------
+# H — api-resilience.sh helper migration (transitively migrates 3 callers)
+# ---------------------------------------------------------------------------
+
+@test "H1 api-resilience.sh sources validator + call_api_with_retry uses guarded_curl" {
+    local script_path="$PROJECT_ROOT/.claude/scripts/lib/api-resilience.sh"
+    [[ -f "$script_path" ]]
+    grep -qE 'source[[:space:]]+.*endpoint-validator\.sh' "$script_path"
+    grep -qE 'endpoint_validator__guarded_curl' "$script_path"
+    bash -n "$script_path"
+}
+
+@test "H2 api-resilience.sh refuses to run with raw curl (fail-closed if validator missing)" {
+    local script_path="$PROJECT_ROOT/.claude/scripts/lib/api-resilience.sh"
+    grep -qE 'endpoint_validator__guarded_curl not available' "$script_path" || {
+        printf 'api-resilience.sh does not have a fail-closed branch when validator is missing\n' >&2
+        return 1
+    }
+}
+
+@test "H3 api-resilience.sh: SSRF rejection (78) and usage error (64) do NOT retry" {
+    local script_path="$PROJECT_ROOT/.claude/scripts/lib/api-resilience.sh"
+    # The migration explicitly states: 78 + 64 are config bugs, not transients
+    grep -qE 'curl_rc == 78' "$script_path"
+    grep -qE 'curl_rc == 64' "$script_path"
+}
+
+# ---------------------------------------------------------------------------
+# C — constructs-* batch + license-validator (5 scripts)
+# ---------------------------------------------------------------------------
+
+@test "C1 constructs-loader.sh sources validator + uses guarded_curl" {
+    _assert_migrated "constructs-loader.sh"
+    _assert_has_allowlist_decl "constructs-loader.sh"
+}
+
+@test "C2 constructs-auth.sh sources validator + uses guarded_curl" {
+    _assert_migrated "constructs-auth.sh"
+    _assert_has_allowlist_decl "constructs-auth.sh"
+}
+
+@test "C3 constructs-browse.sh sources validator + uses guarded_curl (4 sites)" {
+    _assert_migrated "constructs-browse.sh"
+    _assert_has_allowlist_decl "constructs-browse.sh"
+    local count
+    count=$(grep -cE 'endpoint_validator__guarded_curl' \
+        "$PROJECT_ROOT/.claude/scripts/constructs-browse.sh")
+    [[ "$count" -ge 4 ]] || {
+        printf 'constructs-browse: expected at least 4 guarded_curl calls; got %d\n' "$count" >&2
+        return 1
+    }
+}
+
+@test "C4 constructs-install.sh sources validator + uses guarded_curl (2 sites)" {
+    _assert_migrated "constructs-install.sh"
+    _assert_has_allowlist_decl "constructs-install.sh"
+    local count
+    count=$(grep -cE 'endpoint_validator__guarded_curl' \
+        "$PROJECT_ROOT/.claude/scripts/constructs-install.sh")
+    [[ "$count" -ge 2 ]] || return 1
+}
+
+@test "C5 license-validator.sh sources validator + uses guarded_curl" {
+    _assert_migrated "license-validator.sh"
+    _assert_has_allowlist_decl "license-validator.sh"
+}
+
+@test "C6 constructs + license scripts use loa-registry.json allowlist" {
+    for script in constructs-loader.sh constructs-auth.sh constructs-browse.sh \
+                  constructs-install.sh license-validator.sh; do
+        grep -qF 'loa-registry.json' "$PROJECT_ROOT/.claude/scripts/$script" || {
+            printf '%s missing loa-registry.json reference\n' "$script" >&2
+            return 1
+        }
+    done
+}
+
+@test "C7 constructs-* + license scripts pass auth tempfile via --config-auth (NOT --config)" {
+    # The 1E.c.3.a smuggling defense: caller --config is REJECTED by the
+    # wrapper. Migrated scripts MUST use --config-auth instead.
+    for script in constructs-auth.sh constructs-browse.sh constructs-install.sh; do
+        local script_path="$PROJECT_ROOT/.claude/scripts/$script"
+        # Must have at least one --config-auth invocation
+        grep -qE '\-\-config-auth' "$script_path" || {
+            printf '%s does NOT pass auth via --config-auth (smuggling defense)\n' "$script" >&2
+            return 1
+        }
+        # Must NOT have any direct --config inside guarded_curl calls
+        # (heuristic: count `--config "$` occurrences; should be in raw curl
+        # blocks only, but those are gone after migration)
+        if grep -qE 'endpoint_validator__guarded_curl' "$script_path"; then
+            # Confirm no `--config` appears within 5 lines of guarded_curl
+            local violations
+            violations=$(grep -A 5 'endpoint_validator__guarded_curl' "$script_path" \
+                | grep -E '^\s+--config\s' || true)
+            [[ -z "$violations" ]] || {
+                printf '%s passes --config (not --config-auth) within guarded_curl call\n' "$script" >&2
+                printf '%s\n' "$violations" >&2
+                return 1
+            }
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# G — GitHub batch (check-updates only; mount-loa is exempt)
+# ---------------------------------------------------------------------------
+
+@test "G1 check-updates.sh sources validator + uses guarded_curl" {
+    _assert_migrated "check-updates.sh"
+    _assert_has_allowlist_decl "check-updates.sh"
+}
+
+@test "G2 check-updates.sh uses loa-github.json allowlist" {
+    grep -qF 'loa-github.json' "$PROJECT_ROOT/.claude/scripts/check-updates.sh"
+}
+
+# ---------------------------------------------------------------------------
+# M — mount-loa.sh exemption (bootstrap path — validator not on disk yet)
+# ---------------------------------------------------------------------------
+
+@test "M1 mount-loa.sh has [ENDPOINT-VALIDATOR-EXEMPT] rationale banner" {
+    grep -qF 'ENDPOINT-VALIDATOR-EXEMPT' "$PROJECT_ROOT/.claude/scripts/mount-loa.sh"
+}
+
+@test "M2 mount-loa.sh hardens raw curl with --proto =https / --proto-redir / --max-redirs" {
+    local script_path="$PROJECT_ROOT/.claude/scripts/mount-loa.sh"
+    # The bootstrap curl invocations MUST set the same hardened defaults
+    # the validator wrapper would have applied. We grep for all three.
+    grep -qE 'curl[[:space:]]+--proto[[:space:]]+=https' "$script_path"
+    grep -qE '\-\-proto-redir[[:space:]]+=https' "$script_path"
+    grep -qE '\-\-max-redirs[[:space:]]+10' "$script_path"
+}
+
+@test "M3 mount-loa.sh validates _loa_ref against alphanum+dot+slash regex" {
+    # An attacker-controlled _loa_ref could have been used to traverse to a
+    # different repo path. M3 pins the validation regex so this can't drift.
+    grep -qE '\[\[[[:space:]]*!.*_loa_ref.*=~.*A-Za-z' \
+        "$PROJECT_ROOT/.claude/scripts/mount-loa.sh"
+}
+
+@test "M4 mount-loa.sh REJECTS _loa_ref containing dot-dot (BB iter-1 MEDIUM regression guard)" {
+    # The regex `^[A-Za-z0-9._/-]+$` accepts every char in the class
+    # individually, including `..` as TWO separate dots. GitHub's CDN
+    # normalizes `..` server-side per RFC 3986 §5.2.4, so an attacker passing
+    # `--ref=../attacker/repo/refs/heads/main` could pivot to a different
+    # repo. The companion check `[[ "$_loa_ref" == *..* ]]` rejects this.
+    # Source-level pin: a future refactor that drops the `..` check needs to
+    # update this test.
+    grep -qE '\[\[[[:space:]]*"\$_loa_ref"[[:space:]]*==[[:space:]]*\*\.\.\*' \
+        "$PROJECT_ROOT/.claude/scripts/mount-loa.sh"
+    # Behavior-level pin: extract the bash branch into a sub-shell and run
+    # it standalone with a `..`-containing ref. We can't actually invoke
+    # mount-loa.sh end-to-end without massive setup, so verify the regex
+    # logic in isolation.
+    local ref="../attacker/repo"
+    bash -c "[[ ! \"$ref\" =~ ^[A-Za-z0-9._/-]+\$ ]] || [[ \"$ref\" == *..* ]]" \
+        && return 0 || {
+            printf 'expected ref %q to be rejected by either regex or ..-check; both passed\n' "$ref" >&2
+            return 1
+        }
+}
+
+# ---------------------------------------------------------------------------
+# Z — Cumulative check: NO new raw `curl ` invocations on critical lines
+# ---------------------------------------------------------------------------
+
+@test "Z1 model-health-probe / anthropic-oracle / lib-curl-fallback have NO new raw curl regressions" {
+    # 1E.c.3.a migrated 3 sites; this test pins them so a future rebase
+    # doesn't accidentally revert them. Each script must have at least one
+    # guarded_curl call.
+    for script in model-health-probe.sh anthropic-oracle.sh lib-curl-fallback.sh; do
+        grep -qE 'endpoint_validator__guarded_curl' \
+            "$PROJECT_ROOT/.claude/scripts/$script" || {
+            printf '%s lost its guarded_curl migration (1E.c.3.a regression)\n' "$script" >&2
+            return 1
+        }
+    done
+}
+
+@test "Z2 every migrated 1E.c.3.b script declares allowlist constant under canonical tree path" {
+    # The wrapper rejects allowlist paths outside .claude/scripts/lib/allowlists/.
+    # Migrated callers MUST resolve to this path. Match either the literal
+    # path fragment OR a `$LIB_DIR/allowlists/` form (LIB_DIR := SCRIPT_DIR/lib),
+    # since some callers compose the path through a derived var.
+    for script in flatline-semantic-similarity.sh flatline-learning-extractor.sh \
+                  flatline-proposal-review.sh flatline-validate-learning.sh \
+                  constructs-loader.sh constructs-auth.sh constructs-browse.sh \
+                  constructs-install.sh license-validator.sh check-updates.sh; do
+        local script_path="$PROJECT_ROOT/.claude/scripts/$script"
+        if ! grep -qE '(\$SCRIPT_DIR/lib|\$LIB_DIR)/allowlists/[a-z0-9-]+\.json' \
+                "$script_path"; then
+            printf '%s default allowlist does NOT resolve to .claude/scripts/lib/allowlists/\n' "$script" >&2
+            return 1
+        fi
+    done
+}
+
+@test "Z3 wrapper-end-to-end smoke: source api-resilience.sh and call without allowlist override" {
+    # Confirm api-resilience.sh sources cleanly when the validator IS on disk.
+    # We don't actually make a network call; we just check the function is
+    # defined and the validator fail-closed branch is reachable.
+    local probe_out
+    probe_out=$(bash -c "
+        source '$PROJECT_ROOT/.claude/scripts/lib/api-resilience.sh' >/dev/null 2>&1
+        declare -f call_api_with_retry >/dev/null && echo OK
+        declare -f endpoint_validator__guarded_curl >/dev/null && echo VALIDATOR_OK
+    ")
+    [[ "$probe_out" == *'OK'* ]]
+    [[ "$probe_out" == *'VALIDATOR_OK'* ]]
+}


### PR DESCRIPTION
## Summary

Sprint-1E.c.3.b — second wave of bash caller migrations to `endpoint_validator__guarded_curl`. 1E.c.3.a (PR #732, merged at `848d9fac`) shipped the wrapper + 3 callers; this sub-sprint brings the count to 14 callers (12 new + the 3 from prior). The wrapper itself is unchanged.

- **api-resilience helper migrated** (`lib/api-resilience.sh::call_api_with_retry`) — adds `allowlist` parameter + env override; fail-closed if validator missing; exits 78/64 do NOT retry (config bugs, not transients).
- **4 flatline-* fallback paths** migrated (`semantic-similarity`, `learning-extractor`, `proposal-review` × 2, `validate-learning` × 2) using the existing `loa-providers.json` allowlist.
- **5 registry callers migrated** (`constructs-{loader,auth,browse×4,install×2}`, `license-validator`) with new `loa-registry.json` allowlist (api.constructs.network only).
- **`check-updates.sh` migrated** with new `loa-github.json` allowlist (api.github.com only — tightened per BB iter-1 LOW from speculative entries).
- **`mount-loa.sh` × 3 sites kept exempt** with `[ENDPOINT-VALIDATOR-EXEMPT]` rationale (bootstrap path — validator+Python+idna may not be on disk yet). Hardened with `--proto =https / --proto-redir =https / --max-redirs 10` + `_loa_ref` regex validation + dot-dot rejection.

## Bridgebuilder Iter-1 Findings

Subagent (general-purpose migration-correctness) review: **APPROVE** after remediations.

- **MEDIUM**: `mount-loa.sh` `_loa_ref` regex `^[A-Za-z0-9._/-]+$` accepted `..` since each char is individually in the class. GitHub's raw.githubusercontent.com normalizes `..` per RFC 3986 §5.2.4, so `--ref=../attacker/repo/refs/heads/main` would resolve to a different repo. **Fixed** with companion check `[[ "$_loa_ref" == *..* ]]`. M4 bats test pins the regression guard.
- **LOW**: `loa-github.json` had speculative entries (`raw.githubusercontent.com`, `objects.githubusercontent.com`, `github.com`) that no migrated caller currently uses. **Fixed** by tightening to `api.github.com` only; future callers requiring the other hosts add the entry in the same PR.
- **LOW**: `api-resilience.sh` retains pre-migration `2>&1` stderr-merge on the curl invocation. Behavior preserved (rejection paths return BEFORE setting `$http_response`), but warrants a code comment so future reviewers don't "fix" it. **Fixed** with explicit comment.
- **NIT**: pre-existing test-fixture failures in `tests/integration/check-updates.bats` (the test copies `check-updates.sh` to a tmpdir without its sourced deps). 3/11 pass before AND after my migration — verified via `git stash pop`. **Deferred** to a separate fixture-fix sprint.

Subagent paranoid-cypherpunk skipped this sub-sprint since the wrapper itself is unchanged from 1E.c.3.a (PR #732). The migration is mechanical "apply established pattern N more times".

## Test plan

- [x] `bats tests/integration/cycle099-sprint-1ec3b-migration-smoke.bats` — 31 NEW grep-based contract tests (allowlist fixture validity + flatline/registry/github batch migration + mount-loa exemption + dot-dot rejection regression guard + cumulative no-revert)
- [x] `bats tests/integration/endpoint-validator-{guarded-curl,cross-runtime,dns-rebinding,ts-parity}.bats` — 178 tests, 0 regressions (1E.c.3.a coverage unchanged)
- [x] `bats tests/unit/{model-health-probe*,bedrock-health-probe,gpt-review-api,check-updates,flatline-readiness,flatline-arbiter}.bats` — 206 tests, 0 regressions
- [x] `bash -n` clean on all 12 modified scripts
- [x] No `curl --config` smuggling regressions: `grep -nE '^\s+--config\s+"\$' .claude/scripts/{flatline-,constructs-,license-validator,check-updates}*.sh .claude/scripts/lib/api-resilience.sh` returns 0 matches
- [x] All migrated scripts use `--config-auth` (smuggling-safe wrapper flag) — pinned via test C7

**Cumulative**: 415 tests passing across 13 relevant suites; 209 cycle-099 endpoint-validator tests on main (178 pre + 31 new). Pre-existing check-updates integration fixture failures (8/11) confirmed not regressions.

## Deferred to 1E.c.3.c (next PR)

- Flip CI guard `.github/workflows/cycle099-sprint-1e-b-tests.yml::Bash — informational scan for curl/wget` from `::warning::` (always pass) to `::error::` + `exit 1`. Allowlist exception: `endpoint-validator.sh` (the wrapper) + `mount-loa.sh` (bootstrap exempt).
- Webhook-host allowlist for `model_health_probe.alert_webhook_url` (1E.c.3.a MEDIUM, opt-in via `.loa.config.yaml`).
- HIGH-2 from 1E.c.3.a: reject `host: "*"` / `host: ""` in `load_allowlist` (Python canonical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)