### PR TITLE
feat(cycle-099-sprint-2A): JSON Schema for model_aliases_extra + standalone validator (T2.1)

### DIFF
--- a/.claude/data/trajectory-schemas/model-aliases-extra.schema.json
+++ b/.claude/data/trajectory-schemas/model-aliases-extra.schema.json
@@ -26,9 +26,16 @@
         "id": {
           "type": "string",
           "pattern": "^[a-zA-Z0-9._-]+$",
+          "not": {
+            "anyOf": [
+              { "pattern": "\\.\\." },
+              { "pattern": "^[._-]" },
+              { "pattern": "[._-]$" }
+            ]
+          },
           "minLength": 2,
           "maxLength": 64,
-          "description": "FR-2.8 normalization. Rejects shell metacharacters, path separators, NUL bytes. Operator-visible alias used in `skill_models` references."
+          "description": "FR-2.8 normalization. Rejects shell metacharacters, path separators, NUL bytes, dot-dot traversal patterns, leading or trailing dot/underscore/hyphen. The `not.anyOf` clause closes the cycle-099 sprint-1E.c.3.b char-class regex dot-dot bypass: the bare pattern `[a-zA-Z0-9._-]+` accepts `..` because each dot is individually in the class. Sprint 2B+ consumers (e.g., `.run/aliases/<id>.lock`) rely on this."
         },
         "provider": {
           "type": "string",
@@ -50,7 +57,8 @@
         "endpoint": {
           "type": "string",
           "format": "uri",
-          "description": "OPTIONAL — defaults to provider's framework default. If supplied, MUST match provider's allowed_endpoints in loa.defaults.yaml at load time (FR-2.8). Validated by the cycle-099 endpoint-validator (Sprint 1E.b)."
+          "pattern": "^https://[a-zA-Z0-9.-]+(:[0-9]+)?(/.*)?$",
+          "description": "OPTIONAL — defaults to provider's framework default. If supplied, MUST match provider's allowed_endpoints in loa.defaults.yaml at load time (FR-2.8). HTTPS-only is enforced at the schema layer (cypherpunk M2 + gp M1 — `format: uri` is advisory in jsonschema-Python so we add a pattern). Validated by the cycle-099 endpoint-validator (Sprint 1E.b) at request time for full canonicalization."
         },
         "capabilities": {
           "type": "array",
@@ -110,17 +118,23 @@
         },
         "permissions": {
           "type": "object",
-          "description": "OPTIONAL — operator-supplied per-model permissions block. If present, validated against framework provider baseline (FR-1.4). If absent, the FR-1.4 minimal baseline (`chat` only) applies + `acknowledge_permissions_baseline: true` is required (see allOf). Sprint 3 expands this block per DD-1 Option B; Sprint 2 leaves the inner shape OPEN."
+          "minProperties": 1,
+          "description": "OPTIONAL — operator-supplied per-model permissions block. If present, validated against framework provider baseline (FR-1.4). If absent, the FR-1.4 minimal baseline (`chat` only) applies + `acknowledge_permissions_baseline: true` is required (see allOf). Sprint 3 expands this block per DD-1 Option B; Sprint 2 leaves the inner shape OPEN but `minProperties: 1` closes the empty-object bypass (cypherpunk + gp HIGH H1). The downstream loader (Sprint 2B+) MUST reject auth-shaped values inside this block per NFR-Sec-5; the schema-layer defense is the empty-object-rejection only."
         },
         "acknowledge_permissions_baseline": {
-          "type": "boolean",
-          "description": "FR-1.4: explicit operator opt-in to minimal-only permissions when no `permissions` block is supplied. Required when `permissions` is absent (see allOf clause)."
+          "const": true,
+          "description": "FR-1.4: explicit operator opt-in to minimal-only permissions when no `permissions` block is supplied. Required when `permissions` is absent OR empty (see allOf clause). MUST be literal `true` — `false` is a config-mistake (operator declared an opt-in flag set to opt-out, rejected per gp L2 / cypherpunk L4)."
         },
         "auth": false
       },
       "allOf": [
         {
-          "if": { "not": { "required": ["permissions"] } },
+          "if": {
+            "anyOf": [
+              { "not": { "required": ["permissions"] } },
+              { "properties": { "permissions": { "type": "object", "maxProperties": 0 } } }
+            ]
+          },
           "then": { "required": ["acknowledge_permissions_baseline"] }
         }
       ]

--- a/.claude/data/trajectory-schemas/model-aliases-extra.schema.json
+++ b/.claude/data/trajectory-schemas/model-aliases-extra.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "loa://schemas/model-aliases-extra/v1.0.0",
+  "title": "Operator-defined model aliases (cycle-099 model_aliases_extra)",
+  "description": "DD-2 + DD-5 resolution per cycle-099 SDD §3.2. Schema-versioned object validating operator-controlled model entries added via `.loa.config.yaml::model_aliases_extra`. Per NFR-Sec-5 the `auth` field is forbidden — operators reuse the provider's existing credential env var. Per FR-1.4, entries without an explicit `permissions` block MUST set `acknowledge_permissions_baseline: true` to opt into the minimal baseline.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version"],
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0",
+      "description": "Bumped on breaking schema changes. Cycle-099 ships v1.0.0."
+    },
+    "entries": {
+      "type": "array",
+      "description": "List of operator-added model entries. Each entry mirrors the SoT `providers.<p>.models.<id>` shape minus the `auth` field.",
+      "items": { "$ref": "#/$defs/ModelExtra" }
+    }
+  },
+  "$defs": {
+    "ModelExtra": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "provider", "api_id", "capabilities", "context_window", "pricing"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9._-]+$",
+          "minLength": 2,
+          "maxLength": 64,
+          "description": "FR-2.8 normalization. Rejects shell metacharacters, path separators, NUL bytes. Operator-visible alias used in `skill_models` references."
+        },
+        "provider": {
+          "type": "string",
+          "enum": ["openai", "anthropic", "google", "bedrock"],
+          "description": "NFR-Sec-4: new provider types require a System Zone change (.claude/defaults/loa.defaults.yaml::providers). Operators cannot register new provider types via .loa.config.yaml."
+        },
+        "api_id": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9._-]+$",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Vendor-side model id sent over the wire (e.g., `gpt-5.5-pro`). Same charset as `id`."
+        },
+        "endpoint_family": {
+          "type": "string",
+          "enum": ["chat", "responses", "messages", "converse"],
+          "description": "Provider endpoint family. Chat = OpenAI Chat Completions / Anthropic Messages legacy. Responses = OpenAI Responses (gpt-5.x/codex). Messages = Anthropic Messages. Converse = AWS Bedrock Converse."
+        },
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "OPTIONAL — defaults to provider's framework default. If supplied, MUST match provider's allowed_endpoints in loa.defaults.yaml at load time (FR-2.8). Validated by the cycle-099 endpoint-validator (Sprint 1E.b)."
+        },
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["chat", "tools", "function_calling", "code", "thinking_traces", "deep_research"]
+          },
+          "description": "At least one capability required. Used by skills to filter candidate models (e.g., flatline_protocol requires `tools`)."
+        },
+        "context_window": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 10000000,
+          "description": "Vendor-published context window in tokens. Used by Bridgebuilder truncation table."
+        },
+        "token_param": {
+          "type": "string",
+          "enum": ["max_tokens", "max_completion_tokens"],
+          "description": "Vendor's parameter name for the output-token limit. OpenAI Chat = max_tokens; Responses = max_completion_tokens; Anthropic = max_tokens; Bedrock = max_tokens."
+        },
+        "pricing": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["input_per_mtok", "output_per_mtok"],
+          "properties": {
+            "input_per_mtok": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Cost per million input tokens, in micro-cents (10^-8 USD). E.g., $5 / mtok = 5000000."
+            },
+            "output_per_mtok": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Cost per million output tokens, in micro-cents."
+            }
+          },
+          "description": "Per-mtok pricing in micro-cents. Used by L2 cost-budget enforcer."
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max_input": {
+              "type": "integer",
+              "minimum": 1024,
+              "description": "OPTIONAL operator-imposed max input tokens (overrides context_window for input budgeting)."
+            },
+            "truncation_coefficient": {
+              "type": "number",
+              "minimum": 0.05,
+              "maximum": 0.95,
+              "description": "Bridgebuilder truncation budget as fraction of context_window. Default 0.7 framework-wide."
+            }
+          },
+          "description": "OPTIONAL Bridgebuilder-side truncation tuning."
+        },
+        "permissions": {
+          "type": "object",
+          "description": "OPTIONAL — operator-supplied per-model permissions block. If present, validated against framework provider baseline (FR-1.4). If absent, the FR-1.4 minimal baseline (`chat` only) applies + `acknowledge_permissions_baseline: true` is required (see allOf). Sprint 3 expands this block per DD-1 Option B; Sprint 2 leaves the inner shape OPEN."
+        },
+        "acknowledge_permissions_baseline": {
+          "type": "boolean",
+          "description": "FR-1.4: explicit operator opt-in to minimal-only permissions when no `permissions` block is supplied. Required when `permissions` is absent (see allOf clause)."
+        },
+        "auth": false
+      },
+      "allOf": [
+        {
+          "if": { "not": { "required": ["permissions"] } },
+          "then": { "required": ["acknowledge_permissions_baseline"] }
+        }
+      ]
+    }
+  }
+}

--- a/.claude/scripts/lib/validate-model-aliases-extra.py
+++ b/.claude/scripts/lib/validate-model-aliases-extra.py
@@ -167,6 +167,40 @@ def _load_framework_default_ids(framework_yaml: Path | None = None) -> set[str]:
     return ids
 
 
+def _check_duplicate_ids(block: Any) -> list[dict[str, Any]]:
+    """BB iter-2 F6: reject duplicate `id` values within `entries[]`.
+
+    JSON Schema doesn't natively dedupe array elements by an inner key, so
+    we add a Python-side post-validation pass. Operator-shadowing of two
+    entries with the same `id` would create non-deterministic resolution
+    downstream (whichever entry happens to win the dict-merge wins).
+    """
+    if not isinstance(block, dict):
+        return []
+    entries = block.get("entries", [])
+    if not isinstance(entries, list):
+        return []
+    seen: dict[str, int] = {}
+    errors: list[dict[str, Any]] = []
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            continue
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str):
+            continue
+        if entry_id in seen:
+            errors.append({
+                "path": f"entries/{idx}/id",
+                "message": f"id {entry_id!r} duplicates entry #{seen[entry_id]}; "
+                           "each id MUST be unique within entries[]",
+                "validator": "[MODEL-EXTRA-DUPLICATE-ID]",
+                "validator_value": "uniqueness_check",
+            })
+        else:
+            seen[entry_id] = idx
+    return errors
+
+
 def _check_collisions(block: Any, framework_ids: set[str]) -> list[dict[str, Any]]:
     """cypherpunk H3 / IMP-004 — reject entries whose `id` collides with a
     framework-default ID. Operators wanting to MODIFY a framework default
@@ -220,6 +254,8 @@ def validate(
     validator = jsonschema.Draft202012Validator(schema)
     schema_errors = sorted(validator.iter_errors(block), key=lambda e: e.absolute_path)
     errors = _format_validation_errors(schema_errors)
+    # BB iter-2 F6: duplicate-id check (always on; not gated by --no-collision-check)
+    errors.extend(_check_duplicate_ids(block))
     if framework_ids is not None:
         errors.extend(_check_collisions(block, framework_ids))
     return (len(errors) == 0), errors, True

--- a/.claude/scripts/lib/validate-model-aliases-extra.py
+++ b/.claude/scripts/lib/validate-model-aliases-extra.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""validate-model-aliases-extra.py — cycle-099 Sprint 2A (T2.1).
+
+Validates the `model_aliases_extra` block of an operator's `.loa.config.yaml`
+against the canonical JSON Schema at
+`.claude/data/trajectory-schemas/model-aliases-extra.schema.json` (DD-5 path).
+
+This is a STANDALONE validator helper — it does NOT integrate with the
+broader strict-mode loader (Sprint 2B+ scope). Operators and CI workflows
+invoke this directly to catch malformed entries before runtime.
+
+Usage:
+    validate-model-aliases-extra.py [--config <path>] [--block <yaml-path>]
+                                     [--json] [--quiet]
+
+    --config <path>    Path to .loa.config.yaml (default: $PROJECT_ROOT/.loa.config.yaml)
+    --block <path>     YAML jq-path to the model_aliases_extra block
+                       (default: ".model_aliases_extra")
+    --json             Emit machine-readable JSON output
+    --quiet            Exit-code only; suppress stdout
+
+Exit codes:
+    0    valid (or `model_aliases_extra` absent — operator hasn't configured it)
+    78   validation failed (EX_CONFIG)
+    64   usage / IO error (EX_USAGE)
+
+Schema reference: .claude/data/trajectory-schemas/model-aliases-extra.schema.json
+SDD reference: cycle-099-model-registry §3.2 (DD-2 + DD-5 resolution)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import yaml
+
+EXIT_VALID = 0
+EXIT_INVALID = 78
+EXIT_USAGE = 64
+
+
+def _project_root() -> Path:
+    """Walk upward from CWD looking for the .claude/ directory marker.
+
+    Mirrors the cycle-099 PROJECT_ROOT resolution pattern used across other
+    sprint scripts. Falls back to CWD if no marker found.
+    """
+    cwd = Path.cwd().resolve()
+    for parent in [cwd, *cwd.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return cwd
+
+
+def _default_schema_path() -> Path:
+    return _project_root() / ".claude" / "data" / "trajectory-schemas" / "model-aliases-extra.schema.json"
+
+
+def _default_config_path() -> Path:
+    return _project_root() / ".loa.config.yaml"
+
+
+def _load_schema(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+    # Defense-in-depth: assert schema itself is well-formed Draft 2020-12.
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return schema
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"config file not found: {path}")
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _extract_block(config: dict[str, Any], block_path: str) -> Any:
+    """Extract the model_aliases_extra block from the config.
+
+    block_path is a dotted path (yaml-jq style). For Sprint 2A the only
+    supported path is `.model_aliases_extra` — top-level. Future Sprint 2
+    integrations may pass a different path if the loader nests the block
+    under a parent key.
+    """
+    # Strip leading dot if present (jq-style).
+    path = block_path.lstrip(".")
+    if not path:
+        return config
+    parts = path.split(".")
+    cursor: Any = config
+    for part in parts:
+        if not isinstance(cursor, dict):
+            return None
+        cursor = cursor.get(part)
+        if cursor is None:
+            return None
+    return cursor
+
+
+def _format_validation_errors(errors: list[jsonschema.ValidationError]) -> list[dict[str, Any]]:
+    """Convert jsonschema ValidationErrors to a stable JSON-friendly shape."""
+    out = []
+    for err in errors:
+        path_str = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        out.append({
+            "path": path_str,
+            "message": err.message,
+            "validator": err.validator,
+            "validator_value": err.validator_value if isinstance(err.validator_value, (str, int, float, bool, type(None))) else str(err.validator_value),
+        })
+    return out
+
+
+def validate(
+    config: dict[str, Any],
+    schema: dict[str, Any],
+    block_path: str = ".model_aliases_extra",
+) -> tuple[bool, list[dict[str, Any]]]:
+    """Validate a config's model_aliases_extra block against the schema.
+
+    Returns (is_valid, errors). When the block is absent, returns
+    (True, []) — operator hasn't opted in to the extension surface, which
+    is the default state.
+    """
+    block = _extract_block(config, block_path)
+    if block is None:
+        return True, []
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(block), key=lambda e: e.absolute_path)
+    return (len(errors) == 0), _format_validation_errors(errors)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="validate-model-aliases-extra",
+        description=__doc__.split("\n\n")[0],
+    )
+    parser.add_argument("--config", help="Path to .loa.config.yaml")
+    parser.add_argument(
+        "--block",
+        default=".model_aliases_extra",
+        help="YAML path to the model_aliases_extra block (default: .model_aliases_extra)",
+    )
+    parser.add_argument("--schema", help="Override schema path (default: canonical)")
+    parser.add_argument("--json", action="store_true", help="Emit JSON output")
+    parser.add_argument("--quiet", action="store_true", help="Suppress stdout")
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.config) if args.config else _default_config_path()
+    schema_path = Path(args.schema) if args.schema else _default_schema_path()
+
+    try:
+        schema = _load_schema(schema_path)
+    except FileNotFoundError:
+        print(f"validate-model-aliases-extra: schema file not found: {schema_path}", file=sys.stderr)
+        return EXIT_USAGE
+    except (json.JSONDecodeError, jsonschema.SchemaError) as exc:
+        print(f"validate-model-aliases-extra: schema malformed: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    if not config_path.is_file():
+        # Operator has no .loa.config.yaml — vacuous success (no
+        # model_aliases_extra to validate).
+        if not args.quiet:
+            payload = {"valid": True, "block_present": False, "config_path": str(config_path)}
+            if args.json:
+                print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+            else:
+                print(f"OK — no config at {config_path} (no model_aliases_extra to validate)")
+        return EXIT_VALID
+
+    try:
+        config = _load_config(config_path)
+    except yaml.YAMLError as exc:
+        print(f"validate-model-aliases-extra: YAML parse failed for {config_path}: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    valid, errors = validate(config, schema, args.block)
+
+    block = _extract_block(config, args.block)
+    if not args.quiet:
+        payload = {
+            "valid": valid,
+            "block_present": block is not None,
+            "config_path": str(config_path),
+            "schema_id": schema.get("$id", ""),
+            "errors": errors,
+        }
+        if args.json:
+            print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        else:
+            if valid:
+                if block is None:
+                    print(f"OK — no `model_aliases_extra` block in {config_path}")
+                else:
+                    entry_count = len(block.get("entries", [])) if isinstance(block, dict) else 0
+                    print(f"OK — model_aliases_extra valid ({entry_count} entries)")
+            else:
+                print(f"[MODEL-ALIASES-EXTRA-INVALID] schema validation failed:", file=sys.stderr)
+                for err in errors:
+                    print(f"  - {err['path']}: {err['message']}", file=sys.stderr)
+
+    return EXIT_VALID if valid else EXIT_INVALID
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/scripts/lib/validate-model-aliases-extra.py
+++ b/.claude/scripts/lib/validate-model-aliases-extra.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -81,6 +82,9 @@ def _load_config(path: Path) -> dict[str, Any]:
         return yaml.safe_load(f) or {}
 
 
+_BLOCK_PATH_RE = re.compile(r"^\.?[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$")
+
+
 def _extract_block(config: dict[str, Any], block_path: str) -> Any:
     """Extract the model_aliases_extra block from the config.
 
@@ -88,11 +92,21 @@ def _extract_block(config: dict[str, Any], block_path: str) -> Any:
     supported path is `.model_aliases_extra` — top-level. Future Sprint 2
     integrations may pass a different path if the loader nests the block
     under a parent key.
+
+    Path syntax (gp M2 fix — formerly silently swallowed malformed paths):
+      Optional leading dot, then one or more identifier segments separated
+      by single dots. Identifiers are Python-shaped: letter or underscore
+      followed by letters/digits/underscores. Empty paths, multiple leading
+      dots, trailing dots, embedded double-dots all REJECTED with ValueError.
     """
-    # Strip leading dot if present (jq-style).
+    if not isinstance(block_path, str):
+        raise ValueError(f"--block must be a string; got {type(block_path).__name__}")
+    if not _BLOCK_PATH_RE.fullmatch(block_path):
+        raise ValueError(
+            f"--block path {block_path!r} is malformed; expected `.field` or "
+            "`.parent.child` with identifier segments [A-Za-z_][A-Za-z0-9_]*"
+        )
     path = block_path.lstrip(".")
-    if not path:
-        return config
     parts = path.split(".")
     cursor: Any = config
     for part in parts:
@@ -118,23 +132,97 @@ def _format_validation_errors(errors: list[jsonschema.ValidationError]) -> list[
     return out
 
 
+def _load_framework_default_ids(framework_yaml: Path | None = None) -> set[str]:
+    """cypherpunk H3 / IMP-004: load framework-default model IDs so we can
+    reject `model_aliases_extra` entries that collide with framework-shipped
+    IDs. Per SDD §3.3: `model_aliases_extra` ADDS new IDs (entries collide
+    with defaults → reject); `model_aliases_override` MODIFIES existing.
+
+    Returns the set of `id` keys under `providers.<p>.models.<id>` plus the
+    keys of the top-level `aliases:` map. When the framework YAML cannot be
+    located (test fixtures, --schema override, etc.), returns an empty set
+    and skips the collision check (logged via the caller's error list, not
+    via stderr).
+    """
+    path = framework_yaml or (_project_root() / ".claude" / "defaults" / "model-config.yaml")
+    if not path.is_file():
+        return set()
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            doc = yaml.safe_load(f) or {}
+    except (yaml.YAMLError, OSError):
+        return set()
+    ids: set[str] = set()
+    providers = doc.get("providers", {})
+    if isinstance(providers, dict):
+        for _provider, p_def in providers.items():
+            if not isinstance(p_def, dict):
+                continue
+            models = p_def.get("models", {})
+            if isinstance(models, dict):
+                ids.update(str(k) for k in models.keys())
+    aliases = doc.get("aliases", {})
+    if isinstance(aliases, dict):
+        ids.update(str(k) for k in aliases.keys())
+    return ids
+
+
+def _check_collisions(block: Any, framework_ids: set[str]) -> list[dict[str, Any]]:
+    """cypherpunk H3 / IMP-004 — reject entries whose `id` collides with a
+    framework-default ID. Operators wanting to MODIFY a framework default
+    use `model_aliases_override` (separate top-level field — Sprint 2B
+    scope); `model_aliases_extra` is for NEW IDs only.
+    """
+    if not isinstance(block, dict):
+        return []
+    entries = block.get("entries", [])
+    if not isinstance(entries, list):
+        return []
+    errors = []
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            continue
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str):
+            continue
+        if entry_id in framework_ids:
+            errors.append({
+                "path": f"entries/{idx}/id",
+                "message": f"id {entry_id!r} collides with a framework-default model_id; "
+                           f"use `model_aliases_override` to modify existing entries",
+                "validator": "[MODEL-EXTRA-COLLIDES-WITH-DEFAULT]",
+                "validator_value": "framework_default_collision_check",
+            })
+    return errors
+
+
 def validate(
     config: dict[str, Any],
     schema: dict[str, Any],
     block_path: str = ".model_aliases_extra",
-) -> tuple[bool, list[dict[str, Any]]]:
+    framework_ids: set[str] | None = None,
+) -> tuple[bool, list[dict[str, Any]], bool]:
     """Validate a config's model_aliases_extra block against the schema.
 
-    Returns (is_valid, errors). When the block is absent, returns
-    (True, []) — operator hasn't opted in to the extension surface, which
-    is the default state.
+    Returns (is_valid, errors, block_present). When the block is absent,
+    returns (True, [], False) — operator hasn't opted in to the extension
+    surface (default state). When present, runs schema validation AND the
+    cypherpunk H3 collision check against `framework_ids` if provided.
+
+    gp M3 fix: returning `block_present` lets Sprint 2B's loader skip
+    re-extracting the block. (Previously Sprint 2B would have to call
+    _extract_block separately to distinguish vacuous-success from
+    meaningful-success.)
     """
     block = _extract_block(config, block_path)
     if block is None:
-        return True, []
+        return True, [], False
     validator = jsonschema.Draft202012Validator(schema)
-    errors = sorted(validator.iter_errors(block), key=lambda e: e.absolute_path)
-    return (len(errors) == 0), _format_validation_errors(errors)
+    schema_errors = sorted(validator.iter_errors(block), key=lambda e: e.absolute_path)
+    errors = _format_validation_errors(schema_errors)
+    if framework_ids is not None:
+        errors.extend(_check_collisions(block, framework_ids))
+    return (len(errors) == 0), errors, True
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -149,6 +237,17 @@ def main(argv: list[str] | None = None) -> int:
         help="YAML path to the model_aliases_extra block (default: .model_aliases_extra)",
     )
     parser.add_argument("--schema", help="Override schema path (default: canonical)")
+    parser.add_argument(
+        "--framework-defaults",
+        help="Override framework defaults yaml path (default: .claude/defaults/model-config.yaml). "
+             "When set, entries colliding with framework default IDs are rejected per SDD §3.3.",
+    )
+    parser.add_argument(
+        "--no-collision-check",
+        action="store_true",
+        help="Skip the framework-defaults collision check (cypherpunk H3 / IMP-004). "
+             "Default OFF — operators should NOT use this; provided only for Sprint 2B integration tests.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
     parser.add_argument("--quiet", action="store_true", help="Suppress stdout")
     args = parser.parse_args(argv)
@@ -182,13 +281,22 @@ def main(argv: list[str] | None = None) -> int:
         print(f"validate-model-aliases-extra: YAML parse failed for {config_path}: {exc}", file=sys.stderr)
         return EXIT_USAGE
 
-    valid, errors = validate(config, schema, args.block)
+    framework_ids: set[str] | None = None
+    if not args.no_collision_check:
+        fw_path = Path(args.framework_defaults) if args.framework_defaults else None
+        framework_ids = _load_framework_default_ids(fw_path)
 
-    block = _extract_block(config, args.block)
+    try:
+        valid, errors, block_present = validate(config, schema, args.block, framework_ids)
+    except ValueError as exc:
+        print(f"validate-model-aliases-extra: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    block = _extract_block(config, args.block) if block_present else None
     if not args.quiet:
         payload = {
             "valid": valid,
-            "block_present": block is not None,
+            "block_present": block_present,
             "config_path": str(config_path),
             "schema_id": schema.get("$id", ""),
             "errors": errors,

--- a/.claude/scripts/lib/validate-model-aliases-extra.sh
+++ b/.claude/scripts/lib/validate-model-aliases-extra.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# =============================================================================
+# validate-model-aliases-extra.sh — cycle-099 Sprint 2A bash wrapper.
+#
+# Thin shell wrapper around .claude/scripts/lib/validate-model-aliases-extra.py
+# for callers that prefer not to invoke Python directly. Mirrors the
+# cycle-099 endpoint-validator.sh pattern (Python canonical + bash twin).
+#
+# Usage:
+#   validate-model-aliases-extra.sh [--config <path>] [--json] [--quiet]
+#
+# Exit codes:
+#   0    valid
+#   78   validation failed
+#   64   usage / IO error
+#   2    Python interpreter not found
+#
+# The wrapper resolves the Python interpreter the same way other cycle-099
+# bash twins do: prefer .venv/bin/python, fall back to python3 on PATH.
+# =============================================================================
+
+set -euo pipefail
+
+_script_dir() {
+    cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P
+}
+
+_repo_root() {
+    cd "$(_script_dir)/../../.." && pwd -P
+}
+
+_resolve_python() {
+    local repo_root
+    repo_root="$(_repo_root)"
+    if [[ -x "$repo_root/.venv/bin/python" ]]; then
+        printf '%s' "$repo_root/.venv/bin/python"
+        return 0
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+    return 2
+}
+
+_PY="$(_resolve_python)" || {
+    printf 'validate-model-aliases-extra.sh: no python3 interpreter found\n' >&2
+    printf 'Hint: install Python 3.11+ or activate the cheval venv at .venv/\n' >&2
+    exit 2
+}
+
+_TOOL="$(_script_dir)/validate-model-aliases-extra.py"
+if [[ ! -f "$_TOOL" ]]; then
+    printf 'validate-model-aliases-extra.sh: canonical Python tool missing at %q\n' "$_TOOL" >&2
+    exit 2
+fi
+
+# `python -I` (isolated mode) defends against PYTHONPATH / user-site
+# injection. Mirrors the cycle-099 endpoint-validator.sh hardening pattern.
+exec "$_PY" -I "$_TOOL" "$@"

--- a/tests/unit/model-aliases-extra-schema.bats
+++ b/tests/unit/model-aliases-extra-schema.bats
@@ -630,7 +630,9 @@ EOF
     [[ "$status" -eq 0 ]]
 }
 
-@test "E25b reject: acknowledge_permissions_baseline: false (no permissions block)" {
+# gp L4 / cypherpunk L4 fix: acknowledge_permissions_baseline now uses
+# `const: true` so false is REJECTED at the schema layer.
+@test "E25b reject: acknowledge_permissions_baseline: false (gp/cypherpunk L4 fix)" {
     cat > "$WORK_DIR/e25b.yaml" <<'EOF'
 model_aliases_extra:
   schema_version: "1.0.0"
@@ -643,17 +645,278 @@ model_aliases_extra:
       pricing: {input_per_mtok: 100, output_per_mtok: 200}
       acknowledge_permissions_baseline: false
 EOF
-    # NOTE: per the JSON Schema, the allOf clause requires
-    # acknowledge_permissions_baseline to be present (boolean). False
-    # satisfies "required" — it's still present. Per FR-1.4 semantics the
-    # downstream loader (Sprint 2B/2D) is expected to also reject `false`,
-    # but THIS schema only enforces presence. Document the pin.
-    run "$VALIDATOR_PY" --config "$WORK_DIR/e25b.yaml"
-    [[ "$status" -eq 0 ]] || {
-        printf 'NOTE: schema only enforces presence of acknowledge field; got=%d\n' "$status" >&2
-        printf 'Sprint 2B/2D loader integration must enforce true-only semantics.\n' >&2
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e25b.yaml" --quiet
+    [[ "$status" -eq 78 ]] || {
+        printf 'acknowledge_permissions_baseline: false MUST be rejected (const true); got status=%d\n' "$status" >&2
         return 1
     }
+}
+
+# gp + cypherpunk HIGH H1 fix: permissions: {} (empty object) MUST be
+# rejected — previously bypassed FR-1.4 because `if not required[permissions]`
+# only fired when the field was ABSENT. Schema now requires
+# permissions.minProperties: 1 AND the allOf treats empty == absent.
+@test "E26 reject: permissions: {} (empty object bypasses FR-1.4) — H1 fix" {
+    cat > "$WORK_DIR/e26.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      permissions: {}
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e26.yaml" --quiet
+    [[ "$status" -eq 78 ]] || {
+        printf 'permissions: {} MUST be rejected (FR-1.4 bypass); got status=%d\n' "$status" >&2
+        return 1
+    }
+}
+
+# cypherpunk M1 fix: id pattern now has not.anyOf rejecting `..` plus
+# leading/trailing meta chars. The bare regex `[a-zA-Z0-9._-]+` accepted `..`
+# because each `.` is individually in the char class
+# (cycle-099 sprint-1E.c.3.b feedback_charclass_dotdot_bypass).
+@test "E27 reject: id == '..' (charclass dot-dot bypass) — cypherpunk M1 fix" {
+    cat > "$WORK_DIR/e27.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: ".."
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e27.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E27b reject: id with embedded '..' (path traversal pattern)" {
+    cat > "$WORK_DIR/e27b.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: "foo..bar"
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e27b.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E27c reject: id starting with '.' (leading-meta)" {
+    cat > "$WORK_DIR/e27c.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: ".foo"
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e27c.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+# cypherpunk L5: id pattern is ASCII-anchored, so non-ASCII MUST reject.
+# Pin the contract via positive-control-of-rejection.
+@test "E28 reject: id with non-ASCII char (Unicode boundary — cypherpunk L5)" {
+    cat > "$WORK_DIR/e28.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: "éxperimental"
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e28.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+# gp M1 / cypherpunk M2: schema-layer endpoint validation. format: uri is
+# advisory in jsonschema-Python so we added pattern: ^https://. Pin it.
+@test "E29 reject: endpoint with non-https scheme (HTTP)" {
+    cat > "$WORK_DIR/e29.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      endpoint: "http://api.openai.com/v1"
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e29.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E29b reject: endpoint with javascript: scheme (XSS-class payload)" {
+    cat > "$WORK_DIR/e29b.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      endpoint: "javascript:alert(1)"
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e29b.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E29c accept: endpoint with valid https URI" {
+    cat > "$WORK_DIR/e29c.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      endpoint: "https://api.openai.com/v1/responses"
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e29c.yaml"
+    [[ "$status" -eq 0 ]]
+}
+
+# cypherpunk H3 / IMP-004 fix: collision check against framework defaults.
+# Operator-added IDs MUST NOT collide with framework-shipped IDs.
+@test "E30 reject: id collides with framework-default model id — cypherpunk H3 fix" {
+    cat > "$WORK_DIR/e30.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: claude-opus-4-7
+      provider: anthropic
+      api_id: claude-opus-4-7
+      capabilities: [chat]
+      context_window: 200000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e30.yaml" --quiet
+    [[ "$status" -eq 78 ]] || {
+        printf 'collision with framework default claude-opus-4-7 MUST be rejected; got=%d\n' "$status" >&2
+        return 1
+    }
+}
+
+@test "E30b accept: collision check disabled via --no-collision-check" {
+    # Sprint 2B integration tests use this to test schema in isolation.
+    cat > "$WORK_DIR/e30b.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: claude-opus-4-7
+      provider: anthropic
+      api_id: claude-opus-4-7
+      capabilities: [chat]
+      context_window: 200000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e30b.yaml" --no-collision-check
+    [[ "$status" -eq 0 ]]
+}
+
+# cypherpunk L6: yaml.safe_load MUST reject !!python/object tags.
+@test "E31 reject: !!python/object payload (yaml.safe_load contract pin — cypherpunk L6)" {
+    cat > "$WORK_DIR/e31.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: !!python/object/new:os.system [touch /tmp/loa-pwned]
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e31.yaml" --quiet
+    # safe_load throws YAMLError → EXIT_USAGE (64). Pin that contract.
+    [[ "$status" -eq 64 || "$status" -eq 78 ]] || {
+        printf '!!python/object MUST not load; got=%d\n' "$status" >&2
+        return 1
+    }
+    # Sanity: side-effect (file creation) MUST NOT have happened.
+    [[ ! -f /tmp/loa-pwned ]] || {
+        rm -f /tmp/loa-pwned
+        printf 'CRITICAL: !!python/object payload executed!\n' >&2
+        return 1
+    }
+}
+
+# gp M2: malformed --block paths must be rejected, not silently swallowed.
+@test "B4 reject: malformed --block path (empty)" {
+    cat > "$WORK_DIR/b4.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries: []
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/b4.yaml" --block ""
+    [[ "$status" -eq 64 ]] || {
+        printf 'empty --block must reject with EX_USAGE; got=%d\n' "$status" >&2
+        return 1
+    }
+}
+
+@test "B4b reject: malformed --block path (embedded ..)" {
+    cat > "$WORK_DIR/uc1b.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries: []
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/uc1b.yaml" --block ".foo..bar"
+    [[ "$status" -eq 64 ]]
+}
+
+@test "B4c reject: malformed --block path (trailing dot)" {
+    cat > "$WORK_DIR/uc1c.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries: []
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/uc1c.yaml" --block ".foo."
+    [[ "$status" -eq 64 ]]
+}
+
+@test "B4d accept: well-formed --block path (single field)" {
+    cat > "$WORK_DIR/uc1d.yaml" <<'EOF'
+nested:
+  model_aliases_extra:
+    schema_version: "1.0.0"
+    entries: []
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/uc1d.yaml" --block ".nested.model_aliases_extra"
+    [[ "$status" -eq 0 ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/model-aliases-extra-schema.bats
+++ b/tests/unit/model-aliases-extra-schema.bats
@@ -27,15 +27,30 @@ setup() {
     VALIDATOR_PY="$PROJECT_ROOT/.claude/scripts/lib/validate-model-aliases-extra.py"
     VALIDATOR_SH="$PROJECT_ROOT/.claude/scripts/lib/validate-model-aliases-extra.sh"
 
-    [[ -f "$SCHEMA" ]] || skip "schema not present"
-    [[ -f "$VALIDATOR_PY" ]] || skip "Python validator not present"
-    [[ -f "$VALIDATOR_SH" ]] || skip "bash wrapper not present"
+    # BB iter-2 F9: HARD-FAIL on the files this PR ships (schema +
+    # validator). Skip-on-missing was masking CI regressions where a refactor
+    # could rename/move these and silently skip every test in the file.
+    [[ -f "$SCHEMA" ]] || {
+        printf 'FATAL: schema not present at %s — Sprint 2A invariant broken\n' "$SCHEMA" >&2
+        return 1
+    }
+    [[ -f "$VALIDATOR_PY" ]] || {
+        printf 'FATAL: Python validator not present at %s — Sprint 2A invariant broken\n' "$VALIDATOR_PY" >&2
+        return 1
+    }
+    [[ -f "$VALIDATOR_SH" ]] || {
+        printf 'FATAL: bash wrapper not present at %s — Sprint 2A invariant broken\n' "$VALIDATOR_SH" >&2
+        return 1
+    }
 
     if [[ -x "$PROJECT_ROOT/.venv/bin/python" ]]; then
         PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
     else
         PYTHON_BIN="${PYTHON_BIN:-python3}"
     fi
+    # Skip-on-missing for OPTIONAL deps (jsonschema/pyyaml may not be in
+    # ambient python3; cheval venv is preferred). Operators running locally
+    # without venv can still skip cleanly.
     "$PYTHON_BIN" -c "import jsonschema, yaml" 2>/dev/null \
         || skip "jsonschema + pyyaml not available in $PYTHON_BIN"
 
@@ -835,8 +850,9 @@ EOF
 # so concurrent test runs don't share state and stale files from prior
 # failures can't mask current exploits.
 @test "E31 reject: !!python/object payload (yaml.safe_load contract pin — cypherpunk L6)" {
-    local pwned_path="$WORK_DIR/e31-pwned-$$"
-    rm -f "$pwned_path"  # belt-and-suspenders: ensure we start clean
+    # BB iter-2 F2: $WORK_DIR is already per-test (mktemp -d); $$ suffix
+    # was redundant. Drop it.
+    local pwned_path="$WORK_DIR/e31-pwned"
     # Unquoted heredoc so $pwned_path is interpolated into the YAML payload.
     cat > "$WORK_DIR/e31.yaml" <<EOF
 model_aliases_extra:
@@ -851,15 +867,104 @@ model_aliases_extra:
       acknowledge_permissions_baseline: true
 EOF
     run "$VALIDATOR_PY" --config "$WORK_DIR/e31.yaml" --quiet
-    # safe_load throws YAMLError → EXIT_USAGE (64). Pin that contract.
-    [[ "$status" -eq 64 || "$status" -eq 78 ]] || {
-        printf '!!python/object MUST not load; got=%d\n' "$status" >&2
+    # BB iter-2 F3: tighten to exact exit-code pin. safe_load on
+    # !!python/object MUST raise YAMLError → EX_USAGE (64). Allowing 78
+    # would mask a regression where the YAML parsed (gadget chain fired)
+    # and the schema then rejected the result with 78.
+    [[ "$status" -eq 64 ]] || {
+        printf '!!python/object MUST exit 64 (YAMLError path); got=%d\n' "$status" >&2
         return 1
     }
     # Sanity: side-effect (file creation) MUST NOT have happened. The
-    # path is per-test ($WORK_DIR + $$) so a positive result is genuine.
+    # path is per-test ($WORK_DIR) so a positive result is genuine.
     [[ ! -f "$pwned_path" ]] || {
         printf 'CRITICAL: !!python/object payload executed and created %s!\n' "$pwned_path" >&2
+        return 1
+    }
+}
+
+# BB iter-2 F6: reject duplicate ids within entries[]. JSON Schema can't
+# dedupe by inner key natively; Python-side post-validation check fires.
+@test "E32 reject: duplicate id within entries[] (BB F6)" {
+    cat > "$WORK_DIR/e32.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: shadow
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+    - id: shadow
+      provider: anthropic
+      api_id: bar
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e32.yaml" --quiet
+    [[ "$status" -eq 78 ]] || {
+        printf 'duplicate id MUST be rejected; got=%d\n' "$status" >&2
+        return 1
+    }
+}
+
+# BB iter-2 F7: pin pricing minimum:0 — explicitly reject negative values.
+@test "E33 reject: negative pricing.input_per_mtok (BB F7)" {
+    cat > "$WORK_DIR/e33.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: -1, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e33.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E33b reject: negative pricing.output_per_mtok (BB F7)" {
+    cat > "$WORK_DIR/e33b.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: -200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e33b.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+# BB iter-2 F4: --no-collision-check MUST suppress ONLY collision detection,
+# not other schema validation. Pin via mixed-violation fixture.
+@test "E34 --no-collision-check still rejects schema-invalid entries (BB F4)" {
+    cat > "$WORK_DIR/e34.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: claude-opus-4-7
+      provider: azure
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e34.yaml" --no-collision-check --quiet
+    [[ "$status" -eq 78 ]] || {
+        printf '--no-collision-check should suppress collision only, not schema validation; got=%d\n' "$status" >&2
         return 1
     }
 }

--- a/tests/unit/model-aliases-extra-schema.bats
+++ b/tests/unit/model-aliases-extra-schema.bats
@@ -49,25 +49,9 @@ teardown() {
     return 0
 }
 
-# Helper: write a fixture .loa.config.yaml with the given model_aliases_extra
-# block (or full config) and run the validator against it. Sets $status,
-# $output (stderr+stdout merged) per bats `run` convention.
-_run_validator() {
-    local config_path="$1"
-    run "$VALIDATOR_PY" --config "$config_path" --json --quiet
-    return 0
-}
-
-_run_validator_verbose() {
-    local config_path="$1"
-    run "$VALIDATOR_PY" --config "$config_path" --json
-}
-
-# Helper: write a model_aliases_extra block to a fresh fixture file.
-_write_config() {
-    local path="$1" yaml_body="$2"
-    printf '%s\n' "$yaml_body" > "$path"
-}
+# BB iter-1 F4 / unused-helpers: helpers `_run_validator`, `_run_validator_verbose`,
+# `_write_config` were defined but never used (every test inlined `run` and
+# heredoc-write). Removed to avoid drift.
 
 # ---------------------------------------------------------------------------
 # E0 POSITIVE CONTROL — SDD §4.2.1 UC-1 fixture
@@ -847,12 +831,18 @@ EOF
 }
 
 # cypherpunk L6: yaml.safe_load MUST reject !!python/object tags.
+# BB iter-1 hardcoded-tmp-file fix: use $WORK_DIR/-prefixed path with PID
+# so concurrent test runs don't share state and stale files from prior
+# failures can't mask current exploits.
 @test "E31 reject: !!python/object payload (yaml.safe_load contract pin — cypherpunk L6)" {
-    cat > "$WORK_DIR/e31.yaml" <<'EOF'
+    local pwned_path="$WORK_DIR/e31-pwned-$$"
+    rm -f "$pwned_path"  # belt-and-suspenders: ensure we start clean
+    # Unquoted heredoc so $pwned_path is interpolated into the YAML payload.
+    cat > "$WORK_DIR/e31.yaml" <<EOF
 model_aliases_extra:
   schema_version: "1.0.0"
   entries:
-    - id: !!python/object/new:os.system [touch /tmp/loa-pwned]
+    - id: !!python/object/new:os.system [touch $pwned_path]
       provider: openai
       api_id: foo
       capabilities: [chat]
@@ -866,10 +856,10 @@ EOF
         printf '!!python/object MUST not load; got=%d\n' "$status" >&2
         return 1
     }
-    # Sanity: side-effect (file creation) MUST NOT have happened.
-    [[ ! -f /tmp/loa-pwned ]] || {
-        rm -f /tmp/loa-pwned
-        printf 'CRITICAL: !!python/object payload executed!\n' >&2
+    # Sanity: side-effect (file creation) MUST NOT have happened. The
+    # path is per-test ($WORK_DIR + $$) so a positive result is genuine.
+    [[ ! -f "$pwned_path" ]] || {
+        printf 'CRITICAL: !!python/object payload executed and created %s!\n' "$pwned_path" >&2
         return 1
     }
 }

--- a/tests/unit/model-aliases-extra-schema.bats
+++ b/tests/unit/model-aliases-extra-schema.bats
@@ -1,0 +1,729 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/unit/model-aliases-extra-schema.bats
+#
+# cycle-099 Sprint 2A (T2.1) — JSON Schema contract pin for the
+# `.claude/data/trajectory-schemas/model-aliases-extra.schema.json` file
+# (DD-5 path-locked) and the validator helper at
+# `.claude/scripts/lib/validate-model-aliases-extra.{py,sh}`.
+#
+# Closes AC-S2.1 partial (schema correctness; loader integration is Sprint 2B).
+#
+# Test taxonomy:
+#   E0      POSITIVE CONTROL: SDD §4.2.1 UC-1 valid example loads cleanly
+#   E1-E5   STRUCTURAL: missing required fields rejected
+#   E6-E10  TYPE: wrong-type values rejected
+#   E11-E15 ENUM: invalid enum values rejected
+#   E16-E18 CONSTRAINTS: pattern / minLength / maxLength / range rejected
+#   E19-E22 SECURITY: forbidden auth field, glob/wildcard ids, unknown providers
+#   E23-E25 PERMISSIONS: FR-1.4 acknowledge_permissions_baseline gate
+#   B1-B3   BASH TWIN: wrapper API surface
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    SCHEMA="$PROJECT_ROOT/.claude/data/trajectory-schemas/model-aliases-extra.schema.json"
+    VALIDATOR_PY="$PROJECT_ROOT/.claude/scripts/lib/validate-model-aliases-extra.py"
+    VALIDATOR_SH="$PROJECT_ROOT/.claude/scripts/lib/validate-model-aliases-extra.sh"
+
+    [[ -f "$SCHEMA" ]] || skip "schema not present"
+    [[ -f "$VALIDATOR_PY" ]] || skip "Python validator not present"
+    [[ -f "$VALIDATOR_SH" ]] || skip "bash wrapper not present"
+
+    if [[ -x "$PROJECT_ROOT/.venv/bin/python" ]]; then
+        PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+    else
+        PYTHON_BIN="${PYTHON_BIN:-python3}"
+    fi
+    "$PYTHON_BIN" -c "import jsonschema, yaml" 2>/dev/null \
+        || skip "jsonschema + pyyaml not available in $PYTHON_BIN"
+
+    WORK_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+# Helper: write a fixture .loa.config.yaml with the given model_aliases_extra
+# block (or full config) and run the validator against it. Sets $status,
+# $output (stderr+stdout merged) per bats `run` convention.
+_run_validator() {
+    local config_path="$1"
+    run "$VALIDATOR_PY" --config "$config_path" --json --quiet
+    return 0
+}
+
+_run_validator_verbose() {
+    local config_path="$1"
+    run "$VALIDATOR_PY" --config "$config_path" --json
+}
+
+# Helper: write a model_aliases_extra block to a fresh fixture file.
+_write_config() {
+    local path="$1" yaml_body="$2"
+    printf '%s\n' "$yaml_body" > "$path"
+}
+
+# ---------------------------------------------------------------------------
+# E0 POSITIVE CONTROL — SDD §4.2.1 UC-1 fixture
+# ---------------------------------------------------------------------------
+
+@test "E0 positive control: UC-1 (operator adopts gpt-5.7-pro) loads cleanly" {
+    cat > "$WORK_DIR/uc1.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: gpt-5.7-pro
+      provider: openai
+      api_id: gpt-5.7-pro
+      endpoint_family: responses
+      capabilities: [chat, tools, function_calling, code]
+      context_window: 256000
+      pricing:
+        input_per_mtok: 40000000
+        output_per_mtok: 200000000
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/uc1.yaml"
+    [[ "$status" -eq 0 ]] || {
+        printf 'expected status=0; got=%d output=%s\n' "$status" "$output" >&2
+        return 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Vacuous — config missing OR block absent → vacuous success
+# ---------------------------------------------------------------------------
+
+@test "V1 absent config file → vacuous success (operator hasn't created .loa.config.yaml)" {
+    run "$VALIDATOR_PY" --config "$WORK_DIR/nonexistent.yaml"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "V2 config file present without model_aliases_extra → vacuous success" {
+    cat > "$WORK_DIR/no-block.yaml" <<'EOF'
+hounfour:
+  flatline_routing: false
+ride:
+  depth: medium
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/no-block.yaml"
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# E1-E5 STRUCTURAL — missing required fields
+# ---------------------------------------------------------------------------
+
+@test "E1 reject: missing schema_version" {
+    cat > "$WORK_DIR/e1.yaml" <<'EOF'
+model_aliases_extra:
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e1.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E2 reject: entry missing required 'id'" {
+    cat > "$WORK_DIR/e2.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e2.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E3 reject: entry missing required 'provider'" {
+    cat > "$WORK_DIR/e3.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e3.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E4 reject: entry missing required 'pricing'" {
+    cat > "$WORK_DIR/e4.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e4.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E5 reject: pricing missing required input_per_mtok" {
+    cat > "$WORK_DIR/e5.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e5.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+# ---------------------------------------------------------------------------
+# E6-E10 TYPE — wrong-type values
+# ---------------------------------------------------------------------------
+
+@test "E6 reject: schema_version wrong const value" {
+    cat > "$WORK_DIR/e6.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "2.0.0"
+  entries: []
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e6.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E7 reject: context_window as string" {
+    cat > "$WORK_DIR/e7.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: "128000"
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e7.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E8 reject: capabilities not an array" {
+    cat > "$WORK_DIR/e8.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: "chat"
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e8.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E9 reject: pricing.input_per_mtok as float" {
+    cat > "$WORK_DIR/e9.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100.5, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e9.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E10 reject: capabilities empty array (minItems: 1)" {
+    cat > "$WORK_DIR/e10.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: []
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e10.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+# ---------------------------------------------------------------------------
+# E11-E15 ENUM — invalid enum values
+# ---------------------------------------------------------------------------
+
+@test "E11 reject: unknown provider 'azure'" {
+    cat > "$WORK_DIR/e11.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: azure
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e11.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E12 reject: invalid endpoint_family" {
+    cat > "$WORK_DIR/e12.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      endpoint_family: completions
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e12.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E13 reject: unknown capability 'image_generation'" {
+    cat > "$WORK_DIR/e13.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat, image_generation]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e13.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E14 reject: invalid token_param" {
+    cat > "$WORK_DIR/e14.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      token_param: max_output_tokens
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e14.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E15 accept: all 4 valid providers + all valid capabilities + all valid endpoint_families" {
+    cat > "$WORK_DIR/e15.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: m-openai
+      provider: openai
+      api_id: m-openai
+      endpoint_family: chat
+      capabilities: [chat, tools, function_calling, code, thinking_traces, deep_research]
+      context_window: 128000
+      token_param: max_tokens
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+    - id: m-anthropic
+      provider: anthropic
+      api_id: m-anthropic
+      endpoint_family: messages
+      capabilities: [chat]
+      context_window: 200000
+      token_param: max_completion_tokens
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+    - id: m-google
+      provider: google
+      api_id: m-google
+      endpoint_family: responses
+      capabilities: [chat]
+      context_window: 1000000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+    - id: m-bedrock
+      provider: bedrock
+      api_id: m-bedrock
+      endpoint_family: converse
+      capabilities: [chat]
+      context_window: 200000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e15.yaml"
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# E16-E18 CONSTRAINTS — pattern / range
+# ---------------------------------------------------------------------------
+
+@test "E16 reject: id pattern violation (shell metachar)" {
+    cat > "$WORK_DIR/e16.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: "foo;bar"
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e16.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E16b reject: id with path separator" {
+    cat > "$WORK_DIR/e16b.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: "foo/bar"
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e16b.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E16c reject: id with whitespace" {
+    cat > "$WORK_DIR/e16c.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: "foo bar"
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e16c.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E17 reject: context_window below minimum (1024)" {
+    cat > "$WORK_DIR/e17.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 1023
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e17.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E17b reject: context_window above maximum (10000000)" {
+    cat > "$WORK_DIR/e17b.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 10000001
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e17b.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E18 reject: id below minLength (2)" {
+    cat > "$WORK_DIR/e18.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: "x"
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e18.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+# ---------------------------------------------------------------------------
+# E19-E22 SECURITY — auth field forbidden + glob ids + unknown top fields
+# ---------------------------------------------------------------------------
+
+@test "E19 reject: auth field present in entry (NFR-Sec-5)" {
+    cat > "$WORK_DIR/e19.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      auth: {api_key: "sk-evil"}
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e19.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E20 reject: id with glob '*' (cycle-099 sprint-1E.c.3.c host wildcard pattern)" {
+    cat > "$WORK_DIR/e20.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: "*"
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e20.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E21 reject: unknown property at top-level (additionalProperties: false)" {
+    cat > "$WORK_DIR/e21.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries: []
+  unknown_field: "should fail"
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e21.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E22 reject: unknown property in ModelExtra (additionalProperties: false)" {
+    cat > "$WORK_DIR/e22.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+      mystery_field: "should fail"
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e22.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+# ---------------------------------------------------------------------------
+# E23-E25 PERMISSIONS — FR-1.4 acknowledge_permissions_baseline gate
+# ---------------------------------------------------------------------------
+
+@test "E23 reject: no permissions block AND no acknowledge_permissions_baseline" {
+    cat > "$WORK_DIR/e23.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e23.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "E24 accept: permissions block present (no acknowledge needed)" {
+    cat > "$WORK_DIR/e24.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      permissions:
+        chat: {allowed: true}
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e24.yaml"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "E25 accept: acknowledge_permissions_baseline: true (no permissions block)" {
+    cat > "$WORK_DIR/e25.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: true
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e25.yaml"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "E25b reject: acknowledge_permissions_baseline: false (no permissions block)" {
+    cat > "$WORK_DIR/e25b.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries:
+    - id: foo
+      provider: openai
+      api_id: foo
+      capabilities: [chat]
+      context_window: 128000
+      pricing: {input_per_mtok: 100, output_per_mtok: 200}
+      acknowledge_permissions_baseline: false
+EOF
+    # NOTE: per the JSON Schema, the allOf clause requires
+    # acknowledge_permissions_baseline to be present (boolean). False
+    # satisfies "required" — it's still present. Per FR-1.4 semantics the
+    # downstream loader (Sprint 2B/2D) is expected to also reject `false`,
+    # but THIS schema only enforces presence. Document the pin.
+    run "$VALIDATOR_PY" --config "$WORK_DIR/e25b.yaml"
+    [[ "$status" -eq 0 ]] || {
+        printf 'NOTE: schema only enforces presence of acknowledge field; got=%d\n' "$status" >&2
+        printf 'Sprint 2B/2D loader integration must enforce true-only semantics.\n' >&2
+        return 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# B1-B3 BASH TWIN — wrapper exit-code parity
+# ---------------------------------------------------------------------------
+
+@test "B1 bash wrapper: valid config → exit 0" {
+    cat > "$WORK_DIR/b1.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries: []
+EOF
+    run "$VALIDATOR_SH" --config "$WORK_DIR/b1.yaml"
+    [[ "$status" -eq 0 ]] || {
+        printf 'bash wrapper status=%d output=%s\n' "$status" "$output" >&2
+        return 1
+    }
+}
+
+@test "B2 bash wrapper: invalid config → exit 78" {
+    cat > "$WORK_DIR/b2.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "wrong"
+  entries: []
+EOF
+    run "$VALIDATOR_SH" --config "$WORK_DIR/b2.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "B3 bash wrapper: --json passthrough" {
+    cat > "$WORK_DIR/b3.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+  entries: []
+EOF
+    run "$VALIDATOR_SH" --config "$WORK_DIR/b3.yaml" --json
+    [[ "$status" -eq 0 ]]
+    echo "$output" | grep -q '"valid":true' || {
+        printf 'expected "valid":true in JSON output; got: %s\n' "$output" >&2
+        return 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases: schema-validation production smoke
+# ---------------------------------------------------------------------------
+
+@test "S1 schema file is well-formed Draft 2020-12" {
+    "$PYTHON_BIN" -I -c "
+import json, jsonschema, sys
+schema = json.load(open('$SCHEMA'))
+jsonschema.Draft202012Validator.check_schema(schema)
+print('OK')
+"
+}
+
+@test "S2 schema enforces required field set on top-level (schema_version REQUIRED)" {
+    cat > "$WORK_DIR/s2.yaml" <<'EOF'
+model_aliases_extra:
+  entries: []
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/s2.yaml" --quiet
+    [[ "$status" -eq 78 ]]
+}
+
+@test "S3 entries field is OPTIONAL (operator with schema_version only)" {
+    cat > "$WORK_DIR/s3.yaml" <<'EOF'
+model_aliases_extra:
+  schema_version: "1.0.0"
+EOF
+    run "$VALIDATOR_PY" --config "$WORK_DIR/s3.yaml"
+    [[ "$status" -eq 0 ]]
+}


### PR DESCRIPTION
## Summary

Implements cycle-099 Sprint 2 task T2.1 per SDD §3.2 (DD-2 + DD-5). Closes AC-S2.1 partial (schema correctness; loader integration deferred to Sprint 2B+).

## Sprint scope rationale

Sprint 2's full plan is 16 tasks; T2.2's "extend cycle-095 strict-mode loader" assumes an existing strict-mode loader for `.loa.config.yaml` top-level fields. **It does not exist** — operator config is loosely loaded today via per-script `yq eval` calls + `.get('hounfour', {})` in cheval. Building a new strict-mode loader for 30+ top-level fields (auto-detected via `.loa.config.yaml.example`) is its own sprint and risks breaking every loa skill that already extends operator config (`paths`, `ride`, `bridgebuilder`, `harness`, etc.).

**Sprint 2A reduces scope to T2.1 only** — a self-contained schema + standalone validator helper. Sprint 2B+ will integrate the validator at appropriate hook points without coercing the broader loader pattern.

## Three deliverables

### 1. Schema at canonical path
`.claude/data/trajectory-schemas/model-aliases-extra.schema.json` (DD-5 path-locked) — Draft 2020-12 JSON Schema per SDD §3.2. Verbatim from SDD spec including `auth: false` (NFR-Sec-5), FR-1.4 `allOf` permission-acknowledgement gate, FR-2.8 charset constraints, additionalProperties:false at every level.

### 2. Standalone validator helpers
- `.claude/scripts/lib/validate-model-aliases-extra.py` — Python canonical with argparse CLI (`--config`, `--block`, `--schema`, `--json`, `--quiet`)
- `.claude/scripts/lib/validate-model-aliases-extra.sh` — bash twin mirroring cycle-099 endpoint-validator.sh pattern (`python -I` isolated mode, `.venv/bin/python` preference, PATH fallback)

Exit codes: 0 valid · 78 invalid · 64 usage error.

### 3. 38 bats contract pins
`tests/unit/model-aliases-extra-schema.bats`:
- **E0**: POSITIVE CONTROL (SDD §4.2.1 UC-1 — operator adopts gpt-5.7-pro)
- **V1, V2**: VACUOUS (absent config / absent block — operator opt-in default state)
- **E1-E5**: STRUCTURAL (missing required fields rejected)
- **E6-E10**: TYPE (wrong-type values rejected)
- **E11-E15**: ENUM (invalid AND all-valid enum coverage; E15 covers all 4 providers × all 6 capabilities × all 4 endpoint_families)
- **E16-E18**: CONSTRAINTS (pattern / minLength / maxLength / range — incl. shell-metachar, path separator, whitespace, range bounds)
- **E19-E22**: SECURITY (auth field forbidden, glob `*` in id, additionalProperties at top + ModelExtra)
- **E23-E25**: PERMISSIONS (FR-1.4 acknowledge_permissions_baseline gate semantics)
- **B1-B3**: BASH TWIN (exit-code parity + --json passthrough)
- **S1-S3**: SCHEMA SMOKE (Draft 2020-12 well-formed, required-field enforcement, OPTIONAL fields)

## Local verification

194/194 pass across:
- `tests/unit/model-aliases-extra-schema.bats` (38 new)
- `tests/integration/endpoint-validator-*` (cumulative cycle-099)
- `tests/integration/model-health-probe-webhook-opt-in.bats`
- `tests/integration/cycle099-strict-curl-scan.bats`
- `tests/bash/golden_resolution.bats`

0 regressions. Production `.loa.config.yaml` validates cleanly.

## Sprint 2B+ integration path

Validator is invokable today by:
- Operators (`bash .claude/scripts/lib/validate-model-aliases-extra.sh`)
- CI (workflow: pre-commit / pre-merge check on `.loa.config.yaml`)
- Sprint 2B's startup hook (load + validate before consuming `model_aliases_extra`)
- Sprint 2C's FR-3.9 resolver (validate before resolution_path emits)

The schema is the **SHAPE** contract; loader integration is the **WIRING**. Sprint 2B will add a thin loader hook that calls this validator at the correct moment in the agent-startup sequence.

## Quality-gate chain

1. ✅ Implement test-first (38 bats including positive control + edge cases)
2. ⏳ Subagent dual-review (general-purpose + paranoid cypherpunk) — running next
3. ⏳ Bridgebuilder kaironic loop
4. ⏳ Admin-squash after plateau

## Refs

- SDD §3.2 (model_aliases_extra JSON Schema spec)
- SDD §4.2.1 (UC-1 worked example)
- DD-2 (top-level placement) + DD-5 (canonical path)
- Sprint plan T2.1 + AC-S2.1
- NFR-Sec-5 (auth field forbidden) + FR-1.4 (acknowledge_permissions_baseline gate)

## Test plan

- [x] All 38 schema bats pass
- [x] Bash twin parity (B1-B3 mirror exit codes)
- [x] Production `.loa.config.yaml` validates cleanly (no block → vacuous success)
- [x] 0 regressions across cycle-099 cumulative bats suite (194/194)
- [x] Schema is well-formed Draft 2020-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)