### PR TITLE
feat(cycle-099-sprint-2D.d): SC-14 property suite (T2.6 closure)

### DIFF
--- a/.github/workflows/cycle099-sprint-2d-d-property-nightly.yml
+++ b/.github/workflows/cycle099-sprint-2d-d-property-nightly.yml
@@ -3,9 +3,9 @@ name: cycle-099 Sprint 2D.d property suite (nightly stress)
 # cycle-099 Sprint 2D.d (T2.6 closure) — SC-14 nightly stress.
 #
 # Runs `tests/property/model-resolution-properties.bats` at the
-# nightly-stress iteration count (LOA_PROPERTY_ITERATIONS=1000, ~6000
-# cases total across the six FR-3.9 invariants per AC-S2.d.2). The
-# per-PR variant (100 iter) is in
+# nightly-stress iteration count (LOA_PROPERTY_ITERATIONS=1000, ~7000
+# cases total across the six FR-3.9 invariants + I7 positive S5 control
+# per AC-S2.d.2). The per-PR variant (100 iter) is in
 # `cycle099-sprint-2d-d-property.yml`.
 #
 # Cron: 06:00 UTC daily. Manual trigger via workflow_dispatch.

--- a/.github/workflows/cycle099-sprint-2d-d-property-nightly.yml
+++ b/.github/workflows/cycle099-sprint-2d-d-property-nightly.yml
@@ -75,7 +75,11 @@ jobs:
         # Cypherpunk HIGH-6: workflow_dispatch with iterations=1 lets a
         # malicious actor manually trigger and claim "nightly stress
         # passed" with 1 case per invariant. Floor at 100 to enforce
-        # meaningful stress; cap at 100,000 to prevent DoS.
+        # meaningful stress.
+        # BB iter-1 F14: cap at 10,000 (was 100,000). At ~270ms/iter ×
+        # 7 invariants × 10K = ~315 min — still over 60-min timeout, but
+        # we trust the timeout gate to catch absurd configs while the
+        # cap blocks the more obvious DoS scenarios. 100K was decorative.
         run: |
           set -euo pipefail
           iter='${{ github.event.inputs.iterations || '1000' }}'
@@ -87,8 +91,8 @@ jobs:
               echo "::error::iterations floor=100 (got=$iter); nightly stress requires meaningful coverage"
               exit 1
           fi
-          if (( iter > 100000 )); then
-              echo "::error::iterations cap=100000 (got=$iter); higher values risk timeout"
+          if (( iter > 10000 )); then
+              echo "::error::iterations cap=10000 (got=$iter); higher values risk timeout"
               exit 1
           fi
 

--- a/.github/workflows/cycle099-sprint-2d-d-property-nightly.yml
+++ b/.github/workflows/cycle099-sprint-2d-d-property-nightly.yml
@@ -1,0 +1,85 @@
+name: cycle-099 Sprint 2D.d property suite (nightly stress)
+
+# cycle-099 Sprint 2D.d (T2.6 closure) — SC-14 nightly stress.
+#
+# Runs `tests/property/model-resolution-properties.bats` at the
+# nightly-stress iteration count (LOA_PROPERTY_ITERATIONS=1000, ~6000
+# cases total across the six FR-3.9 invariants per AC-S2.d.2). The
+# per-PR variant (100 iter) is in
+# `cycle099-sprint-2d-d-property.yml`.
+#
+# Cron: 06:00 UTC daily. Manual trigger via workflow_dispatch.
+#
+# Per R-SDD-7 mitigation: seed base is logged on every run so operators
+# can reproduce a failure by running the bats locally with the same
+# LOA_PROPERTY_SEED_BASE.
+#
+# This workflow does NOT block PRs. It is informational; failures
+# surface via GitHub Actions notifications and require manual triage.
+
+on:
+  schedule:
+    # 06:00 UTC daily. SDD §7.3 — nightly stress complements per-PR
+    # invariant verification with broader state-space coverage.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Iterations per invariant (default 1000)'
+        required: false
+        default: '1000'
+      seed_base:
+        description: 'Seed base (default github.run_number)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cycle099-sprint-2d-d-property-nightly
+  cancel-in-progress: false
+
+jobs:
+  property-stress:
+    name: Sprint 2D.d nightly stress
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      # PINNING: SHA verified against actions/checkout v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # PINNING: SHA matches actions/setup-python v5.3.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.13'
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install 'pyyaml==6.0.2'
+
+      - name: Install yq v4.52.4 (pinned + checksum verified)
+        run: |
+          set -euo pipefail
+          local_yq=/usr/local/bin/yq
+          expected_sha256='0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c'
+          sudo wget -qO "$local_yq" https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "$expected_sha256  $local_yq" | sha256sum -c -
+          sudo chmod +x "$local_yq"
+
+      - name: Install bats-core + jq
+        run: sudo apt-get update && sudo apt-get install -y bats jq
+
+      - name: Run nightly stress (1000 iterations × 6 invariants)
+        env:
+          LOA_PROPERTY_ITERATIONS: ${{ github.event.inputs.iterations || '1000' }}
+          # Seed base falls back to github.run_id (always set) when no
+          # workflow_dispatch input is provided. This ensures every nightly
+          # run exercises a different slice of the seed space.
+          LOA_PROPERTY_SEED_BASE: ${{ github.event.inputs.seed_base || github.run_id }}
+        run: |
+          set -euo pipefail
+          echo "Property nightly stress seed base: $LOA_PROPERTY_SEED_BASE"
+          echo "Iterations per invariant:          $LOA_PROPERTY_ITERATIONS"
+          bats --print-output-on-failure tests/property/model-resolution-properties.bats

--- a/.github/workflows/cycle099-sprint-2d-d-property-nightly.yml
+++ b/.github/workflows/cycle099-sprint-2d-d-property-nightly.yml
@@ -71,7 +71,28 @@ jobs:
       - name: Install bats-core + jq
         run: sudo apt-get update && sudo apt-get install -y bats jq
 
-      - name: Run nightly stress (1000 iterations × 6 invariants)
+      - name: Validate dispatch inputs
+        # Cypherpunk HIGH-6: workflow_dispatch with iterations=1 lets a
+        # malicious actor manually trigger and claim "nightly stress
+        # passed" with 1 case per invariant. Floor at 100 to enforce
+        # meaningful stress; cap at 100,000 to prevent DoS.
+        run: |
+          set -euo pipefail
+          iter='${{ github.event.inputs.iterations || '1000' }}'
+          if ! [[ "$iter" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::iterations must be a positive integer; got=$iter"
+              exit 1
+          fi
+          if (( iter < 100 )); then
+              echo "::error::iterations floor=100 (got=$iter); nightly stress requires meaningful coverage"
+              exit 1
+          fi
+          if (( iter > 100000 )); then
+              echo "::error::iterations cap=100000 (got=$iter); higher values risk timeout"
+              exit 1
+          fi
+
+      - name: Run nightly stress (1000 iterations × 7 invariants)
         env:
           LOA_PROPERTY_ITERATIONS: ${{ github.event.inputs.iterations || '1000' }}
           # Seed base falls back to github.run_id (always set) when no

--- a/.github/workflows/cycle099-sprint-2d-d-property.yml
+++ b/.github/workflows/cycle099-sprint-2d-d-property.yml
@@ -3,9 +3,10 @@ name: cycle-099 Sprint 2D.d property suite (PR check)
 # cycle-099 Sprint 2D.d (T2.6 closure) — SC-14 property suite (per-PR check).
 #
 # Runs `tests/property/model-resolution-properties.bats` at the per-PR
-# iteration count (LOA_PROPERTY_ITERATIONS=100, ~600 cases total across the
-# six FR-3.9 invariants per AC-S2.d.1). Nightly stress at 1000 iterations is
-# in `cycle099-sprint-2d-d-property-nightly.yml`.
+# iteration count (LOA_PROPERTY_ITERATIONS=100, ~700 cases total across
+# the six FR-3.9 invariants + I7 positive S5 control per AC-S2.d.1).
+# Nightly stress at 1000 iterations is in
+# `cycle099-sprint-2d-d-property-nightly.yml`.
 #
 # Triggers on PRs that touch the resolver, the property generator, the
 # property bats, or this workflow itself. The workflow is also pushed on

--- a/.github/workflows/cycle099-sprint-2d-d-property.yml
+++ b/.github/workflows/cycle099-sprint-2d-d-property.yml
@@ -1,0 +1,80 @@
+name: cycle-099 Sprint 2D.d property suite (PR check)
+
+# cycle-099 Sprint 2D.d (T2.6 closure) — SC-14 property suite (per-PR check).
+#
+# Runs `tests/property/model-resolution-properties.bats` at the per-PR
+# iteration count (LOA_PROPERTY_ITERATIONS=100, ~600 cases total across the
+# six FR-3.9 invariants per AC-S2.d.1). Nightly stress at 1000 iterations is
+# in `cycle099-sprint-2d-d-property-nightly.yml`.
+#
+# Triggers on PRs that touch the resolver, the property generator, the
+# property bats, or this workflow itself. The workflow is also pushed on
+# main.
+#
+# Per AC-S2.d.3 the property runner shells out to the canonical Python
+# resolver (`python3 .claude/scripts/lib/model-resolver.py resolve`).
+
+on:
+  pull_request:
+    paths:
+      - '.claude/scripts/lib/model-resolver.py'
+      - '.claude/data/trajectory-schemas/model-resolver-output.schema.json'
+      - 'tests/property/lib/property-gen.bash'
+      - 'tests/property/model-resolution-properties.bats'
+      - '.github/workflows/cycle099-sprint-2d-d-property.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/scripts/lib/model-resolver.py'
+      - '.claude/data/trajectory-schemas/model-resolver-output.schema.json'
+      - 'tests/property/lib/property-gen.bash'
+      - 'tests/property/model-resolution-properties.bats'
+      - '.github/workflows/cycle099-sprint-2d-d-property.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cycle099-sprint-2d-d-property-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  property-suite:
+    name: Sprint 2D.d property suite (100 iter / invariant)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # PINNING: SHA verified against actions/checkout v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # PINNING: SHA matches actions/setup-python v5.3.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.13'
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install 'pyyaml==6.0.2'
+
+      - name: Install yq v4.52.4 (pinned + checksum verified)
+        run: |
+          set -euo pipefail
+          local_yq=/usr/local/bin/yq
+          expected_sha256='0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c'
+          sudo wget -qO "$local_yq" https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "$expected_sha256  $local_yq" | sha256sum -c -
+          sudo chmod +x "$local_yq"
+
+      - name: Install bats-core + jq
+        run: sudo apt-get update && sudo apt-get install -y bats jq
+
+      - name: Run property suite (100 iterations × 6 invariants)
+        env:
+          LOA_PROPERTY_ITERATIONS: '100'
+          LOA_PROPERTY_SEED_BASE: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          echo "Property suite seed base: $LOA_PROPERTY_SEED_BASE"
+          echo "Iterations per invariant: $LOA_PROPERTY_ITERATIONS"
+          bats --print-output-on-failure tests/property/model-resolution-properties.bats

--- a/.github/workflows/cycle099-sprint-2d-d-property.yml
+++ b/.github/workflows/cycle099-sprint-2d-d-property.yml
@@ -15,20 +15,25 @@ name: cycle-099 Sprint 2D.d property suite (PR check)
 # resolver (`python3 .claude/scripts/lib/model-resolver.py resolve`).
 
 on:
+  # Cypherpunk HIGH-5 fix: glob `tests/property/**` so future
+  # property test additions trigger this workflow without requiring
+  # a workflow file edit. Schema files included for completeness.
   pull_request:
     paths:
       - '.claude/scripts/lib/model-resolver.py'
       - '.claude/data/trajectory-schemas/model-resolver-output.schema.json'
-      - 'tests/property/lib/property-gen.bash'
-      - 'tests/property/model-resolution-properties.bats'
+      - '.claude/data/trajectory-schemas/model-aliases-extra.schema.json'
+      - '.claude/data/trajectory-schemas/model-aliases-override.schema.json'
+      - 'tests/property/**'
       - '.github/workflows/cycle099-sprint-2d-d-property.yml'
   push:
     branches: [main]
     paths:
       - '.claude/scripts/lib/model-resolver.py'
       - '.claude/data/trajectory-schemas/model-resolver-output.schema.json'
-      - 'tests/property/lib/property-gen.bash'
-      - 'tests/property/model-resolution-properties.bats'
+      - '.claude/data/trajectory-schemas/model-aliases-extra.schema.json'
+      - '.claude/data/trajectory-schemas/model-aliases-override.schema.json'
+      - 'tests/property/**'
       - '.github/workflows/cycle099-sprint-2d-d-property.yml'
 
 permissions:
@@ -69,10 +74,28 @@ jobs:
       - name: Install bats-core + jq
         run: sudo apt-get update && sudo apt-get install -y bats jq
 
-      - name: Run property suite (100 iterations × 6 invariants)
+      - name: Compute seed base from sha + run_id
+        # Cypherpunk MED-3: github.run_number is monotonic and predictable;
+        # an attacker can pad PRs to advance run_number past seeds where
+        # they engineered a resolver bug. Mixing in the PR's HEAD sha and
+        # the workflow run_id yields a non-attacker-controlled seed_base
+        # while remaining deterministic per-run (seed is logged for repro).
+        id: seed
+        run: |
+          set -euo pipefail
+          sb=$(printf '%s|%s' "${{ github.sha }}" "${{ github.run_id }}" \
+              | python3 -c 'import hashlib,sys; print(int(hashlib.sha256(sys.stdin.buffer.read()).hexdigest()[:8],16))')
+          # Ensure positive (sha256 prefix ⊆ 0..2^32-1 already; positive).
+          # Also ensure non-zero (bats setup() rejects zero).
+          if [[ -z "$sb" ]] || [[ "$sb" == "0" ]]; then
+              sb=1
+          fi
+          echo "seed_base=$sb" >> "$GITHUB_OUTPUT"
+
+      - name: Run property suite (100 iterations × 7 invariants)
         env:
           LOA_PROPERTY_ITERATIONS: '100'
-          LOA_PROPERTY_SEED_BASE: ${{ github.run_number }}
+          LOA_PROPERTY_SEED_BASE: ${{ steps.seed.outputs.seed_base }}
         run: |
           set -euo pipefail
           echo "Property suite seed base: $LOA_PROPERTY_SEED_BASE"

--- a/tests/property/lib/property-gen.bash
+++ b/tests/property/lib/property-gen.bash
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tests/property/lib/property-gen.bash
+#
+# cycle-099 Sprint 2D.d (T2.6 closure) — bash property generator for the
+# FR-3.9 6-stage resolver per SDD §5 + DD-6 + SC-14.
+#
+# Emits N random valid model-config + operator_config combinations to stdout
+# and exposes ~6 invariant-specific generator functions. Each invariant
+# generator accepts an integer seed and emits:
+#   * the merged-config YAML on stdout
+#   * a top-level `_property_query` block declaring which (skill, role) the
+#     test should query and the expected outcome shape
+#
+# The resolver (`.claude/scripts/lib/model-resolver.py`) ignores the
+# `_property_query` block — it only consumes `framework_defaults` /
+# `operator_config` / `runtime_state`. Bats consumes `_property_query` via
+# `yq` to drive the assertion.
+#
+# Determinism: SHA-256 of "${seed}|${tag}" → integer mod range. Same seed +
+# tag → same value, across hosts. CI logs the failing seed; operators
+# reproduce by setting LOA_PROPERTY_SEED=N and running the bats locally.
+#
+# Per DD-6: 0 new dependencies (python3 is already required by the resolver).
+# =============================================================================
+
+# Idempotent source guard.
+[[ "${LOA_PROPERTY_GEN_LOADED:-0}" == "1" ]] && return 0
+LOA_PROPERTY_GEN_LOADED=1
+
+# -----------------------------------------------------------------------------
+# Internal helpers
+# -----------------------------------------------------------------------------
+
+# Reject control-byte injection in seed/tag. These flow into a YAML scalar
+# (the generated config) and into Python via stdin; control bytes here
+# would either crash YAML parsing or smuggle line-continuation. The
+# resolver itself rejects [INPUT-CONTROL-BYTE], but the generator must
+# reject earlier so a buggy caller doesn't accidentally produce
+# error-shaped output that masquerades as a "real" property failure.
+_prop_assert_clean() {
+    local label="$1" val="$2"
+    if printf '%s' "$val" | LC_ALL=C grep -q '[[:cntrl:]]'; then
+        printf '[property-gen] %s contains control byte; refusing\n' "$label" >&2
+        return 1
+    fi
+    return 0
+}
+
+# Hash (seed,tag) → integer in [0, max). Stable across hosts (SHA-256).
+prop_rand_int() {
+    local seed="$1" tag="$2" max="$3"
+    _prop_assert_clean "seed" "$seed" || return 1
+    _prop_assert_clean "tag" "$tag" || return 1
+    if [[ -z "$max" ]] || ! [[ "$max" =~ ^[1-9][0-9]*$ ]]; then
+        printf '[property-gen] invalid max=%q\n' "$max" >&2
+        return 1
+    fi
+    printf '%s|%s' "$seed" "$tag" | LOA_PROP_MAX="$max" python3 -c '
+import hashlib, os, sys
+data = sys.stdin.buffer.read()
+m = int(os.environ["LOA_PROP_MAX"])
+print(int(hashlib.sha256(data).hexdigest()[:8], 16) % m)
+'
+}
+
+# Pick one element from a list deterministically by (seed, tag).
+prop_pick() {
+    local seed="$1" tag="$2"; shift 2
+    local n
+    n=$(prop_rand_int "$seed" "$tag" "$#") || return 1
+    # bash arrays are 1-indexed in `set --` positional context; n is 0-indexed
+    eval "printf '%s\n' \"\${$((n + 1))}\""
+}
+
+# Pool of values that satisfy the resolver's pattern constraints.
+# These also avoid known reserved tier names where the test contract
+# would be ambiguous.
+_PROP_PROVIDERS=(anthropic openai google operator-extra-vendor)
+_PROP_MODEL_IDS=(model-alpha-1 model-beta-2 model-gamma-3.4 model-delta_5 alpha.7 beta_9 m1 m2)
+_PROP_ALIAS_NAMES=(opus haiku sonnet flash gpt5 nova lite mini)
+_PROP_ALIAS_NAMES_PRO=(opus haiku sonnet)   # have *-pro variants in the framework block
+_PROP_SKILL_NAMES=(researcher writer reviewer flatline_protocol bridgebuilder gardener)
+_PROP_ROLE_NAMES=(primary secondary tertiary reviewer)
+_PROP_TIER_NAMES=(max cheap mid tiny)
+
+# -----------------------------------------------------------------------------
+# Invariant generators
+#
+# Contract: each function reads a single argument $seed (integer) and
+# emits exactly one merged-config YAML to stdout. The YAML's
+# `_property_query` block declares the (skill, role) tuple to query and
+# the expected outcome family. The bats runner reads both via yq.
+# -----------------------------------------------------------------------------
+
+# Invariant 1: when both `skill_models.<skill>.<role>: provider:model_id`
+# (S1) and legacy `<skill>.models.<role>: alias` (S4) are present, S1 wins.
+# Resolution path MUST start with stage 1; MUST NOT contain stage 4.
+prop_gen_inv1_config() {
+    local seed="$1"
+    local skill role provider model_id alias_name framework_target
+    skill=$(prop_pick "$seed" "inv1.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
+    role=$(prop_pick "$seed" "inv1.role" "${_PROP_ROLE_NAMES[@]}") || return 1
+    provider=$(prop_pick "$seed" "inv1.provider" "${_PROP_PROVIDERS[@]}") || return 1
+    model_id=$(prop_pick "$seed" "inv1.model_id" "${_PROP_MODEL_IDS[@]}") || return 1
+    alias_name=$(prop_pick "$seed" "inv1.alias" "${_PROP_ALIAS_NAMES[@]}") || return 1
+    framework_target=$(prop_pick "$seed" "inv1.framework_target" "${_PROP_MODEL_IDS[@]}") || return 1
+    cat <<YAML
+_property_query:
+  invariant: 1
+  skill: "$skill"
+  role: "$role"
+  expected_pin_provider: "$provider"
+  expected_pin_model_id: "$model_id"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $model_id:
+          context_window: 200000
+        $framework_target:
+          context_window: 100000
+  aliases:
+    $alias_name: { provider: $provider, model_id: $framework_target }
+  agents: {}
+operator_config:
+  skill_models:
+    $skill:
+      $role: "$provider:$model_id"
+  $skill:
+    models:
+      $role: $alias_name
+YAML
+}
+
+# Invariant 2: same id in BOTH `model_aliases_extra` and
+# `model_aliases_override` → `[MODEL-EXTRA-OVERRIDE-CONFLICT]` error
+# (stage 0). Never silent tiebreaker.
+prop_gen_inv2_config() {
+    local seed="$1"
+    local skill role conflict_id provider extra_target_id override_target_id
+    skill=$(prop_pick "$seed" "inv2.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
+    role=$(prop_pick "$seed" "inv2.role" "${_PROP_ROLE_NAMES[@]}") || return 1
+    conflict_id=$(prop_pick "$seed" "inv2.conflict" "${_PROP_ALIAS_NAMES[@]}") || return 1
+    provider=$(prop_pick "$seed" "inv2.provider" "${_PROP_PROVIDERS[@]}") || return 1
+    extra_target_id=$(prop_pick "$seed" "inv2.extra_target" "${_PROP_MODEL_IDS[@]}") || return 1
+    override_target_id=$(prop_pick "$seed" "inv2.override_target" "${_PROP_MODEL_IDS[@]}") || return 1
+    cat <<YAML
+_property_query:
+  invariant: 2
+  skill: "$skill"
+  role: "$role"
+  expected_error_code: "[MODEL-EXTRA-OVERRIDE-CONFLICT]"
+  expected_stage_failed: 0
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $extra_target_id:
+          context_window: 100000
+        $override_target_id:
+          context_window: 100000
+  aliases: {}
+  agents: {}
+operator_config:
+  model_aliases_extra:
+    $conflict_id: { provider: $provider, model_id: $extra_target_id }
+  model_aliases_override:
+    $conflict_id: { provider: $provider, model_id: $override_target_id }
+YAML
+}
+
+# Invariant 3: `prefer_pro_models: true` overlay always last in
+# resolution_path. Generates a config that resolves at S2 (direct alias
+# hit) with a known *-pro framework variant, AND `prefer_pro_models: true`.
+# Stage 6 entry MUST exist; MUST be the last entry of resolution_path.
+prop_gen_inv3_config() {
+    local seed="$1"
+    local skill role provider alias_base alias_pro
+    skill=$(prop_pick "$seed" "inv3.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
+    role=$(prop_pick "$seed" "inv3.role" "${_PROP_ROLE_NAMES[@]}") || return 1
+    provider=$(prop_pick "$seed" "inv3.provider" "${_PROP_PROVIDERS[@]}") || return 1
+    alias_base=$(prop_pick "$seed" "inv3.alias_base" "${_PROP_ALIAS_NAMES_PRO[@]}") || return 1
+    alias_pro="${alias_base}-pro"
+    cat <<YAML
+_property_query:
+  invariant: 3
+  skill: "$skill"
+  role: "$role"
+  expected_alias_base: "$alias_base"
+  expected_alias_pro: "$alias_pro"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        ${alias_base}-base-model:
+          context_window: 200000
+        ${alias_base}-pro-model:
+          context_window: 400000
+  aliases:
+    $alias_base: { provider: $provider, model_id: ${alias_base}-base-model }
+    $alias_pro: { provider: $provider, model_id: ${alias_base}-pro-model }
+  agents: {}
+operator_config:
+  prefer_pro_models: true
+  skill_models:
+    $skill:
+      $role: $alias_base
+YAML
+}
+
+# Invariant 4: deprecation warning emitted iff stage 4 was the resolution
+# path. Generates two flavours per seed (driven by a coin flip):
+#   * legacy_only=true  → only legacy `<skill>.models.<role>` set; expects
+#     stage4 hit + warning="[LEGACY-SHAPE-DEPRECATED]"
+#   * legacy_only=false → only `skill_models.<skill>.<role>` set, no legacy;
+#     expects NO warning anywhere
+# The biconditional: warning ⟺ stage 4 in resolution_path.
+prop_gen_inv4_config() {
+    local seed="$1"
+    local skill role provider alias_name model_target legacy_only_n legacy_only
+    skill=$(prop_pick "$seed" "inv4.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
+    role=$(prop_pick "$seed" "inv4.role" "${_PROP_ROLE_NAMES[@]}") || return 1
+    provider=$(prop_pick "$seed" "inv4.provider" "${_PROP_PROVIDERS[@]}") || return 1
+    alias_name=$(prop_pick "$seed" "inv4.alias" "${_PROP_ALIAS_NAMES[@]}") || return 1
+    model_target=$(prop_pick "$seed" "inv4.target" "${_PROP_MODEL_IDS[@]}") || return 1
+    legacy_only_n=$(prop_rand_int "$seed" "inv4.flavour" 2) || return 1
+    if [[ "$legacy_only_n" == "0" ]]; then
+        legacy_only="true"
+    else
+        legacy_only="false"
+    fi
+    cat <<YAML
+_property_query:
+  invariant: 4
+  skill: "$skill"
+  role: "$role"
+  legacy_only: $legacy_only
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $model_target:
+          context_window: 100000
+  aliases:
+    $alias_name: { provider: $provider, model_id: $model_target }
+  agents: {}
+operator_config:
+YAML
+    if [[ "$legacy_only" == "true" ]]; then
+        # Legacy shape only — S4 path
+        cat <<YAML
+  $skill:
+    models:
+      $role: $alias_name
+YAML
+    else
+        # Modern shape only — S2 direct-alias path; no legacy block
+        cat <<YAML
+  skill_models:
+    $skill:
+      $role: $alias_name
+YAML
+    fi
+}
+
+# Invariant 5: operator-set tier_groups.mappings precedence over framework
+# default. Generator sets DIFFERENT alias targets in operator vs framework
+# tier_groups for the same (tier, provider) cell, both aliases existing in
+# framework_aliases pointing to DIFFERENT models. Resolver MUST resolve via
+# the operator's alias.
+prop_gen_inv5_config() {
+    local seed="$1"
+    local skill role tier provider operator_alias framework_alias operator_target framework_target
+    skill=$(prop_pick "$seed" "inv5.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
+    role=$(prop_pick "$seed" "inv5.role" "${_PROP_ROLE_NAMES[@]}") || return 1
+    tier=$(prop_pick "$seed" "inv5.tier" "${_PROP_TIER_NAMES[@]}") || return 1
+    provider=$(prop_pick "$seed" "inv5.provider" "${_PROP_PROVIDERS[@]}") || return 1
+    # Two distinct alias names that both resolve in framework_aliases but
+    # point to distinct models. Suffixes guarantee distinctness without
+    # depending on prop_pick's randomness producing different values.
+    operator_alias=$(prop_pick "$seed" "inv5.opaa" "${_PROP_ALIAS_NAMES[@]}")-op || return 1
+    framework_alias=$(prop_pick "$seed" "inv5.fwaa" "${_PROP_ALIAS_NAMES[@]}")-fw || return 1
+    operator_target=$(prop_pick "$seed" "inv5.optgt" "${_PROP_MODEL_IDS[@]}")-operator || return 1
+    framework_target=$(prop_pick "$seed" "inv5.fwtgt" "${_PROP_MODEL_IDS[@]}")-framework || return 1
+    cat <<YAML
+_property_query:
+  invariant: 5
+  skill: "$skill"
+  role: "$role"
+  tier: "$tier"
+  expected_resolved_alias: "$operator_alias"
+  expected_resolved_model_id: "$operator_target"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $operator_target:
+          context_window: 100000
+        $framework_target:
+          context_window: 100000
+  aliases:
+    $operator_alias: { provider: $provider, model_id: $operator_target }
+    $framework_alias: { provider: $provider, model_id: $framework_target }
+  tier_groups:
+    mappings:
+      $tier:
+        $provider: $framework_alias
+  agents: {}
+operator_config:
+  tier_groups:
+    mappings:
+      $tier:
+        $provider: $operator_alias
+  skill_models:
+    $skill:
+      $role: $tier
+YAML
+}
+
+# Invariant 6: unmapped tier produces FR-3.8 fail-closed error
+# (`[TIER-NO-MAPPING]`); MUST NOT silently fall through to S5.
+# Generator sets:
+#   * a tier-tag in skill_models that resolves at S2 → cascades to S3
+#   * NO tier_groups.mappings for that tier (operator OR framework)
+#   * a working `agents.<skill>` that WOULD resolve at S5 if reached
+# The invariant is that resolver returns the S3 error, never the S5 hit.
+prop_gen_inv6_config() {
+    local seed="$1"
+    local skill role tier provider s5_alias s5_target
+    skill=$(prop_pick "$seed" "inv6.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
+    role=$(prop_pick "$seed" "inv6.role" "${_PROP_ROLE_NAMES[@]}") || return 1
+    tier=$(prop_pick "$seed" "inv6.tier" "${_PROP_TIER_NAMES[@]}") || return 1
+    provider=$(prop_pick "$seed" "inv6.provider" "${_PROP_PROVIDERS[@]}") || return 1
+    s5_alias=$(prop_pick "$seed" "inv6.s5_alias" "${_PROP_ALIAS_NAMES[@]}")-s5 || return 1
+    s5_target=$(prop_pick "$seed" "inv6.s5_target" "${_PROP_MODEL_IDS[@]}")-s5 || return 1
+    cat <<YAML
+_property_query:
+  invariant: 6
+  skill: "$skill"
+  role: "$role"
+  tier: "$tier"
+  expected_error_code: "[TIER-NO-MAPPING]"
+  expected_stage_failed: 3
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $s5_target:
+          context_window: 100000
+  aliases:
+    $s5_alias: { provider: $provider, model_id: $s5_target }
+  tier_groups:
+    mappings: {}
+  agents:
+    $skill:
+      model: $s5_alias
+operator_config:
+  skill_models:
+    $skill:
+      $role: $tier
+YAML
+}
+
+# -----------------------------------------------------------------------------
+# Invariant dispatcher (keeps the bats runner small).
+# -----------------------------------------------------------------------------
+
+prop_gen() {
+    local invariant="$1" seed="$2"
+    case "$invariant" in
+        1) prop_gen_inv1_config "$seed" ;;
+        2) prop_gen_inv2_config "$seed" ;;
+        3) prop_gen_inv3_config "$seed" ;;
+        4) prop_gen_inv4_config "$seed" ;;
+        5) prop_gen_inv5_config "$seed" ;;
+        6) prop_gen_inv6_config "$seed" ;;
+        *) printf '[property-gen] unknown invariant=%q\n' "$invariant" >&2; return 1 ;;
+    esac
+}

--- a/tests/property/lib/property-gen.bash
+++ b/tests/property/lib/property-gen.bash
@@ -65,21 +65,45 @@ print(int(hashlib.sha256(data).hexdigest()[:8], 16) % m)
 }
 
 # Pick one element from a list deterministically by (seed, tag).
+# Uses bash slice substitution `${@:idx:1}` instead of `eval` to keep the
+# code path metaprogramming-free (cypherpunk HIGH-4: avoid eval-on-positional).
+# Validates `n` post-Python (cypherpunk MED-6: bounds-check defense even
+# though prop_rand_int's mod-N already constrains n in [0, $#)).
 prop_pick() {
     local seed="$1" tag="$2"; shift 2
+    local count=$#
+    if (( count == 0 )); then
+        printf '[property-gen] prop_pick called with empty list\n' >&2
+        return 1
+    fi
     local n
-    n=$(prop_rand_int "$seed" "$tag" "$#") || return 1
-    # bash arrays are 1-indexed in `set --` positional context; n is 0-indexed
-    eval "printf '%s\n' \"\${$((n + 1))}\""
+    n=$(prop_rand_int "$seed" "$tag" "$count") || return 1
+    if ! [[ "$n" =~ ^(0|[1-9][0-9]*)$ ]] || (( n < 0 )) || (( n >= count )); then
+        printf '[property-gen] prop_pick got invalid n=%q (count=%q)\n' "$n" "$count" >&2
+        return 1
+    fi
+    printf '%s\n' "${@:$((n + 1)):1}"
 }
 
 # Pool of values that satisfy the resolver's pattern constraints.
 # These also avoid known reserved tier names where the test contract
 # would be ambiguous.
+#
+# Pool-design invariants:
+#   * `_PROP_ALIAS_NAMES` MUST NOT contain entries with `-pro` suffix —
+#     INV3 constructs `${alias_base}-pro` and registers it in
+#     framework_aliases; collision would create silent shadowing.
+#   * `_PROP_ALIAS_NAMES` and `_PROP_ALIAS_NAMES_PRO` MUST be disjoint
+#     from `_PROP_TIER_NAMES` (max/cheap/mid/tiny) — otherwise IMP-007
+#     alias-collides-with-tier triggers and the resolver takes the
+#     tier-tag interpretation, breaking direct-alias-path assertions.
 _PROP_PROVIDERS=(anthropic openai google operator-extra-vendor)
 _PROP_MODEL_IDS=(model-alpha-1 model-beta-2 model-gamma-3.4 model-delta_5 alpha.7 beta_9 m1 m2)
-_PROP_ALIAS_NAMES=(opus haiku sonnet flash gpt5 nova lite mini)
-_PROP_ALIAS_NAMES_PRO=(opus haiku sonnet)   # have *-pro variants in the framework block
+_PROP_ALIAS_NAMES=(opus haiku sonnet flash gpt5 nova lite gemini)
+# Cypherpunk MED-4: expanded from 3 → 8 entries to widen INV3's
+# distinct-config space from ~288 to ~768. Each entry has a `-pro`
+# variant registered by the inv3 generator at YAML emission time.
+_PROP_ALIAS_NAMES_PRO=(opus haiku sonnet flash nova premium expert deluxe)
 _PROP_SKILL_NAMES=(researcher writer reviewer flatline_protocol bridgebuilder gardener)
 _PROP_ROLE_NAMES=(primary secondary tertiary reviewer)
 _PROP_TIER_NAMES=(max cheap mid tiny)
@@ -96,6 +120,12 @@ _PROP_TIER_NAMES=(max cheap mid tiny)
 # Invariant 1: when both `skill_models.<skill>.<role>: provider:model_id`
 # (S1) and legacy `<skill>.models.<role>: alias` (S4) are present, S1 wins.
 # Resolution path MUST start with stage 1; MUST NOT contain stage 4.
+#
+# Cypherpunk HIGH-1: `framework_target` carries `-fwt` suffix to guarantee
+# disjointness from `model_id` (both pick from `_PROP_MODEL_IDS`).
+# Without the suffix, a 1/8 collision rate made the
+# `actual_model_id == expected_pin_model_id` assertion vacuously true on
+# ~12 of 100 iterations even if a buggy resolver took the S4 path.
 prop_gen_inv1_config() {
     local seed="$1"
     local skill role provider model_id alias_name framework_target
@@ -104,7 +134,7 @@ prop_gen_inv1_config() {
     provider=$(prop_pick "$seed" "inv1.provider" "${_PROP_PROVIDERS[@]}") || return 1
     model_id=$(prop_pick "$seed" "inv1.model_id" "${_PROP_MODEL_IDS[@]}") || return 1
     alias_name=$(prop_pick "$seed" "inv1.alias" "${_PROP_ALIAS_NAMES[@]}") || return 1
-    framework_target=$(prop_pick "$seed" "inv1.framework_target" "${_PROP_MODEL_IDS[@]}") || return 1
+    framework_target=$(prop_pick "$seed" "inv1.framework_target" "${_PROP_MODEL_IDS[@]}")-fwt || return 1
     cat <<YAML
 _property_query:
   invariant: 1
@@ -134,21 +164,36 @@ operator_config:
 YAML
 }
 
-# Invariant 2: same id in BOTH `model_aliases_extra` and
-# `model_aliases_override` → `[MODEL-EXTRA-OVERRIDE-CONFLICT]` error
-# (stage 0). Never silent tiebreaker.
+# Invariant 2: same-priority pre-validation mechanisms always produce
+# an error (stage 0). Never silent tiebreaker.
+#
+# Two flavours via `seed mod 2`:
+#   F0: id collides in `model_aliases_extra` and `model_aliases_override`
+#       → `[MODEL-EXTRA-OVERRIDE-CONFLICT]`
+#   F1: `model_aliases_override` targets unknown framework model_id
+#       → `[OVERRIDE-UNKNOWN-MODEL]`
+#
+# Cypherpunk MED-1: targets carry `-extra-tgt` / `-override-tgt` suffixes
+# to guarantee distinct framework_models keys (without suffix, both pick
+# from `_PROP_MODEL_IDS` with 1/8 collision rate, producing degenerate
+# same-target configs).
 prop_gen_inv2_config() {
     local seed="$1"
-    local skill role conflict_id provider extra_target_id override_target_id
+    local skill role conflict_id provider extra_target_id override_target_id flavour_n
     skill=$(prop_pick "$seed" "inv2.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
     role=$(prop_pick "$seed" "inv2.role" "${_PROP_ROLE_NAMES[@]}") || return 1
     conflict_id=$(prop_pick "$seed" "inv2.conflict" "${_PROP_ALIAS_NAMES[@]}") || return 1
     provider=$(prop_pick "$seed" "inv2.provider" "${_PROP_PROVIDERS[@]}") || return 1
-    extra_target_id=$(prop_pick "$seed" "inv2.extra_target" "${_PROP_MODEL_IDS[@]}") || return 1
-    override_target_id=$(prop_pick "$seed" "inv2.override_target" "${_PROP_MODEL_IDS[@]}") || return 1
-    cat <<YAML
+    extra_target_id=$(prop_pick "$seed" "inv2.extra_target" "${_PROP_MODEL_IDS[@]}")-extra-tgt || return 1
+    override_target_id=$(prop_pick "$seed" "inv2.override_target" "${_PROP_MODEL_IDS[@]}")-override-tgt || return 1
+    flavour_n=$(prop_rand_int "$seed" "inv2.flavour" 2) || return 1
+
+    if [[ "$flavour_n" == "0" ]]; then
+        # F0: extra + override id collision
+        cat <<YAML
 _property_query:
   invariant: 2
+  flavour: "extra_override_id_collision"
   skill: "$skill"
   role: "$role"
   expected_error_code: "[MODEL-EXTRA-OVERRIDE-CONFLICT]"
@@ -170,27 +215,131 @@ operator_config:
   model_aliases_override:
     $conflict_id: { provider: $provider, model_id: $override_target_id }
 YAML
+    else
+        # F1: override targets a model_id that is NOT in framework models
+        local unknown_id="${override_target_id}-not-in-framework"
+        cat <<YAML
+_property_query:
+  invariant: 2
+  flavour: "override_unknown_model"
+  skill: "$skill"
+  role: "$role"
+  expected_error_code: "[OVERRIDE-UNKNOWN-MODEL]"
+  expected_stage_failed: 0
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $extra_target_id:
+          context_window: 100000
+  aliases: {}
+  agents: {}
+operator_config:
+  model_aliases_override:
+    $conflict_id: { provider: $provider, model_id: $unknown_id }
+YAML
+    fi
 }
 
-# Invariant 3: `prefer_pro_models: true` overlay always last in
-# resolution_path. Generates a config that resolves at S2 (direct alias
-# hit) with a known *-pro framework variant, AND `prefer_pro_models: true`.
-# Stage 6 entry MUST exist; MUST be the last entry of resolution_path.
+# Invariant 3: `prefer_pro_models` overlay (S6) — exactness invariants:
+#   * `prefer_pro_models: false` (or absent) ⟹ NO stage 6 entry in path.
+#   * `prefer_pro_models: true`  ⟹ exactly one stage 6 entry, AND it is
+#     the LAST entry of resolution_path.
+#
+# Cypherpunk CRIT-1 / GP HIGH-1: multi-flavour generator covers all
+# distinct emission-paths so a regression that mis-orders S6 cannot ship
+# silently. Each invocation chooses one of 8 flavours via `seed mod 8`:
+#
+#   F0: prefer_pro=false, S2-direct-alias path → no S6 entry
+#   F1: prefer_pro=true,  S1-explicit-pin path  → S6 skipped:no_alias_to_overlay (last)
+#   F2: prefer_pro=true,  S2-direct-alias, with pro variant → S6 applied (last)
+#   F3: prefer_pro=true,  S2-direct-alias, NO pro variant → S6 skipped:no_pro_variant_for_alias (last)
+#   F4: prefer_pro=true,  S3-tier-cascade, with pro variant → S6 applied (last)
+#   F5: prefer_pro=true,  S4-legacy + respect_prefer_pro=true, with pro variant → S6 applied (last)
+#   F6: prefer_pro=true,  S4-legacy WITHOUT respect_prefer_pro → S6 skipped:legacy_shape_without_respect_prefer_pro (last)
+#   F7: prefer_pro=true,  S5-framework-default, with pro variant → S6 applied (last)
 prop_gen_inv3_config() {
     local seed="$1"
-    local skill role provider alias_base alias_pro
+    local skill role provider alias_base alias_pro flavour_n flavour
     skill=$(prop_pick "$seed" "inv3.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
     role=$(prop_pick "$seed" "inv3.role" "${_PROP_ROLE_NAMES[@]}") || return 1
     provider=$(prop_pick "$seed" "inv3.provider" "${_PROP_PROVIDERS[@]}") || return 1
     alias_base=$(prop_pick "$seed" "inv3.alias_base" "${_PROP_ALIAS_NAMES_PRO[@]}") || return 1
     alias_pro="${alias_base}-pro"
-    cat <<YAML
+    flavour_n=$(prop_rand_int "$seed" "inv3.flavour" 8) || return 1
+
+    case "$flavour_n" in
+        0)
+            flavour="prefer_pro_false_s2"
+            cat <<YAML
 _property_query:
   invariant: 3
+  flavour: "$flavour"
   skill: "$skill"
   role: "$role"
-  expected_alias_base: "$alias_base"
-  expected_alias_pro: "$alias_pro"
+  prefer_pro: false
+  expect_stage6_count: 0
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        ${alias_base}-base-model:
+          context_window: 200000
+        ${alias_base}-pro-model:
+          context_window: 400000
+  aliases:
+    $alias_base: { provider: $provider, model_id: ${alias_base}-base-model }
+    $alias_pro: { provider: $provider, model_id: ${alias_base}-pro-model }
+  agents: {}
+operator_config:
+  skill_models:
+    $skill:
+      $role: $alias_base
+YAML
+            ;;
+        1)
+            flavour="prefer_pro_true_s1_pin"
+            local target="${alias_base}-base-model"
+            cat <<YAML
+_property_query:
+  invariant: 3
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  prefer_pro: true
+  expect_stage6_count: 1
+  expect_stage6_outcome: "skipped"
+  expect_stage6_reason: "no_alias_to_overlay"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $target:
+          context_window: 200000
+  aliases: {}
+  agents: {}
+operator_config:
+  prefer_pro_models: true
+  skill_models:
+    $skill:
+      $role: "$provider:$target"
+YAML
+            ;;
+        2)
+            flavour="prefer_pro_true_s2_with_pro"
+            cat <<YAML
+_property_query:
+  invariant: 3
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  prefer_pro: true
+  expect_stage6_count: 1
+  expect_stage6_outcome: "applied"
+  expect_alias_pro: "$alias_pro"
 schema_version: 2
 framework_defaults:
   providers:
@@ -210,35 +359,222 @@ operator_config:
     $skill:
       $role: $alias_base
 YAML
+            ;;
+        3)
+            flavour="prefer_pro_true_s2_no_pro_variant"
+            # Use a different alias name (not from PRO pool) so no -pro
+            # variant exists. We register only the base alias.
+            local plain_alias
+            plain_alias=$(prop_pick "$seed" "inv3.plain" "${_PROP_ALIAS_NAMES[@]}") || return 1
+            cat <<YAML
+_property_query:
+  invariant: 3
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  prefer_pro: true
+  expect_stage6_count: 1
+  expect_stage6_outcome: "skipped"
+  expect_stage6_reason: "no_pro_variant_for_alias"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        ${plain_alias}-target:
+          context_window: 200000
+  aliases:
+    $plain_alias: { provider: $provider, model_id: ${plain_alias}-target }
+  agents: {}
+operator_config:
+  prefer_pro_models: true
+  skill_models:
+    $skill:
+      $role: $plain_alias
+YAML
+            ;;
+        4)
+            flavour="prefer_pro_true_s3_cascade_with_pro"
+            local tier
+            tier=$(prop_pick "$seed" "inv3.tier" "${_PROP_TIER_NAMES[@]}") || return 1
+            cat <<YAML
+_property_query:
+  invariant: 3
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  prefer_pro: true
+  expect_stage6_count: 1
+  expect_stage6_outcome: "applied"
+  expect_alias_pro: "$alias_pro"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        ${alias_base}-base-model:
+          context_window: 200000
+        ${alias_base}-pro-model:
+          context_window: 400000
+  aliases:
+    $alias_base: { provider: $provider, model_id: ${alias_base}-base-model }
+    $alias_pro: { provider: $provider, model_id: ${alias_base}-pro-model }
+  tier_groups:
+    mappings:
+      $tier:
+        $provider: $alias_base
+  agents: {}
+operator_config:
+  prefer_pro_models: true
+  skill_models:
+    $skill:
+      $role: $tier
+YAML
+            ;;
+        5)
+            flavour="prefer_pro_true_s4_with_respect"
+            cat <<YAML
+_property_query:
+  invariant: 3
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  prefer_pro: true
+  expect_stage6_count: 1
+  expect_stage6_outcome: "applied"
+  expect_alias_pro: "$alias_pro"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        ${alias_base}-base-model:
+          context_window: 200000
+        ${alias_base}-pro-model:
+          context_window: 400000
+  aliases:
+    $alias_base: { provider: $provider, model_id: ${alias_base}-base-model }
+    $alias_pro: { provider: $provider, model_id: ${alias_base}-pro-model }
+  agents: {}
+operator_config:
+  prefer_pro_models: true
+  $skill:
+    respect_prefer_pro: true
+    models:
+      $role: $alias_base
+YAML
+            ;;
+        6)
+            flavour="prefer_pro_true_s4_no_respect"
+            cat <<YAML
+_property_query:
+  invariant: 3
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  prefer_pro: true
+  expect_stage6_count: 1
+  expect_stage6_outcome: "skipped"
+  expect_stage6_reason: "legacy_shape_without_respect_prefer_pro"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        ${alias_base}-base-model:
+          context_window: 200000
+        ${alias_base}-pro-model:
+          context_window: 400000
+  aliases:
+    $alias_base: { provider: $provider, model_id: ${alias_base}-base-model }
+    $alias_pro: { provider: $provider, model_id: ${alias_base}-pro-model }
+  agents: {}
+operator_config:
+  prefer_pro_models: true
+  $skill:
+    models:
+      $role: $alias_base
+YAML
+            ;;
+        7)
+            flavour="prefer_pro_true_s5_with_pro"
+            cat <<YAML
+_property_query:
+  invariant: 3
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  prefer_pro: true
+  expect_stage6_count: 1
+  expect_stage6_outcome: "applied"
+  expect_alias_pro: "$alias_pro"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        ${alias_base}-base-model:
+          context_window: 200000
+        ${alias_base}-pro-model:
+          context_window: 400000
+  aliases:
+    $alias_base: { provider: $provider, model_id: ${alias_base}-base-model }
+    $alias_pro: { provider: $provider, model_id: ${alias_base}-pro-model }
+  agents:
+    $skill:
+      model: $alias_base
+operator_config:
+  prefer_pro_models: true
+YAML
+            ;;
+        *)
+            printf '[property-gen] inv3 unexpected flavour=%q\n' "$flavour_n" >&2
+            return 1
+            ;;
+    esac
 }
 
-# Invariant 4: deprecation warning emitted iff stage 4 was the resolution
-# path. Generates two flavours per seed (driven by a coin flip):
-#   * legacy_only=true  → only legacy `<skill>.models.<role>` set; expects
-#     stage4 hit + warning="[LEGACY-SHAPE-DEPRECATED]"
-#   * legacy_only=false → only `skill_models.<skill>.<role>` set, no legacy;
-#     expects NO warning anywhere
-# The biconditional: warning ⟺ stage 4 in resolution_path.
+# Invariant 4: deprecation warning emitted ⟺ stage 4 was the resolution
+# path. Strengthened to per-entry biconditional:
+#
+#   * any entry has `details.warning == "[LEGACY-SHAPE-DEPRECATED]"`
+#       ⟺ that entry's `label == "stage4_legacy_shape"`
+#
+# i.e., the warning never appears outside the S4 entry, AND every S4
+# resolution emits the warning.
+#
+# Cypherpunk CRIT-2 / GP HIGH-2: three flavours via `seed mod 3` cover
+# both the resolvable-S4-path AND the unresolvable-alias-falls-through
+# case (where stage 4 returns None, falling through to S5; biconditional
+# must still hold — no warning anywhere).
+#
+#   F0: legacy shape only, alias resolvable → S4 hit + warning
+#   F1: modern shape only (skill_models), no legacy block → no S4, no warning
+#   F2: legacy shape only, alias UNRESOLVABLE → S4 returns None, falls
+#       through to S5 (must be present); biconditional: no warning
 prop_gen_inv4_config() {
     local seed="$1"
-    local skill role provider alias_name model_target legacy_only_n legacy_only
+    local skill role provider alias_name model_target s5_alias s5_target flavour_n flavour
     skill=$(prop_pick "$seed" "inv4.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
     role=$(prop_pick "$seed" "inv4.role" "${_PROP_ROLE_NAMES[@]}") || return 1
     provider=$(prop_pick "$seed" "inv4.provider" "${_PROP_PROVIDERS[@]}") || return 1
     alias_name=$(prop_pick "$seed" "inv4.alias" "${_PROP_ALIAS_NAMES[@]}") || return 1
-    model_target=$(prop_pick "$seed" "inv4.target" "${_PROP_MODEL_IDS[@]}") || return 1
-    legacy_only_n=$(prop_rand_int "$seed" "inv4.flavour" 2) || return 1
-    if [[ "$legacy_only_n" == "0" ]]; then
-        legacy_only="true"
-    else
-        legacy_only="false"
-    fi
-    cat <<YAML
+    model_target=$(prop_pick "$seed" "inv4.target" "${_PROP_MODEL_IDS[@]}")-tgt || return 1
+    s5_alias=$(prop_pick "$seed" "inv4.s5_alias" "${_PROP_ALIAS_NAMES[@]}")-s5 || return 1
+    s5_target=$(prop_pick "$seed" "inv4.s5_target" "${_PROP_MODEL_IDS[@]}")-s5tgt || return 1
+    flavour_n=$(prop_rand_int "$seed" "inv4.flavour" 3) || return 1
+
+    case "$flavour_n" in
+        0)
+            flavour="legacy_resolvable"
+            cat <<YAML
 _property_query:
   invariant: 4
+  flavour: "$flavour"
   skill: "$skill"
   role: "$role"
-  legacy_only: $legacy_only
+  expect_warning: true
+  expect_stage4: true
 schema_version: 2
 framework_defaults:
   providers:
@@ -250,46 +586,111 @@ framework_defaults:
     $alias_name: { provider: $provider, model_id: $model_target }
   agents: {}
 operator_config:
-YAML
-    if [[ "$legacy_only" == "true" ]]; then
-        # Legacy shape only — S4 path
-        cat <<YAML
   $skill:
     models:
       $role: $alias_name
 YAML
-    else
-        # Modern shape only — S2 direct-alias path; no legacy block
-        cat <<YAML
+            ;;
+        1)
+            flavour="modern_no_legacy"
+            cat <<YAML
+_property_query:
+  invariant: 4
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  expect_warning: false
+  expect_stage4: false
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $model_target:
+          context_window: 100000
+  aliases:
+    $alias_name: { provider: $provider, model_id: $model_target }
+  agents: {}
+operator_config:
   skill_models:
     $skill:
       $role: $alias_name
 YAML
-    fi
+            ;;
+        2)
+            flavour="legacy_unresolvable_falls_to_s5"
+            # Legacy shape references an alias name that does NOT exist
+            # in framework_aliases. Stage 4 returns None per resolver
+            # `_stage4_legacy_shape:467`; falls through to stage 5 where
+            # `agents.<skill>.model` resolves the alternate alias. No
+            # warning emitted anywhere along this path — the resolver
+            # only emits the S4 warning when S4 successfully returns.
+            cat <<YAML
+_property_query:
+  invariant: 4
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  expect_warning: false
+  expect_stage4: false
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $s5_target:
+          context_window: 100000
+  aliases:
+    $s5_alias: { provider: $provider, model_id: $s5_target }
+  agents:
+    $skill:
+      model: $s5_alias
+operator_config:
+  $skill:
+    models:
+      $role: $alias_name-unresolvable
+YAML
+            ;;
+        *)
+            printf '[property-gen] inv4 unexpected flavour=%q\n' "$flavour_n" >&2
+            return 1
+            ;;
+    esac
 }
 
 # Invariant 5: operator-set tier_groups.mappings precedence over framework
 # default. Generator sets DIFFERENT alias targets in operator vs framework
-# tier_groups for the same (tier, provider) cell, both aliases existing in
-# framework_aliases pointing to DIFFERENT models. Resolver MUST resolve via
-# the operator's alias.
+# tier_groups for the same (tier, provider) cell. Resolver MUST resolve
+# via the operator's alias.
+#
+# GP MED-1: two flavours probe the precedence at different granularities:
+#   F0: single-provider, both operator and framework have same provider
+#       under the tier with different aliases → tests value precedence.
+#   F1: multi-provider, operator declares 2 providers under tier and
+#       framework declares 2 different providers — verifies the resolver
+#       picks `provider=sorted(operator_keys)[0]`, NOT a framework key.
+#
+# Cypherpunk HIGH-3: bats also asserts `has_stage5=false` so a resolver
+# bug that "took stage3 correctly but ALSO emitted stage5" surfaces.
 prop_gen_inv5_config() {
     local seed="$1"
-    local skill role tier provider operator_alias framework_alias operator_target framework_target
+    local skill role tier provider operator_alias framework_alias operator_target framework_target flavour_n flavour
     skill=$(prop_pick "$seed" "inv5.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
     role=$(prop_pick "$seed" "inv5.role" "${_PROP_ROLE_NAMES[@]}") || return 1
     tier=$(prop_pick "$seed" "inv5.tier" "${_PROP_TIER_NAMES[@]}") || return 1
     provider=$(prop_pick "$seed" "inv5.provider" "${_PROP_PROVIDERS[@]}") || return 1
-    # Two distinct alias names that both resolve in framework_aliases but
-    # point to distinct models. Suffixes guarantee distinctness without
-    # depending on prop_pick's randomness producing different values.
     operator_alias=$(prop_pick "$seed" "inv5.opaa" "${_PROP_ALIAS_NAMES[@]}")-op || return 1
     framework_alias=$(prop_pick "$seed" "inv5.fwaa" "${_PROP_ALIAS_NAMES[@]}")-fw || return 1
     operator_target=$(prop_pick "$seed" "inv5.optgt" "${_PROP_MODEL_IDS[@]}")-operator || return 1
     framework_target=$(prop_pick "$seed" "inv5.fwtgt" "${_PROP_MODEL_IDS[@]}")-framework || return 1
-    cat <<YAML
+    flavour_n=$(prop_rand_int "$seed" "inv5.flavour" 2) || return 1
+
+    if [[ "$flavour_n" == "0" ]]; then
+        flavour="single_provider"
+        cat <<YAML
 _property_query:
   invariant: 5
+  flavour: "$flavour"
   skill: "$skill"
   role: "$role"
   tier: "$tier"
@@ -321,6 +722,68 @@ operator_config:
     $skill:
       $role: $tier
 YAML
+    else
+        flavour="multi_provider"
+        # Operator has providers `op1` and `op2`; framework has `op2`
+        # and `op3`. Resolver picks `provider=sorted(op1, op2)[0]=op1`.
+        # The operator-keys are what's sorted, NOT the framework's.
+        # This catches bugs where the resolver picks from
+        # framework_tier_mappings.keys() when it shouldn't.
+        local op1="provider-aaa"
+        local op2="provider-bbb"
+        local op3="provider-ccc"
+        local op1_alias="${operator_alias}-op1"
+        local op1_target="${operator_target}-op1"
+        local op2_alias="${operator_alias}-op2"
+        local op2_target="${operator_target}-op2"
+        local op3_alias="${framework_alias}-op3"
+        local op3_target="${framework_target}-op3"
+        cat <<YAML
+_property_query:
+  invariant: 5
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  tier: "$tier"
+  expected_resolved_alias: "$op1_alias"
+  expected_resolved_model_id: "$op1_target"
+  expected_resolved_provider: "$op1"
+schema_version: 2
+framework_defaults:
+  providers:
+    $op1:
+      models:
+        $op1_target:
+          context_window: 100000
+    $op2:
+      models:
+        $op2_target:
+          context_window: 100000
+    $op3:
+      models:
+        $op3_target:
+          context_window: 100000
+  aliases:
+    $op1_alias: { provider: $op1, model_id: $op1_target }
+    $op2_alias: { provider: $op2, model_id: $op2_target }
+    $op3_alias: { provider: $op3, model_id: $op3_target }
+  tier_groups:
+    mappings:
+      $tier:
+        $op2: $op2_alias
+        $op3: $op3_alias
+  agents: {}
+operator_config:
+  tier_groups:
+    mappings:
+      $tier:
+        $op1: $op1_alias
+        $op2: $op2_alias
+  skill_models:
+    $skill:
+      $role: $tier
+YAML
+    fi
 }
 
 # Invariant 6: unmapped tier produces FR-3.8 fail-closed error
@@ -368,6 +831,86 @@ operator_config:
 YAML
 }
 
+# Invariant 7: positive S5 control — when no `skill_models` and no
+# legacy `<skill>.models.<role>` are set, but `agents.<skill>.{model,
+# default_tier}` IS set, the resolver MUST hit S5 (`stage5_framework_default`)
+# and produce the expected provider/model_id.
+#
+# Cypherpunk HIGH-3: I6 asserts "S5 not in resolution_path" when tier is
+# unmapped. Without a positive control, a regression that broke S5
+# entirely (always returns None) would still pass I6. I7 is the positive
+# counterpart: under the right config, S5 must hit.
+#
+# Two flavours via `seed mod 2`:
+#   F0: agents.<skill>.model directly set → S5 hit via direct model alias
+#   F1: agents.<skill>.default_tier set + tier_groups.mappings populated
+#       → S5 hit via default_tier cascade
+prop_gen_inv7_config() {
+    local seed="$1"
+    local skill role provider alias_name model_target tier flavour_n flavour
+    skill=$(prop_pick "$seed" "inv7.skill" "${_PROP_SKILL_NAMES[@]}") || return 1
+    role=$(prop_pick "$seed" "inv7.role" "${_PROP_ROLE_NAMES[@]}") || return 1
+    provider=$(prop_pick "$seed" "inv7.provider" "${_PROP_PROVIDERS[@]}") || return 1
+    alias_name=$(prop_pick "$seed" "inv7.alias" "${_PROP_ALIAS_NAMES[@]}") || return 1
+    model_target=$(prop_pick "$seed" "inv7.target" "${_PROP_MODEL_IDS[@]}")-s5 || return 1
+    tier=$(prop_pick "$seed" "inv7.tier" "${_PROP_TIER_NAMES[@]}") || return 1
+    flavour_n=$(prop_rand_int "$seed" "inv7.flavour" 2) || return 1
+
+    if [[ "$flavour_n" == "0" ]]; then
+        flavour="agents_direct_model"
+        cat <<YAML
+_property_query:
+  invariant: 7
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  expected_resolved_provider: "$provider"
+  expected_resolved_model_id: "$model_target"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $model_target:
+          context_window: 100000
+  aliases:
+    $alias_name: { provider: $provider, model_id: $model_target }
+  agents:
+    $skill:
+      model: $alias_name
+operator_config: {}
+YAML
+    else
+        flavour="agents_default_tier"
+        cat <<YAML
+_property_query:
+  invariant: 7
+  flavour: "$flavour"
+  skill: "$skill"
+  role: "$role"
+  expected_resolved_provider: "$provider"
+  expected_resolved_model_id: "$model_target"
+schema_version: 2
+framework_defaults:
+  providers:
+    $provider:
+      models:
+        $model_target:
+          context_window: 100000
+  aliases:
+    $alias_name: { provider: $provider, model_id: $model_target }
+  tier_groups:
+    mappings:
+      $tier:
+        $provider: $alias_name
+  agents:
+    $skill:
+      default_tier: $tier
+operator_config: {}
+YAML
+    fi
+}
+
 # -----------------------------------------------------------------------------
 # Invariant dispatcher (keeps the bats runner small).
 # -----------------------------------------------------------------------------
@@ -381,6 +924,7 @@ prop_gen() {
         4) prop_gen_inv4_config "$seed" ;;
         5) prop_gen_inv5_config "$seed" ;;
         6) prop_gen_inv6_config "$seed" ;;
+        7) prop_gen_inv7_config "$seed" ;;
         *) printf '[property-gen] unknown invariant=%q\n' "$invariant" >&2; return 1 ;;
     esac
 }

--- a/tests/property/model-resolution-properties.bats
+++ b/tests/property/model-resolution-properties.bats
@@ -7,17 +7,31 @@
 # Verifies the six FR-3.9 invariants on ~100 random valid configs per
 # invariant per CI run; nightly stress runs at ~1000 iterations.
 #
-# Six invariants (per FR-3.9 v1.2 SC-14):
+# Six invariants (per FR-3.9 v1.2 SC-14) plus one positive S5 control:
 #   I1. (S1) and (S4) both present → (S1) wins.
-#   I2. Two same-priority mechanisms always produce error
-#       (extra+override id collision → [MODEL-EXTRA-OVERRIDE-CONFLICT]).
-#   I3. prefer_pro overlay always applied last (S6 entry, when present,
-#       is the last entry in resolution_path).
-#   I4. Deprecation warning emitted ⟺ S4 was the resolution path.
+#   I2. Two same-priority pre-validation mechanisms always produce error
+#       (extra+override id collision → [MODEL-EXTRA-OVERRIDE-CONFLICT];
+#       override-targets-unknown-id → [OVERRIDE-UNKNOWN-MODEL]).
+#   I3. prefer_pro overlay invariants:
+#         * prefer_pro=false ⟹ no S6 entry in resolution_path
+#         * prefer_pro=true  ⟹ exactly one S6 entry, and it is LAST
+#       Multi-flavour generator covers all 5 S6-emission paths
+#       (post-S1, post-S2, post-S3, post-S4 (with/without respect),
+#       post-S5) plus applied/skipped variants.
+#   I4. Per-entry biconditional: deprecation warning ⟺ stage4 entry.
+#       Multi-flavour generator covers legacy-resolvable / modern-only /
+#       legacy-unresolvable-falls-to-S5.
 #   I5. Operator-set tier_groups mapping resolves before framework default
 #       when both define the same (tier, provider) mapping.
+#       Multi-flavour generator covers single-provider and multi-provider
+#       (verifies `provider=sorted(operator_keys)[0]`, not framework's).
 #   I6. Unmapped tier produces [TIER-NO-MAPPING] (stage_failed=3); never
 #       silently falls through to S5.
+#   I7. (positive S5 control) framework_defaults `agents.<skill>` resolves
+#       cleanly via S5 when no operator overrides are set. Multi-flavour
+#       covers `agents.<skill>.model` direct and `agents.<skill>.default_tier`
+#       cascade. Catches a regression where S5 always returns None — a
+#       failure mode that the negative-only I6 cannot detect.
 #
 # Determinism: each iteration's seed is `${LOA_PROPERTY_SEED_BASE} + i`.
 # Default base=1, default iterations=100. Operators reproduce a CI failure
@@ -49,9 +63,23 @@ setup_file() {
 }
 
 setup() {
-    command -v jq >/dev/null 2>&1 || skip "jq not present"
-    command -v yq >/dev/null 2>&1 || skip "yq not present"
-    command -v python3 >/dev/null 2>&1 || skip "python3 not present"
+    # Cypherpunk MED-5: in CI (`$CI` is set by GitHub Actions), tool
+    # absence is a hard failure, not a skip. Skipping in CI silently
+    # turns red checks green.
+    _tool_check() {
+        local tool="$1"
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            if [[ -n "${CI:-}" ]]; then
+                printf '[property-bats] FATAL: %s not present in CI\n' "$tool" >&2
+                return 1
+            else
+                skip "$tool not present"
+            fi
+        fi
+    }
+    _tool_check jq
+    _tool_check yq
+    _tool_check python3
     # shellcheck source=tests/property/lib/property-gen.bash
     source "$PROPERTY_GEN_LIB"
     WORK_DIR="$(mktemp -d)"
@@ -102,19 +130,40 @@ _read_query() {
 }
 
 # Pretty failure dump for reproducibility.
+# Cypherpunk HIGH-7: control bytes in any stream are stripped before
+# emission to CI logs. Even though hardcoded pools today contain none,
+# resolver stderr may carry attacker-controlled bytes from a future
+# diagnostic-leak path; pre-emptive strip prevents terminal-control-
+# sequence injection into CI runner stdout.
 _dump_failure() {
     local invariant="$1" seed="$2" detail="$3"
+    local strip_ctl='tr -d \000-\010\013-\037'
     {
         printf '\n========== property-fail invariant=%s seed=%s ==========\n' "$invariant" "$seed"
         printf '%s\n' "$detail"
         printf '----- config -----\n'
-        cat "$CFG"
+        # shellcheck disable=SC2002
+        if [[ -s "$CFG" ]]; then
+            cat "$CFG" | tr -d '\000-\010\013-\037'
+        else
+            printf '[empty]\n'
+        fi
         printf '\n----- resolver output -----\n'
-        cat "$OUT" 2>/dev/null || true
+        if [[ -s "$OUT" ]]; then
+            tr -d '\000-\010\013-\037' < "$OUT"
+        else
+            printf '[empty]\n'
+        fi
         printf '\n----- resolver stderr -----\n'
-        cat "$WORK_DIR/stderr.log" 2>/dev/null || true
+        if [[ -s "$WORK_DIR/stderr.log" ]]; then
+            tr -d '\000-\010\013-\037' < "$WORK_DIR/stderr.log"
+        else
+            printf '[empty]\n'
+        fi
         printf '----- end -----\n'
     } >&2
+    # Suppress unused-variable warning for the strip_ctl reference above.
+    : "$strip_ctl"
 }
 
 # ---------------------------------------------------------------------
@@ -161,8 +210,8 @@ _dump_failure() {
 # ---------------------------------------------------------------------
 # Invariant 2 — same id in extra+override → MODEL-EXTRA-OVERRIDE-CONFLICT
 # ---------------------------------------------------------------------
-@test "I2: model_aliases_extra/override id collision yields error, never silent tiebreaker" {
-    local i seed skill role expected_code expected_stage
+@test "I2: same-priority pre-validation mechanisms always produce error (extra/override collision OR override-unknown-id)" {
+    local i seed skill role flavour expected_code expected_stage
     local actual_code actual_stage has_resolution_path
     for ((i=0; i<ITER; i++)); do
         seed=$((BASE + i))
@@ -171,35 +220,36 @@ _dump_failure() {
             return 1
         }
         _read_query skill role
+        flavour=$(yq '._property_query.flavour' "$CFG")
         expected_code=$(yq '._property_query.expected_error_code' "$CFG")
         expected_stage=$(yq '._property_query.expected_stage_failed' "$CFG")
-        _run_resolver "$skill" "$role" || { _dump_failure 2 "$seed" "resolver crashed"; return 1; }
+        _run_resolver "$skill" "$role" || { _dump_failure 2 "$seed" "resolver crashed (flavour=$flavour)"; return 1; }
 
         actual_code=$(jq -r '.error.code // empty' "$OUT")
         actual_stage=$(jq -r '.error.stage_failed // empty' "$OUT")
         has_resolution_path=$(jq -r 'has("resolution_path")' "$OUT")
 
         if [[ "$actual_code" != "$expected_code" ]]; then
-            _dump_failure 2 "$seed" "expected error.code=$expected_code got=$actual_code"
+            _dump_failure 2 "$seed" "flavour=$flavour expected error.code=$expected_code got=$actual_code"
             return 1
         fi
         if [[ "$actual_stage" != "$expected_stage" ]]; then
-            _dump_failure 2 "$seed" "expected error.stage_failed=$expected_stage got=$actual_stage"
+            _dump_failure 2 "$seed" "flavour=$flavour expected error.stage_failed=$expected_stage got=$actual_stage"
             return 1
         fi
         if [[ "$has_resolution_path" != "false" ]]; then
-            _dump_failure 2 "$seed" "resolution_path unexpectedly present alongside error"
+            _dump_failure 2 "$seed" "flavour=$flavour resolution_path unexpectedly present alongside error"
             return 1
         fi
     done
 }
 
 # ---------------------------------------------------------------------
-# Invariant 3 — prefer_pro overlay (S6) always applied last
+# Invariant 3 — prefer_pro overlay (S6) ordering exactness
 # ---------------------------------------------------------------------
-@test "I3: stage6 entry, when present, is always the last entry in resolution_path" {
-    local i seed skill role expected_alias_base expected_alias_pro
-    local last_stage last_label last_to last_outcome path_len last_idx
+@test "I3: prefer_pro=false ⟹ no S6 entry; prefer_pro=true ⟹ exactly one S6 entry, and it is LAST" {
+    local i seed skill role flavour prefer_pro expected_count expected_outcome expected_reason expected_alias_pro
+    local stage6_count last_stage last_label last_outcome last_reason last_to path_len last_idx
     for ((i=0; i<ITER; i++)); do
         seed=$((BASE + i))
         prop_gen_inv3_config "$seed" > "$CFG" || {
@@ -207,46 +257,93 @@ _dump_failure() {
             return 1
         }
         _read_query skill role
-        expected_alias_base=$(yq '._property_query.expected_alias_base' "$CFG")
-        expected_alias_pro=$(yq '._property_query.expected_alias_pro' "$CFG")
-        _run_resolver "$skill" "$role" || { _dump_failure 3 "$seed" "resolver crashed"; return 1; }
+        flavour=$(yq '._property_query.flavour' "$CFG")
+        prefer_pro=$(yq '._property_query.prefer_pro' "$CFG")
+        expected_count=$(yq '._property_query.expect_stage6_count' "$CFG")
+        expected_outcome=$(yq '._property_query.expect_stage6_outcome // ""' "$CFG")
+        expected_reason=$(yq '._property_query.expect_stage6_reason // ""' "$CFG")
+        expected_alias_pro=$(yq '._property_query.expect_alias_pro // ""' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 3 "$seed" "resolver crashed (flavour=$flavour)"; return 1; }
+
+        # Count of stage 6 entries (must be 0 or 1).
+        stage6_count=$(jq -r '[.resolution_path[]?.stage // empty] | map(select(. == 6)) | length' "$OUT")
+        if [[ "$stage6_count" != "$expected_count" ]]; then
+            _dump_failure 3 "$seed" "flavour=$flavour expected stage6_count=$expected_count got=$stage6_count"
+            return 1
+        fi
 
         path_len=$(jq -r '.resolution_path | length' "$OUT")
         if [[ -z "$path_len" ]] || [[ "$path_len" == "null" ]] || [[ "$path_len" == "0" ]]; then
-            _dump_failure 3 "$seed" "expected non-empty resolution_path"
+            _dump_failure 3 "$seed" "flavour=$flavour expected non-empty resolution_path"
             return 1
         fi
         last_idx=$((path_len - 1))
-        last_stage=$(jq -r ".resolution_path[$last_idx].stage" "$OUT")
-        last_label=$(jq -r ".resolution_path[$last_idx].label" "$OUT")
-        last_outcome=$(jq -r ".resolution_path[$last_idx].outcome" "$OUT")
-        last_to=$(jq -r ".resolution_path[$last_idx].details.to // empty" "$OUT")
 
-        if [[ "$last_stage" != "6" ]]; then
-            _dump_failure 3 "$seed" "expected last stage=6 got=$last_stage"
-            return 1
-        fi
-        if [[ "$last_label" != "stage6_prefer_pro_overlay" ]]; then
-            _dump_failure 3 "$seed" "expected last label=stage6_prefer_pro_overlay got=$last_label"
-            return 1
-        fi
-        if [[ "$last_outcome" != "applied" ]]; then
-            _dump_failure 3 "$seed" "expected last outcome=applied got=$last_outcome"
-            return 1
-        fi
-        if [[ "$last_to" != "$expected_alias_pro" ]]; then
-            _dump_failure 3 "$seed" "expected stage6.details.to=$expected_alias_pro got=$last_to"
-            return 1
+        if [[ "$prefer_pro" == "false" ]]; then
+            # No S6 entry should appear anywhere; this is the negative
+            # control. Path resolves via S2 direct alias.
+            last_stage=$(jq -r ".resolution_path[$last_idx].stage" "$OUT")
+            if [[ "$last_stage" == "6" ]]; then
+                _dump_failure 3 "$seed" "flavour=$flavour prefer_pro=false but stage6 present at last"
+                return 1
+            fi
+        else
+            # prefer_pro=true: stage 6 MUST be the last entry, AND no
+            # stage 6 may appear at any non-last index.
+            last_stage=$(jq -r ".resolution_path[$last_idx].stage" "$OUT")
+            last_label=$(jq -r ".resolution_path[$last_idx].label" "$OUT")
+            last_outcome=$(jq -r ".resolution_path[$last_idx].outcome" "$OUT")
+            last_reason=$(jq -r ".resolution_path[$last_idx].details.reason // empty" "$OUT")
+            last_to=$(jq -r ".resolution_path[$last_idx].details.to // empty" "$OUT")
+            if [[ "$last_stage" != "6" ]]; then
+                _dump_failure 3 "$seed" "flavour=$flavour expected last stage=6 got=$last_stage"
+                return 1
+            fi
+            if [[ "$last_label" != "stage6_prefer_pro_overlay" ]]; then
+                _dump_failure 3 "$seed" "flavour=$flavour expected last label=stage6_prefer_pro_overlay got=$last_label"
+                return 1
+            fi
+            # Per-flavour outcome assertion.
+            if [[ -n "$expected_outcome" ]] && [[ "$last_outcome" != "$expected_outcome" ]]; then
+                _dump_failure 3 "$seed" "flavour=$flavour expected last outcome=$expected_outcome got=$last_outcome"
+                return 1
+            fi
+            # When `applied`, verify the retargeted alias name; when
+            # `skipped`, verify the skip reason.
+            if [[ "$last_outcome" == "applied" ]] && [[ -n "$expected_alias_pro" ]]; then
+                if [[ "$last_to" != "$expected_alias_pro" ]]; then
+                    _dump_failure 3 "$seed" "flavour=$flavour expected stage6.details.to=$expected_alias_pro got=$last_to"
+                    return 1
+                fi
+            fi
+            if [[ "$last_outcome" == "skipped" ]] && [[ -n "$expected_reason" ]]; then
+                if [[ "$last_reason" != "$expected_reason" ]]; then
+                    _dump_failure 3 "$seed" "flavour=$flavour expected stage6.details.reason=$expected_reason got=$last_reason"
+                    return 1
+                fi
+            fi
+            # Defense-in-depth: also verify that no stage 6 entry exists
+            # at any non-last index. The stage6_count==1 above is a
+            # sufficient check (stage6_count==1 + last==6 ⟹ no stage 6
+            # at non-last index), but we surface a clearer error if the
+            # invariant is violated.
+            local stage6_at_non_last
+            stage6_at_non_last=$(jq -r --argjson last "$last_idx" \
+                '[.resolution_path | to_entries[] | select(.value.stage == 6 and .key != $last)] | length' "$OUT")
+            if [[ "$stage6_at_non_last" != "0" ]]; then
+                _dump_failure 3 "$seed" "flavour=$flavour stage 6 entry at non-last index ($stage6_at_non_last entries)"
+                return 1
+            fi
         fi
     done
 }
 
 # ---------------------------------------------------------------------
-# Invariant 4 — deprecation warning emitted ⟺ S4 was the resolution path
+# Invariant 4 — deprecation warning emitted ⟺ stage 4 entry (per-entry)
 # ---------------------------------------------------------------------
-@test "I4: deprecation warning iff stage4 was on the resolution path (biconditional)" {
-    local i seed skill role legacy_only
-    local has_stage4 has_warning
+@test "I4: deprecation warning ⟺ stage 4 entry — per-entry biconditional" {
+    local i seed skill role flavour expect_warning expect_stage4
+    local has_stage4 has_warning warning_only_on_stage4 stage4_always_has_warning
     for ((i=0; i<ITER; i++)); do
         seed=$((BASE + i))
         prop_gen_inv4_config "$seed" > "$CFG" || {
@@ -254,36 +351,47 @@ _dump_failure() {
             return 1
         }
         _read_query skill role
-        legacy_only=$(yq '._property_query.legacy_only' "$CFG")
-        _run_resolver "$skill" "$role" || { _dump_failure 4 "$seed" "resolver crashed"; return 1; }
+        flavour=$(yq '._property_query.flavour' "$CFG")
+        expect_warning=$(yq '._property_query.expect_warning' "$CFG")
+        expect_stage4=$(yq '._property_query.expect_stage4' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 4 "$seed" "resolver crashed (flavour=$flavour)"; return 1; }
 
         has_stage4=$(jq -r '[.resolution_path[]?.label // empty] | any(. == "stage4_legacy_shape")' "$OUT")
         has_warning=$(jq -r '[.resolution_path[]?.details.warning // empty] | any(. == "[LEGACY-SHAPE-DEPRECATED]")' "$OUT")
 
-        if [[ "$legacy_only" == "true" ]]; then
-            if [[ "$has_stage4" != "true" ]]; then
-                _dump_failure 4 "$seed" "legacy_only=true but no stage4 in resolution_path"
-                return 1
-            fi
-            if [[ "$has_warning" != "true" ]]; then
-                _dump_failure 4 "$seed" "legacy_only=true but no [LEGACY-SHAPE-DEPRECATED] warning"
-                return 1
-            fi
-        else
-            if [[ "$has_stage4" != "false" ]]; then
-                _dump_failure 4 "$seed" "legacy_only=false but stage4 is present"
-                return 1
-            fi
-            if [[ "$has_warning" != "false" ]]; then
-                _dump_failure 4 "$seed" "legacy_only=false but [LEGACY-SHAPE-DEPRECATED] warning present"
-                return 1
-            fi
+        # Flavour-specific positive controls.
+        if [[ "$has_stage4" != "$expect_stage4" ]]; then
+            _dump_failure 4 "$seed" "flavour=$flavour expected has_stage4=$expect_stage4 got=$has_stage4"
+            return 1
+        fi
+        if [[ "$has_warning" != "$expect_warning" ]]; then
+            _dump_failure 4 "$seed" "flavour=$flavour expected has_warning=$expect_warning got=$has_warning"
+            return 1
         fi
 
-        # Biconditional: stage4_present ⟺ warning_present (catches a bug
-        # where the warning is on a non-stage-4 entry, e.g. via copy-paste).
-        if [[ "$has_stage4" != "$has_warning" ]]; then
-            _dump_failure 4 "$seed" "biconditional violated: has_stage4=$has_stage4 has_warning=$has_warning"
+        # GP HIGH-2 strengthen: per-entry biconditional. The warning
+        # MUST appear ONLY on stage4 entries, AND every stage4 entry
+        # MUST carry the warning. Catches a bug where the warning is
+        # emitted on (e.g.) stage5 via copy-paste — the per-resolution
+        # check would not detect that if stage4 is also present.
+        warning_only_on_stage4=$(jq -r '
+            [.resolution_path[]?
+             | select(.details.warning == "[LEGACY-SHAPE-DEPRECATED]")
+             | .label]
+            | all(. == "stage4_legacy_shape")
+        ' "$OUT")
+        if [[ "$warning_only_on_stage4" != "true" ]]; then
+            _dump_failure 4 "$seed" "flavour=$flavour deprecation warning found on a non-stage4 entry"
+            return 1
+        fi
+        stage4_always_has_warning=$(jq -r '
+            [.resolution_path[]?
+             | select(.label == "stage4_legacy_shape")
+             | .details.warning // ""]
+            | all(. == "[LEGACY-SHAPE-DEPRECATED]")
+        ' "$OUT")
+        if [[ "$stage4_always_has_warning" != "true" ]]; then
+            _dump_failure 4 "$seed" "flavour=$flavour stage4 entry without [LEGACY-SHAPE-DEPRECATED] warning"
             return 1
         fi
     done
@@ -293,8 +401,8 @@ _dump_failure() {
 # Invariant 5 — operator tier_groups precedence over framework default
 # ---------------------------------------------------------------------
 @test "I5: operator tier_groups.mappings resolves before framework default" {
-    local i seed skill role expected_alias expected_model_id
-    local resolved_model_id resolved_alias has_stage3
+    local i seed skill role flavour expected_alias expected_model_id expected_provider
+    local resolved_provider resolved_model_id resolved_alias has_stage3 has_stage5
     for ((i=0; i<ITER; i++)); do
         seed=$((BASE + i))
         prop_gen_inv5_config "$seed" > "$CFG" || {
@@ -302,24 +410,41 @@ _dump_failure() {
             return 1
         }
         _read_query skill role
+        flavour=$(yq '._property_query.flavour' "$CFG")
         expected_alias=$(yq '._property_query.expected_resolved_alias' "$CFG")
         expected_model_id=$(yq '._property_query.expected_resolved_model_id' "$CFG")
-        _run_resolver "$skill" "$role" || { _dump_failure 5 "$seed" "resolver crashed"; return 1; }
+        # multi_provider flavour additionally pins expected_resolved_provider
+        # to verify provider=sorted(operator_keys)[0], not framework's keys.
+        expected_provider=$(yq '._property_query.expected_resolved_provider // ""' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 5 "$seed" "resolver crashed (flavour=$flavour)"; return 1; }
 
+        resolved_provider=$(jq -r '.resolved_provider // empty' "$OUT")
         resolved_model_id=$(jq -r '.resolved_model_id // empty' "$OUT")
         has_stage3=$(jq -r '[.resolution_path[]?.label // empty] | any(. == "stage3_tier_groups")' "$OUT")
+        has_stage5=$(jq -r '[.resolution_path[]?.label // empty] | any(. == "stage5_framework_default")' "$OUT")
         resolved_alias=$(jq -r '[.resolution_path[]? | select(.label=="stage3_tier_groups") | .details.resolved_alias][0] // empty' "$OUT")
 
         if [[ "$has_stage3" != "true" ]]; then
-            _dump_failure 5 "$seed" "expected stage3_tier_groups in resolution_path"
+            _dump_failure 5 "$seed" "flavour=$flavour expected stage3_tier_groups in resolution_path"
+            return 1
+        fi
+        # Cypherpunk HIGH-3: assert S5 is NOT in resolution_path. A
+        # resolver bug that resolved at S3 correctly but ALSO emitted
+        # S5 (e.g., a mis-merged early-return) would otherwise pass.
+        if [[ "$has_stage5" == "true" ]]; then
+            _dump_failure 5 "$seed" "flavour=$flavour stage5_framework_default unexpectedly present alongside stage3"
             return 1
         fi
         if [[ "$resolved_alias" != "$expected_alias" ]]; then
-            _dump_failure 5 "$seed" "expected stage3.details.resolved_alias=$expected_alias got=$resolved_alias"
+            _dump_failure 5 "$seed" "flavour=$flavour expected stage3.details.resolved_alias=$expected_alias got=$resolved_alias"
             return 1
         fi
         if [[ "$resolved_model_id" != "$expected_model_id" ]]; then
-            _dump_failure 5 "$seed" "expected resolved_model_id=$expected_model_id got=$resolved_model_id"
+            _dump_failure 5 "$seed" "flavour=$flavour expected resolved_model_id=$expected_model_id got=$resolved_model_id"
+            return 1
+        fi
+        if [[ -n "$expected_provider" ]] && [[ "$resolved_provider" != "$expected_provider" ]]; then
+            _dump_failure 5 "$seed" "flavour=$flavour expected resolved_provider=$expected_provider got=$resolved_provider"
             return 1
         fi
     done
@@ -361,6 +486,47 @@ _dump_failure() {
         fi
         if [[ "$has_stage5" != "false" ]]; then
             _dump_failure 6 "$seed" "stage5_framework_default present — silent S5 fall-through detected"
+            return 1
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------
+# Invariant 7 — positive S5 control (cypherpunk HIGH-3 / GP MED-1)
+# ---------------------------------------------------------------------
+@test "I7: framework_defaults agents.<skill> resolves cleanly via S5 — positive S5 control" {
+    local i seed skill role flavour expected_provider expected_model_id
+    local resolved_provider resolved_model_id has_stage5 has_error
+    for ((i=0; i<ITER; i++)); do
+        seed=$((BASE + i))
+        prop_gen_inv7_config "$seed" > "$CFG" || {
+            _dump_failure 7 "$seed" "generator failed"
+            return 1
+        }
+        _read_query skill role
+        flavour=$(yq '._property_query.flavour' "$CFG")
+        expected_provider=$(yq '._property_query.expected_resolved_provider' "$CFG")
+        expected_model_id=$(yq '._property_query.expected_resolved_model_id' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 7 "$seed" "resolver crashed (flavour=$flavour)"; return 1; }
+
+        has_error=$(jq -r 'has("error")' "$OUT")
+        if [[ "$has_error" == "true" ]]; then
+            _dump_failure 7 "$seed" "flavour=$flavour S5 positive control returned error"
+            return 1
+        fi
+        has_stage5=$(jq -r '[.resolution_path[]?.label // empty] | any(. == "stage5_framework_default")' "$OUT")
+        resolved_provider=$(jq -r '.resolved_provider // empty' "$OUT")
+        resolved_model_id=$(jq -r '.resolved_model_id // empty' "$OUT")
+        if [[ "$has_stage5" != "true" ]]; then
+            _dump_failure 7 "$seed" "flavour=$flavour expected stage5 hit; got resolution_path missing it"
+            return 1
+        fi
+        if [[ "$resolved_provider" != "$expected_provider" ]]; then
+            _dump_failure 7 "$seed" "flavour=$flavour expected resolved_provider=$expected_provider got=$resolved_provider"
+            return 1
+        fi
+        if [[ "$resolved_model_id" != "$expected_model_id" ]]; then
+            _dump_failure 7 "$seed" "flavour=$flavour expected resolved_model_id=$expected_model_id got=$resolved_model_id"
             return 1
         fi
     done

--- a/tests/property/model-resolution-properties.bats
+++ b/tests/property/model-resolution-properties.bats
@@ -1,0 +1,367 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/property/model-resolution-properties.bats
+#
+# cycle-099 Sprint 2D.d (T2.6 closure) — SC-14 property suite.
+#
+# Verifies the six FR-3.9 invariants on ~100 random valid configs per
+# invariant per CI run; nightly stress runs at ~1000 iterations.
+#
+# Six invariants (per FR-3.9 v1.2 SC-14):
+#   I1. (S1) and (S4) both present → (S1) wins.
+#   I2. Two same-priority mechanisms always produce error
+#       (extra+override id collision → [MODEL-EXTRA-OVERRIDE-CONFLICT]).
+#   I3. prefer_pro overlay always applied last (S6 entry, when present,
+#       is the last entry in resolution_path).
+#   I4. Deprecation warning emitted ⟺ S4 was the resolution path.
+#   I5. Operator-set tier_groups mapping resolves before framework default
+#       when both define the same (tier, provider) mapping.
+#   I6. Unmapped tier produces [TIER-NO-MAPPING] (stage_failed=3); never
+#       silently falls through to S5.
+#
+# Determinism: each iteration's seed is `${LOA_PROPERTY_SEED_BASE} + i`.
+# Default base=1, default iterations=100. Operators reproduce a CI failure
+# by running:
+#
+#     LOA_PROPERTY_SEED_BASE=<failed-seed> LOA_PROPERTY_ITERATIONS=1 \
+#       bats tests/property/model-resolution-properties.bats
+#
+# Per AC-S2.d.3: shells out to canonical Python resolver. The fully-qualified
+# command is `python3 .claude/scripts/lib/model-resolver.py resolve` because
+# the resolver lives at a hyphenated path (not an importable module). This
+# satisfies the spirit of the AC ("invokes the canonical Python resolver").
+# =============================================================================
+
+setup_file() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    export SCRIPT_DIR PROJECT_ROOT
+    export PROPERTY_GEN_LIB="$PROJECT_ROOT/tests/property/lib/property-gen.bash"
+    export RESOLVER_PY="$PROJECT_ROOT/.claude/scripts/lib/model-resolver.py"
+    [[ -f "$PROPERTY_GEN_LIB" ]] || {
+        printf '[property-bats] property-gen library missing\n' >&2
+        return 1
+    }
+    [[ -f "$RESOLVER_PY" ]] || {
+        printf '[property-bats] resolver missing\n' >&2
+        return 1
+    }
+}
+
+setup() {
+    command -v jq >/dev/null 2>&1 || skip "jq not present"
+    command -v yq >/dev/null 2>&1 || skip "yq not present"
+    command -v python3 >/dev/null 2>&1 || skip "python3 not present"
+    # shellcheck source=tests/property/lib/property-gen.bash
+    source "$PROPERTY_GEN_LIB"
+    WORK_DIR="$(mktemp -d)"
+    CFG="$WORK_DIR/config.yaml"
+    OUT="$WORK_DIR/resolver.json"
+    ITER="${LOA_PROPERTY_ITERATIONS:-100}"
+    BASE="${LOA_PROPERTY_SEED_BASE:-1}"
+    if ! [[ "$ITER" =~ ^[1-9][0-9]*$ ]]; then
+        skip "LOA_PROPERTY_ITERATIONS must be a positive integer"
+    fi
+    if ! [[ "$BASE" =~ ^[1-9][0-9]*$ ]]; then
+        skip "LOA_PROPERTY_SEED_BASE must be a positive integer"
+    fi
+}
+
+teardown() {
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+# Helpers --------------------------------------------------------------
+
+# Run resolver against $CFG with (skill, role); writes JSON to $OUT.
+# Returns 0 on success-OR-error-block (resolver exits 0 success / 1 error,
+# both are valid resolver behavior; we differentiate via the JSON shape).
+_run_resolver() {
+    local skill="$1" role="$2"
+    python3 "$RESOLVER_PY" resolve --config "$CFG" --skill "$skill" --role "$role" \
+        > "$OUT" 2>"$WORK_DIR/stderr.log" || true
+    if ! [[ -s "$OUT" ]]; then
+        printf '[property-bats] resolver produced empty stdout; stderr was:\n' >&2
+        cat "$WORK_DIR/stderr.log" >&2
+        return 1
+    fi
+}
+
+# Read query metadata from $CFG; sets bash-level locals via printf -v.
+# Caller declares the locals and passes them by name.
+_read_query() {
+    local skill_var="$1" role_var="$2"
+    local s r
+    s=$(yq '._property_query.skill' "$CFG")
+    r=$(yq '._property_query.role' "$CFG")
+    printf -v "$skill_var" '%s' "$s"
+    printf -v "$role_var" '%s' "$r"
+}
+
+# Pretty failure dump for reproducibility.
+_dump_failure() {
+    local invariant="$1" seed="$2" detail="$3"
+    {
+        printf '\n========== property-fail invariant=%s seed=%s ==========\n' "$invariant" "$seed"
+        printf '%s\n' "$detail"
+        printf '----- config -----\n'
+        cat "$CFG"
+        printf '\n----- resolver output -----\n'
+        cat "$OUT" 2>/dev/null || true
+        printf '\n----- resolver stderr -----\n'
+        cat "$WORK_DIR/stderr.log" 2>/dev/null || true
+        printf '----- end -----\n'
+    } >&2
+}
+
+# ---------------------------------------------------------------------
+# Invariant 1 — explicit pin (S1) always wins over legacy shape (S4)
+# ---------------------------------------------------------------------
+@test "I1: skill_models pin always wins over legacy <skill>.models entry" {
+    local i seed skill role expected_provider expected_model_id
+    local first_label has_stage4 actual_provider actual_model_id
+    for ((i=0; i<ITER; i++)); do
+        seed=$((BASE + i))
+        prop_gen_inv1_config "$seed" > "$CFG" || {
+            _dump_failure 1 "$seed" "generator failed"
+            return 1
+        }
+        _read_query skill role
+        expected_provider=$(yq '._property_query.expected_pin_provider' "$CFG")
+        expected_model_id=$(yq '._property_query.expected_pin_model_id' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 1 "$seed" "resolver crashed"; return 1; }
+
+        actual_provider=$(jq -r '.resolved_provider // empty' "$OUT")
+        actual_model_id=$(jq -r '.resolved_model_id // empty' "$OUT")
+        first_label=$(jq -r '.resolution_path[0].label // empty' "$OUT")
+        has_stage4=$(jq -r '[.resolution_path[]?.label // empty] | any(. == "stage4_legacy_shape")' "$OUT")
+
+        if [[ "$actual_provider" != "$expected_provider" ]]; then
+            _dump_failure 1 "$seed" "expected resolved_provider=$expected_provider got=$actual_provider"
+            return 1
+        fi
+        if [[ "$actual_model_id" != "$expected_model_id" ]]; then
+            _dump_failure 1 "$seed" "expected resolved_model_id=$expected_model_id got=$actual_model_id"
+            return 1
+        fi
+        if [[ "$first_label" != "stage1_pin_check" ]]; then
+            _dump_failure 1 "$seed" "expected first stage label=stage1_pin_check got=$first_label"
+            return 1
+        fi
+        if [[ "$has_stage4" != "false" ]]; then
+            _dump_failure 1 "$seed" "stage4_legacy_shape unexpectedly present in resolution_path"
+            return 1
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------
+# Invariant 2 — same id in extra+override → MODEL-EXTRA-OVERRIDE-CONFLICT
+# ---------------------------------------------------------------------
+@test "I2: model_aliases_extra/override id collision yields error, never silent tiebreaker" {
+    local i seed skill role expected_code expected_stage
+    local actual_code actual_stage has_resolution_path
+    for ((i=0; i<ITER; i++)); do
+        seed=$((BASE + i))
+        prop_gen_inv2_config "$seed" > "$CFG" || {
+            _dump_failure 2 "$seed" "generator failed"
+            return 1
+        }
+        _read_query skill role
+        expected_code=$(yq '._property_query.expected_error_code' "$CFG")
+        expected_stage=$(yq '._property_query.expected_stage_failed' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 2 "$seed" "resolver crashed"; return 1; }
+
+        actual_code=$(jq -r '.error.code // empty' "$OUT")
+        actual_stage=$(jq -r '.error.stage_failed // empty' "$OUT")
+        has_resolution_path=$(jq -r 'has("resolution_path")' "$OUT")
+
+        if [[ "$actual_code" != "$expected_code" ]]; then
+            _dump_failure 2 "$seed" "expected error.code=$expected_code got=$actual_code"
+            return 1
+        fi
+        if [[ "$actual_stage" != "$expected_stage" ]]; then
+            _dump_failure 2 "$seed" "expected error.stage_failed=$expected_stage got=$actual_stage"
+            return 1
+        fi
+        if [[ "$has_resolution_path" != "false" ]]; then
+            _dump_failure 2 "$seed" "resolution_path unexpectedly present alongside error"
+            return 1
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------
+# Invariant 3 — prefer_pro overlay (S6) always applied last
+# ---------------------------------------------------------------------
+@test "I3: stage6 entry, when present, is always the last entry in resolution_path" {
+    local i seed skill role expected_alias_base expected_alias_pro
+    local last_stage last_label last_to last_outcome path_len last_idx
+    for ((i=0; i<ITER; i++)); do
+        seed=$((BASE + i))
+        prop_gen_inv3_config "$seed" > "$CFG" || {
+            _dump_failure 3 "$seed" "generator failed"
+            return 1
+        }
+        _read_query skill role
+        expected_alias_base=$(yq '._property_query.expected_alias_base' "$CFG")
+        expected_alias_pro=$(yq '._property_query.expected_alias_pro' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 3 "$seed" "resolver crashed"; return 1; }
+
+        path_len=$(jq -r '.resolution_path | length' "$OUT")
+        if [[ -z "$path_len" ]] || [[ "$path_len" == "null" ]] || [[ "$path_len" == "0" ]]; then
+            _dump_failure 3 "$seed" "expected non-empty resolution_path"
+            return 1
+        fi
+        last_idx=$((path_len - 1))
+        last_stage=$(jq -r ".resolution_path[$last_idx].stage" "$OUT")
+        last_label=$(jq -r ".resolution_path[$last_idx].label" "$OUT")
+        last_outcome=$(jq -r ".resolution_path[$last_idx].outcome" "$OUT")
+        last_to=$(jq -r ".resolution_path[$last_idx].details.to // empty" "$OUT")
+
+        if [[ "$last_stage" != "6" ]]; then
+            _dump_failure 3 "$seed" "expected last stage=6 got=$last_stage"
+            return 1
+        fi
+        if [[ "$last_label" != "stage6_prefer_pro_overlay" ]]; then
+            _dump_failure 3 "$seed" "expected last label=stage6_prefer_pro_overlay got=$last_label"
+            return 1
+        fi
+        if [[ "$last_outcome" != "applied" ]]; then
+            _dump_failure 3 "$seed" "expected last outcome=applied got=$last_outcome"
+            return 1
+        fi
+        if [[ "$last_to" != "$expected_alias_pro" ]]; then
+            _dump_failure 3 "$seed" "expected stage6.details.to=$expected_alias_pro got=$last_to"
+            return 1
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------
+# Invariant 4 — deprecation warning emitted ⟺ S4 was the resolution path
+# ---------------------------------------------------------------------
+@test "I4: deprecation warning iff stage4 was on the resolution path (biconditional)" {
+    local i seed skill role legacy_only
+    local has_stage4 has_warning
+    for ((i=0; i<ITER; i++)); do
+        seed=$((BASE + i))
+        prop_gen_inv4_config "$seed" > "$CFG" || {
+            _dump_failure 4 "$seed" "generator failed"
+            return 1
+        }
+        _read_query skill role
+        legacy_only=$(yq '._property_query.legacy_only' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 4 "$seed" "resolver crashed"; return 1; }
+
+        has_stage4=$(jq -r '[.resolution_path[]?.label // empty] | any(. == "stage4_legacy_shape")' "$OUT")
+        has_warning=$(jq -r '[.resolution_path[]?.details.warning // empty] | any(. == "[LEGACY-SHAPE-DEPRECATED]")' "$OUT")
+
+        if [[ "$legacy_only" == "true" ]]; then
+            if [[ "$has_stage4" != "true" ]]; then
+                _dump_failure 4 "$seed" "legacy_only=true but no stage4 in resolution_path"
+                return 1
+            fi
+            if [[ "$has_warning" != "true" ]]; then
+                _dump_failure 4 "$seed" "legacy_only=true but no [LEGACY-SHAPE-DEPRECATED] warning"
+                return 1
+            fi
+        else
+            if [[ "$has_stage4" != "false" ]]; then
+                _dump_failure 4 "$seed" "legacy_only=false but stage4 is present"
+                return 1
+            fi
+            if [[ "$has_warning" != "false" ]]; then
+                _dump_failure 4 "$seed" "legacy_only=false but [LEGACY-SHAPE-DEPRECATED] warning present"
+                return 1
+            fi
+        fi
+
+        # Biconditional: stage4_present ⟺ warning_present (catches a bug
+        # where the warning is on a non-stage-4 entry, e.g. via copy-paste).
+        if [[ "$has_stage4" != "$has_warning" ]]; then
+            _dump_failure 4 "$seed" "biconditional violated: has_stage4=$has_stage4 has_warning=$has_warning"
+            return 1
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------
+# Invariant 5 — operator tier_groups precedence over framework default
+# ---------------------------------------------------------------------
+@test "I5: operator tier_groups.mappings resolves before framework default" {
+    local i seed skill role expected_alias expected_model_id
+    local resolved_model_id resolved_alias has_stage3
+    for ((i=0; i<ITER; i++)); do
+        seed=$((BASE + i))
+        prop_gen_inv5_config "$seed" > "$CFG" || {
+            _dump_failure 5 "$seed" "generator failed"
+            return 1
+        }
+        _read_query skill role
+        expected_alias=$(yq '._property_query.expected_resolved_alias' "$CFG")
+        expected_model_id=$(yq '._property_query.expected_resolved_model_id' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 5 "$seed" "resolver crashed"; return 1; }
+
+        resolved_model_id=$(jq -r '.resolved_model_id // empty' "$OUT")
+        has_stage3=$(jq -r '[.resolution_path[]?.label // empty] | any(. == "stage3_tier_groups")' "$OUT")
+        resolved_alias=$(jq -r '[.resolution_path[]? | select(.label=="stage3_tier_groups") | .details.resolved_alias][0] // empty' "$OUT")
+
+        if [[ "$has_stage3" != "true" ]]; then
+            _dump_failure 5 "$seed" "expected stage3_tier_groups in resolution_path"
+            return 1
+        fi
+        if [[ "$resolved_alias" != "$expected_alias" ]]; then
+            _dump_failure 5 "$seed" "expected stage3.details.resolved_alias=$expected_alias got=$resolved_alias"
+            return 1
+        fi
+        if [[ "$resolved_model_id" != "$expected_model_id" ]]; then
+            _dump_failure 5 "$seed" "expected resolved_model_id=$expected_model_id got=$resolved_model_id"
+            return 1
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------
+# Invariant 6 — unmapped tier ⇒ TIER-NO-MAPPING; never falls through to S5
+# ---------------------------------------------------------------------
+@test "I6: unmapped tier produces [TIER-NO-MAPPING]; never silently falls through to S5" {
+    local i seed skill role expected_code expected_stage
+    local actual_code actual_stage has_stage5 has_resolution_path
+    for ((i=0; i<ITER; i++)); do
+        seed=$((BASE + i))
+        prop_gen_inv6_config "$seed" > "$CFG" || {
+            _dump_failure 6 "$seed" "generator failed"
+            return 1
+        }
+        _read_query skill role
+        expected_code=$(yq '._property_query.expected_error_code' "$CFG")
+        expected_stage=$(yq '._property_query.expected_stage_failed' "$CFG")
+        _run_resolver "$skill" "$role" || { _dump_failure 6 "$seed" "resolver crashed"; return 1; }
+
+        actual_code=$(jq -r '.error.code // empty' "$OUT")
+        actual_stage=$(jq -r '.error.stage_failed // empty' "$OUT")
+        has_resolution_path=$(jq -r 'has("resolution_path")' "$OUT")
+        has_stage5=$(jq -r '[.resolution_path[]?.label // empty] | any(. == "stage5_framework_default")' "$OUT")
+
+        if [[ "$actual_code" != "$expected_code" ]]; then
+            _dump_failure 6 "$seed" "expected error.code=$expected_code got=$actual_code"
+            return 1
+        fi
+        if [[ "$actual_stage" != "$expected_stage" ]]; then
+            _dump_failure 6 "$seed" "expected error.stage_failed=$expected_stage got=$actual_stage"
+            return 1
+        fi
+        if [[ "$has_resolution_path" != "false" ]]; then
+            _dump_failure 6 "$seed" "resolution_path present alongside error (silent fall-through suspected)"
+            return 1
+        fi
+        if [[ "$has_stage5" != "false" ]]; then
+            _dump_failure 6 "$seed" "stage5_framework_default present — silent S5 fall-through detected"
+            return 1
+        fi
+    done
+}

--- a/tests/property/model-resolution-properties.bats
+++ b/tests/property/model-resolution-properties.bats
@@ -137,14 +137,12 @@ _read_query() {
 # sequence injection into CI runner stdout.
 _dump_failure() {
     local invariant="$1" seed="$2" detail="$3"
-    local strip_ctl='tr -d \000-\010\013-\037'
     {
         printf '\n========== property-fail invariant=%s seed=%s ==========\n' "$invariant" "$seed"
         printf '%s\n' "$detail"
         printf '----- config -----\n'
-        # shellcheck disable=SC2002
         if [[ -s "$CFG" ]]; then
-            cat "$CFG" | tr -d '\000-\010\013-\037'
+            tr -d '\000-\010\013-\037' < "$CFG"
         else
             printf '[empty]\n'
         fi
@@ -162,8 +160,6 @@ _dump_failure() {
         fi
         printf '----- end -----\n'
     } >&2
-    # Suppress unused-variable warning for the strip_ctl reference above.
-    : "$strip_ctl"
 }
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes **T2.6 entirely** by shipping the cycle-099 SC-14 property suite. Verifies the FR-3.9 6-stage resolver against ~700 random configs per PR (100 iter × 7 invariants) plus a 1000-iter nightly stress.

Bundles:
- **`tests/property/lib/property-gen.bash`** — bash property generator (~580 LOC); SHA-256-of-(seed,tag) deterministic random across hosts. 7 invariant-specific generators with multi-flavour internal dispatch.
- **`tests/property/model-resolution-properties.bats`** — 7 bats tests, one per invariant. On failure dumps full config + resolver output (control-byte stripped) for reproducibility.
- **`.github/workflows/cycle099-sprint-2d-d-property.yml`** — per-PR check at 100 iter × 7. Seed base from `sha256(github.sha + github.run_id)`.
- **`.github/workflows/cycle099-sprint-2d-d-property-nightly.yml`** — cron `0 6 * * *` + workflow_dispatch with iter floor=100, cap=100,000.

## Seven invariants

| Inv | Spec |
|---|---|
| I1 | (S1) and (S4) both present → (S1) wins |
| I2 | Same-priority pre-validation always produces error (extra+override collision OR override-unknown-id) |
| I3 | `prefer_pro=false ⟹ no S6 entry`; `prefer_pro=true ⟹ exactly one S6, LAST` (8 flavours covering all S6 emission paths) |
| I4 | Per-entry biconditional: `warning ⟺ stage4 entry` (3 flavours including legacy-unresolvable-falls-to-S5) |
| I5 | Operator tier_groups.mappings resolves before framework default (single + multi-provider flavours) |
| I6 | Unmapped tier ⇒ `[TIER-NO-MAPPING]` (stage_failed=3); never silently falls through to S5 |
| I7 | (positive S5 control) Framework `agents.<skill>` resolves cleanly via S5 — closes the "S5 ships dead, I6 doesn't notice" gap |

## Subagent dual-review pre-merge

Parallel general-purpose + paranoid cypherpunk on commit `8f421117`. **Combined: 2 CRIT + 10 HIGH + 10 MED + 9 LOW.**

CRIT and HIGH all addressed in `cefb3e60`; selected MED also addressed; LOW deferred to cycle-100 hardening.

| Severity | ID | Catch | Fix |
|---|---|---|---|
| CRIT | CYP-1 | I3 vacuous green — generator only emits S2-direct path | Multi-flavour I3 (8 flavours) covering all S6 emission paths + prefer_pro=false control |
| CRIT | CYP-2 | I4 biconditional vacuous — generator hardcoded resolvable alias | Added `legacy_unresolvable_falls_to_s5` flavour |
| HIGH | CYP-1 | I1 model_id collision (1/8 rate from same pool) | `-fwt` suffix forces disjointness |
| HIGH | GP-2 | I4 biconditional dead code | Strengthened to per-entry biconditional |
| HIGH | CYP-3 | I6 negative-only — no positive S5 control | Added I7 |
| HIGH | GP-3 | I5 doesn't pin S5 absence | Added `has_stage5=false` check |
| HIGH | CYP-4 | `prop_pick` uses eval | Replaced with `${@:n+1:1}` + n validation |
| HIGH | CYP-5 | paths trigger forward-compat hole | Glob `tests/property/**` |
| HIGH | CYP-6 | `iterations=1` workflow_dispatch bypass | Floor=100, cap=100,000 |
| HIGH | CYP-7 | dump leaks ctrl bytes / TTY injection | `tr -d` strip on dump |

Plus 6 MED fixes (I2 same-target degenerate, I5 multi-provider precedence, schema files in paths, run_number predictable seed → sha256(sha+run_id), 288→768 inv3 distinct configs, CI-fail-on-missing-tools).

## Verification

- 100 iter × 7 invariants: 7/7 ok (~3:30 wall-clock)
- Regression: `tests/integration/sprint-2D-resolver-parity.bats` (27 P) + `tests/bash/golden_resolution.bats` (16 G) all green
- Coverage: 99-100 distinct configs per invariant in 100 seeds (was 82 for inv3 pre-fix)

## Test plan

- [x] Unit-level: property generator function smoke (manual)
- [x] Integration-level: 100-iter property bats locally
- [x] Adjacent regression: sprint-2D parity (P-series) + golden resolution (G-series)
- [ ] CI: per-PR property workflow runs at 100 iter
- [ ] CI: cross-runtime-diff gate stays green
- [ ] CI: production-yaml smoke stays green

Refs cycle-099: `grimoires/loa/cycles/cycle-099-model-registry/RESUMPTION.md` (Brief G option A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)