### PR TITLE
fix(cycle-099): pin LC_ALL=C in gen-adapter-maps.sh for locale-immune codegen

### DIFF
--- a/.claude/scripts/gen-adapter-maps.sh
+++ b/.claude/scripts/gen-adapter-maps.sh
@@ -30,6 +30,15 @@
 
 set -euo pipefail
 
+# Pin locale to POSIX C so `sort -u` byte-orders deterministically across hosts.
+# Without this, en_AU/de_DE/etc. produce a different ordering for `gemini-3.1-pro`
+# vs `gemini-3-flash` (locale collation puts `.` < `-`; C puts `-` (0x2D) < `.` (0x2E)).
+# CI runs under `C.UTF-8` and the committed generated-model-maps.sh reflects that
+# byte-order. Latent bug surfaced in cycle-099 Sprint 2E (PR #750) where a local
+# regen under en_AU.UTF-8 produced a different VALID_FLATLINE_MODELS ordering.
+# Canonical convention used by butterfreezone-gen.sh, verify-invariants.sh, etc.
+export LC_ALL=C
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 


### PR DESCRIPTION
## Summary

- Adds `export LC_ALL=C` near the top of `.claude/scripts/gen-adapter-maps.sh` so the script's `sort -u` produces deterministic byte-order across hosts regardless of operator locale.
- Closes the latent bug surfaced (and worked-around manually) in PR #750: en_AU.UTF-8 ordered `gemini-3.1-pro` before `gemini-3-flash`, but the committed `generated-model-maps.sh` was produced under CI's `C.UTF-8` (POSIX byte-order: `-` 0x2D < `.` 0x2E), causing a drift-gate false-positive.
- Mirrors the convention already used by `butterfreezone-gen.sh`, `butterfreezone-validate.sh`, `butterfreezone-construct-gen.sh`, and `verify-invariants.sh`.

## The bug

```bash
# Before this fix:
LC_ALL=en_AU.UTF-8 bash .claude/scripts/gen-adapter-maps.sh --check
# → DRIFT-DETECTED: gemini-3.1-pro / gemini-3.1-pro-preview reordered
LC_ALL=C.UTF-8 bash .claude/scripts/gen-adapter-maps.sh --check
# → OK: matches YAML
```

After this fix all four invocations (`en_AU.UTF-8` / `C.UTF-8` / `de_DE.UTF-8` / `LANG`-only-no-`LC_ALL`) produce byte-identical output that matches the committed `generated-model-maps.sh`.

## Why `LC_ALL=C` not `LC_ALL=C.UTF-8`

- C and C.UTF-8 produce byte-identical output for ASCII content (all current model aliases).
- C is universally available; C.UTF-8 is missing on some macOS configurations.
- C is the established repo convention (4 prior generator scripts use `export LC_ALL=C`).

## Test plan

- [x] `bats tests/unit/gen-adapter-maps.bats` — 18 tests pass
- [x] `bats tests/integration/model-registry-sync.bats` — 13 tests pass
- [x] cycle-099 sentinel batch — 104 tests pass
- [x] `bats tests/integration/sprint-2D-resolver-parity.bats` — 27 tests pass
- [x] Locale-immunity verification: 4 distinct locales produce byte-identical output matching committed `generated-model-maps.sh`
- [x] `bash .claude/scripts/gen-adapter-maps.sh --check` reports OK
- [ ] Drift-gate CI passes (`model-registry-drift.yml`)

## Provenance

- Surfaced in: PR #750 (cycle-099 Sprint 2E)
- Cycle: 099 (operator-tooling hardening, post-Sprint-2E)
- Brief: `grimoires/loa/cycles/cycle-099-model-registry/RESUMPTION.md` Brief I — Option D

🤖 Generated with [Claude Code](https://claude.com/claude-code)