### PR TITLE
fix(cheval): #755 submodule symlinks + #756 alias validation + #759 degraded consensus

### DIFF
--- a/.claude/scripts/flatline-readiness.sh
+++ b/.claude/scripts/flatline-readiness.sh
@@ -132,7 +132,128 @@ check_enabled() {
 check_models() {
     MODELS[primary]=$(read_config_value ".flatline_protocol.models.primary" "opus")
     MODELS[secondary]=$(read_config_value ".flatline_protocol.models.secondary" "gpt-5.3-codex")
-    MODELS[tertiary]=$(read_config_value ".flatline_protocol.models.tertiary" "gemini-2.5-pro")
+    # Issue #756: orchestrator's get_model_tertiary() reads hounfour first,
+    # then flatline_protocol.models.tertiary. Mirror that lookup order so
+    # readiness reports the same active tertiary the orchestrator will use —
+    # otherwise readiness can show "Tertiary: gemini-2.5-pro" while the
+    # orchestrator runs gemini-3.1-pro-preview, which masks misconfiguration.
+    local tertiary_hounfour
+    tertiary_hounfour=$(read_config_value ".hounfour.flatline_tertiary_model" "")
+    if [[ -n "$tertiary_hounfour" ]]; then
+        MODELS[tertiary]="$tertiary_hounfour"
+    else
+        MODELS[tertiary]=$(read_config_value ".flatline_protocol.models.tertiary" "gemini-2.5-pro")
+    fi
+}
+
+# Issue #756: eager validation against the alias registry. Without this, an
+# operator setting `hounfour.flatline_tertiary_model: gemini-3.1-pro-preview`
+# (the canonical google api id, NOT a registered alias) sees readiness report
+# READY but every Flatline tertiary call then fails with cheval's
+# `Unknown alias: 'gemini-3.1-pro-preview'`. Surface DEGRADED + actionable
+# error AT readiness time instead of after the operator burns API spend.
+#
+# Accepts:
+#   1. Registered alias name (in `.aliases` of model-config.yaml).
+#   2. Explicit pin form `<provider>:<model_id>` (matches FR-3.9 stage 1).
+#
+# Populates ALIAS_VALIDATION_ERRORS[role] = error string on miss.
+declare -A ALIAS_VALIDATION_ERRORS
+declare -a REGISTERED_ALIASES_CACHE=()
+_REGISTERED_ALIASES_LOADED=false
+_REGISTRY_AVAILABLE=false  # set to true when registry actually loaded ≥1 alias
+
+_load_registered_aliases() {
+    if [[ "$_REGISTERED_ALIASES_LOADED" == "true" ]]; then
+        return 0
+    fi
+    local defaults_yaml="${LOA_DEFAULTS_YAML:-${PROJECT_ROOT:-.}/.claude/defaults/model-config.yaml}"
+    if [[ ! -f "$defaults_yaml" ]]; then
+        # Registry unavailable: alias validation must be SKIPPED (not applied
+        # to an empty cache). is_valid_alias gates on _REGISTRY_AVAILABLE so
+        # operators in submodule-without-defaults-symlink mode (issue #755 if
+        # not yet applied) don't see false-positive DEGRADED states. The
+        # operator's actual misconfiguration (a model_id where alias is
+        # expected) will surface later via cheval — degraded behaviour, but
+        # this readiness check is informational, not the canonical defense.
+        # Warning behind LOA_FLATLINE_VERBOSE=1 because bats `run` merges
+        # stderr into output, polluting JSON-parse assertions in existing
+        # readiness tests that don't have the defaults yaml available.
+        if [[ "${LOA_FLATLINE_VERBOSE:-0}" == "1" ]]; then
+            echo "WARNING: $defaults_yaml not found; alias validation skipped (#756 gate inactive)" >&2
+        fi
+        _REGISTERED_ALIASES_LOADED=true
+        return 0
+    fi
+    # Read alias keys from yaml. yq exits non-zero on missing key; tolerate.
+    local aliases_str
+    aliases_str=$(yq -r '.aliases // {} | keys | .[]' "$defaults_yaml" 2>/dev/null || true)
+    if [[ -n "$aliases_str" ]]; then
+        # Read alias-by-alias into the array (newline-delimited).
+        while IFS= read -r alias_name; do
+            [[ -n "$alias_name" ]] && REGISTERED_ALIASES_CACHE+=("$alias_name")
+        done <<< "$aliases_str"
+    fi
+    if [[ ${#REGISTERED_ALIASES_CACHE[@]} -gt 0 ]]; then
+        _REGISTRY_AVAILABLE=true
+    fi
+    _REGISTERED_ALIASES_LOADED=true
+}
+
+# is_valid_alias <model_or_pin> — return 0 if valid, 1 if not. Quiet — caller
+# decides whether to emit error.
+is_valid_alias() {
+    local model="$1"
+    [[ -z "$model" ]] && return 1
+    # Accept explicit pin form `<provider>:<model_id>` (FR-3.9 stage 1).
+    # The bash twin's _stage1_explicit_pin uses the same partition.
+    if [[ "$model" == *:* ]]; then
+        local provider="${model%%:*}"
+        local model_id="${model#*:}"
+        # Reject URL-shaped values (cycle-099 #761 hardening). A legitimate
+        # provider:model_id pin never has `//` after the colon.
+        if [[ "$model_id" == //* ]]; then
+            return 1
+        fi
+        if [[ -n "$provider" && -n "$model_id" ]]; then
+            return 0
+        fi
+    fi
+    _load_registered_aliases
+    local registered
+    for registered in "${REGISTERED_ALIASES_CACHE[@]:-}"; do
+        if [[ "$registered" == "$model" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Issue #756 main validator: cross-check each role's configured model
+# against the alias registry. Records error messages with the alias-list
+# hint so operators can map their mistake to the correct alias name.
+# Skip entirely when the registry isn't loadable (submodule without defaults
+# symlink; test isolation that strips defaults yaml). The check is
+# informational; the canonical failure mode is cheval rejecting at runtime.
+check_alias_registry() {
+    _load_registered_aliases
+    if [[ "$_REGISTRY_AVAILABLE" != "true" ]]; then
+        return 0
+    fi
+    local roles=("primary" "secondary" "tertiary")
+    local role
+    for role in "${roles[@]}"; do
+        local model="${MODELS[$role]:-}"
+        [[ -z "$model" ]] && continue
+        if ! is_valid_alias "$model"; then
+            local hint=""
+            if [[ ${#REGISTERED_ALIASES_CACHE[@]} -gt 0 ]]; then
+                hint=" Available aliases: $(printf '%s, ' "${REGISTERED_ALIASES_CACHE[@]}" | sed 's/, $//')"
+            fi
+            ALIAS_VALIDATION_ERRORS[$role]="Configured $role '$model' is not a registered alias and not a 'provider:model_id' pin.$hint"
+            RECOMMENDATIONS+=("Set ${role^} to a registered alias (e.g. 'gemini-3.1-pro' instead of 'gemini-3.1-pro-preview') or use 'google:<model_id>' pin form")
+        fi
+    done
 }
 
 check_provider_keys() {
@@ -192,13 +313,28 @@ determine_status() {
         fi
     done
 
+    # Issue #756: any alias-validation error downgrades to DEGRADED
+    # regardless of provider-key availability. An invalid alias means the
+    # actual cheval call will fail, so READY would be a lie.
+    # bash 5.2 still raises "unbound variable" on `${!foo[@]}` for an empty
+    # associative array under `set -u`; gate via `${foo[@]+_}` first.
+    local alias_error_count=0
+    if [[ "${ALIAS_VALIDATION_ERRORS[@]+_}" ]]; then
+        local _role
+        for _role in "${!ALIAS_VALIDATION_ERRORS[@]}"; do
+            if [[ -n "${ALIAS_VALIDATION_ERRORS[$_role]}" ]]; then
+                alias_error_count=$((alias_error_count + 1))
+            fi
+        done
+    fi
+
     if [[ $configured_count -eq 0 ]]; then
         echo "NO_API_KEYS"
         return 2
     elif [[ $available_count -eq 0 ]]; then
         echo "NO_API_KEYS"
         return 2
-    elif [[ $available_count -lt $configured_count ]]; then
+    elif [[ $available_count -lt $configured_count ]] || [[ $alias_error_count -gt 0 ]]; then
         echo "DEGRADED"
         return 3
     else
@@ -241,6 +377,27 @@ output_json() {
         --arg tertiary "${MODELS[tertiary]:-}" \
         '{primary: $primary, secondary: $secondary, tertiary: $tertiary}')
 
+    # Issue #756: surface alias-validation errors in JSON output. Operators
+    # parsing this output (CI, dashboards) need a machine-readable signal,
+    # not a recommendations text-blob.
+    # `${ALIAS_VALIDATION_ERRORS[@]+_}` guard to avoid bash 5.2's strict-mode
+    # `unbound variable` on accessing an empty associative array's keys.
+    local alias_errors_json="{}"
+    if [[ "${ALIAS_VALIDATION_ERRORS[@]+_}" ]]; then
+        # Reach individual entries via the +_ guard form so missing keys
+        # produce empty strings instead of raising under set -u.
+        local _ae_primary _ae_secondary _ae_tertiary
+        _ae_primary="${ALIAS_VALIDATION_ERRORS[primary]+${ALIAS_VALIDATION_ERRORS[primary]}}"
+        _ae_secondary="${ALIAS_VALIDATION_ERRORS[secondary]+${ALIAS_VALIDATION_ERRORS[secondary]}}"
+        _ae_tertiary="${ALIAS_VALIDATION_ERRORS[tertiary]+${ALIAS_VALIDATION_ERRORS[tertiary]}}"
+        alias_errors_json=$(jq -n \
+            --arg primary "$_ae_primary" \
+            --arg secondary "$_ae_secondary" \
+            --arg tertiary "$_ae_tertiary" \
+            '{primary: $primary, secondary: $secondary, tertiary: $tertiary}
+             | with_entries(select(.value != ""))')
+    fi
+
     # Build recommendations array
     local recs_json
     if [[ ${#RECOMMENDATIONS[@]} -gt 0 ]]; then
@@ -257,6 +414,7 @@ output_json() {
         --argjson exit_code "$exit_code" \
         --argjson providers "$providers_json" \
         --argjson models "$models_json" \
+        --argjson alias_errors "$alias_errors_json" \
         --argjson recommendations "$recs_json" \
         --arg timestamp "$timestamp" \
         '{
@@ -264,6 +422,7 @@ output_json() {
             exit_code: $exit_code,
             providers: $providers,
             models: $models,
+            alias_validation_errors: $alias_errors,
             recommendations: $recommendations,
             timestamp: $timestamp
         }'
@@ -339,6 +498,12 @@ main() {
 
     # Read model configuration
     check_models
+
+    # Issue #756: validate configured models against the alias registry
+    # BEFORE provider-key checks, so a misconfigured alias surfaces DEGRADED
+    # even if all keys are present. Without this, the operator hits cheval's
+    # `Unknown alias: ...` at runtime instead of seeing the readiness signal.
+    check_alias_registry
 
     # Check provider API keys
     check_provider_keys

--- a/.claude/scripts/lib/symlink-manifest.sh
+++ b/.claude/scripts/lib/symlink-manifest.sh
@@ -24,12 +24,23 @@ get_symlink_manifest() {
   local repo_root="${2:-$(pwd)}"
 
   # Phase 1: Directory symlinks (top-level .claude/ dirs that map 1:1 to submodule)
+  # Issue #755 fix: cycle-099 introduced the cheval Python adapter at
+  # .claude/adapters/cheval.py and the canonical model registry at
+  # .claude/defaults/model-config.yaml. Both are required by model-invoke +
+  # any Flatline-routed call. Without them, fresh-clone consumer repos see:
+  #   - "cheval.py not found at .claude/adapters/cheval.py"
+  #   - "Available agents: []" (cheval loader's Layer 1 System Zone defaults
+  #     can't read .claude/defaults/model-config.yaml)
+  # Both are framework-managed (System Zone) directories that map 1:1 to
+  # the submodule, same as scripts / protocols / hooks / data / schemas.
   MANIFEST_DIR_SYMLINKS=(
     ".claude/scripts:../${submodule}/.claude/scripts"
     ".claude/protocols:../${submodule}/.claude/protocols"
     ".claude/hooks:../${submodule}/.claude/hooks"
     ".claude/data:../${submodule}/.claude/data"
     ".claude/schemas:../${submodule}/.claude/schemas"
+    ".claude/adapters:../${submodule}/.claude/adapters"
+    ".claude/defaults:../${submodule}/.claude/defaults"
   )
 
   # Phase 2: File and nested symlinks (deeper paths with 2-level relative targets)

--- a/.claude/scripts/scoring-engine.sh
+++ b/.claude/scripts/scoring-engine.sh
@@ -726,8 +726,43 @@ main() {
     fi
 
     if [[ "$gpt_count" == "0" && "$opus_count" == "0" ]]; then
-        error "No items to score in either file"
-        exit 3
+        # Issue #759: emit structured DEGRADED consensus instead of `exit 3`
+        # with no stdout. The flatline-orchestrator captures this via
+        # `result=$(run_consensus ...)`; an empty result silently produces
+        # zero stdout from the orchestrator on partial-success Phase 1
+        # (operator spent ~$0.66 with no actionable output). The structured
+        # output below preserves the consensus contract (high_consensus,
+        # disputed, low_value, blockers arrays + summary) while signalling
+        # the degraded state via `degraded: true` + `confidence: "degraded"`
+        # + `degradation_reason: "no_items_to_score"`. Exit 0 because empty
+        # consensus IS a valid consensus result, not an error condition —
+        # ZERO findings is a meaningful outcome on a clean document review.
+        log "WARNING: both input files empty (no items to score) — emitting degraded consensus per #759"
+        # Schema mirrors `calculate_consensus_with_blockers` output (uses
+        # `consensus_summary` key + top-level `confidence`/`degraded`) so
+        # downstream parsers (orchestrator, dashboards) treat this as a
+        # normal consensus result with empty arrays.
+        jq -n '{
+            consensus_summary: {
+                high_consensus_count: 0,
+                disputed_count: 0,
+                low_value_count: 0,
+                blocker_count: 0,
+                model_agreement_percent: 0,
+                models: 2,
+                tertiary_items: 0,
+                confidence: "degraded"
+            },
+            high_consensus: [],
+            disputed: [],
+            low_value: [],
+            blockers: [],
+            degraded: true,
+            degraded_model: "both",
+            confidence: "degraded",
+            degradation_reason: "no_items_to_score"
+        }'
+        exit 0
     fi
 
     local mode_display="standard"

--- a/.claude/scripts/tests/test-mount-symlinks.bats
+++ b/.claude/scripts/tests/test-mount-symlinks.bats
@@ -23,6 +23,8 @@ create_mock_submodule() {
     mkdir -p "${submodule_path}/.claude/hooks"
     mkdir -p "${submodule_path}/.claude/data"
     mkdir -p "${submodule_path}/.claude/schemas"
+    mkdir -p "${submodule_path}/.claude/adapters"
+    mkdir -p "${submodule_path}/.claude/defaults"
     mkdir -p "${submodule_path}/.claude/skills/loa-test-skill"
     mkdir -p "${submodule_path}/.claude/commands"
     mkdir -p "${submodule_path}/.claude/loa/reference"
@@ -38,6 +40,8 @@ create_mock_submodule() {
     echo "# hook" > "${submodule_path}/.claude/hooks/test.sh"
     echo '{}' > "${submodule_path}/.claude/data/test.json"
     echo '{}' > "${submodule_path}/.claude/schemas/test.json"
+    echo '#!/usr/bin/env python3' > "${submodule_path}/.claude/adapters/cheval.py"
+    echo 'providers: {}' > "${submodule_path}/.claude/defaults/model-config.yaml"
     echo '{}' > "${submodule_path}/.claude/settings.json"
     echo "name: test" > "${submodule_path}/.claude/skills/loa-test-skill/index.yaml"
     echo "# cmd" > "${submodule_path}/.claude/commands/test.md"
@@ -58,6 +62,9 @@ create_test_symlinks() {
     ln -sf "../${submodule_path}/.claude/hooks" ".claude/hooks"
     ln -sf "../${submodule_path}/.claude/data" ".claude/data"
     ln -sf "../${submodule_path}/.claude/schemas" ".claude/schemas"
+    # Issue #755: cheval requires .claude/adapters/ + .claude/defaults/.
+    ln -sf "../${submodule_path}/.claude/adapters" ".claude/adapters"
+    ln -sf "../${submodule_path}/.claude/defaults" ".claude/defaults"
 
     # File symlinks under .claude/loa/
     ln -sf "../../${submodule_path}/.claude/loa/CLAUDE.loa.md" ".claude/loa/CLAUDE.loa.md"
@@ -179,7 +186,7 @@ teardown() {
     [ "${output}" -ge 1 ]
 }
 
-@test "symlink manifest includes all 5 directory symlinks" {
+@test "symlink manifest includes all 7 directory symlinks (incl. cheval-#755)" {
     local manifest_lib="${SCRIPT_DIR}/lib/symlink-manifest.sh"
     run grep -A30 "MANIFEST_DIR_SYMLINKS=(" "$manifest_lib"
     echo "$output" | grep -q ".claude/scripts"
@@ -187,6 +194,23 @@ teardown() {
     echo "$output" | grep -q ".claude/hooks"
     echo "$output" | grep -q ".claude/data"
     echo "$output" | grep -q ".claude/schemas"
+    # Issue #755 — cheval Python adapter + canonical model registry
+    echo "$output" | grep -q ".claude/adapters"
+    echo "$output" | grep -q ".claude/defaults"
+}
+
+@test "adapters_symlink: .claude/adapters is a symlink to submodule (#755)" {
+    [[ -L .claude/adapters ]]
+    [[ "$(readlink .claude/adapters)" == "../.loa/.claude/adapters" ]]
+    # And cheval.py reachable via the symlink (the regression mode #755 reports).
+    [[ -f .claude/adapters/cheval.py ]]
+}
+
+@test "defaults_symlink: .claude/defaults is a symlink to submodule (#755)" {
+    [[ -L .claude/defaults ]]
+    [[ "$(readlink .claude/defaults)" == "../.loa/.claude/defaults" ]]
+    # And model-config.yaml reachable via the symlink.
+    [[ -f .claude/defaults/model-config.yaml ]]
 }
 
 @test "symlink manifest includes loa file symlinks" {

--- a/tests/unit/issue-756-flatline-tertiary-validation.bats
+++ b/tests/unit/issue-756-flatline-tertiary-validation.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/unit/issue-756-flatline-tertiary-validation.bats
+#
+# Issue #756: hounfour.flatline_tertiary_model silently fails when set to a
+# model name instead of an alias. flatline-readiness should eagerly validate
+# the configured tertiary against the alias registry and downgrade to
+# DEGRADED with a precise error rather than reporting READY.
+#
+# Tests:
+#   T1 — readiness reads hounfour.flatline_tertiary_model first (matching orchestrator order)
+#   T2 — readiness falls back to flatline_protocol.models.tertiary when hounfour path is absent
+#   T3 — registered alias passes validation (gemini-3.1-pro)
+#   T4 — model_id (NOT an alias, e.g. gemini-3.1-pro-preview) FAILS validation with DEGRADED + alias-list hint
+#   T5 — provider:model_id pin form passes validation (S1 explicit-pin path)
+#   T6 — unknown alias FAILS validation with DEGRADED + alias-list hint
+#   T7 — primary + secondary also validated (regression — same defect class on these slots)
+# =============================================================================
+
+setup() {
+    PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    READINESS="$PROJECT_ROOT/.claude/scripts/flatline-readiness.sh"
+    [[ -f "$READINESS" ]] || skip "flatline-readiness.sh not present"
+    command -v yq >/dev/null 2>&1 || skip "yq not present"
+    command -v jq >/dev/null 2>&1 || skip "jq not present"
+
+    WORK_DIR="$(mktemp -d)"
+    # Need a .claude/ marker for bootstrap's auto-detect to land on WORK_DIR.
+    mkdir -p "$WORK_DIR/.claude"
+    # Symlink defaults dir so check_alias_registry can read aliases. (#755 in
+    # one — the alias registry would never load otherwise on a fresh repo.)
+    ln -sf "$PROJECT_ROOT/.claude/defaults" "$WORK_DIR/.claude/defaults"
+    cd "$WORK_DIR"
+
+    # Mock GOOGLE_API_KEY etc. so provider-key checks don't fail us.
+    export ANTHROPIC_API_KEY=test-anthro-key
+    export OPENAI_API_KEY=test-openai-key
+    export GOOGLE_API_KEY=test-google-key
+
+    # Override PROJECT_ROOT so bootstrap reads the test config, not the real one.
+    export PROJECT_ROOT="$WORK_DIR"
+    export LOA_CONFIG_FILE="$WORK_DIR/.loa.config.yaml"
+}
+
+teardown() {
+    cd /
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+_write_config() {
+    cat > "$LOA_CONFIG_FILE" <<YAML
+$1
+YAML
+}
+
+@test "T1 — readiness reads hounfour.flatline_tertiary_model first (matches orchestrator order)" {
+    _write_config 'flatline_protocol:
+  enabled: true
+  models:
+    primary: opus
+    secondary: gpt-5.3-codex
+    tertiary: gemini-2.5-pro
+hounfour:
+  flatline_tertiary_model: gemini-3.1-pro'
+    run env PROJECT_ROOT="$WORK_DIR" "$READINESS" --json
+    [[ "$status" -eq 0 || "$status" -eq 3 ]]
+    # The reported tertiary should be from hounfour path (gemini-3.1-pro), not flatline_protocol path (gemini-2.5-pro).
+    [[ "$output" == *"gemini-3.1-pro"* ]]
+    [[ "$output" != *"\"tertiary\":\"gemini-2.5-pro\""* ]]
+}
+
+@test "T2 — readiness falls back to flatline_protocol.models.tertiary when hounfour path is absent" {
+    _write_config 'flatline_protocol:
+  enabled: true
+  models:
+    primary: opus
+    secondary: gpt-5.3-codex
+    tertiary: gemini-2.5-pro'
+    run env PROJECT_ROOT="$WORK_DIR" "$READINESS" --json
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"gemini-2.5-pro"* ]]
+}
+
+@test "T3 — registered alias (gemini-3.1-pro) passes validation" {
+    _write_config 'flatline_protocol:
+  enabled: true
+  models:
+    primary: opus
+    secondary: gpt-5.3-codex
+    tertiary: gemini-2.5-pro
+hounfour:
+  flatline_tertiary_model: gemini-3.1-pro'
+    run env PROJECT_ROOT="$WORK_DIR" "$READINESS" --json
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"\"status\": \"READY\""* ]]
+}
+
+@test "T4 — model_id (NOT alias) FAILS validation with DEGRADED + alias-list hint (#756 main repro)" {
+    # gemini-3.1-pro-preview is the model_id; the registered alias is gemini-3.1-pro.
+    # Operator misuse — readiness MUST surface DEGRADED + actionable error.
+    _write_config 'flatline_protocol:
+  enabled: true
+  models:
+    primary: opus
+    secondary: gpt-5.3-codex
+    tertiary: gemini-2.5-pro
+hounfour:
+  flatline_tertiary_model: gemini-3.1-pro-preview'
+    run env PROJECT_ROOT="$WORK_DIR" "$READINESS" --json
+    # Must NOT be 0 (READY); should be 3 (DEGRADED) per the script's existing exit-code contract.
+    [[ "$status" -eq 3 ]]
+    [[ "$output" == *"\"status\": \"DEGRADED\""* ]]
+    # The error message MUST mention 'gemini-3.1-pro-preview' (the operator's value)
+    # so they can find their config entry.
+    [[ "$output" == *"gemini-3.1-pro-preview"* ]]
+    # And MUST suggest a registered alias (e.g., 'gemini-3.1-pro' is the closest match).
+    [[ "$output" == *"alias"* ]]
+}
+
+@test "T5 — provider:model_id pin form passes validation (S1 explicit-pin)" {
+    _write_config 'flatline_protocol:
+  enabled: true
+  models:
+    primary: opus
+    secondary: gpt-5.3-codex
+    tertiary: gemini-2.5-pro
+hounfour:
+  flatline_tertiary_model: "google:gemini-3.1-pro-preview"'
+    run env PROJECT_ROOT="$WORK_DIR" "$READINESS" --json
+    # Pin form is valid.
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"\"status\": \"READY\""* ]]
+}
+
+@test "T6 — unknown alias FAILS validation with DEGRADED + alias-list hint" {
+    _write_config 'flatline_protocol:
+  enabled: true
+  models:
+    primary: opus
+    secondary: gpt-5.3-codex
+    tertiary: gemini-2.5-pro
+hounfour:
+  flatline_tertiary_model: completely-fictional-model-name-xyz'
+    run env PROJECT_ROOT="$WORK_DIR" "$READINESS" --json
+    [[ "$status" -eq 3 ]]
+    [[ "$output" == *"\"status\": \"DEGRADED\""* ]]
+    [[ "$output" == *"completely-fictional-model-name-xyz"* ]]
+}
+
+@test "T7 — primary + secondary also validated (regression — same defect class)" {
+    # If we only validate tertiary, an operator setting an invalid primary
+    # would still see READY. The fix should validate ALL three roles.
+    _write_config 'flatline_protocol:
+  enabled: true
+  models:
+    primary: completely-fictional-primary-xyz
+    secondary: gpt-5.3-codex
+    tertiary: gemini-2.5-pro'
+    run env PROJECT_ROOT="$WORK_DIR" "$READINESS" --json
+    [[ "$status" -eq 3 ]]
+    [[ "$output" == *"\"status\": \"DEGRADED\""* ]]
+    [[ "$output" == *"completely-fictional-primary-xyz"* ]]
+}

--- a/tests/unit/issue-756-flatline-tertiary-validation.bats
+++ b/tests/unit/issue-756-flatline-tertiary-validation.bats
@@ -66,10 +66,16 @@ YAML
 hounfour:
   flatline_tertiary_model: gemini-3.1-pro'
     run env PROJECT_ROOT="$WORK_DIR" "$READINESS" --json
-    [[ "$status" -eq 0 || "$status" -eq 3 ]]
-    # The reported tertiary should be from hounfour path (gemini-3.1-pro), not flatline_protocol path (gemini-2.5-pro).
-    [[ "$output" == *"gemini-3.1-pro"* ]]
-    [[ "$output" != *"\"tertiary\":\"gemini-2.5-pro\""* ]]
+    # gemini-3.1-pro IS a registered alias → status 0 (READY); pin precisely.
+    # BB iter-1 F2 fix: tightened from `0 || 3` ambiguous oracle to exact 0.
+    [ "$status" -eq 0 ]
+    # BB iter-1 F1 fix: jq-extract the actual tertiary field instead of
+    # substring-matching the raw output. Substring match was vulnerable to
+    # JSON-whitespace shape (`"tertiary":"x"` vs `"tertiary": "x"`) and to
+    # false-positives from an aliases-list error hint elsewhere in the JSON.
+    local tertiary
+    tertiary=$(echo "$output" | jq -r '.models.tertiary')
+    [[ "$tertiary" == "gemini-3.1-pro" ]]
 }
 
 @test "T2 — readiness falls back to flatline_protocol.models.tertiary when hounfour path is absent" {
@@ -80,8 +86,11 @@ hounfour:
     secondary: gpt-5.3-codex
     tertiary: gemini-2.5-pro'
     run env PROJECT_ROOT="$WORK_DIR" "$READINESS" --json
-    [[ "$status" -eq 0 ]]
-    [[ "$output" == *"gemini-2.5-pro"* ]]
+    [ "$status" -eq 0 ]
+    # BB iter-1 F1 fix: jq-extract instead of substring-match.
+    local tertiary
+    tertiary=$(echo "$output" | jq -r '.models.tertiary')
+    [[ "$tertiary" == "gemini-2.5-pro" ]]
 }
 
 @test "T3 — registered alias (gemini-3.1-pro) passes validation" {
@@ -148,6 +157,10 @@ hounfour:
     [[ "$status" -eq 3 ]]
     [[ "$output" == *"\"status\": \"DEGRADED\""* ]]
     [[ "$output" == *"completely-fictional-model-name-xyz"* ]]
+    # BB iter-1 F3 fix: pin the alias-list hint that the test name promises.
+    # Without this, T6 only confirmed the bad value was echoed — not that
+    # operators get the actionable "here are valid aliases" guidance.
+    [[ "$output" == *"alias"* ]]
 }
 
 @test "T7 — primary + secondary also validated (regression — same defect class)" {

--- a/tests/unit/issue-759-scoring-engine-degraded-output.bats
+++ b/tests/unit/issue-759-scoring-engine-degraded-output.bats
@@ -121,10 +121,17 @@ teardown() {
         --json
     [ "$status" -eq 0 ]
     echo "$output" | jq empty
-    # Top-level `confidence` exists in BOTH the regular and degraded shapes.
-    [[ "$(echo "$output" | jq -r '.confidence // "?"')" =~ ^(single_model|full|degraded)$ ]]
-    # And NOT the #759 sentinel (this is the "single empty" path, not the "both empty" path).
+    # BB iter-1 F5 fix: regex tightened — `degraded` was permitted (matched
+    # the #759 path the test is supposed to NOT hit). For "single-empty" the
+    # confidence MUST be single_model or full. The degradation_reason check
+    # below also verifies we're not on the both-empty branch, but the
+    # confidence regex now mirrors the test intent.
+    [[ "$(echo "$output" | jq -r '.confidence // "?"')" =~ ^(single_model|full)$ ]]
     [[ "$(echo "$output" | jq -r '.degradation_reason // "none"')" != "no_items_to_score" ]]
+    # BB iter-1 F6 fix: assert the consensus contract is intact — at least
+    # one of the two valid summary keys must be present; if both are absent
+    # the JSON shape is broken and the prior assertions wouldn't catch it.
+    [[ "$(echo "$output" | jq 'has("consensus_summary") or has("summary")')" == "true" ]]
 }
 
 @test "B1.6 — orchestrator-style capture: result=\$(scoring-engine ...) yields non-empty when degraded" {

--- a/tests/unit/issue-759-scoring-engine-degraded-output.bats
+++ b/tests/unit/issue-759-scoring-engine-degraded-output.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+# =============================================================================
+# tests/unit/issue-759-scoring-engine-degraded-output.bats
+#
+# Issue #759: flatline-orchestrator emits empty stdout + 'ERROR: No items to
+# score' on partial-success Phase 1 (3-of-6 OK). When both score files have
+# zero items, scoring-engine.sh should emit a structured DEGRADED consensus
+# JSON instead of `exit 3` with no output, so:
+#   - operators get a machine-readable result (CI / dashboards)
+#   - the orchestrator's `result=$(run_consensus ...)` capture isn't empty
+#   - the empty-consensus state is observable, not silent
+#
+# Tests (B1):
+#   B1.1 — both empty → emit structured JSON (not exit 3 with empty stdout)
+#   B1.2 — JSON contains required top-level fields (high_consensus, disputed, etc.)
+#   B1.3 — degraded=true and confidence="degraded" set on empty-input output
+#   B1.4 — exit 0 (success — empty consensus IS a valid consensus result)
+#   B1.5 — single-non-empty input still produces consensus (regression — was already supported)
+#   B1.6 — orchestrator captures non-empty stdout when both inputs degraded
+# =============================================================================
+
+setup() {
+    PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    SCORING_ENGINE="$PROJECT_ROOT/.claude/scripts/scoring-engine.sh"
+    [[ -f "$SCORING_ENGINE" ]] || skip "scoring-engine.sh not present"
+    command -v jq >/dev/null 2>&1 || skip "jq not present"
+
+    WORK_DIR="$(mktemp -d)"
+    cd "$WORK_DIR"
+
+    # Empty score files (both Phase 1 calls failed → both arrays empty).
+    echo '{"scores":[]}' > "$WORK_DIR/gpt-empty.json"
+    echo '{"scores":[]}' > "$WORK_DIR/opus-empty.json"
+    echo '{"concerns":[]}' > "$WORK_DIR/gpt-skeptic-empty.json"
+    echo '{"concerns":[]}' > "$WORK_DIR/opus-skeptic-empty.json"
+
+    # Non-empty score files for regression coverage.
+    cat > "$WORK_DIR/gpt-with-scores.json" <<'JSON'
+{"scores":[{"id":"f1","weight":600,"justification":"test"}]}
+JSON
+    cat > "$WORK_DIR/opus-with-scores.json" <<'JSON'
+{"scores":[{"id":"f1","weight":700,"justification":"test"}]}
+JSON
+}
+
+teardown() {
+    cd /
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+@test "B1.1 — both empty inputs → emit JSON to stdout (not silent exit 3)" {
+    run --separate-stderr "$SCORING_ENGINE" \
+        --gpt-scores "$WORK_DIR/gpt-empty.json" \
+        --opus-scores "$WORK_DIR/opus-empty.json" \
+        --include-blockers \
+        --skeptic-gpt "$WORK_DIR/gpt-skeptic-empty.json" \
+        --skeptic-opus "$WORK_DIR/opus-skeptic-empty.json" \
+        --json
+    # Stdout MUST contain valid JSON (non-empty between { and }).
+    [[ -n "$output" ]]
+    echo "$output" | jq empty
+}
+
+@test "B1.2 — JSON contains required top-level fields per consensus contract" {
+    run --separate-stderr "$SCORING_ENGINE" \
+        --gpt-scores "$WORK_DIR/gpt-empty.json" \
+        --opus-scores "$WORK_DIR/opus-empty.json" \
+        --include-blockers \
+        --json
+    echo "$output" | jq empty
+    # Required fields per consensus output contract (regular path uses
+    # `consensus_summary`; #759 degraded path mirrors that key).
+    [[ "$(echo "$output" | jq 'has("consensus_summary")')" == "true" ]]
+    [[ "$(echo "$output" | jq 'has("high_consensus")')" == "true" ]]
+    [[ "$(echo "$output" | jq 'has("disputed")')" == "true" ]]
+    [[ "$(echo "$output" | jq 'has("low_value")')" == "true" ]]
+    [[ "$(echo "$output" | jq 'has("blockers")')" == "true" ]]
+    [[ "$(echo "$output" | jq '.high_consensus | type == "array"')" == "true" ]]
+    [[ "$(echo "$output" | jq '.disputed | type == "array"')" == "true" ]]
+}
+
+@test "B1.3 — degraded=true and confidence reflects empty-input state" {
+    run --separate-stderr "$SCORING_ENGINE" \
+        --gpt-scores "$WORK_DIR/gpt-empty.json" \
+        --opus-scores "$WORK_DIR/opus-empty.json" \
+        --include-blockers \
+        --json
+    [[ "$(echo "$output" | jq -r '.degraded // false')" == "true" ]]
+    [[ "$(echo "$output" | jq -r '.confidence // "?"')" == "degraded" ]]
+    [[ "$(echo "$output" | jq -r '.degradation_reason // "?"')" == "no_items_to_score" ]]
+    # Empty arrays — the degraded state should not invent findings.
+    [[ "$(echo "$output" | jq -r '.consensus_summary.high_consensus_count')" == "0" ]]
+    [[ "$(echo "$output" | jq -r '.consensus_summary.disputed_count')" == "0" ]]
+}
+
+@test "B1.4 — exit 0 (empty consensus IS a valid result, not an error)" {
+    run --separate-stderr "$SCORING_ENGINE" \
+        --gpt-scores "$WORK_DIR/gpt-empty.json" \
+        --opus-scores "$WORK_DIR/opus-empty.json" \
+        --include-blockers \
+        --json
+    [ "$status" -eq 0 ]
+}
+
+@test "B1.5 — single-empty input still produces consensus (regression)" {
+    # gpt empty + opus has scores: should produce single-model consensus,
+    # NOT trigger the "no items in either file" path. Pre-#759 the regular
+    # output uses `consensus_summary` key + top-level `confidence`; the
+    # degraded path emits `summary` key. Either is valid per the existing
+    # contract — test that we got A consensus, not the degraded path.
+    run --separate-stderr "$SCORING_ENGINE" \
+        --gpt-scores "$WORK_DIR/gpt-empty.json" \
+        --opus-scores "$WORK_DIR/opus-with-scores.json" \
+        --include-blockers \
+        --json
+    [ "$status" -eq 0 ]
+    echo "$output" | jq empty
+    # Top-level `confidence` exists in BOTH the regular and degraded shapes.
+    [[ "$(echo "$output" | jq -r '.confidence // "?"')" =~ ^(single_model|full|degraded)$ ]]
+    # And NOT the #759 sentinel (this is the "single empty" path, not the "both empty" path).
+    [[ "$(echo "$output" | jq -r '.degradation_reason // "none"')" != "no_items_to_score" ]]
+}
+
+@test "B1.6 — orchestrator-style capture: result=\$(scoring-engine ...) yields non-empty when degraded" {
+    # Mirrors the orchestrator's run_consensus capture pattern. When the
+    # scoring engine returns empty stdout, this captures "" and the
+    # orchestrator's stdout is silently empty (the #759 main symptom).
+    local result
+    result=$("$SCORING_ENGINE" \
+        --gpt-scores "$WORK_DIR/gpt-empty.json" \
+        --opus-scores "$WORK_DIR/opus-empty.json" \
+        --include-blockers \
+        --skeptic-gpt "$WORK_DIR/gpt-skeptic-empty.json" \
+        --skeptic-opus "$WORK_DIR/opus-skeptic-empty.json" \
+        --json) || true
+    [[ -n "$result" ]] || { echo "FAIL — result was empty (#759 reproduction)" >&2; return 1; }
+    echo "$result" | jq empty
+    [[ "$(echo "$result" | jq 'has("consensus_summary")')" == "true" ]]
+}


### PR DESCRIPTION
## Summary

Three independent operator-facing bugs from today's cheval-issue triage, batched because they all affect the cheval/flatline pipeline and share a quality-gate chain.

## Closes

- #755 — Submodule install missing `.claude/adapters` and `.claude/defaults` symlinks → `model-invoke` fails + cheval agent registry empty on fresh clones
- #756 — `hounfour.flatline_tertiary_model` accepts model_id silently; readiness reports READY but Flatline calls fail at runtime with `Unknown alias`
- #759 — flatline-orchestrator emits empty stdout on partial-success Phase 1 (B1: empty consensus → structured JSON instead of `exit 3`). B2 (preserve surviving Phase 1 raw outputs) deferred to a follow-up.

## What landed

| File | Lines | Purpose |
|---|---|---|
| `.claude/scripts/lib/symlink-manifest.sh` | +11 | #755 — add `.claude/adapters` + `.claude/defaults` to MANIFEST_DIR_SYMLINKS |
| `.claude/scripts/tests/test-mount-symlinks.bats` | +26 | #755 — mock submodule + new symlink + 2 regression tests |
| `.claude/scripts/flatline-readiness.sh` | +169 | #756 — hounfour-first lookup + `is_valid_alias()` + `check_alias_registry()` + DEGRADED gate + JSON `alias_validation_errors` |
| `tests/unit/issue-756-flatline-tertiary-validation.bats` (new) | +166 | #756 — 7 tests (T1-T7) |
| `.claude/scripts/scoring-engine.sh` | +39 | #759 — both-empty path emits structured DEGRADED JSON instead of `exit 3` |
| `tests/unit/issue-759-scoring-engine-degraded-output.bats` (new) | +145 | #759 — 6 tests (B1.1-B1.6) |

## Test plan

- [x] 23/23 `.claude/scripts/tests/test-mount-symlinks.bats` (#755 regression coverage)
- [x] 7/7 `tests/unit/issue-756-flatline-tertiary-validation.bats`
- [x] 6/6 `tests/unit/issue-759-scoring-engine-degraded-output.bats`
- [x] 23/23 `tests/unit/flatline-readiness.bats` (no regression)
- [x] 300 tests across all relevant flatline + cheval + cycle-099 sentinel suites — 0 regressions
- [ ] CI gates pass

## Operational notes

- **#756 alias-registry gate**: `_load_registered_aliases` is gracefully skipped when `.claude/defaults/model-config.yaml` is unavailable (e.g., in test isolation, or in submodule-without-#755-symlinks mode). The gate is informational; canonical defense remains cheval rejecting at runtime.
- **#759 schema choice**: degraded output uses `consensus_summary` key + top-level `confidence`/`degraded`/`degradation_reason` matching the regular path's shape, so dashboards/parsers treat this as a normal consensus result with empty arrays.
- **B2 deferred**: surviving Phase 1 raw outputs (when partial Phase 1 fails) should be preservable. Larger structural change — orchestrator-side state preservation across phases. Filing follow-up after this lands.
- **Followup #761** (S1-pin URL-shape): unrelated; tracked separately. The new `is_valid_alias()` in this PR explicitly rejects URL-shaped pins (defense matches the #761 fix).

## Provenance

- Cycle: 099 cheval-issue triage (post Sprint 2F)
- Brief: Operator-priority issue list received 2026-05-07; Sprint 2F + locale-pin shipped first; this PR closes 3 of 5 cheval issues. (#757 codex-headless long-prompt failure deferred to next session per operator direction; #758 was already-fixed at PR #752 and was closed with a comment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)