### PR TITLE
fix(cycle-099): #761 _stage1_explicit_pin rejects URL-shape values

### DIFF
--- a/.claude/scripts/lib/model-resolver.py
+++ b/.claude/scripts/lib/model-resolver.py
@@ -467,10 +467,34 @@ def _stage1_explicit_pin(skill_models_value: Any) -> dict | None:
 
     Returns a partial result dict (no resolution_path yet, just provider+model_id+
     stage entry) on hit, None on miss.
+
+    Issue #761 hardening: reject URL-shaped values. A legitimate
+    `provider:model_id` pin never contains `://`, never starts with `//`,
+    and never contains `?` (query-string). When an operator pastes a URL
+    like `https://user:secret@host?api_key=v` into this field, naive
+    partition-on-`:` would produce `provider="https"` and `model_id="//user:
+    secret@host?api_key=v"` — the `://` URL-userinfo regex in log-redactor
+    requires `://` framing in the SAME string, but partitioning strips the
+    `://` from `model_id` and leaves only `//`. So `secret-token` would
+    surface in `resolved_model_id` unredacted in validate-bindings JSON
+    output. Falling through to S2 → S3 closes the leak (no URL-shape value
+    ever reaches output), and the operator gets a clean `[TIER-NO-MAPPING]`
+    error pointing at their misconfigured value.
     """
     if not isinstance(skill_models_value, str):
         return None
     if ":" not in skill_models_value:
+        return None
+    # #761: URL sentinel rejection. Three patterns flag URL-shape:
+    # 1. `://` anywhere — explicit URL scheme separator
+    # 2. Leading `//` — partial URL fragment (paranoid; `:` won't be first char
+    #    so partition wouldn't produce this organically, but defense-in-depth)
+    # 3. `?` anywhere — query-string sentinel; provider:model_id never has it
+    if "://" in skill_models_value:
+        return None
+    if skill_models_value.startswith("//"):
+        return None
+    if "?" in skill_models_value:
         return None
     provider, _, model_id = skill_models_value.partition(":")
     if not provider or not model_id:

--- a/.claude/skills/bridgebuilder-review/resources/lib/model-resolver.generated.ts
+++ b/.claude/skills/bridgebuilder-review/resources/lib/model-resolver.generated.ts
@@ -5,7 +5,7 @@
 // .claude/scripts/lib/codegen/model-resolver.ts.j2 + the canonical
 // .claude/scripts/lib/model-resolver.py source.
 //
-// Source content hash: 85e3ffec9404295bc0ca14b6f5209967015dbbe84f27cb8d0c8711e71e1877da
+// Source content hash: 6dde2fe2fe39e2919cc60d925845a88cd510e2f5d365be1712cbea97e32f0d06
 // Generator version:   1.0
 // Generated at:        (deterministic — wall-clock excluded)
 //

--- a/tests/bash/golden_resolution.sh
+++ b/tests/bash/golden_resolution.sh
@@ -293,6 +293,15 @@ _stage1_explicit_pin() {
     local val="$1"
     [[ -z "$val" ]] && return
     [[ "$val" != *":"* ]] && return
+    # #761: reject URL-shape values. A legitimate provider:model_id pin
+    # never contains `://`, never starts with `//`, and never contains `?`.
+    # Naive partition would surface URL fragments in resolved_model_id and
+    # bypass the redactor's `://`-anchored regex; falling through to
+    # S2/S3/S5 closes the leak. Mirror the canonical Python at
+    # .claude/scripts/lib/model-resolver.py::_stage1_explicit_pin.
+    [[ "$val" == *"://"* ]] && return
+    [[ "$val" == //* ]] && return
+    [[ "$val" == *"?"* ]] && return
     local provider="${val%%:*}"
     local model_id="${val#*:}"
     [[ -z "$provider" ]] && return

--- a/tests/integration/cycle099-sprint-2F-validate-bindings.bats
+++ b/tests/integration/cycle099-sprint-2F-validate-bindings.bats
@@ -301,39 +301,22 @@ YAML
     [[ "$stderr" != *"[BINDING-OVERRIDDEN]"* ]]
 }
 
-@test "V15 — JSON output passes URL secrets through log-redactor" {
-    # merged-with-url.yaml puts a URL with userinfo + ?api_key= secret into
-    # skill_models.<skill>.<role> so it surfaces in details.pin via S1.
-    # The redactor's contract (per `.claude/scripts/lib/log-redactor.py`
-    # docstring) is URL-framed secrets ONLY: `://userinfo@` and `?param=value`.
-    # Test what the redactor IS responsible for:
+@test "V15 — URL-shape pin: secret never reaches validate-bindings output (#761 closure)" {
+    # Original V15 (Sprint 2F) tested redactor behavior on URL secrets that
+    # surfaced in `details.pin` via S1 explicit-pin. #761 closed that surface
+    # at the source: `_stage1_explicit_pin` rejects URL-shape values
+    # entirely, falling through to S2/S3/S5 with no URL fragment in
+    # `resolution_path` or `resolved_*` fields. The hardened assertion is
+    # now structural rather than redactor-dependent: NO part of the pasted
+    # URL EVER appears in the JSON output. Status may be 0 (clean) or 1
+    # (unresolved binding); both are valid post-#761 — what matters is that
+    # the secret-bearing input never echoes into output.
     run "$MODEL_INVOKE" --validate-bindings --merged-config "$WORK_DIR/merged-with-url.yaml"
-    [ "$status" -eq 0 ]
-    # The `?api_key=should-be-redacted` query secret MUST be masked.
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+    [[ "$output" != *"secret-token"* ]]
     [[ "$output" != *"should-be-redacted"* ]]
-    # The `https://leaky-user:secret-token@` userinfo MUST be masked in
-    # details.pin (where the full URL with `://` framing surfaces).
-    [[ "$output" != *"https://leaky-user:secret-token@"* ]]
-    # AND the redaction sentinel MUST appear (proves redactor was invoked).
-    [[ "$output" == *"REDACTED"* ]]
-    # NOTE: `secret-token` may still appear in `resolved_model_id` because S1
-    # splits the value at the first `:`, leaving `//leaky-user:secret-token@`
-    # (without `://` anchor) in the model_id field. That's a resolver-side
-    # concern (S1 should arguably reject URL-shaped input — tracked separately,
-    # out of Sprint 2F scope). The redactor is doing exactly what its
-    # contract says: URL-FRAMED secrets are masked; raw fragments are not.
-    #
-    # BB-iter1 F7 fix: capture the known-leak as a structured xfail so a
-    # future fix to S1 (rejecting URL-shaped pin values) flips this assertion
-    # green and the suite catches the regression. Until then, the assertion
-    # below DOCUMENTS the gap rather than silently tolerating it.
-    # TODO(cycle-099-followup): when `_stage1_explicit_pin` rejects values
-    # containing `://`, replace this comment with `[[ "$output" != *"secret-token"* ]]`.
-    if [[ "$output" != *"secret-token"* ]]; then
-        # Negation-of-bug — leak is closed. Pin behavior so a regression
-        # re-introducing the leak triggers a test-redesign signal.
-        echo "INFO — secret-token no longer in resolved_model_id; tighten V15 + close S1-pin URL-shape issue" >&2
-    fi
+    [[ "$output" != *"leaky-user"* ]]
+    [[ "$output" != *"https://"* ]]
 }
 
 @test "V16 — makes ZERO API calls (no provider HTTP traffic)" {
@@ -458,11 +441,14 @@ YAML
     # We test the redactor integration directly by checking a synthesized line
     # via the resolver that hits an alias whose details could carry a URL.
     # Simpler check: confirm no plaintext "secret-token" appears in stderr trace.
+    # `|| true` because URL-shape pin causes #761 fall-through → resolver
+    # exits 1 (unresolved). The trace-emission defense being tested is
+    # orthogonal to the resolution outcome.
     local stderr_out
     stderr_out=$(LOA_DEBUG_MODEL_RESOLUTION=1 python3 "$RESOLVER" resolve \
         --config "$WORK_DIR/merged-with-url.yaml" \
         --skill test_skill \
-        --role primary 2>&1 >/dev/null)
+        --role primary 2>&1 >/dev/null) || true
     [[ "$stderr_out" != *"secret-token"* ]]
     [[ "$stderr_out" != *"should-be-redacted"* ]]
 }

--- a/tests/unit/issue-761-stage1-pin-url-rejection.bats
+++ b/tests/unit/issue-761-stage1-pin-url-rejection.bats
@@ -1,0 +1,206 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+# =============================================================================
+# tests/unit/issue-761-stage1-pin-url-rejection.bats
+#
+# Issue #761: `_stage1_explicit_pin` partitions skill_models.<skill>.<role>
+# values at the first `:`. If an operator pastes a URL like
+# `https://user:secret@host?api_key=v` into that field, the resolver treats
+# `https` as the provider and the rest as model_id. The redactor masks
+# userinfo in `details.pin` (full URL with `://` framing), but
+# `resolved_model_id` carries `//user:secret@...` (no `://` anchor) which
+# the redactor's regex doesn't catch — secret leaks to validate-bindings
+# JSON output.
+#
+# Fix: S1 rejects values containing `://`, leading `//`, or `?` (URL
+# sentinels). Operators still get a clear `provider:model_id` pin path; URL-
+# shaped misconfiguration falls through to S2 → S3 → [TIER-NO-MAPPING].
+#
+# Tests:
+#   P1 — positive control: valid `provider:model_id` pin still resolves at S1
+#   P2 — pin with simple alphanumeric model_id (no special chars) works
+#   P3 — pin with dot in model_id (e.g. claude-opus-4-7) works
+#   N1 — URL with full `://` scheme is rejected (FALL through, NOT S1 hit)
+#   N2 — value starting with `//` (S1-strip artifact) is rejected
+#   N3 — value containing `?` (query-string sentinel) is rejected
+#   N4 — URL-with-secret no longer surfaces secret in resolved_model_id
+#   V1 — Sprint 2F V15 xfail flips green: secret-token absent from JSON
+# =============================================================================
+
+setup() {
+    PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    RESOLVER="$PROJECT_ROOT/.claude/scripts/lib/model-resolver.py"
+    MODEL_INVOKE="$PROJECT_ROOT/.claude/scripts/model-invoke"
+    [[ -f "$RESOLVER" ]] || skip "model-resolver.py not present"
+    command -v python3 >/dev/null 2>&1 || skip "python3 not present"
+    command -v jq >/dev/null 2>&1 || skip "jq not present"
+
+    WORK_DIR="$(mktemp -d)"
+
+    # Minimal valid config used by all tests. The skill_models tertiary
+    # value is overridden per-test via _write_pin.
+    cat > "$WORK_DIR/base.yaml" <<'YAML'
+schema_version: 2
+framework_defaults:
+  providers:
+    anthropic:
+      models:
+        claude-opus-4-7:
+          capabilities: [chat]
+          context_window: 1000000
+          pricing: { input_per_mtok: 15000000, output_per_mtok: 75000000 }
+        claude-haiku-4-5-20251001:
+          capabilities: [chat]
+          context_window: 200000
+          pricing: { input_per_mtok: 1000000, output_per_mtok: 5000000 }
+  aliases:
+    opus: { provider: anthropic, model_id: claude-opus-4-7 }
+    tiny: { provider: anthropic, model_id: claude-haiku-4-5-20251001 }
+  tier_groups:
+    mappings:
+      tiny: { anthropic: tiny }
+operator_config:
+  skill_models:
+    test_skill:
+      primary: PIN_VALUE_PLACEHOLDER
+runtime_state: {}
+YAML
+}
+
+teardown() {
+    if [[ -n "${WORK_DIR:-}" ]] && [[ -d "$WORK_DIR" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    return 0
+}
+
+_write_pin() {
+    local pin_value="$1"
+    sed "s|PIN_VALUE_PLACEHOLDER|$pin_value|" "$WORK_DIR/base.yaml" > "$WORK_DIR/cfg.yaml"
+}
+
+# --------------------------------------------------------------------------
+# P-series: positive controls (valid provider:model_id pins still work)
+# --------------------------------------------------------------------------
+
+@test "P1 — valid provider:model_id pin resolves at S1 (positive control)" {
+    _write_pin "anthropic:claude-opus-4-7"
+    run --separate-stderr python3 "$RESOLVER" resolve \
+        --config "$WORK_DIR/cfg.yaml" --skill test_skill --role primary
+    [ "$status" -eq 0 ]
+    local stage1
+    stage1=$(echo "$output" | jq -r '.resolution_path[] | select(.stage == 1) | .label')
+    [[ "$stage1" == "stage1_pin_check" ]]
+    [[ "$(echo "$output" | jq -r '.resolved_provider')" == "anthropic" ]]
+    [[ "$(echo "$output" | jq -r '.resolved_model_id')" == "claude-opus-4-7" ]]
+}
+
+@test "P2 — pin with alphanumeric provider+model_id works" {
+    _write_pin "openai:gpt-5.5-pro"
+    run --separate-stderr python3 "$RESOLVER" resolve \
+        --config "$WORK_DIR/cfg.yaml" --skill test_skill --role primary
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.resolved_provider')" == "openai" ]]
+    [[ "$(echo "$output" | jq -r '.resolved_model_id')" == "gpt-5.5-pro" ]]
+}
+
+@test "P3 — pin with dotted model_id (anthropic:claude-haiku-4-5-20251001) works" {
+    _write_pin "anthropic:claude-haiku-4-5-20251001"
+    run --separate-stderr python3 "$RESOLVER" resolve \
+        --config "$WORK_DIR/cfg.yaml" --skill test_skill --role primary
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.resolved_model_id')" == "claude-haiku-4-5-20251001" ]]
+}
+
+# --------------------------------------------------------------------------
+# N-series: negative tests (URL-shaped values are rejected at S1)
+# --------------------------------------------------------------------------
+
+@test "N1 — URL with :// scheme falls through S1 (NOT a pin hit)" {
+    _write_pin "https://example.com/v1/chat"
+    run --separate-stderr python3 "$RESOLVER" resolve \
+        --config "$WORK_DIR/cfg.yaml" --skill test_skill --role primary
+    # S1 rejects URL-shape (this is the fix). S2 also bypasses any
+    # `:`-containing value (the existing behavior that defers to S1). With
+    # neither S1 nor S2 firing, S3 isn't invoked either; cascade falls
+    # through legacy/agents/prefer_pro to NO-RESOLUTION at S5. The KEY
+    # security property is that no URL fragment ever surfaces in resolved_*.
+    [ "$status" -eq 1 ]
+    # No stage 1 hit in resolution_path.
+    [[ "$(echo "$output" | jq '[.resolution_path[]? | select(.stage == 1)] | length')" == "0" ]]
+    # Error is one of the fall-through codes (NO-RESOLUTION or TIER-NO-MAPPING
+    # depending on internal cascade). Not a pin hit.
+    local err_code
+    err_code=$(echo "$output" | jq -r '.error.code // "none"')
+    [[ "$err_code" == "[NO-RESOLUTION]" || "$err_code" == "[TIER-NO-MAPPING]" ]]
+}
+
+@test "N2 — value starting with // is rejected" {
+    _write_pin "//user:pass@host"
+    run --separate-stderr python3 "$RESOLVER" resolve \
+        --config "$WORK_DIR/cfg.yaml" --skill test_skill --role primary
+    [ "$status" -eq 1 ]
+    [[ "$(echo "$output" | jq '[.resolution_path[]? | select(.stage == 1)] | length')" == "0" ]]
+}
+
+@test "N3 — value with ? (query-string sentinel) is rejected" {
+    _write_pin "anthropic:claude-opus-4-7?api_key=secret"
+    run --separate-stderr python3 "$RESOLVER" resolve \
+        --config "$WORK_DIR/cfg.yaml" --skill test_skill --role primary
+    [ "$status" -eq 1 ]
+    [[ "$(echo "$output" | jq '[.resolution_path[]? | select(.stage == 1)] | length')" == "0" ]]
+}
+
+@test "N4 — URL with userinfo+secret: secret NOT in resolved_model_id" {
+    # The #761 main repro: operator pastes a URL with secret-token@. Pre-fix,
+    # `secret-token` surfaced in resolved_model_id (S1 split made //user:secret@
+    # the model_id, redactor's `://` regex didn't match). Post-fix, S1 rejects
+    # the entire URL-shape value AND the JSON output never carries the secret.
+    _write_pin "https://leaky-user:secret-token@api.example.com/v1?api_key=v"
+    run --separate-stderr python3 "$RESOLVER" resolve \
+        --config "$WORK_DIR/cfg.yaml" --skill test_skill --role primary
+    # Even if S2/S3 surfaces an error, the secret must NOT appear anywhere.
+    [[ "$output" != *"secret-token"* ]]
+    [[ "$output" != *"leaky-user:secret-token"* ]]
+}
+
+# --------------------------------------------------------------------------
+# V-series: Sprint 2F V15 follow-up (xfail flips green)
+# --------------------------------------------------------------------------
+
+@test "V1 — Sprint 2F V15 xfail flips: validate-bindings JSON does NOT carry secret" {
+    [[ -f "$MODEL_INVOKE" ]] || skip "model-invoke not present"
+    cat > "$WORK_DIR/merged-with-url.yaml" <<'YAML'
+schema_version: 2
+framework_defaults:
+  providers:
+    anthropic:
+      models:
+        claude-opus-4-7:
+          capabilities: [chat]
+          context_window: 1000000
+          pricing: { input_per_mtok: 15000000, output_per_mtok: 75000000 }
+  aliases:
+    opus: { provider: anthropic, model_id: claude-opus-4-7 }
+  tier_groups:
+    mappings:
+      tiny: { anthropic: opus }
+operator_config:
+  skill_models:
+    test_skill:
+      primary: "https://leaky-user:secret-token@api.example.com/v1/chat?api_key=should-be-redacted&model=foo"
+runtime_state: {}
+YAML
+    run --separate-stderr "$MODEL_INVOKE" --validate-bindings \
+        --merged-config "$WORK_DIR/merged-with-url.yaml"
+    # Either status 0 (resolved via fall-through) or 1 (unresolved). Both fine
+    # for THIS test — what matters is the output content.
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+    # The hardened assertion that V15's TODO promised: secret-token MUST NOT
+    # appear anywhere in the JSON output. Pre-fix this leaked via
+    # resolved_model_id; post-#761 it never reaches output at all.
+    [[ "$output" != *"secret-token"* ]]
+    [[ "$output" != *"should-be-redacted"* ]]
+}


### PR DESCRIPTION
## Summary

Closes #761. `_stage1_explicit_pin` now rejects URL-shaped `skill_models.<skill>.<role>` values (`://`, leading `//`, `?`-containing) so an operator pasting a URL with userinfo+secret cannot leak it through `resolved_model_id` in validate-bindings JSON output.

## What landed

| File | Lines | Purpose |
|---|---|---|
| `.claude/scripts/lib/model-resolver.py` | +24 | Canonical Python — three URL sentinels in `_stage1_explicit_pin` |
| `tests/bash/golden_resolution.sh` | +9 | Bash twin — cross-runtime parity |
| `.claude/skills/bridgebuilder-review/resources/lib/model-resolver.generated.ts` | regen | TS regenerated via Python+Jinja2 codegen |
| `tests/unit/issue-761-stage1-pin-url-rejection.bats` (new) | +206 | 8 tests (P1-P3 positive controls + N1-N4 negative + V1 Sprint 2F xfail flip) |
| `tests/integration/cycle099-sprint-2F-validate-bindings.bats` | -27/+15 | Retire-and-replace V15 (URL-redaction premise invalidated by #761) + `\|\| true` on D8 |

## Test plan

- [x] 8/8 issue-761 bats pass
- [x] 38/38 Sprint 2F validate-bindings bats pass (V15 + D8 updated)
- [x] 27/27 sprint-2D-resolver-parity (cross-runtime byte-equality)
- [x] 7/7 property suite
- [x] 25/25 legacy-adapter-still-works
- [x] 18/18 gen-adapter-maps + 13/13 model-registry-sync
- [x] 23/23 flatline-readiness + 7/7 #756 + 6/6 #759
- [x] 172/172 across all relevant sentinels — 0 regressions
- [ ] CI gates pass

## Provenance

- Cycle: 099 follow-up (post Sprint 2F + cheval triage)
- Origin: Sprint 2F BB iter-1 F7 (V15 known-leak xfail) → tracking issue #761 → this fix
- Sprint 2F V15 had structured TODO/info-emit; this PR flips it to a hard assertion (`secret-token` MUST NOT appear in JSON output) — and goes further by removing the leak source entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)