### PR TITLE
feat(cycle-098): sprint-4 — L4 graduated-trust (FR-L4-1..8)

### DIFF
--- a/.claude/data/trajectory-schemas/trust-events/trust-auto-drop.payload.schema.json
+++ b/.claude/data/trajectory-schemas/trust-events/trust-auto-drop.payload.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/trust-events/trust-auto-drop.payload.schema.json",
+  "title": "L4 trust.auto_drop Payload",
+  "description": "Auto-drop transition emitted by trust_record_override per FR-L4-3. Auto-drop ratchets tier DOWN per the configured auto_drop_on_override rule and starts the cooldown timer. The decision_id MUST reference an externally-knowable record (e.g., panel decision id) so the auditor can correlate.",
+  "type": "object",
+  "required": [
+    "scope",
+    "capability",
+    "actor",
+    "from_tier",
+    "to_tier",
+    "decision_id",
+    "reason",
+    "cooldown_until"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "scope": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "capability": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "actor": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "from_tier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{1,32}$"
+    },
+    "to_tier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{1,32}$",
+      "description": "Tier resolved per the configured drop_to step (default: drop one rank toward default_tier)."
+    },
+    "decision_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "External record correlating this override (e.g., panel-decisions.jsonl id, PR number, audit-event id)."
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096
+    },
+    "cooldown_until": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC; cooldown enforced until this time. Computed as ts_utc + cooldown_seconds."
+    },
+    "cooldown_seconds": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Effective cooldown window applied. Echoed for auditor convenience."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/trust-events/trust-auto-raise-eligible.payload.schema.json
+++ b/.claude/data/trajectory-schemas/trust-events/trust-auto-raise-eligible.payload.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/trust-events/trust-auto-raise-eligible.payload.schema.json",
+  "title": "L4 trust.auto_raise_eligible Payload",
+  "description": "Eligibility-marker event emitted when conditions met for an auto-raise (FR-L4-4). The eligibility detector itself is deferred to FU-3; the cycle-098 implementation ships a stub that ALWAYS returns eligibility_required (operator must invoke trust_grant manually). This event records that the stub was consulted and what conditions were claimed.",
+  "type": "object",
+  "required": [
+    "scope",
+    "capability",
+    "actor",
+    "current_tier",
+    "next_tier",
+    "stub_outcome"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "scope": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "capability": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "actor": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "current_tier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{1,32}$"
+    },
+    "next_tier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{1,32}$",
+      "description": "Tier the eligibility check was evaluating a raise toward."
+    },
+    "stub_outcome": {
+      "type": "string",
+      "enum": ["eligibility_required"],
+      "description": "Sprint 4 ships only the stub outcome. FU-3 will extend with 'eligible' once alignment-tracking detector ships."
+    },
+    "stub_message": {
+      "type": "string",
+      "maxLength": 4096,
+      "description": "Operator-facing message explaining the deferral."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/trust-events/trust-disable.payload.schema.json
+++ b/.claude/data/trajectory-schemas/trust-events/trust-disable.payload.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/trust-events/trust-disable.payload.schema.json",
+  "title": "L4 trust.disable Payload",
+  "description": "[L4-DISABLED] sealing event emitted by trust_disable. Per PRD §849 row L4: on disable the ledger is preserved (immutable hash-chain); subsequent reads return last-known-tier per scope; no new transitions allowed.",
+  "type": "object",
+  "required": ["operator", "reason", "sealed_at"],
+  "additionalProperties": false,
+  "properties": {
+    "operator": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096
+    },
+    "sealed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC. Echoes ts_utc for auditor convenience."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/trust-events/trust-force-grant.payload.schema.json
+++ b/.claude/data/trajectory-schemas/trust-events/trust-force-grant.payload.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/trust-events/trust-force-grant.payload.schema.json",
+  "title": "L4 trust.force_grant Payload",
+  "description": "Force-grant exception emitted when trust_grant --force overrides cooldown. cycle-098 Sprint 4C — FR-L4-8. force-grant is a protected-class operation per protected-class-router; recordable but never silent.",
+  "type": "object",
+  "required": [
+    "scope",
+    "capability",
+    "actor",
+    "from_tier",
+    "to_tier",
+    "operator",
+    "reason",
+    "cooldown_remaining_seconds_at_grant"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "scope": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "capability": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "actor": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "from_tier": {
+      "type": ["string", "null"],
+      "pattern": "^[A-Za-z0-9_-]{1,32}$"
+    },
+    "to_tier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{1,32}$"
+    },
+    "operator": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "description": "REQUIRED for force-grant; auditor-facing rationale. No default."
+    },
+    "cooldown_remaining_seconds_at_grant": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Cooldown seconds remaining when force-grant fired. 0 means cooldown had already elapsed (operator chose to use --force redundantly)."
+    },
+    "cooldown_until_at_grant": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/trust-events/trust-grant.payload.schema.json
+++ b/.claude/data/trajectory-schemas/trust-events/trust-grant.payload.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/trust-events/trust-grant.payload.schema.json",
+  "title": "L4 trust.grant Payload",
+  "description": "Operator-grant transition event. cycle-098 Sprint 4A. trust.grant entries record an operator-driven tier transition that satisfies a configured TransitionRule. Force-grant is a separate event type (trust.force_grant); regular trust.grant entries MUST NOT bypass cooldown.",
+  "type": "object",
+  "required": [
+    "scope",
+    "capability",
+    "actor",
+    "from_tier",
+    "to_tier",
+    "operator",
+    "reason"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "scope": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "capability": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "actor": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "from_tier": {
+      "type": ["string", "null"],
+      "pattern": "^[A-Za-z0-9_-]{1,32}$",
+      "description": "null when this is the initial transition from default_tier (recorded as transition_type=initial)."
+    },
+    "to_tier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{1,32}$"
+    },
+    "operator": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "Operator slug performing the grant. Verified against OPERATORS.md."
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "description": "Operator-provided rationale (audit-required; no implicit default)."
+    },
+    "transition_rule_id": {
+      "type": ["string", "null"],
+      "description": "Operator-config rule id that authorized this transition (e.g., 'T0_to_T1_default'). null when none configured (auditor signal)."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/trust-events/trust-query.payload.schema.json
+++ b/.claude/data/trajectory-schemas/trust-events/trust-query.payload.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/trust-events/trust-query.payload.schema.json",
+  "title": "L4 trust.query Payload",
+  "description": "Read-event payload emitted by trust_query. cycle-098 Sprint 4A — FR-L4-1. Optional emission gated by LOA_TRUST_EMIT_QUERY_EVENTS=1 (off by default; query traffic is high-frequency).",
+  "type": "object",
+  "required": [
+    "scope",
+    "capability",
+    "actor",
+    "tier",
+    "in_cooldown",
+    "auto_raise_eligible"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "scope": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "Logical scope (e.g., 'flatline', 'mount', 'deploy'). Caller-defined."
+    },
+    "capability": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "Logical capability within the scope (e.g., 'merge_main', 'auto_apply')."
+    },
+    "actor": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "Operator slug from OPERATORS.md (verified via operator-identity.sh when LOA_TRUST_REQUIRE_KNOWN_ACTOR=1)."
+    },
+    "tier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{1,32}$",
+      "description": "Resolved tier (e.g., 'T0'..'T3') — operator-defined per .loa.config.yaml::graduated_trust.tier_definitions."
+    },
+    "in_cooldown": {
+      "type": "boolean",
+      "description": "True iff the most recent transition was an auto_drop and ts_now < cooldown_until."
+    },
+    "auto_raise_eligible": {
+      "type": "boolean",
+      "description": "Stub indicator (FR-L4-4 / FU-3 deferral). Currently always false; auto-raise requires operator action."
+    },
+    "ledger_entries_seen": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Optional counter of ledger entries scanned for this (scope, capability, actor) triple. Diagnostic only."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/trust-events/trust-response.schema.json
+++ b/.claude/data/trajectory-schemas/trust-events/trust-response.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://0xhoneyjar.dev/loa/schemas/trust-events/trust-response.schema.json",
+  "title": "L4 TrustResponse",
+  "description": "Return shape of trust_query. Per SDD §5.6.2. NOT an audit envelope payload — this is the read-API output. Validated by tests; not enforced via audit_emit (queries do not always emit events).",
+  "type": "object",
+  "required": [
+    "scope",
+    "capability",
+    "actor",
+    "tier",
+    "transition_history",
+    "in_cooldown_until",
+    "auto_raise_eligible"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "scope": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "capability": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "actor": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "tier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{1,32}$"
+    },
+    "transition_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["from_tier", "to_tier", "transition_type", "ts_utc", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "from_tier": {
+            "type": ["string", "null"],
+            "pattern": "^[A-Za-z0-9_-]{1,32}$"
+          },
+          "to_tier": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,32}$"
+          },
+          "transition_type": {
+            "type": "string",
+            "enum": ["initial", "operator_grant", "auto_drop", "force_grant", "auto_raise_eligible"]
+          },
+          "ts_utc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "decision_id": {
+            "type": ["string", "null"]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "in_cooldown_until": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "auto_raise_eligible": {
+      "type": "boolean",
+      "description": "Always false in cycle-098 per FU-3 deferral."
+    }
+  }
+}

--- a/.claude/data/trajectory-schemas/trust-events/trust-response.schema.json
+++ b/.claude/data/trajectory-schemas/trust-events/trust-response.schema.json
@@ -34,8 +34,9 @@
             "pattern": "^[A-Za-z0-9_-]{1,32}$"
           },
           "to_tier": {
-            "type": "string",
-            "pattern": "^[A-Za-z0-9_-]{1,32}$"
+            "type": ["string", "null"],
+            "pattern": "^[A-Za-z0-9_-]{1,32}$",
+            "description": "null for trust.auto_raise_eligible entries (informational; no tier change)"
           },
           "transition_type": {
             "type": "string",
@@ -44,6 +45,11 @@
           "ts_utc": {
             "type": "string",
             "format": "date-time"
+          },
+          "cooldown_until": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "Frozen cooldown_until from auto_drop payloads; null for non-auto_drop transitions"
           },
           "decision_id": {
             "type": ["string", "null"]

--- a/.claude/loa/CLAUDE.loa.md
+++ b/.claude/loa/CLAUDE.loa.md
@@ -331,6 +331,27 @@ The L3 chassis runs scheduled autonomous cycles via a 5-phase DispatchContract (
 
 **Reference**: `.claude/skills/scheduled-cycle-template/SKILL.md` (caller-facing usage) + `grimoires/loa/sdd.md` §5.5 (full API spec).
 
+## L4 Graduated-Trust (cycle-098 Sprint 4)
+
+The L4 primitive maintains a per-(scope, capability, actor) trust ledger where tier ratchets up by demonstrated alignment (operator grants) and ratchets down automatically on observed override (record_override → auto_drop + cooldown). Hash-chained for tamper detection; TRACKED in git for reconstructability. Library: `.claude/scripts/lib/graduated-trust-lib.sh`. Schemas: `.claude/data/trajectory-schemas/trust-events/`. Skill: `.claude/skills/graduated-trust/`.
+
+### Graduated-Trust Constraints
+
+| Rule | Why |
+|------|-----|
+| ALWAYS use `trust_grant` (not direct `audit_emit "L4" "trust.grant"`) for tier transitions | trust_grant validates the transition against operator-defined transition_rules (FR-L4-2), enforces cooldown (FR-L4-3), and serializes via the .txn.lock. Direct audit_emit bypasses all of these and corrupts the trust contract. |
+| ALWAYS configure at least one `auto_drop_on_override` rule when `graduated_trust.enabled: true` | trust_record_override refuses to invent drop semantics. Without an explicit rule (or `from: any, to_lower: true` fallback), every override returns exit 3 — observable as a misconfiguration loop. |
+| ALWAYS prefer the FROZEN `payload.cooldown_until` over recomputing from current `cooldown_seconds` config | Audit-immutability: changing cooldown_seconds in operator config later must NOT retroactively shift past windows. The 4A resolver reads the frozen value; tooling that bypasses the lib MUST do the same. |
+| NEVER share the audit_emit lock file (`<log>.lock`) with a transaction lock — use `<log>.txn.lock` for read-modify-write atoms | audit_emit's flock guards the chain append; a higher-level transaction (cooldown check vs concurrent writer) needs its own lock. Same lock = deadlock when the transaction calls audit_emit. |
+| NEVER call `trust_grant --force` without a `--reason` | Force-grant is the only path that bypasses cooldown. Reason is the auditor's only signal; the lib refuses an empty/missing reason (exit 2). |
+| ALWAYS treat `trust.force_grant` as a protected-class operation per `protected-classes.yaml` | Force-grant overrides the safety mechanism; protected-class-router classifies it as operator-bound by definition. Tools that wrap trust_grant --force MUST go through the operator-confirmation flow. |
+| ALWAYS reconstruct via `trust_recover_chain` (not by hand) when chain validation fails | trust_recover_chain wraps audit_recover_chain which knows the TRACKED-log git-history walk path. Hand-rolled rebuilds reintroduce path-resolution bugs (cycle-098 Sprint 4 patched a basename-vs-repo-relative-path defect in `_audit_recover_from_git`). |
+| ALWAYS emit `trust.disable` via `trust_disable` (not by appending [L4-DISABLED] manually) | trust_disable acquires the txn lock, refuses double-seal, and writes a properly-chained envelope. A bare `[L4-DISABLED]` marker leaves the chain unsealed and the next writer can append a new entry, breaking the seal contract. |
+| MAY enable `LOA_TRUST_REQUIRE_KNOWN_ACTOR=1` for deployments that maintain `OPERATORS.md` | When set, both `actor` and `operator` MUST resolve via operator-identity. Off by default to ease first-install friction; turn on for production deployments with a populated OPERATORS.md. |
+| MAY enable `LOA_TRUST_EMIT_QUERY_EVENTS=1` to record every read | Off by default because query traffic is high-frequency; turn on when an auditor specifically wants the read trail. |
+
+**Reference**: `.claude/skills/graduated-trust/SKILL.md` (caller-facing usage) + `grimoires/loa/cycles/cycle-098-agent-network/sdd.md` §5.6 (full API spec).
+
 ## Conventions
 
 - Never skip phases - each builds on previous

--- a/.claude/scripts/audit-envelope.sh
+++ b/.claude/scripts/audit-envelope.sh
@@ -900,16 +900,40 @@ _audit_recover_from_git() {
     local log_path="$1"
     local git_dir
     git_dir="$(dirname "$log_path")"
-    local rel_path
-    rel_path="$(basename "$log_path")"
 
     if ! git -C "$git_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         return 1
     fi
 
+    # Resolve the repo root + repo-relative path. The previous implementation
+    # used basename(log_path) which failed for logs in subdirectories
+    # (e.g., .run/trust-ledger.jsonl) because git pathspecs and `git show
+    # <commit>:<path>` are repo-rooted, not log-dir-rooted. cycle-098 sprint-4
+    # uncovered this when L4 began exercising audit_recover_chain via
+    # trust_recover_chain.
+    local repo_root abs_log rel_to_root
+    repo_root="$(git -C "$git_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -z "$repo_root" ]]; then
+        return 1
+    fi
+    # Canonicalize the log path so realpath gives us a comparable string.
+    if command -v realpath >/dev/null 2>&1; then
+        abs_log="$(realpath "$log_path" 2>/dev/null || true)"
+    else
+        abs_log="$(cd "$git_dir" && pwd)/$(basename "$log_path")"
+    fi
+    if [[ -z "$abs_log" ]]; then
+        return 1
+    fi
+    rel_to_root="${abs_log#"$repo_root"/}"
+    if [[ "$rel_to_root" == "$abs_log" ]]; then
+        # Did not start with repo_root (defensive — should not happen)
+        return 1
+    fi
+
     # Walk commits newest-to-oldest.
     local commits
-    commits="$(git -C "$git_dir" log --pretty=format:%H -- "$rel_path" 2>/dev/null || true)"
+    commits="$(git -C "$repo_root" log --pretty=format:%H -- "$rel_to_root" 2>/dev/null || true)"
     if [[ -z "$commits" ]]; then
         return 1
     fi
@@ -918,7 +942,7 @@ _audit_recover_from_git() {
     while IFS= read -r commit; do
         [[ -z "$commit" ]] && continue
         local content
-        if ! content="$(git -C "$git_dir" show "${commit}:${rel_path}" 2>/dev/null)"; then
+        if ! content="$(git -C "$repo_root" show "${commit}:${rel_to_root}" 2>/dev/null)"; then
             continue
         fi
         if _audit_chain_validates_lines "$content"; then

--- a/.claude/scripts/audit-envelope.sh
+++ b/.claude/scripts/audit-envelope.sh
@@ -916,18 +916,24 @@ _audit_recover_from_git() {
     if [[ -z "$repo_root" ]]; then
         return 1
     fi
-    # Canonicalize the log path so realpath gives us a comparable string.
-    if command -v realpath >/dev/null 2>&1; then
-        abs_log="$(realpath "$log_path" 2>/dev/null || true)"
-    else
-        abs_log="$(cd "$git_dir" && pwd)/$(basename "$log_path")"
+    # Canonicalize repo_root + log_path so the prefix-strip is exact.
+    # Sprint 4 cypherpunk audit HIGH-4: realpath is required (no fallback that
+    # silently drops subdir context); also canonicalize repo_root because
+    # rev-parse --show-toplevel may report a path that differs from realpath
+    # in symlinked-checkout scenarios.
+    if ! command -v realpath >/dev/null 2>&1; then
+        _audit_log "audit_recover_chain: realpath unavailable; cannot resolve repo-relative log path safely"
+        return 1
     fi
+    repo_root="$(realpath "$repo_root" 2>/dev/null || echo "$repo_root")"
+    abs_log="$(realpath "$log_path" 2>/dev/null || true)"
     if [[ -z "$abs_log" ]]; then
         return 1
     fi
     rel_to_root="${abs_log#"$repo_root"/}"
-    if [[ "$rel_to_root" == "$abs_log" ]]; then
-        # Did not start with repo_root (defensive — should not happen)
+    if [[ "$rel_to_root" == "$abs_log" ]] || [[ "$rel_to_root" == /* ]]; then
+        # Did not start with repo_root, OR strip left an absolute path
+        # (defensive — would only happen with a degenerate root).
         return 1
     fi
 

--- a/.claude/scripts/lib/graduated-trust-lib.sh
+++ b/.claude/scripts/lib/graduated-trust-lib.sh
@@ -1,0 +1,705 @@
+#!/usr/bin/env bash
+# =============================================================================
+# graduated-trust-lib.sh — L4 graduated-trust (cycle-098 Sprint 4)
+#
+# cycle-098 Sprint 4 — implementation of the L4 per-(scope, capability, actor)
+# trust ledger per RFC #656, PRD FR-L4 (8 ACs), SDD §1.4.2 + §5.6.
+#
+# Composition (does NOT reinvent):
+#   - 1A audit envelope:       audit_emit + audit_verify_chain
+#   - 1B signing scheme:       audit_emit honors LOA_AUDIT_SIGNING_KEY_ID
+#   - 1B protected-class:      is_protected_class("trust.force_grant")
+#   - 1B operator-identity:    operator_identity_verify (when known-actor required)
+#   - 1.5 trust-store check:   audit_emit auto-verifies trust-store
+#
+# Sprint slice that this file ships in:
+#   - 4A (FOUNDATION): schemas, config getters, input validators,
+#                      trust_query + ledger walker (FR-L4-1)
+#   - 4B (TRANSITIONS): trust_grant, trust_record_override
+#                       (FR-L4-2, FR-L4-3) — TODO Sprint 4B
+#   - 4C (INTEGRITY):   trust_verify_chain, reconstruction, force-grant,
+#                       auto-raise stub (FR-L4-4, FR-L4-5, FR-L4-7, FR-L4-8)
+#                       — TODO Sprint 4C
+#   - 4D (SEAL/CLI):    trust_disable, concurrent-write tests
+#                       (FR-L4-6) — TODO Sprint 4D
+#
+# Verdict semantics (PRD §FR-L4 + SDD §5.6.3):
+#   - First query returns default_tier (FR-L4-1).
+#   - Only configured transitions allowed (FR-L4-2; arbitrary jumps return error).
+#   - recordOverride auto-drops + starts cooldown (FR-L4-3).
+#   - Force-grant in cooldown logged as exception with reason (FR-L4-8).
+#
+# Public functions (full set; some are 4B+ stubs at this stage):
+#   trust_query <scope> <capability> <actor>
+#       Returns TrustResponse JSON on stdout. Exit 0 on success; 2 on bad input;
+#       1 on ledger / config error.
+#
+#   trust_grant     <scope> <capability> <actor> <new_tier> [--force] [--reason <text>] [--operator <slug>]
+#                   — TODO 4B (regular) / 4C (--force exception path)
+#
+#   trust_record_override <scope> <capability> <actor> <decision_id> <reason>
+#                   — TODO 4B
+#
+#   trust_verify_chain
+#                   — TODO 4C
+#
+#   trust_disable [--reason <text>] [--operator <slug>]
+#                   — TODO 4D
+#
+# Environment variables:
+#   LOA_TRUST_LEDGER_FILE         override .run/trust-ledger.jsonl path
+#   LOA_TRUST_CONFIG_FILE         override .loa.config.yaml path
+#   LOA_TRUST_TEST_NOW            test-only override for "now" (ISO-8601)
+#   LOA_TRUST_EMIT_QUERY_EVENTS   when "1", trust_query also emits trust.query
+#                                 audit event (off by default; query traffic
+#                                 high-frequency)
+#   LOA_TRUST_REQUIRE_KNOWN_ACTOR when "1", actor MUST resolve via
+#                                 operator-identity (OPERATORS.md). Off by
+#                                 default for low-friction first install.
+#   LOA_TRUST_DEFAULT_TIER        env override of graduated_trust.default_tier
+#   LOA_TRUST_COOLDOWN_SECONDS    env override of graduated_trust.cooldown_seconds
+#
+# Exit codes:
+#   0 = success
+#   1 = ledger/config error (e.g., chain broken, ledger sealed [L4-DISABLED])
+#   2 = invalid arguments
+#   3 = configuration error (e.g., missing tier_definitions when L4 enabled)
+# =============================================================================
+
+set -euo pipefail
+
+if [[ "${_LOA_L4_LIB_SOURCED:-0}" == "1" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+_LOA_L4_LIB_SOURCED=1
+
+_L4_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_L4_REPO_ROOT="$(cd "${_L4_DIR}/../../.." && pwd)"
+_L4_AUDIT_ENVELOPE="${_L4_REPO_ROOT}/.claude/scripts/audit-envelope.sh"
+_L4_PROTECTED_ROUTER="${_L4_REPO_ROOT}/.claude/scripts/lib/protected-class-router.sh"
+_L4_OPERATOR_IDENTITY="${_L4_REPO_ROOT}/.claude/scripts/operator-identity.sh"
+_L4_SCHEMA_DIR="${_L4_REPO_ROOT}/.claude/data/trajectory-schemas/trust-events"
+
+# shellcheck source=../audit-envelope.sh
+source "${_L4_AUDIT_ENVELOPE}"
+# shellcheck source=protected-class-router.sh
+source "${_L4_PROTECTED_ROUTER}"
+# shellcheck source=../operator-identity.sh
+source "${_L4_OPERATOR_IDENTITY}"
+
+_l4_log() { echo "[graduated-trust] $*" >&2; }
+
+# -----------------------------------------------------------------------------
+# Defaults (overridable via env vars or .loa.config.yaml).
+# -----------------------------------------------------------------------------
+_L4_DEFAULT_LEDGER=".run/trust-ledger.jsonl"
+_L4_DEFAULT_TIER="T0"
+_L4_DEFAULT_COOLDOWN_SECONDS="604800"   # 7 days, per SDD §5.6.3
+
+# -----------------------------------------------------------------------------
+# Input validation regexes.
+#
+# Scope, capability, actor are operator-supplied identifiers. We pin them to a
+# conservative charset (alphanumeric + . _ - / : @) that:
+#   - excludes shell metacharacters ($ ` " ' \ ; & | < > ( ) { } [ ])
+#   - excludes whitespace, newlines, control bytes
+#   - tolerates common namespace separators ('.', '/', ':')
+#
+# THIS REGEX IS NOT SUFFICIENT ON ITS OWN — per cycle-099 charclass dot-dot
+# memory entry, `^[A-Za-z0-9._/-]+$` accepts `..` because each dot is
+# individually in class. We pair it with explicit *..* + url-shape rejection
+# in `_l4_validate_token` below.
+# -----------------------------------------------------------------------------
+_L4_TOKEN_RE='^[A-Za-z0-9._/:@-]{1,256}$'
+_L4_TIER_RE='^[A-Za-z0-9_-]{1,32}$'
+_L4_INT_RE='^[0-9]+$'
+
+# -----------------------------------------------------------------------------
+# _l4_validate_token <value> <field_name>
+#
+# Validates an operator-supplied identifier. Rejects:
+#   - empty
+#   - non-matching charset
+#   - dot-dot sequences (charclass-bypass defense)
+#   - URL-shape sentinels (`://`, leading `//`, leading `?`) — pasted-secret defense
+# -----------------------------------------------------------------------------
+_l4_validate_token() {
+    local value="$1"
+    local field="$2"
+    if [[ -z "$value" ]]; then
+        _l4_log "ERROR: $field is empty"
+        return 1
+    fi
+    if ! [[ "$value" =~ $_L4_TOKEN_RE ]]; then
+        _l4_log "ERROR: $field='$value' does not match $_L4_TOKEN_RE"
+        return 1
+    fi
+    if [[ "$value" == *..* ]]; then
+        _l4_log "ERROR: $field='$value' contains '..' (path traversal sentinel)"
+        return 1
+    fi
+    # URL-shape sentinels (cycle-099 #761 pattern). Operators sometimes paste
+    # the wrong field; reject anything that looks like a URL or query string.
+    if [[ "$value" == *://* ]] || [[ "$value" == //* ]] || [[ "$value" == \?* ]]; then
+        _l4_log "ERROR: $field='$value' looks URL-shaped (rejected)"
+        return 1
+    fi
+    return 0
+}
+
+_l4_validate_tier() {
+    local value="$1"
+    local field="$2"
+    if [[ -z "$value" ]] || ! [[ "$value" =~ $_L4_TIER_RE ]]; then
+        _l4_log "ERROR: $field='$value' does not match $_L4_TIER_RE"
+        return 1
+    fi
+    return 0
+}
+
+_l4_validate_int() {
+    local value="$1"
+    local field="$2"
+    if [[ -z "$value" ]] || ! [[ "$value" =~ $_L4_INT_RE ]]; then
+        _l4_log "ERROR: $field='$value' is not a non-negative integer"
+        return 1
+    fi
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# _l4_config_path — return resolved .loa.config.yaml path.
+# -----------------------------------------------------------------------------
+_l4_config_path() {
+    echo "${LOA_TRUST_CONFIG_FILE:-${_L4_REPO_ROOT}/.loa.config.yaml}"
+}
+
+# -----------------------------------------------------------------------------
+# _l4_ledger_path — return resolved .run/trust-ledger.jsonl path.
+# -----------------------------------------------------------------------------
+_l4_ledger_path() {
+    if [[ -n "${LOA_TRUST_LEDGER_FILE:-}" ]]; then
+        echo "$LOA_TRUST_LEDGER_FILE"
+    else
+        echo "${_L4_REPO_ROOT}/${_L4_DEFAULT_LEDGER}"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# _l4_config_get <yaml_path> [default]
+#
+# Read a value from .loa.config.yaml using yq if available, else PyYAML.
+# `<yaml_path>` is a yq dotted expression (e.g., '.graduated_trust.default_tier').
+# -----------------------------------------------------------------------------
+_l4_config_get() {
+    local yq_path="$1"
+    local default="${2:-}"
+    local config
+    config="$(_l4_config_path)"
+    [[ -f "$config" ]] || { echo "$default"; return 0; }
+    if command -v yq >/dev/null 2>&1; then
+        local result
+        result="$(yq -r "${yq_path} // \"\"" "$config" 2>/dev/null || true)"
+        if [[ -z "$result" || "$result" == "null" ]]; then
+            echo "$default"
+        else
+            echo "$result"
+        fi
+        return 0
+    fi
+    local clean_path="${yq_path#.}"
+    python3 - "$config" "$clean_path" "$default" <<'PY' 2>/dev/null || echo "$default"
+import sys
+try:
+    import yaml
+except ImportError:
+    print(sys.argv[3])
+    sys.exit(0)
+try:
+    with open(sys.argv[1]) as f:
+        doc = yaml.safe_load(f) or {}
+except Exception:
+    print(sys.argv[3])
+    sys.exit(0)
+parts = sys.argv[2].split('.')
+node = doc
+for p in parts:
+    if isinstance(node, dict) and p in node:
+        node = node[p]
+    else:
+        print(sys.argv[3])
+        sys.exit(0)
+if node is None or node == "":
+    print(sys.argv[3])
+else:
+    print(node)
+PY
+}
+
+# -----------------------------------------------------------------------------
+# _l4_enabled — is L4 enabled in operator config?
+# Returns 0 (true) when graduated_trust.enabled is true; 1 otherwise.
+# Default: false (operator must opt in).
+# -----------------------------------------------------------------------------
+_l4_enabled() {
+    local v
+    v="$(_l4_config_get '.graduated_trust.enabled' 'false')"
+    [[ "$v" == "true" ]]
+}
+
+_l4_get_default_tier() {
+    if [[ -n "${LOA_TRUST_DEFAULT_TIER:-}" ]]; then
+        echo "$LOA_TRUST_DEFAULT_TIER"
+        return 0
+    fi
+    _l4_config_get '.graduated_trust.default_tier' "$_L4_DEFAULT_TIER"
+}
+
+_l4_get_cooldown_seconds() {
+    local s
+    if [[ -n "${LOA_TRUST_COOLDOWN_SECONDS:-}" ]]; then
+        s="$LOA_TRUST_COOLDOWN_SECONDS"
+    else
+        s="$(_l4_config_get '.graduated_trust.cooldown_seconds' "$_L4_DEFAULT_COOLDOWN_SECONDS")"
+    fi
+    if ! _l4_validate_int "$s" "cooldown_seconds"; then
+        echo "$_L4_DEFAULT_COOLDOWN_SECONDS"
+        return 0
+    fi
+    echo "$s"
+}
+
+# -----------------------------------------------------------------------------
+# _l4_get_tier_definitions
+#
+# Returns a JSON object: { "T0": {description: "..."}, ... } from
+# .loa.config.yaml::graduated_trust.tier_definitions. Returns "{}" when
+# L4 is disabled or no tier_definitions are configured.
+# -----------------------------------------------------------------------------
+_l4_get_tier_definitions() {
+    local config
+    config="$(_l4_config_path)"
+    if [[ ! -f "$config" ]]; then
+        echo '{}'
+        return 0
+    fi
+    if command -v yq >/dev/null 2>&1; then
+        local result
+        result="$(yq -o=json '.graduated_trust.tier_definitions // {}' "$config" 2>/dev/null || echo '{}')"
+        if [[ -z "$result" || "$result" == "null" ]]; then
+            echo '{}'
+        else
+            printf '%s\n' "$result" | jq -c .
+        fi
+        return 0
+    fi
+    python3 - "$config" <<'PY' 2>/dev/null || echo '{}'
+import sys, json
+try:
+    import yaml
+except ImportError:
+    print('{}'); sys.exit(0)
+try:
+    with open(sys.argv[1]) as f:
+        doc = yaml.safe_load(f) or {}
+except Exception:
+    print('{}'); sys.exit(0)
+node = ((doc or {}).get('graduated_trust') or {}).get('tier_definitions') or {}
+print(json.dumps(node))
+PY
+}
+
+# -----------------------------------------------------------------------------
+# _l4_get_transition_rules
+#
+# Returns a JSON array of transition rules from
+# .loa.config.yaml::graduated_trust.transition_rules. Each rule has the shape
+# documented in SDD §5.6.3:
+#   { from: "T0", to: "T1", requires: "operator_grant" }
+#   { from: "any", to_lower: true, via: "auto_drop_on_override" }
+#
+# Returns "[]" when none configured.
+# -----------------------------------------------------------------------------
+_l4_get_transition_rules() {
+    local config
+    config="$(_l4_config_path)"
+    if [[ ! -f "$config" ]]; then
+        echo '[]'
+        return 0
+    fi
+    if command -v yq >/dev/null 2>&1; then
+        local result
+        result="$(yq -o=json '.graduated_trust.transition_rules // []' "$config" 2>/dev/null || echo '[]')"
+        if [[ -z "$result" || "$result" == "null" ]]; then
+            echo '[]'
+        else
+            printf '%s\n' "$result" | jq -c .
+        fi
+        return 0
+    fi
+    python3 - "$config" <<'PY' 2>/dev/null || echo '[]'
+import sys, json
+try:
+    import yaml
+except ImportError:
+    print('[]'); sys.exit(0)
+try:
+    with open(sys.argv[1]) as f:
+        doc = yaml.safe_load(f) or {}
+except Exception:
+    print('[]'); sys.exit(0)
+node = ((doc or {}).get('graduated_trust') or {}).get('transition_rules') or []
+print(json.dumps(node))
+PY
+}
+
+# -----------------------------------------------------------------------------
+# _l4_now_iso8601 — current UTC time, microsecond precision.
+# Honors LOA_TRUST_TEST_NOW for deterministic tests. Format must match
+# ts_utc field of audit envelope (RFC 3339 with offset Z).
+# -----------------------------------------------------------------------------
+_l4_now_iso8601() {
+    if [[ -n "${LOA_TRUST_TEST_NOW:-}" ]]; then
+        echo "$LOA_TRUST_TEST_NOW"
+        return 0
+    fi
+    python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z")'
+}
+
+# -----------------------------------------------------------------------------
+# _l4_iso_to_epoch_seconds <iso8601>
+#
+# Convert RFC 3339 / ISO-8601 to epoch seconds (integer, truncated). Used to
+# compare timestamps for cooldown enforcement. Trailing Z and offsets handled.
+# Outputs the integer; exits non-zero on parse failure.
+# -----------------------------------------------------------------------------
+_l4_iso_to_epoch_seconds() {
+    local iso="$1"
+    python3 -c '
+import sys
+from datetime import datetime
+s = sys.argv[1]
+# Normalize: trailing Z -> +00:00 for fromisoformat
+if s.endswith("Z"):
+    s = s[:-1] + "+00:00"
+try:
+    dt = datetime.fromisoformat(s)
+except Exception as e:
+    print(f"_l4_iso_to_epoch_seconds: parse failure: {e}", file=sys.stderr)
+    sys.exit(1)
+print(int(dt.timestamp()))
+' "$iso"
+}
+
+# -----------------------------------------------------------------------------
+# _l4_ledger_is_sealed [<ledger_file>]
+#
+# Returns 0 (true) when the ledger's last entry is event_type=trust.disable.
+# Per PRD §849: on disable, the ledger is preserved (immutable hash-chain);
+# subsequent reads return last-known-tier per scope; no new transitions.
+#
+# Returns 1 (false) when ledger absent or last entry is not trust.disable.
+# -----------------------------------------------------------------------------
+_l4_ledger_is_sealed() {
+    local ledger="${1:-$(_l4_ledger_path)}"
+    [[ -f "$ledger" ]] || return 1
+    [[ -s "$ledger" ]] || return 1
+    local last_event
+    last_event="$(tail -n 1 "$ledger" 2>/dev/null | jq -r '.event_type // ""' 2>/dev/null || true)"
+    [[ "$last_event" == "trust.disable" ]]
+}
+
+# -----------------------------------------------------------------------------
+# _l4_walk_ledger <ledger_file> <scope> <capability> <actor>
+#
+# Stream-filter the ledger and emit a transition_history JSON array on stdout.
+# Each emitted item has shape:
+#   { from_tier, to_tier, transition_type, ts_utc, decision_id|null, reason }
+#
+# Emits "[]" when no entries match. Accepts events:
+#   trust.grant       -> transition_type:"operator_grant" (or "initial" when from_tier null)
+#   trust.auto_drop   -> transition_type:"auto_drop"
+#   trust.force_grant -> transition_type:"force_grant"
+#   trust.auto_raise_eligible -> transition_type:"auto_raise_eligible"
+#
+# trust.disable and trust.query are ignored (not transitions).
+#
+# CRITICAL: filter is a jq pipeline driven by --arg (no string interpolation;
+# defense per cycle-098 jq-injection memory).
+# -----------------------------------------------------------------------------
+_l4_walk_ledger() {
+    local ledger="$1"
+    local scope="$2"
+    local capability="$3"
+    local actor="$4"
+
+    if [[ ! -f "$ledger" ]] || [[ ! -s "$ledger" ]]; then
+        echo '[]'
+        return 0
+    fi
+
+    # jq slurp-then-map: stream JSONL into array, filter by selector, project.
+    # --slurp consumes the file as a single array. --raw-input + decode would
+    # be heavier; the ledger file is bounded by retention and per-line sizes.
+    jq -sc \
+        --arg scope "$scope" \
+        --arg capability "$capability" \
+        --arg actor "$actor" \
+        '
+        map(
+          select(
+            (.payload.scope == $scope) and
+            (.payload.capability == $capability) and
+            (.payload.actor == $actor) and
+            (.event_type == "trust.grant" or
+             .event_type == "trust.auto_drop" or
+             .event_type == "trust.force_grant" or
+             .event_type == "trust.auto_raise_eligible")
+          )
+          | {
+              from_tier: (.payload.from_tier // null),
+              to_tier:   (.payload.to_tier // .payload.next_tier),
+              transition_type: (
+                if .event_type == "trust.grant" then
+                  (if (.payload.from_tier // null) == null then "initial" else "operator_grant" end)
+                elif .event_type == "trust.auto_drop" then "auto_drop"
+                elif .event_type == "trust.force_grant" then "force_grant"
+                elif .event_type == "trust.auto_raise_eligible" then "auto_raise_eligible"
+                else "operator_grant"
+                end
+              ),
+              ts_utc: .ts_utc,
+              decision_id: (.payload.decision_id // null),
+              reason: (.payload.reason // "")
+            }
+        )
+        ' "$ledger"
+}
+
+# -----------------------------------------------------------------------------
+# _l4_resolve_state <transition_history_json> <default_tier> <cooldown_seconds> <now_iso>
+#
+# Given a transition_history JSON array, the configured default_tier, the
+# cooldown window, and "now", compute:
+#   - effective tier (last to_tier, else default_tier)
+#   - in_cooldown_until (ISO-8601 if last *non-revoking* transition was an
+#     auto_drop AND now < its cooldown_until; else null)
+#
+# Emits JSON: {tier, in_cooldown_until} on stdout.
+#
+# Cooldown semantics (matches FR-L4-3 + FR-L4-8 narrative):
+#   - auto_drop sets cooldown_until = ts_utc(auto_drop) + cooldown_seconds.
+#   - operator_grant DOES NOT clear cooldown_until on its own (operator must
+#     use --force, which records trust.force_grant; force_grant CLEARS the
+#     cooldown).
+#   - force_grant therefore clears the cooldown.
+# -----------------------------------------------------------------------------
+_l4_resolve_state() {
+    local history_json="$1"
+    local default_tier="$2"
+    local cooldown_seconds="$3"
+    local now_iso="$4"
+
+    python3 - "$history_json" "$default_tier" "$cooldown_seconds" "$now_iso" <<'PY'
+import json, sys
+from datetime import datetime, timedelta
+
+history = json.loads(sys.argv[1] or "[]")
+default_tier = sys.argv[2]
+cooldown_seconds = int(sys.argv[3])
+now_iso = sys.argv[4]
+
+def parse_iso(s):
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+now = parse_iso(now_iso)
+
+tier = default_tier
+cooldown_until_iso = None
+last_auto_drop_until = None
+
+for entry in history:
+    ttype = entry.get("transition_type")
+    to_tier = entry.get("to_tier")
+    ts_utc = entry.get("ts_utc")
+    if to_tier:
+        tier = to_tier
+    if ttype == "auto_drop" and ts_utc:
+        try:
+            t = parse_iso(ts_utc)
+            last_auto_drop_until = t + timedelta(seconds=cooldown_seconds)
+        except Exception:
+            pass
+    elif ttype == "force_grant":
+        # force_grant clears the cooldown
+        last_auto_drop_until = None
+    # operator_grant / initial / auto_raise_eligible: do NOT clear cooldown
+
+if last_auto_drop_until is not None and now < last_auto_drop_until:
+    s = last_auto_drop_until.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    cooldown_until_iso = s
+
+print(json.dumps({"tier": tier, "in_cooldown_until": cooldown_until_iso}))
+PY
+}
+
+# =============================================================================
+# Public API
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# trust_query <scope> <capability> <actor>
+#
+# FR-L4-1: First query for any (scope, capability, actor) returns default_tier.
+#
+# Returns TrustResponse (SDD §5.6.2 / trust-response.schema.json):
+#   {
+#     scope, capability, actor, tier,
+#     transition_history: [...],
+#     in_cooldown_until: ISO-8601 | null,
+#     auto_raise_eligible: boolean
+#   }
+# on stdout. Exit 0 success / 2 bad input / 1 ledger or config error.
+# -----------------------------------------------------------------------------
+trust_query() {
+    local scope="${1:-}"
+    local capability="${2:-}"
+    local actor="${3:-}"
+
+    if [[ -z "$scope" || -z "$capability" || -z "$actor" ]]; then
+        _l4_log "trust_query: missing required argument (scope, capability, actor)"
+        return 2
+    fi
+
+    _l4_validate_token "$scope" "scope" || return 2
+    _l4_validate_token "$capability" "capability" || return 2
+    _l4_validate_token "$actor" "actor" || return 2
+
+    if [[ "${LOA_TRUST_REQUIRE_KNOWN_ACTOR:-0}" == "1" ]]; then
+        if ! operator_identity_lookup "$actor" >/dev/null 2>&1; then
+            _l4_log "trust_query: actor='$actor' not found in OPERATORS.md (LOA_TRUST_REQUIRE_KNOWN_ACTOR=1)"
+            return 2
+        fi
+    fi
+
+    local default_tier cooldown_seconds now_iso ledger
+    default_tier="$(_l4_get_default_tier)"
+    cooldown_seconds="$(_l4_get_cooldown_seconds)"
+    now_iso="$(_l4_now_iso8601)"
+    ledger="$(_l4_ledger_path)"
+
+    if ! _l4_validate_tier "$default_tier" "default_tier"; then
+        return 3
+    fi
+
+    local history state tier in_cooldown_until
+    history="$(_l4_walk_ledger "$ledger" "$scope" "$capability" "$actor")" || history='[]'
+    state="$(_l4_resolve_state "$history" "$default_tier" "$cooldown_seconds" "$now_iso")"
+    tier="$(echo "$state" | jq -r '.tier')"
+    in_cooldown_until="$(echo "$state" | jq -r '.in_cooldown_until')"
+    if [[ "$in_cooldown_until" == "null" ]]; then
+        in_cooldown_until=""
+    fi
+
+    # Build TrustResponse JSON.
+    local response
+    if [[ -n "$in_cooldown_until" ]]; then
+        response="$(jq -nc \
+            --arg scope "$scope" \
+            --arg capability "$capability" \
+            --arg actor "$actor" \
+            --arg tier "$tier" \
+            --argjson history "$history" \
+            --arg cooldown_until "$in_cooldown_until" \
+            '{
+                scope: $scope,
+                capability: $capability,
+                actor: $actor,
+                tier: $tier,
+                transition_history: $history,
+                in_cooldown_until: $cooldown_until,
+                auto_raise_eligible: false
+            }')"
+    else
+        response="$(jq -nc \
+            --arg scope "$scope" \
+            --arg capability "$capability" \
+            --arg actor "$actor" \
+            --arg tier "$tier" \
+            --argjson history "$history" \
+            '{
+                scope: $scope,
+                capability: $capability,
+                actor: $actor,
+                tier: $tier,
+                transition_history: $history,
+                in_cooldown_until: null,
+                auto_raise_eligible: false
+            }')"
+    fi
+
+    # Optional emission of trust.query event.
+    if [[ "${LOA_TRUST_EMIT_QUERY_EVENTS:-0}" == "1" ]]; then
+        local in_cooldown_bool="false"
+        [[ -n "$in_cooldown_until" ]] && in_cooldown_bool="true"
+        local entries_seen
+        entries_seen="$(echo "$history" | jq 'length')"
+        local payload
+        payload="$(jq -nc \
+            --arg scope "$scope" \
+            --arg capability "$capability" \
+            --arg actor "$actor" \
+            --arg tier "$tier" \
+            --argjson in_cooldown "$in_cooldown_bool" \
+            --argjson entries_seen "$entries_seen" \
+            '{
+                scope: $scope,
+                capability: $capability,
+                actor: $actor,
+                tier: $tier,
+                in_cooldown: $in_cooldown,
+                auto_raise_eligible: false,
+                ledger_entries_seen: $entries_seen
+            }')"
+        # Best-effort: don't fail trust_query if audit log is unwritable in
+        # a test fixture without LOA_AUDIT_LOG_DIR. Errors logged to stderr.
+        audit_emit "L4" "trust.query" "$payload" "$ledger" \
+            || _l4_log "trust_query: audit_emit trust.query failed (non-fatal)"
+    fi
+
+    printf '%s\n' "$response"
+}
+
+# -----------------------------------------------------------------------------
+# trust_grant — TODO Sprint 4B (regular path) / 4C (--force exception path).
+# -----------------------------------------------------------------------------
+trust_grant() {
+    _l4_log "trust_grant: not yet implemented (Sprint 4B/4C)"
+    return 99
+}
+
+# -----------------------------------------------------------------------------
+# trust_record_override — TODO Sprint 4B.
+# -----------------------------------------------------------------------------
+trust_record_override() {
+    _l4_log "trust_record_override: not yet implemented (Sprint 4B)"
+    return 99
+}
+
+# -----------------------------------------------------------------------------
+# trust_verify_chain — TODO Sprint 4C.
+# -----------------------------------------------------------------------------
+trust_verify_chain() {
+    _l4_log "trust_verify_chain: not yet implemented (Sprint 4C)"
+    return 99
+}
+
+# -----------------------------------------------------------------------------
+# trust_disable — TODO Sprint 4D.
+# -----------------------------------------------------------------------------
+trust_disable() {
+    _l4_log "trust_disable: not yet implemented (Sprint 4D)"
+    return 99
+}

--- a/.claude/scripts/lib/graduated-trust-lib.sh
+++ b/.claude/scripts/lib/graduated-trust-lib.sh
@@ -96,6 +96,13 @@ _L4_DEFAULT_LEDGER=".run/trust-ledger.jsonl"
 _L4_DEFAULT_TIER="T0"
 _L4_DEFAULT_COOLDOWN_SECONDS="604800"   # 7 days, per SDD §5.6.3
 
+# Hard ceiling on cooldown_until - ts_utc. Defends against ledger-write
+# adversaries who craft auto_drop entries with cooldown_until in the far
+# future (operator-stuck DoS) or in the distant past (cooldown nullification).
+# 90 days. The resolver clamps to this window even when payload.cooldown_until
+# claims otherwise. Sprint 4C cypherpunk audit CRIT-2.
+_L4_MAX_COOLDOWN_SECONDS="7776000"      # 90 days
+
 # -----------------------------------------------------------------------------
 # Input validation regexes.
 #
@@ -162,6 +169,33 @@ _l4_validate_int() {
     local field="$2"
     if [[ -z "$value" ]] || ! [[ "$value" =~ $_L4_INT_RE ]]; then
         _l4_log "ERROR: $field='$value' is not a non-negative integer"
+        return 1
+    fi
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# _l4_validate_reason <reason> <field_name>
+#
+# Reason / rationale strings flow into audit envelope payloads (JSON-escaped
+# so injection is safe at the parser level), but they also flow into
+# downstream tooling that uses line-oriented `grep -F` against the JSONL.
+# Reject control bytes (corrupt line-oriented consumers) and JSONL field
+# substrings (defeat grep-based auditors). Sprint 4 cypherpunk MED-2.
+# -----------------------------------------------------------------------------
+_l4_validate_reason() {
+    local reason="$1"
+    local field="$2"
+    if (( ${#reason} > 4096 )); then
+        _l4_log "ERROR: $field exceeds 4096 chars"
+        return 1
+    fi
+    if [[ "$reason" =~ [[:cntrl:]] ]]; then
+        _l4_log "ERROR: $field contains control bytes"
+        return 1
+    fi
+    if [[ "$reason" == *'"event_type":'* ]] || [[ "$reason" == *'"prev_hash":'* ]]; then
+        _l4_log "ERROR: $field contains JSONL field substring (rejected to protect grep-based auditors)"
         return 1
     fi
     return 0
@@ -245,6 +279,44 @@ _l4_enabled() {
     local v
     v="$(_l4_config_get '.graduated_trust.enabled' 'false')"
     [[ "$v" == "true" ]]
+}
+
+# -----------------------------------------------------------------------------
+# _l4_require_enabled
+#
+# Sprint 4 cypherpunk audit HIGH-3: gate every write entry-point. Writes
+# proceed only when graduated_trust.enabled=true. Refuses with exit 1 when
+# disabled or unconfigured.
+#
+# Reads are NOT gated — operators can inspect prior state via trust_query
+# even after disabling the primitive (matches PRD §849 read-still-works-on-
+# sealed-ledger).
+# -----------------------------------------------------------------------------
+_l4_require_enabled() {
+    if ! _l4_enabled; then
+        _l4_log "graduated_trust.enabled is not true; refusing write (set graduated_trust.enabled: true in .loa.config.yaml)"
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# _l4_require_chain_intact <ledger>
+#
+# Sprint 4 cypherpunk audit HIGH-2: refuse to APPEND to a broken chain. If
+# audit_verify_chain reports breakage, the operator must run trust_recover_chain
+# (FR-L4-7) before further writes. Reads are NOT gated — they may degrade
+# gracefully via _l4_walk_ledger which already filters non-JSON marker lines.
+#
+# Empty / missing ledger is treated as intact (clean install).
+# -----------------------------------------------------------------------------
+_l4_require_chain_intact() {
+    local ledger="$1"
+    [[ -f "$ledger" ]] || return 0
+    [[ -s "$ledger" ]] || return 0
+    if ! audit_verify_chain "$ledger" >/dev/null 2>&1; then
+        _l4_log "ledger chain integrity broken at '$ledger'; run trust_recover_chain before further writes"
+        return 1
+    fi
 }
 
 _l4_get_default_tier() {
@@ -355,11 +427,17 @@ PY
 
 # -----------------------------------------------------------------------------
 # _l4_now_iso8601 — current UTC time, microsecond precision.
-# Honors LOA_TRUST_TEST_NOW for deterministic tests. Format must match
-# ts_utc field of audit envelope (RFC 3339 with offset Z).
+#
+# Honors LOA_TRUST_TEST_NOW for deterministic tests, but ONLY when test mode
+# is detected (LOA_TRUST_TEST_MODE=1, or running under bats via
+# BATS_TEST_DIRNAME). Production paths ignore LOA_TRUST_TEST_NOW so that an
+# adversary that can set env vars cannot rewrite history's "now" to clear
+# cooldowns or pre-date force-grants. Sprint 4 cypherpunk audit MED-4.
+# Format matches ts_utc field of audit envelope (RFC 3339 with offset Z).
 # -----------------------------------------------------------------------------
 _l4_now_iso8601() {
-    if [[ -n "${LOA_TRUST_TEST_NOW:-}" ]]; then
+    if [[ -n "${LOA_TRUST_TEST_NOW:-}" ]] \
+        && { [[ "${LOA_TRUST_TEST_MODE:-0}" == "1" ]] || [[ -n "${BATS_TEST_DIRNAME:-}" ]]; }; then
         echo "$LOA_TRUST_TEST_NOW"
         return 0
     fi
@@ -394,19 +472,30 @@ print(int(dt.timestamp()))
 # -----------------------------------------------------------------------------
 # _l4_ledger_is_sealed [<ledger_file>]
 #
-# Returns 0 (true) when the ledger's last entry is event_type=trust.disable.
-# Per PRD §849: on disable, the ledger is preserved (immutable hash-chain);
-# subsequent reads return last-known-tier per scope; no new transitions.
+# Returns 0 (true) when the ledger contains ANY trust.disable event_type.
+# Sprint 4 cypherpunk audit CRIT-1: scanning only the tail line is unsafe
+# because audit_recover_chain appends `[CHAIN-BROKEN]` / `[CHAIN-RECOVERED ...]`
+# marker lines after the last JSON entry. With tail-only scanning, a sealed
+# ledger followed by a marker would falsely appear unsealed and accept new
+# transitions after the seal.
 #
-# Returns 1 (false) when ledger absent or last entry is not trust.disable.
+# The seal is a STATE, not a tail position. Per PRD §849: on disable the
+# ledger is preserved (immutable hash-chain); subsequent reads return last-
+# known-tier per scope; no new transitions allowed.
+#
+# Returns 0 (true) on first matching trust.disable line; 1 (false) when no
+# such line exists or the ledger is absent.
 # -----------------------------------------------------------------------------
 _l4_ledger_is_sealed() {
     local ledger="${1:-$(_l4_ledger_path)}"
     [[ -f "$ledger" ]] || return 1
     [[ -s "$ledger" ]] || return 1
-    local last_event
-    last_event="$(tail -n 1 "$ledger" 2>/dev/null | jq -r '.event_type // ""' 2>/dev/null || true)"
-    [[ "$last_event" == "trust.disable" ]]
+    # Skip non-JSON marker lines (lines starting with `[`); for each remaining
+    # line, parse event_type. Match on first trust.disable found.
+    # awk over grep so an all-marker ledger doesn't trip pipefail.
+    awk '!/^\[/' "$ledger" 2>/dev/null \
+        | jq -r 'select(.event_type == "trust.disable") | .event_type' 2>/dev/null \
+        | grep -q '^trust\.disable$'
 }
 
 # -----------------------------------------------------------------------------
@@ -439,9 +528,21 @@ _l4_walk_ledger() {
     fi
 
     # jq slurp-then-map: stream JSONL into array, filter by selector, project.
-    # --slurp consumes the file as a single array. --raw-input + decode would
-    # be heavier; the ledger file is bounded by retention and per-line sizes.
-    jq -sc \
+    # --slurp consumes the file as a single array.
+    #
+    # Sprint 4 cypherpunk audit HIGH-1: filter marker lines (lines starting
+    # with `[` — appended by audit_recover_chain after recovery / chain-break)
+    # before jq -s. Without the filter, jq -s parse-errors and the caller
+    # (trust_query) silently falls back to '[]' (default-tier) — turning every
+    # query into a default-tier response on a partially-recovered ledger.
+    #
+    # If the filtered content fails to parse (corruption beyond marker lines),
+    # this function returns non-zero so the caller can refuse to act on a
+    # broken ledger rather than degrading to default_tier silently.
+    # awk over grep so an all-marker ledger produces empty stdout (exit 0)
+    # rather than tripping pipefail (grep -v exits 1 on no match).
+    awk '!/^\[/' "$ledger" 2>/dev/null \
+        | jq -sc \
         --arg scope "$scope" \
         --arg capability "$capability" \
         --arg actor "$actor" \
@@ -458,7 +559,13 @@ _l4_walk_ledger() {
           )
           | {
               from_tier: (.payload.from_tier // null),
-              to_tier:   (.payload.to_tier // .payload.next_tier),
+              # Auto-raise-eligible is informational; do NOT carry a to_tier
+              # (resolver if-to_tier guard treats null as no-op).
+              to_tier: (
+                if .event_type == "trust.auto_raise_eligible" then null
+                else (.payload.to_tier // null)
+                end
+              ),
               transition_type: (
                 if .event_type == "trust.grant" then
                   (if (.payload.from_tier // null) == null then "initial" else "operator_grant" end)
@@ -477,7 +584,7 @@ _l4_walk_ledger() {
               reason: (.payload.reason // "")
             }
         )
-        ' "$ledger"
+        '
 }
 
 # -----------------------------------------------------------------------------
@@ -504,7 +611,8 @@ _l4_resolve_state() {
     local cooldown_seconds="$3"
     local now_iso="$4"
 
-    python3 - "$history_json" "$default_tier" "$cooldown_seconds" "$now_iso" <<'PY'
+    local max_cooldown="${_L4_MAX_COOLDOWN_SECONDS}"
+    python3 - "$history_json" "$default_tier" "$cooldown_seconds" "$now_iso" "$max_cooldown" <<'PY'
 import json, sys
 from datetime import datetime, timedelta
 
@@ -512,6 +620,7 @@ history = json.loads(sys.argv[1] or "[]")
 default_tier = sys.argv[2]
 cooldown_seconds = int(sys.argv[3])
 now_iso = sys.argv[4]
+max_cooldown_seconds = int(sys.argv[5])
 
 def parse_iso(s):
     if s.endswith("Z"):
@@ -535,18 +644,36 @@ for entry in history:
         # payload (captured at override-time per Sprint 4B). Fall back to
         # ts_utc + current-config cooldown_seconds for legacy entries that
         # might predate the frozen field.
+        #
+        # Sprint 4 cypherpunk audit CRIT-2: clamp the frozen value to
+        # [ts_utc, ts_utc + max_cooldown_seconds]. An adversary that can
+        # write the ledger could otherwise craft a frozen cooldown_until of
+        # 9999-12-31 (operator-stuck-forever DoS) or 1970-01-01 (cooldown
+        # nullification). The hard ceiling defends both.
         frozen = entry.get("cooldown_until")
+        candidate = None
         if frozen:
             try:
-                last_auto_drop_until = parse_iso(frozen)
+                candidate = parse_iso(frozen)
             except Exception:
-                last_auto_drop_until = None
-        elif ts_utc:
+                candidate = None
+        if candidate is None and ts_utc:
+            try:
+                candidate = parse_iso(ts_utc) + timedelta(seconds=cooldown_seconds)
+            except Exception:
+                candidate = None
+        if candidate is not None and ts_utc:
             try:
                 t = parse_iso(ts_utc)
-                last_auto_drop_until = t + timedelta(seconds=cooldown_seconds)
+                lo = t  # cooldown cannot end before its own start
+                hi = t + timedelta(seconds=max_cooldown_seconds)
+                if candidate < lo:
+                    candidate = lo
+                elif candidate > hi:
+                    candidate = hi
             except Exception:
                 pass
+        last_auto_drop_until = candidate
     elif ttype == "force_grant":
         # force_grant clears the cooldown
         last_auto_drop_until = None
@@ -818,6 +945,8 @@ trust_grant() {
         return 2
     fi
 
+    _l4_require_enabled || return 1
+
     _l4_validate_token "$scope"      "scope"      || return 2
     _l4_validate_token "$capability" "capability" || return 2
     _l4_validate_token "$actor"      "actor"      || return 2
@@ -827,17 +956,27 @@ trust_grant() {
         _l4_log "trust_grant: --reason is required (audit-mandatory rationale)"
         return 2
     fi
-    if (( ${#reason} > 4096 )); then
-        _l4_log "trust_grant: reason exceeds 4096 chars"
-        return 2
-    fi
+    _l4_validate_reason "$reason" "reason" || return 2
 
     if [[ -z "$operator" ]]; then
-        # Default to actor only if operator unspecified; this captures the
-        # self-grant convention used by single-operator deployments.
+        if (( force == 1 )); then
+            # Cypherpunk HIGH-6: force-grant requires explicit --operator
+            # (cannot self-force-grant). The auditor must be able to
+            # distinguish operator-driven from agent-driven force-grants.
+            _l4_log "trust_grant --force: --operator is required and must be distinct from actor (cannot self-force-grant)"
+            return 2
+        fi
+        # Default to actor only if operator unspecified AND not force-grant;
+        # this captures the self-grant convention used by single-operator
+        # deployments (regular grants only).
         operator="$actor"
     fi
     _l4_validate_token "$operator" "operator" || return 2
+
+    if (( force == 1 )) && [[ "$operator" == "$actor" ]]; then
+        _l4_log "trust_grant --force: --operator must be distinct from actor (cypherpunk HIGH-6)"
+        return 2
+    fi
 
     if [[ "${LOA_TRUST_REQUIRE_KNOWN_ACTOR:-0}" == "1" ]]; then
         operator_identity_lookup "$operator" >/dev/null 2>&1 || {
@@ -871,7 +1010,7 @@ trust_grant() {
     # own flock on <log>.lock proceeds without deadlock.
     local rc=0
     {
-        flock -w 10 9 || {
+        flock -w 30 9 || {
             _l4_log "trust_grant: failed to acquire txn lock on $lock_file"
             return 1
         }
@@ -879,8 +1018,11 @@ trust_grant() {
         # Refuse if ledger sealed.
         if _l4_ledger_is_sealed "$ledger"; then
             _l4_log "trust_grant: ledger is sealed [L4-DISABLED]; no further transitions allowed"
-            return 1
+            return 3
         fi
+
+        # HIGH-2: refuse to append to a broken chain.
+        _l4_require_chain_intact "$ledger" || return 1
 
         # Read current state.
         local current_tier from_tier_for_event in_cooldown_until response
@@ -1023,27 +1165,28 @@ trust_record_override() {
         _l4_log "trust_record_override: missing required argument (scope, capability, actor, decision_id, reason)"
         return 2
     fi
+
+    _l4_require_enabled || return 1
+
     _l4_validate_token "$scope"      "scope"      || return 2
     _l4_validate_token "$capability" "capability" || return 2
     _l4_validate_token "$actor"      "actor"      || return 2
 
     # decision_id is opaque (panel-decision-id, PR url, audit-event id) so we
     # accept a wider charset than scope/capability/actor — but reject control
-    # bytes and quote/backtick chars.
+    # bytes, quote/backtick chars, and angle brackets (HTML/markdown injection
+    # defense per cypherpunk MED-3; decision_ids flow into PR comments + UIs).
     if [[ -z "$decision_id" ]]; then
         _l4_log "trust_record_override: decision_id empty"; return 2
     fi
     if (( ${#decision_id} > 512 )); then
         _l4_log "trust_record_override: decision_id exceeds 512 chars"; return 2
     fi
-    if [[ "$decision_id" =~ [\$\`\"\'\\] ]] || [[ "$decision_id" =~ [[:cntrl:]] ]]; then
+    if [[ "$decision_id" =~ [\$\`\"\'\\\<\>] ]] || [[ "$decision_id" =~ [[:cntrl:]] ]]; then
         _l4_log "trust_record_override: decision_id contains forbidden characters"
         return 2
     fi
-    if (( ${#reason} > 4096 )); then
-        _l4_log "trust_record_override: reason exceeds 4096 chars"
-        return 2
-    fi
+    _l4_validate_reason "$reason" "reason" || return 2
 
     local ledger lock_file
     ledger="$(_l4_ledger_path)"
@@ -1055,7 +1198,7 @@ trust_record_override() {
 
     local rc=0
     {
-        flock -w 10 9 || {
+        flock -w 30 9 || {
             _l4_log "trust_record_override: failed to acquire txn lock on $lock_file"
             return 1
         }
@@ -1064,6 +1207,9 @@ trust_record_override() {
             _l4_log "trust_record_override: ledger is sealed [L4-DISABLED]"
             return 3
         fi
+
+        # HIGH-2: refuse to append to a broken chain.
+        _l4_require_chain_intact "$ledger" || return 1
 
         # Read current state.
         local response current_tier
@@ -1175,6 +1321,13 @@ _trust_force_grant_impl() {
         _l4_log "trust_grant --force: --reason is required (FR-L4-8)"
         return 2
     fi
+    _l4_validate_reason "$reason" "reason" || return 2
+
+    # Force-grant requires explicit operator distinct from actor (HIGH-6).
+    if [[ -z "$operator" || "$operator" == "$actor" ]]; then
+        _l4_log "trust_grant --force: --operator must be set and distinct from actor"
+        return 2
+    fi
 
     local ledger lock_file
     ledger="$(_l4_ledger_path)"
@@ -1186,15 +1339,18 @@ _trust_force_grant_impl() {
 
     local rc=0
     {
-        flock -w 10 9 || {
+        flock -w 30 9 || {
             _l4_log "trust_grant --force: failed to acquire txn lock on $lock_file"
             return 1
         }
 
         if _l4_ledger_is_sealed "$ledger"; then
             _l4_log "trust_grant --force: ledger is sealed [L4-DISABLED]"
-            return 1
+            return 3
         fi
+
+        # HIGH-2: refuse to append to a broken chain.
+        _l4_require_chain_intact "$ledger" || return 1
 
         local response current_tier in_cooldown_until
         response="$(trust_query "$scope" "$capability" "$actor")" || return 1
@@ -1429,7 +1585,14 @@ trust_disable() {
         case "$1" in
             --reason)   reason="${2:-}";   shift 2 ;;
             --operator) operator="${2:-}"; shift 2 ;;
-            *)          shift ;;
+            --*)
+                _l4_log "trust_disable: unknown flag '$1'"
+                return 2
+                ;;
+            *)
+                _l4_log "trust_disable: unexpected positional argument '$1'"
+                return 2
+                ;;
         esac
     done
 
@@ -1437,15 +1600,14 @@ trust_disable() {
         _l4_log "trust_disable: --reason is required"
         return 2
     fi
-    if (( ${#reason} > 4096 )); then
-        _l4_log "trust_disable: reason exceeds 4096 chars"
-        return 2
-    fi
+    _l4_validate_reason "$reason" "reason" || return 2
     if [[ -z "$operator" ]]; then
         _l4_log "trust_disable: --operator is required"
         return 2
     fi
     _l4_validate_token "$operator" "operator" || return 2
+
+    _l4_require_enabled || return 1
 
     local ledger lock_file
     ledger="$(_l4_ledger_path)"
@@ -1457,7 +1619,7 @@ trust_disable() {
 
     local rc=0
     {
-        flock -w 10 9 || {
+        flock -w 30 9 || {
             _l4_log "trust_disable: failed to acquire txn lock on $lock_file"
             return 1
         }
@@ -1466,6 +1628,9 @@ trust_disable() {
             _l4_log "trust_disable: ledger already sealed; ignoring"
             return 3
         fi
+
+        # HIGH-2: refuse to append to a broken chain.
+        _l4_require_chain_intact "$ledger" || return 1
 
         local sealed_at
         sealed_at="$(_l4_now_iso8601)"

--- a/.claude/scripts/lib/graduated-trust-lib.sh
+++ b/.claude/scripts/lib/graduated-trust-lib.sh
@@ -1409,9 +1409,79 @@ trust_auto_raise_check() {
 }
 
 # -----------------------------------------------------------------------------
-# trust_disable — TODO Sprint 4D.
+# trust_disable [--reason <text>] [--operator <slug>]
+#
+# Sprint 4D — emits a trust.disable event sealing the ledger. Per PRD §849
+# (L4 row): on disable, the ledger is preserved (immutable hash-chain);
+# subsequent reads return last-known-tier; no further transitions allowed.
+#
+# Already-sealed ledgers reject re-disable (no double-seal).
+#
+# Exit codes:
+#   0 disable recorded
+#   1 ledger / audit_emit error
+#   2 invalid argument
+#   3 ledger already sealed (idempotent refusal)
 # -----------------------------------------------------------------------------
 trust_disable() {
-    _l4_log "trust_disable: not yet implemented (Sprint 4D)"
-    return 99
+    local reason="" operator=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --reason)   reason="${2:-}";   shift 2 ;;
+            --operator) operator="${2:-}"; shift 2 ;;
+            *)          shift ;;
+        esac
+    done
+
+    if [[ -z "$reason" ]]; then
+        _l4_log "trust_disable: --reason is required"
+        return 2
+    fi
+    if (( ${#reason} > 4096 )); then
+        _l4_log "trust_disable: reason exceeds 4096 chars"
+        return 2
+    fi
+    if [[ -z "$operator" ]]; then
+        _l4_log "trust_disable: --operator is required"
+        return 2
+    fi
+    _l4_validate_token "$operator" "operator" || return 2
+
+    local ledger lock_file
+    ledger="$(_l4_ledger_path)"
+    lock_file="$(_l4_txn_lock_path "$ledger")"
+    mkdir -p "$(dirname "$ledger")"
+    : > "$lock_file" 2>/dev/null || touch "$lock_file"
+
+    _audit_require_flock || return 1
+
+    local rc=0
+    {
+        flock -w 10 9 || {
+            _l4_log "trust_disable: failed to acquire txn lock on $lock_file"
+            return 1
+        }
+
+        if _l4_ledger_is_sealed "$ledger"; then
+            _l4_log "trust_disable: ledger already sealed; ignoring"
+            return 3
+        fi
+
+        local sealed_at
+        sealed_at="$(_l4_now_iso8601)"
+
+        local payload
+        payload="$(jq -nc \
+            --arg operator "$operator" \
+            --arg reason "$reason" \
+            --arg sealed_at "$sealed_at" \
+            '{operator: $operator, reason: $reason, sealed_at: $sealed_at}')"
+
+        if ! audit_emit "L4" "trust.disable" "$payload" "$ledger"; then
+            _l4_log "trust_disable: audit_emit failed"
+            return 1
+        fi
+    } 9>"$lock_file"
+    rc=$?
+    return "$rc"
 }

--- a/.claude/scripts/lib/graduated-trust-lib.sh
+++ b/.claude/scripts/lib/graduated-trust-lib.sh
@@ -673,19 +673,451 @@ trust_query() {
 }
 
 # -----------------------------------------------------------------------------
-# trust_grant — TODO Sprint 4B (regular path) / 4C (--force exception path).
+# _l4_txn_lock_path <ledger>
+#
+# Returns the path of the transaction lock file. SEPARATE from audit_emit's
+# `<log>.lock` to avoid deadlock when our transaction calls audit_emit (each
+# flocks a distinct lock file). The transaction lock guards the whole
+# read-validate-write atom (cooldown check vs concurrent writes).
 # -----------------------------------------------------------------------------
-trust_grant() {
-    _l4_log "trust_grant: not yet implemented (Sprint 4B/4C)"
-    return 99
+_l4_txn_lock_path() {
+    echo "$1.txn.lock"
 }
 
 # -----------------------------------------------------------------------------
-# trust_record_override — TODO Sprint 4B.
+# _l4_find_grant_rule <from_tier> <to_tier>
+#
+# Walk transition_rules JSON; emit the first rule whose (from, to) matches and
+# requires == operator_grant. Returns "" when no rule matches (caller treats
+# as transition rejected per FR-L4-2).
+# -----------------------------------------------------------------------------
+_l4_find_grant_rule() {
+    local from="$1"
+    local to="$2"
+    local rules
+    rules="$(_l4_get_transition_rules)"
+    echo "$rules" | jq -c \
+        --arg from "$from" \
+        --arg to "$to" \
+        '
+        .[] | select(
+            (.from == $from) and
+            (.to == $to) and
+            ((.requires // "") == "operator_grant")
+        )
+        ' | head -n 1
+}
+
+# -----------------------------------------------------------------------------
+# _l4_find_auto_drop_rule <from_tier>
+#
+# Walk transition_rules JSON; emit the first rule whose `via` is
+# `auto_drop_on_override` AND whose `from` matches (or is "any"). Returns ""
+# when no rule matches (caller treats as no auto-drop available — error).
+#
+# Two valid shapes:
+#   {from: "T2", to: "T1", via: "auto_drop_on_override"}     (explicit drop_to)
+#   {from: "any", to_lower: true, via: "auto_drop_on_override"}  (drop to default_tier)
+#
+# When matching the "any/to_lower:true" form, the caller must compute
+# `drop_to = default_tier` (this lib does not infer arbitrary tier ordering).
+# -----------------------------------------------------------------------------
+_l4_find_auto_drop_rule() {
+    local from="$1"
+    local rules
+    rules="$(_l4_get_transition_rules)"
+    echo "$rules" | jq -c \
+        --arg from "$from" \
+        '
+        .[] | select(
+            ((.via // "") == "auto_drop_on_override") and
+            ((.from == $from) or (.from == "any"))
+        )
+        ' | head -n 1
+}
+
+# -----------------------------------------------------------------------------
+# _l4_iso_add_seconds <iso8601> <seconds>
+#
+# Returns ISO-8601 of <iso> + <seconds> (UTC, ms precision). Used to compute
+# cooldown_until = ts_utc + cooldown_seconds. Exits non-zero on parse failure.
+# -----------------------------------------------------------------------------
+_l4_iso_add_seconds() {
+    local iso="$1"
+    local secs="$2"
+    python3 -c '
+import sys
+from datetime import datetime, timedelta
+s = sys.argv[1]
+secs = int(sys.argv[2])
+if s.endswith("Z"):
+    s = s[:-1] + "+00:00"
+try:
+    dt = datetime.fromisoformat(s)
+except Exception as e:
+    print(f"_l4_iso_add_seconds: parse failure: {e}", file=sys.stderr)
+    sys.exit(1)
+print((dt + timedelta(seconds=secs)).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z")
+' "$iso" "$secs"
+}
+
+# -----------------------------------------------------------------------------
+# trust_grant <scope> <capability> <actor> <new_tier> [--reason <text>] [--operator <slug>]
+#
+# FR-L4-2: Only configured transitions allowed; arbitrary jumps return error.
+# FR-L4-3 interaction: cooldown blocks regular trust_grant. Operator must use
+# trust_grant --force (Sprint 4C) which routes via trust.force_grant.
+#
+# Exit codes:
+#   0 grant succeeded; trust.grant entry appended
+#   2 invalid argument
+#   3 transition rejected (no matching rule, or cooldown active)
+#   1 ledger / audit_emit error
+#
+# Sprint 4B implements the regular path. --force routes to trust_force_grant
+# in Sprint 4C; for now, --force returns 99 (not implemented).
+# -----------------------------------------------------------------------------
+trust_grant() {
+    local scope="" capability="" actor="" new_tier=""
+    local reason="" operator="" force=0
+
+    # Positional first 4 args; remaining are flags.
+    local positional=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --force)         force=1; shift ;;
+            --reason)        reason="${2:-}"; shift 2 ;;
+            --operator)      operator="${2:-}"; shift 2 ;;
+            *)               positional+=("$1"); shift ;;
+        esac
+    done
+    # Restore positionals.
+    set -- ${positional[@]+"${positional[@]}"}
+    scope="${1:-}"
+    capability="${2:-}"
+    actor="${3:-}"
+    new_tier="${4:-}"
+
+    if [[ -z "$scope" || -z "$capability" || -z "$actor" || -z "$new_tier" ]]; then
+        _l4_log "trust_grant: missing required argument (scope, capability, actor, new_tier)"
+        return 2
+    fi
+
+    if (( force == 1 )); then
+        # Sprint 4C wires the force path. Caller used --force prematurely.
+        _l4_log "trust_grant --force: not yet implemented (Sprint 4C will wire trust.force_grant)"
+        return 99
+    fi
+
+    _l4_validate_token "$scope"      "scope"      || return 2
+    _l4_validate_token "$capability" "capability" || return 2
+    _l4_validate_token "$actor"      "actor"      || return 2
+    _l4_validate_tier  "$new_tier"   "new_tier"   || return 2
+
+    if [[ -z "$reason" ]]; then
+        _l4_log "trust_grant: --reason is required (audit-mandatory rationale)"
+        return 2
+    fi
+    if (( ${#reason} > 4096 )); then
+        _l4_log "trust_grant: reason exceeds 4096 chars"
+        return 2
+    fi
+
+    if [[ -z "$operator" ]]; then
+        # Default to actor only if operator unspecified; this captures the
+        # self-grant convention used by single-operator deployments.
+        operator="$actor"
+    fi
+    _l4_validate_token "$operator" "operator" || return 2
+
+    if [[ "${LOA_TRUST_REQUIRE_KNOWN_ACTOR:-0}" == "1" ]]; then
+        operator_identity_lookup "$operator" >/dev/null 2>&1 || {
+            _l4_log "trust_grant: operator='$operator' not found in OPERATORS.md"
+            return 2
+        }
+        operator_identity_lookup "$actor" >/dev/null 2>&1 || {
+            _l4_log "trust_grant: actor='$actor' not found in OPERATORS.md"
+            return 2
+        }
+    fi
+
+    local ledger lock_file
+    ledger="$(_l4_ledger_path)"
+    lock_file="$(_l4_txn_lock_path "$ledger")"
+    mkdir -p "$(dirname "$ledger")"
+    : > "$lock_file" 2>/dev/null || touch "$lock_file"
+
+    _audit_require_flock || return 1
+
+    # Hold txn lock for the whole read-validate-write transaction.
+    # CRITICAL: this is the .txn.lock file (NOT <log>.lock), so audit_emit's
+    # own flock on <log>.lock proceeds without deadlock.
+    local rc=0
+    {
+        flock -w 10 9 || {
+            _l4_log "trust_grant: failed to acquire txn lock on $lock_file"
+            return 1
+        }
+
+        # Refuse if ledger sealed.
+        if _l4_ledger_is_sealed "$ledger"; then
+            _l4_log "trust_grant: ledger is sealed [L4-DISABLED]; no further transitions allowed"
+            return 1
+        fi
+
+        # Read current state.
+        local current_tier from_tier_for_event in_cooldown_until response
+        response="$(trust_query "$scope" "$capability" "$actor")" || {
+            _l4_log "trust_grant: trust_query failed"
+            return 1
+        }
+        current_tier="$(echo "$response" | jq -r '.tier')"
+        in_cooldown_until="$(echo "$response" | jq -r '.in_cooldown_until')"
+        if [[ "$in_cooldown_until" == "null" || -z "$in_cooldown_until" ]]; then
+            in_cooldown_until=""
+        fi
+
+        # Cooldown check (FR-L4-3 enforcement).
+        if [[ -n "$in_cooldown_until" ]]; then
+            _l4_log "trust_grant: cooldown active until '$in_cooldown_until' for ($scope,$capability,$actor); use --force (Sprint 4C) to override"
+            return 3
+        fi
+
+        # Determine from_tier_for_event:
+        #   - If transition_history empty AND new_tier == default_tier: invalid
+        #     (already at default_tier — no-op)
+        #   - If transition_history empty: from_tier null (initial)
+        #   - Else: from_tier = current_tier
+        local hist_len
+        hist_len="$(echo "$response" | jq '.transition_history | length')"
+        if [[ "$hist_len" == "0" ]]; then
+            from_tier_for_event=""
+        else
+            from_tier_for_event="$current_tier"
+        fi
+
+        # No-op detection: cannot transition to current tier.
+        if [[ "$current_tier" == "$new_tier" ]]; then
+            _l4_log "trust_grant: ($scope,$capability,$actor) is already at tier '$new_tier' (no-op)"
+            return 3
+        fi
+
+        # Transition validation (FR-L4-2):
+        #   - Initial transition (from_tier null) MUST match a rule with
+        #     from = default_tier.
+        #   - Non-initial transition MUST match a rule with from = current_tier.
+        local rule rule_id from_for_rule
+        if [[ -z "$from_tier_for_event" ]]; then
+            from_for_rule="$(_l4_get_default_tier)"
+        else
+            from_for_rule="$current_tier"
+        fi
+        rule="$(_l4_find_grant_rule "$from_for_rule" "$new_tier")"
+        if [[ -z "$rule" ]]; then
+            _l4_log "trust_grant: no transition_rule allows operator_grant from '$from_for_rule' to '$new_tier' (FR-L4-2)"
+            return 3
+        fi
+        rule_id="$(echo "$rule" | jq -r '.id // ""')"
+
+        # Build payload + emit.
+        local from_arg from_kind
+        if [[ -z "$from_tier_for_event" ]]; then
+            from_arg="null"
+            from_kind="null"
+        else
+            from_arg="$from_tier_for_event"
+            from_kind="string"
+        fi
+        local payload
+        if [[ "$from_kind" == "null" ]]; then
+            payload="$(jq -nc \
+                --arg scope "$scope" \
+                --arg capability "$capability" \
+                --arg actor "$actor" \
+                --arg to_tier "$new_tier" \
+                --arg operator "$operator" \
+                --arg reason "$reason" \
+                --arg rule_id "$rule_id" \
+                '{
+                    scope: $scope, capability: $capability, actor: $actor,
+                    from_tier: null, to_tier: $to_tier,
+                    operator: $operator, reason: $reason,
+                    transition_rule_id: (if $rule_id == "" then null else $rule_id end)
+                }')"
+        else
+            payload="$(jq -nc \
+                --arg scope "$scope" \
+                --arg capability "$capability" \
+                --arg actor "$actor" \
+                --arg from_tier "$from_arg" \
+                --arg to_tier "$new_tier" \
+                --arg operator "$operator" \
+                --arg reason "$reason" \
+                --arg rule_id "$rule_id" \
+                '{
+                    scope: $scope, capability: $capability, actor: $actor,
+                    from_tier: $from_tier, to_tier: $to_tier,
+                    operator: $operator, reason: $reason,
+                    transition_rule_id: (if $rule_id == "" then null else $rule_id end)
+                }')"
+        fi
+
+        if ! audit_emit "L4" "trust.grant" "$payload" "$ledger"; then
+            _l4_log "trust_grant: audit_emit trust.grant failed"
+            return 1
+        fi
+    } 9>"$lock_file"
+    rc=$?
+    return "$rc"
+}
+
+# -----------------------------------------------------------------------------
+# trust_record_override <scope> <capability> <actor> <decision_id> <reason>
+#
+# FR-L4-3: recordOverride produces auto-drop per rules; cooldown enforced.
+#
+# Auto-drop semantics:
+#   - Look up auto_drop_on_override rule for from=current_tier (or any).
+#   - drop_to = rule.to (when explicit) | default_tier (when from=any/to_lower)
+#   - cooldown_until = ts_utc(now) + cooldown_seconds
+#
+# Idempotency note: a record_override at the same (scope, capability, actor)
+# while ALREADY in cooldown is allowed (the override might come from a
+# different decision_id). The lib emits a fresh trust.auto_drop entry with the
+# new decision_id; cooldown_until is computed from the NEW ts_utc (rolling
+# cooldown). This matches the operator-intuitive interpretation of "every
+# override re-arms the cooldown timer."
+#
+# Exit codes:
+#   0 override recorded; trust.auto_drop entry appended
+#   2 invalid argument
+#   3 no auto_drop rule configured (operator must define one to enable
+#       FR-L4-3) OR ledger sealed
+#   1 audit_emit / I/O error
 # -----------------------------------------------------------------------------
 trust_record_override() {
-    _l4_log "trust_record_override: not yet implemented (Sprint 4B)"
-    return 99
+    local scope="${1:-}"
+    local capability="${2:-}"
+    local actor="${3:-}"
+    local decision_id="${4:-}"
+    local reason="${5:-}"
+
+    if [[ -z "$scope" || -z "$capability" || -z "$actor" || -z "$decision_id" || -z "$reason" ]]; then
+        _l4_log "trust_record_override: missing required argument (scope, capability, actor, decision_id, reason)"
+        return 2
+    fi
+    _l4_validate_token "$scope"      "scope"      || return 2
+    _l4_validate_token "$capability" "capability" || return 2
+    _l4_validate_token "$actor"      "actor"      || return 2
+
+    # decision_id is opaque (panel-decision-id, PR url, audit-event id) so we
+    # accept a wider charset than scope/capability/actor — but reject control
+    # bytes and quote/backtick chars.
+    if [[ -z "$decision_id" ]]; then
+        _l4_log "trust_record_override: decision_id empty"; return 2
+    fi
+    if (( ${#decision_id} > 512 )); then
+        _l4_log "trust_record_override: decision_id exceeds 512 chars"; return 2
+    fi
+    if [[ "$decision_id" =~ [\$\`\"\'\\] ]] || [[ "$decision_id" =~ [[:cntrl:]] ]]; then
+        _l4_log "trust_record_override: decision_id contains forbidden characters"
+        return 2
+    fi
+    if (( ${#reason} > 4096 )); then
+        _l4_log "trust_record_override: reason exceeds 4096 chars"
+        return 2
+    fi
+
+    local ledger lock_file
+    ledger="$(_l4_ledger_path)"
+    lock_file="$(_l4_txn_lock_path "$ledger")"
+    mkdir -p "$(dirname "$ledger")"
+    : > "$lock_file" 2>/dev/null || touch "$lock_file"
+
+    _audit_require_flock || return 1
+
+    local rc=0
+    {
+        flock -w 10 9 || {
+            _l4_log "trust_record_override: failed to acquire txn lock on $lock_file"
+            return 1
+        }
+
+        if _l4_ledger_is_sealed "$ledger"; then
+            _l4_log "trust_record_override: ledger is sealed [L4-DISABLED]"
+            return 3
+        fi
+
+        # Read current state.
+        local response current_tier
+        response="$(trust_query "$scope" "$capability" "$actor")" || {
+            _l4_log "trust_record_override: trust_query failed"
+            return 1
+        }
+        current_tier="$(echo "$response" | jq -r '.tier')"
+
+        # Find auto_drop rule (explicit from=current_tier preferred; else any).
+        local rule rule_to rule_to_lower drop_to
+        rule="$(_l4_find_auto_drop_rule "$current_tier")"
+        if [[ -z "$rule" ]]; then
+            _l4_log "trust_record_override: no auto_drop_on_override rule configured for from='$current_tier' (FR-L4-3 requires operator to define one)"
+            return 3
+        fi
+        rule_to="$(echo "$rule" | jq -r '.to // ""')"
+        rule_to_lower="$(echo "$rule" | jq -r '.to_lower // false | tostring')"
+
+        if [[ -n "$rule_to" ]]; then
+            drop_to="$rule_to"
+        elif [[ "$rule_to_lower" == "true" ]]; then
+            drop_to="$(_l4_get_default_tier)"
+        else
+            _l4_log "trust_record_override: matched rule has neither .to nor .to_lower (malformed)"
+            return 3
+        fi
+
+        # Validate drop_to is a sane tier and is NOT a raise.
+        _l4_validate_tier "$drop_to" "drop_to" || return 3
+        if [[ "$drop_to" == "$current_tier" ]]; then
+            _l4_log "trust_record_override: auto_drop computed drop_to='$drop_to' equals current_tier (no-op rule misconfigured)"
+            return 3
+        fi
+
+        # Compute cooldown_until.
+        local now_iso cooldown_seconds cooldown_until
+        now_iso="$(_l4_now_iso8601)"
+        cooldown_seconds="$(_l4_get_cooldown_seconds)"
+        cooldown_until="$(_l4_iso_add_seconds "$now_iso" "$cooldown_seconds")" || {
+            _l4_log "trust_record_override: cooldown_until computation failed"
+            return 1
+        }
+
+        # Build payload.
+        local payload
+        payload="$(jq -nc \
+            --arg scope "$scope" \
+            --arg capability "$capability" \
+            --arg actor "$actor" \
+            --arg from_tier "$current_tier" \
+            --arg to_tier "$drop_to" \
+            --arg decision_id "$decision_id" \
+            --arg reason "$reason" \
+            --arg cooldown_until "$cooldown_until" \
+            --argjson cooldown_seconds "$cooldown_seconds" \
+            '{
+                scope: $scope, capability: $capability, actor: $actor,
+                from_tier: $from_tier, to_tier: $to_tier,
+                decision_id: $decision_id, reason: $reason,
+                cooldown_until: $cooldown_until,
+                cooldown_seconds: $cooldown_seconds
+            }')"
+
+        if ! audit_emit "L4" "trust.auto_drop" "$payload" "$ledger"; then
+            _l4_log "trust_record_override: audit_emit trust.auto_drop failed"
+            return 1
+        fi
+    } 9>"$lock_file"
+    rc=$?
+    return "$rc"
 }
 
 # -----------------------------------------------------------------------------

--- a/.claude/scripts/lib/graduated-trust-lib.sh
+++ b/.claude/scripts/lib/graduated-trust-lib.sh
@@ -469,6 +469,10 @@ _l4_walk_ledger() {
                 end
               ),
               ts_utc: .ts_utc,
+              # Frozen cooldown_until from the auto_drop payload — preserves
+              # audit-immutability when operator config changes cooldown_seconds
+              # AFTER an override has been recorded. null for non-auto_drop events.
+              cooldown_until: (.payload.cooldown_until // null),
               decision_id: (.payload.decision_id // null),
               reason: (.payload.reason // "")
             }
@@ -526,12 +530,23 @@ for entry in history:
     ts_utc = entry.get("ts_utc")
     if to_tier:
         tier = to_tier
-    if ttype == "auto_drop" and ts_utc:
-        try:
-            t = parse_iso(ts_utc)
-            last_auto_drop_until = t + timedelta(seconds=cooldown_seconds)
-        except Exception:
-            pass
+    if ttype == "auto_drop":
+        # Audit-immutability: prefer the FROZEN cooldown_until from the event
+        # payload (captured at override-time per Sprint 4B). Fall back to
+        # ts_utc + current-config cooldown_seconds for legacy entries that
+        # might predate the frozen field.
+        frozen = entry.get("cooldown_until")
+        if frozen:
+            try:
+                last_auto_drop_until = parse_iso(frozen)
+            except Exception:
+                last_auto_drop_until = None
+        elif ts_utc:
+            try:
+                t = parse_iso(ts_utc)
+                last_auto_drop_until = t + timedelta(seconds=cooldown_seconds)
+            except Exception:
+                pass
     elif ttype == "force_grant":
         # force_grant clears the cooldown
         last_auto_drop_until = None
@@ -803,12 +818,6 @@ trust_grant() {
         return 2
     fi
 
-    if (( force == 1 )); then
-        # Sprint 4C wires the force path. Caller used --force prematurely.
-        _l4_log "trust_grant --force: not yet implemented (Sprint 4C will wire trust.force_grant)"
-        return 99
-    fi
-
     _l4_validate_token "$scope"      "scope"      || return 2
     _l4_validate_token "$capability" "capability" || return 2
     _l4_validate_token "$actor"      "actor"      || return 2
@@ -839,6 +848,14 @@ trust_grant() {
             _l4_log "trust_grant: actor='$actor' not found in OPERATORS.md"
             return 2
         }
+    fi
+
+    # FR-L4-8 force path (Sprint 4C): emits trust.force_grant with cooldown
+    # remaining at grant time recorded for the auditor.
+    if (( force == 1 )); then
+        _trust_force_grant_impl \
+            "$scope" "$capability" "$actor" "$new_tier" "$operator" "$reason"
+        return $?
     fi
 
     local ledger lock_file
@@ -1121,11 +1138,274 @@ trust_record_override() {
 }
 
 # -----------------------------------------------------------------------------
-# trust_verify_chain — TODO Sprint 4C.
+# _trust_force_grant_impl <scope> <capability> <actor> <new_tier> <operator> <reason>
+#
+# FR-L4-8: Force-grant in cooldown logged as exception with reason.
+#
+# Internal implementation invoked by `trust_grant --force`. Differences vs the
+# regular grant path:
+#   - Reason is REQUIRED (4096 max; same as regular path).
+#   - Cooldown remaining at grant-time captured into the payload (auditor
+#     evidence; 0 means cooldown had already elapsed when --force fired).
+#   - Routes via the protected-class taxonomy: caller is operator-bound
+#     (the protected-class-router classifies trust.force_grant as a
+#     protected operation per .claude/data/protected-classes.yaml).
+#   - Writes trust.force_grant event type (NOT trust.grant); ledger walker
+#     and resolver treat trust.force_grant as a transition that CLEARS the
+#     cooldown (per _l4_resolve_state semantics already shipped in 4A).
+#
+# Exit codes: same as trust_grant.
+# -----------------------------------------------------------------------------
+_trust_force_grant_impl() {
+    local scope="$1"
+    local capability="$2"
+    local actor="$3"
+    local new_tier="$4"
+    local operator="$5"
+    local reason="$6"
+
+    # Re-validation here is paranoid (trust_grant already validated). Cheap
+    # defense-in-depth for the case where this gets called directly.
+    _l4_validate_token "$scope"      "scope"      || return 2
+    _l4_validate_token "$capability" "capability" || return 2
+    _l4_validate_token "$actor"      "actor"      || return 2
+    _l4_validate_token "$operator"   "operator"   || return 2
+    _l4_validate_tier  "$new_tier"   "new_tier"   || return 2
+    if [[ -z "$reason" ]]; then
+        _l4_log "trust_grant --force: --reason is required (FR-L4-8)"
+        return 2
+    fi
+
+    local ledger lock_file
+    ledger="$(_l4_ledger_path)"
+    lock_file="$(_l4_txn_lock_path "$ledger")"
+    mkdir -p "$(dirname "$ledger")"
+    : > "$lock_file" 2>/dev/null || touch "$lock_file"
+
+    _audit_require_flock || return 1
+
+    local rc=0
+    {
+        flock -w 10 9 || {
+            _l4_log "trust_grant --force: failed to acquire txn lock on $lock_file"
+            return 1
+        }
+
+        if _l4_ledger_is_sealed "$ledger"; then
+            _l4_log "trust_grant --force: ledger is sealed [L4-DISABLED]"
+            return 1
+        fi
+
+        local response current_tier in_cooldown_until
+        response="$(trust_query "$scope" "$capability" "$actor")" || return 1
+        current_tier="$(echo "$response" | jq -r '.tier')"
+        in_cooldown_until="$(echo "$response" | jq -r '.in_cooldown_until')"
+        if [[ "$in_cooldown_until" == "null" || -z "$in_cooldown_until" ]]; then
+            in_cooldown_until=""
+        fi
+
+        # Compute cooldown_remaining_seconds_at_grant. 0 when cooldown has
+        # elapsed (operator chose to use --force redundantly — still legal,
+        # but auditor sees zero-remaining and can flag).
+        local now_iso now_epoch cooldown_until_epoch remaining=0
+        now_iso="$(_l4_now_iso8601)"
+        if [[ -n "$in_cooldown_until" ]]; then
+            now_epoch="$(_l4_iso_to_epoch_seconds "$now_iso")"
+            cooldown_until_epoch="$(_l4_iso_to_epoch_seconds "$in_cooldown_until")"
+            if (( cooldown_until_epoch > now_epoch )); then
+                remaining=$(( cooldown_until_epoch - now_epoch ))
+            fi
+        fi
+
+        # No-op detection.
+        if [[ "$current_tier" == "$new_tier" ]]; then
+            _l4_log "trust_grant --force: ($scope,$capability,$actor) already at '$new_tier' (no-op)"
+            return 3
+        fi
+
+        # Determine from_tier_for_event.
+        local from_tier_for_event hist_len
+        hist_len="$(echo "$response" | jq '.transition_history | length')"
+        if [[ "$hist_len" == "0" ]]; then
+            from_tier_for_event=""
+        else
+            from_tier_for_event="$current_tier"
+        fi
+
+        # Build payload.
+        local payload
+        if [[ -z "$from_tier_for_event" ]]; then
+            if [[ -n "$in_cooldown_until" ]]; then
+                payload="$(jq -nc \
+                    --arg scope "$scope" --arg capability "$capability" --arg actor "$actor" \
+                    --arg to_tier "$new_tier" --arg operator "$operator" --arg reason "$reason" \
+                    --argjson remaining "$remaining" --arg cooldown_until "$in_cooldown_until" \
+                    '{
+                        scope: $scope, capability: $capability, actor: $actor,
+                        from_tier: null, to_tier: $to_tier,
+                        operator: $operator, reason: $reason,
+                        cooldown_remaining_seconds_at_grant: $remaining,
+                        cooldown_until_at_grant: $cooldown_until
+                    }')"
+            else
+                payload="$(jq -nc \
+                    --arg scope "$scope" --arg capability "$capability" --arg actor "$actor" \
+                    --arg to_tier "$new_tier" --arg operator "$operator" --arg reason "$reason" \
+                    --argjson remaining "$remaining" \
+                    '{
+                        scope: $scope, capability: $capability, actor: $actor,
+                        from_tier: null, to_tier: $to_tier,
+                        operator: $operator, reason: $reason,
+                        cooldown_remaining_seconds_at_grant: $remaining,
+                        cooldown_until_at_grant: null
+                    }')"
+            fi
+        else
+            if [[ -n "$in_cooldown_until" ]]; then
+                payload="$(jq -nc \
+                    --arg scope "$scope" --arg capability "$capability" --arg actor "$actor" \
+                    --arg from_tier "$from_tier_for_event" --arg to_tier "$new_tier" \
+                    --arg operator "$operator" --arg reason "$reason" \
+                    --argjson remaining "$remaining" --arg cooldown_until "$in_cooldown_until" \
+                    '{
+                        scope: $scope, capability: $capability, actor: $actor,
+                        from_tier: $from_tier, to_tier: $to_tier,
+                        operator: $operator, reason: $reason,
+                        cooldown_remaining_seconds_at_grant: $remaining,
+                        cooldown_until_at_grant: $cooldown_until
+                    }')"
+            else
+                payload="$(jq -nc \
+                    --arg scope "$scope" --arg capability "$capability" --arg actor "$actor" \
+                    --arg from_tier "$from_tier_for_event" --arg to_tier "$new_tier" \
+                    --arg operator "$operator" --arg reason "$reason" \
+                    --argjson remaining "$remaining" \
+                    '{
+                        scope: $scope, capability: $capability, actor: $actor,
+                        from_tier: $from_tier, to_tier: $to_tier,
+                        operator: $operator, reason: $reason,
+                        cooldown_remaining_seconds_at_grant: $remaining,
+                        cooldown_until_at_grant: null
+                    }')"
+            fi
+        fi
+
+        if ! audit_emit "L4" "trust.force_grant" "$payload" "$ledger"; then
+            _l4_log "trust_grant --force: audit_emit trust.force_grant failed"
+            return 1
+        fi
+    } 9>"$lock_file"
+    rc=$?
+    return "$rc"
+}
+
+# -----------------------------------------------------------------------------
+# trust_verify_chain [<ledger_file>]
+#
+# FR-L4-5: hash-chain integrity validates; tampering detectable.
+#
+# Wraps audit_verify_chain (1A library). Honors LOA_TRUST_LEDGER_FILE override.
+# Exit 0 on intact chain; non-zero with stderr explanation otherwise.
 # -----------------------------------------------------------------------------
 trust_verify_chain() {
-    _l4_log "trust_verify_chain: not yet implemented (Sprint 4C)"
-    return 99
+    local ledger="${1:-$(_l4_ledger_path)}"
+    if [[ ! -f "$ledger" ]]; then
+        _l4_log "trust_verify_chain: ledger does not exist: $ledger"
+        return 2
+    fi
+    audit_verify_chain "$ledger"
+}
+
+# -----------------------------------------------------------------------------
+# trust_recover_chain [<ledger_file>]
+#
+# FR-L4-7: Reconstructable from git history if local file lost.
+#
+# Wraps audit_recover_chain (1A). Per SDD §3.7, the trust-ledger.jsonl is
+# TRACKED in git; audit_recover_chain prefers the git-history recovery path
+# for tracked logs. Returns 0 on successful recovery; non-zero on failure
+# (and audit_recover_chain itself appends [CHAIN-BROKEN] marker).
+# -----------------------------------------------------------------------------
+trust_recover_chain() {
+    local ledger="${1:-$(_l4_ledger_path)}"
+    audit_recover_chain "$ledger"
+}
+
+# -----------------------------------------------------------------------------
+# trust_auto_raise_check <scope> <capability> <actor> <next_tier>
+#
+# FR-L4-4 (stub per FU-3 deferral): Auto-raise eligibility check.
+#
+# Sprint 4 ships only the stub: returns "eligibility_required" via stdout JSON
+# and emits a trust.auto_raise_eligible audit event recording that the stub
+# was consulted. The auto-raise itself REQUIRES operator action (trust_grant);
+# the lib will not silently raise tiers in this cycle.
+#
+# FU-3 follow-up will extend with an `eligible` outcome once an alignment-
+# tracking detector ships (e.g., 7-consecutive-aligned).
+#
+# Exit codes:
+#   0 stub consulted; outcome="eligibility_required" emitted to stdout
+#   2 invalid argument
+#   1 audit_emit failure
+# -----------------------------------------------------------------------------
+trust_auto_raise_check() {
+    local scope="${1:-}"
+    local capability="${2:-}"
+    local actor="${3:-}"
+    local next_tier="${4:-}"
+
+    if [[ -z "$scope" || -z "$capability" || -z "$actor" || -z "$next_tier" ]]; then
+        _l4_log "trust_auto_raise_check: missing required argument (scope, capability, actor, next_tier)"
+        return 2
+    fi
+    _l4_validate_token "$scope"      "scope"      || return 2
+    _l4_validate_token "$capability" "capability" || return 2
+    _l4_validate_token "$actor"      "actor"      || return 2
+    _l4_validate_tier  "$next_tier"  "next_tier"  || return 2
+
+    local response current_tier
+    response="$(trust_query "$scope" "$capability" "$actor")" || return 1
+    current_tier="$(echo "$response" | jq -r '.tier')"
+
+    local stub_message
+    stub_message="auto-raise eligibility detector deferred to FU-3; operator must invoke trust_grant manually"
+
+    local payload
+    payload="$(jq -nc \
+        --arg scope "$scope" \
+        --arg capability "$capability" \
+        --arg actor "$actor" \
+        --arg current_tier "$current_tier" \
+        --arg next_tier "$next_tier" \
+        --arg stub_message "$stub_message" \
+        '{
+            scope: $scope, capability: $capability, actor: $actor,
+            current_tier: $current_tier, next_tier: $next_tier,
+            stub_outcome: "eligibility_required",
+            stub_message: $stub_message
+        }')"
+
+    local ledger
+    ledger="$(_l4_ledger_path)"
+    mkdir -p "$(dirname "$ledger")"
+    if ! audit_emit "L4" "trust.auto_raise_eligible" "$payload" "$ledger"; then
+        _l4_log "trust_auto_raise_check: audit_emit failed"
+        return 1
+    fi
+
+    # Echo the stub outcome JSON to stdout for caller convenience.
+    jq -nc \
+        --arg scope "$scope" \
+        --arg capability "$capability" \
+        --arg actor "$actor" \
+        --arg current_tier "$current_tier" \
+        --arg next_tier "$next_tier" \
+        '{
+            scope: $scope, capability: $capability, actor: $actor,
+            current_tier: $current_tier, next_tier: $next_tier,
+            stub_outcome: "eligibility_required"
+        }'
 }
 
 # -----------------------------------------------------------------------------

--- a/.claude/skills/graduated-trust/SKILL.md
+++ b/.claude/skills/graduated-trust/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: graduated-trust
+description: L4 graduated-trust ledger — per-(scope, capability, actor) trust tier with hash-chained immutable history, configurable transitions, auto-drop on operator override + cooldown enforcement, and force-grant audit-logged exceptions
+agent: general-purpose
+context: scoped
+parallel_threshold: 3000
+timeout_minutes: 5
+zones:
+  system:
+    path: .claude
+    permission: read
+  state:
+    paths: [grimoires/loa, .run]
+    permission: read-write
+  app:
+    paths: [src, lib, app]
+    permission: read
+allowed-tools: Read, Bash
+capabilities:
+  schema_version: 1
+  read_files: true
+  search_code: false
+  write_files: false
+  execute_commands: true
+  web_access: false
+  user_interaction: false
+  agent_spawn: false
+  task_management: false
+cost-profile: lightweight
+---
+
+# graduated-trust — L4 Per-(scope,capability,actor) Trust Ledger (cycle-098 Sprint 4)
+
+## Purpose
+
+The L4 primitive maintains a per-(scope, capability, actor) trust ledger
+where trust **ratchets up** by demonstrated alignment (operator-driven
+grants) and **ratchets down automatically** on observed override (record-
+override → auto-drop + cooldown). The ledger is hash-chained for tamper
+detection and TRACKED in git for reconstructability if the working-tree
+file is lost.
+
+This is the **relational trust model** for the agent network: it answers
+"how much autonomy may actor A exercise in capability C of scope S?" with
+an evidence-grounded tier rather than a hardcoded permission.
+
+## Source
+
+- RFC: [#656](https://github.com/0xHoneyJar/loa/issues/656)
+- PRD: `grimoires/loa/cycles/cycle-098-agent-network/prd.md` §FR-L4
+- SDD: `grimoires/loa/cycles/cycle-098-agent-network/sdd.md` §1.4.2 + §5.6
+- Sprint plan: `grimoires/loa/sprint.md` (cycle-098 Sprint 4 row at the time of cycle-098; also reproduced in this cycle's grimoire)
+
+## Public API
+
+All functions are sourced from `.claude/scripts/lib/graduated-trust-lib.sh`.
+
+| Function | Purpose | Exit | FR |
+|----------|---------|------|-----|
+| `trust_query <scope> <capability> <actor>` | Read TrustResponse JSON | 0/2 | FR-L4-1 |
+| `trust_grant <scope> <capability> <actor> <new_tier> --reason <r> [--operator <o>]` | Operator-driven raise (subject to transition_rules + cooldown) | 0/1/2/3 | FR-L4-2 |
+| `trust_grant ... --force --reason <r>` | Force-grant exception (cooldown bypass; audit-logged with cooldown_remaining) | 0/1/2/3 | FR-L4-8 |
+| `trust_record_override <scope> <capability> <actor> <decision_id> <reason>` | Auto-drop on observed override; starts cooldown | 0/1/2/3 | FR-L4-3 |
+| `trust_verify_chain` | Hash-chain integrity walk | 0/1/2 | FR-L4-5 |
+| `trust_recover_chain` | Reconstruct from git history | 0/1/2 | FR-L4-7 |
+| `trust_auto_raise_check <scope> <capability> <actor> <next_tier>` | Auto-raise eligibility stub (FU-3 deferral) | 0/1/2 | FR-L4-4 |
+| `trust_disable --reason <r> --operator <o>` | Seal ledger (immutable; reads still work) | 0/1/2/3 | PRD §849 |
+
+## Configuration
+
+```yaml
+# .loa.config.yaml
+graduated_trust:
+  enabled: true
+  default_tier: T0
+  tier_definitions:
+    T0:
+      description: "No autonomous action permitted; operator-bound for all decisions"
+    T1:
+      description: "Routine read-only operations permitted; mutations require operator confirmation"
+    T2:
+      description: "Routine mutations permitted; production / destructive operations operator-bound"
+    T3:
+      description: "Full autonomous action; only protected-class decisions operator-bound"
+  transition_rules:
+    - { from: T0, to: T1, requires: operator_grant, id: T0_to_T1 }
+    - { from: T1, to: T2, requires: operator_grant, id: T1_to_T2 }
+    - { from: T2, to: T3, requires: operator_grant, id: T2_to_T3 }
+    # Auto-drop rules (per from_tier explicit, OR any/to_lower:true to default_tier)
+    - { from: T2, to: T1, via: auto_drop_on_override }
+    - { from: T3, to: T1, via: auto_drop_on_override }
+    - { from: any, to_lower: true, via: auto_drop_on_override }
+  cooldown_seconds: 604800   # 7 days
+```
+
+## TrustResponse shape (SDD §5.6.2)
+
+```json
+{
+  "scope": "flatline",
+  "capability": "merge_main",
+  "actor": "deep-name",
+  "tier": "T2",
+  "transition_history": [
+    { "from_tier": null, "to_tier": "T1", "transition_type": "initial",
+      "ts_utc": "...", "decision_id": null, "reason": "alignment-validated" },
+    { "from_tier": "T1", "to_tier": "T2", "transition_type": "operator_grant",
+      "ts_utc": "...", "decision_id": null, "reason": "after sprint-N pass" }
+  ],
+  "in_cooldown_until": null,
+  "auto_raise_eligible": false
+}
+```
+
+Schema: `.claude/data/trajectory-schemas/trust-events/trust-response.schema.json`
+
+## Semantics
+
+### Default tier (FR-L4-1)
+
+The first query for any (scope, capability, actor) triple returns the configured `default_tier` (default `T0` when unset). No ledger writes happen on read.
+
+### Transition validation (FR-L4-2)
+
+Only `operator_grant` rules permit raises. Arbitrary jumps (T0→T3) reject with exit 3 unless a rule explicitly allows them. Re-granting the current tier is rejected as no-op.
+
+### Auto-drop + cooldown (FR-L4-3)
+
+`trust_record_override` looks up the `auto_drop_on_override` rule for the current tier (explicit `from: <tier>` preferred; `from: any, to_lower: true` falls through to `default_tier`). The auto-drop event captures **frozen** `cooldown_until = ts_utc + cooldown_seconds` in the payload — operators can change `cooldown_seconds` later without retroactively shifting past windows (audit-immutability).
+
+Rolling cooldown: every override re-arms the timer. Each override is a distinct ledger entry (same hash chain).
+
+### Force-grant exception (FR-L4-8)
+
+`trust_grant --force --reason <r>` overrides cooldown. The event records `cooldown_remaining_seconds_at_grant` (0 when force fires outside cooldown) and `cooldown_until_at_grant` for auditor evidence. `trust.force_grant` is registered in `protected-classes.yaml` — callers using it are operator-bound by definition.
+
+### Hash-chain (FR-L4-5)
+
+The ledger is a JSONL chain via `audit-envelope.sh::audit_emit`: each entry's `prev_hash` references the SHA-256 of the prior entry's canonical (RFC 8785 JCS) form. Tampering with any byte breaks the chain — `trust_verify_chain` walks it and returns non-zero on first break.
+
+### Reconstruction from git (FR-L4-7)
+
+`.run/trust-ledger.jsonl` is **TRACKED** in git per SDD §3.7. `trust_recover_chain` walks `git log` newest-to-oldest; the first commit whose file content validates becomes the recovery base. `[CHAIN-GAP-RECOVERED-FROM-GIT commit=<sha>]` and `[CHAIN-RECOVERED source=git_history]` markers are appended.
+
+### Auto-raise stub (FR-L4-4 / FU-3)
+
+`trust_auto_raise_check` always returns `eligibility_required` in cycle-098. The auto-raise *eligibility detector* (e.g., 7-consecutive-aligned alignment-tracking) is deferred to FU-3. The lib emits a `trust.auto_raise_eligible` audit event so consultations are visible.
+
+### Disable / seal (PRD §849)
+
+`trust_disable --reason <r> --operator <o>` writes `trust.disable` as the final event. After sealing, reads still return last-known-tier; further grants/overrides reject. Re-disable is a no-op (idempotent).
+
+## Concurrency model (FR-L4-6)
+
+The lib uses TWO distinct lock files to avoid deadlock:
+
+| File | Purpose | Holder |
+|------|---------|--------|
+| `<ledger>.txn.lock` | Read-modify-write transaction (cooldown check vs concurrent writer) | trust_grant / trust_record_override / trust_disable |
+| `<ledger>.lock` | Chain-append exclusion | audit_emit (1A library) |
+
+Per FR-L4-6, concurrent writes from runtime + cron + CLI are flock-based-serialized. Tests:
+- `tests/integration/trust-concurrent-writes.bats` — 10+ parallel writers across 3 simulated entry points (runtime, cron, CLI) all converge to a valid chain
+
+## Composition
+
+| Layer | Used for |
+|-------|----------|
+| 1A audit envelope | hash-chain + signing + chain recovery |
+| 1B signing | Ed25519 sigs honored when LOA_AUDIT_SIGNING_KEY_ID is set |
+| 1B protected-class-router | trust.force_grant pre-classified protected |
+| 1B operator-identity | LOA_TRUST_REQUIRE_KNOWN_ACTOR=1 enforces OPERATORS.md |
+
+## Environment overrides
+
+| Var | Effect |
+|-----|--------|
+| `LOA_TRUST_LEDGER_FILE` | override `.run/trust-ledger.jsonl` path |
+| `LOA_TRUST_CONFIG_FILE` | override `.loa.config.yaml` path |
+| `LOA_TRUST_TEST_NOW` | test-only "now" override (ISO-8601) |
+| `LOA_TRUST_EMIT_QUERY_EVENTS=1` | emit `trust.query` events on read (default off) |
+| `LOA_TRUST_REQUIRE_KNOWN_ACTOR=1` | reject unknown actor/operator (OPERATORS.md gate) |
+| `LOA_TRUST_DEFAULT_TIER` | env override of `graduated_trust.default_tier` |
+| `LOA_TRUST_COOLDOWN_SECONDS` | env override of `graduated_trust.cooldown_seconds` |
+
+## Operator quickstart
+
+```bash
+# Read current tier
+.claude/scripts/lib/graduated-trust-lib.sh   # source it from your own script
+trust_query flatline merge_main deep-name
+
+# Grant T0 -> T1 (assuming a configured T0_to_T1 rule)
+trust_grant flatline merge_main deep-name T1 --reason "validated initial alignment"
+
+# Record a panel override -> auto-drop + cooldown
+trust_record_override flatline merge_main deep-name "panel-decision-2026-05-07" "operator overrode panel"
+
+# Emergency force-grant during cooldown
+trust_grant flatline merge_main deep-name T2 --force --reason "incident response"
+
+# Verify the chain
+trust_verify_chain && echo "intact"
+
+# Reconstruct from git history if local file lost
+trust_recover_chain
+```
+
+## Failure modes
+
+| Mode | Symptom | Recovery |
+|------|---------|----------|
+| `[L4-DISABLED]` ledger | grants/overrides exit 3 with "ledger is sealed" | Operator re-init: rotate ledger file path; previous file kept as immutable archive |
+| `[CHAIN-BROKEN]` after recovery failure | trust_verify_chain non-zero; trust_recover_chain returns 1 | Operator inspects `git log` manually; restores from offline backup |
+| no `auto_drop_on_override` rule configured | trust_record_override exits 3 | Operator MUST add a rule (the lib refuses to invent drop semantics) |
+| trust-store INVALID | audit_emit refuses; grants exit 1 | Per `audit-keys-bootstrap` runbook |
+
+## Tests
+
+| Suite | Location | Tests |
+|-------|----------|-------|
+| schemas | `tests/unit/trust-events-schemas.bats` | 10 |
+| validators + config getters | `tests/unit/graduated-trust-lib-defaults.bats` | 21 |
+| trust_query (FR-L4-1) | `tests/integration/trust-query-default-tier.bats` | 17 |
+| trust_grant + trust_record_override (FR-L4-2 + FR-L4-3) | `tests/integration/trust-grant-and-override.bats` | 21 |
+| chain integrity + reconstruction + force-grant + auto-raise (FR-L4-4 + FR-L4-5 + FR-L4-7 + FR-L4-8) | `tests/integration/trust-chain-and-force-grant.bats` | 16 |
+| concurrent writes (FR-L4-6) + disable seal | `tests/integration/trust-concurrent-and-disable.bats` | (Sprint 4D) |
+
+Total: 100+ tests across the four sub-sprints.

--- a/.claude/skills/graduated-trust/SKILL.md
+++ b/.claude/skills/graduated-trust/SKILL.md
@@ -57,7 +57,7 @@ All functions are sourced from `.claude/scripts/lib/graduated-trust-lib.sh`.
 
 | Function | Purpose | Exit | FR |
 |----------|---------|------|-----|
-| `trust_query <scope> <capability> <actor>` | Read TrustResponse JSON | 0/2 | FR-L4-1 |
+| `trust_query <scope> <capability> <actor>` | Read TrustResponse JSON | 0/1/2/3 | FR-L4-1 |
 | `trust_grant <scope> <capability> <actor> <new_tier> --reason <r> [--operator <o>]` | Operator-driven raise (subject to transition_rules + cooldown) | 0/1/2/3 | FR-L4-2 |
 | `trust_grant ... --force --reason <r>` | Force-grant exception (cooldown bypass; audit-logged with cooldown_remaining) | 0/1/2/3 | FR-L4-8 |
 | `trust_record_override <scope> <capability> <actor> <decision_id> <reason>` | Auto-drop on observed override; starts cooldown | 0/1/2/3 | FR-L4-3 |
@@ -224,6 +224,6 @@ trust_recover_chain
 | trust_query (FR-L4-1) | `tests/integration/trust-query-default-tier.bats` | 17 |
 | trust_grant + trust_record_override (FR-L4-2 + FR-L4-3) | `tests/integration/trust-grant-and-override.bats` | 21 |
 | chain integrity + reconstruction + force-grant + auto-raise (FR-L4-4 + FR-L4-5 + FR-L4-7 + FR-L4-8) | `tests/integration/trust-chain-and-force-grant.bats` | 16 |
-| concurrent writes (FR-L4-6) + disable seal | `tests/integration/trust-concurrent-and-disable.bats` | (Sprint 4D) |
+| concurrent writes (FR-L4-6) + disable seal | `tests/integration/trust-concurrent-and-disable.bats` | 13 |
 
 Total: 100+ tests across the four sub-sprints.

--- a/grimoires/loa/lore/patterns.yaml
+++ b/grimoires/loa/lore/patterns.yaml
@@ -186,3 +186,127 @@
   related:
     - fail-closed-cost-gate
     - governance-isomorphism
+
+- id: graduated-trust
+  term: Graduated Trust
+  short: >-
+    Per-(scope, capability, actor) trust ledger where tier ratchets up by
+    demonstrated alignment (operator grants) and ratchets down automatically
+    on observed override (record_override → auto_drop + cooldown). Hash-chained
+    for tamper detection, TRACKED in git for reconstructability, force-grant
+    permitted but recorded as an exception. Trust is not a permission you
+    flip; it is the audit-grounded cumulative position of an actor in a
+    particular capability of a particular scope.
+  context: >-
+    The default agent-permission model — a binary "this actor can do X / can
+    not do X" — collapses two distinct ideas: capability (what is technically
+    permissible) and trust (whether to grant the permission HERE, NOW, given
+    history). cycle-098 L4 splits them. Capability lives in the protected-
+    classes taxonomy; trust lives in a per-(scope, capability, actor) tier
+    derived from the immutable history of grants and overrides. The semantics
+    are operator-intuitive: a tier raises only via an explicit operator
+    decision against a configured transition_rule (no implicit ratchets); a
+    tier drops automatically the moment the operator overrides an autonomous
+    decision (the override IS the signal that demonstrated alignment was
+    over-claimed). Cooldown enforces that the drop is more than a beat — it
+    creates a window during which the actor must re-earn trust through
+    operator engagement, not through silence. Force-grant exists for the
+    incident-response case but is registered in protected-classes and emits
+    trust.force_grant with cooldown_remaining captured at grant-time —
+    auditor sees every bypass.
+  source:
+    cycle: "cycle-098-agent-network"
+    sprint: "Sprint 4 (L4 graduated-trust)"
+    rfc: "https://github.com/0xHoneyJar/loa/issues/656"
+    date: "2026-05-07"
+  tags:
+    - architecture
+    - autonomous-systems
+    - trust
+    - audit-trail
+    - pattern
+  status: Active
+  challenges: []
+  lineage: null
+  superseded_by: null
+  related:
+    - fail-closed-cost-gate
+    - scheduled-cycle
+    - governance-isomorphism
+
+- id: auto-drop
+  term: Auto-Drop on Operator Override
+  short: >-
+    Automatic, audit-mandatory tier descent triggered the moment an operator
+    overrides an autonomous decision. The override IS the signal — no separate
+    "demote" intent is required. The drop emits trust.auto_drop with a frozen
+    cooldown_until in the payload, immune to later changes in operator
+    cooldown_seconds config (audit-immutability).
+  context: >-
+    Trust models that require an operator to explicitly demote an actor after
+    a bad call rarely produce timely demotions: the operator's attention is
+    on resolving the immediate problem, not on bookkeeping. cycle-098 L4
+    inverts this: the override action itself records the demotion. The
+    operator does not need a second step. recordOverride takes a decision_id
+    referencing the externally-knowable record (panel decision id, PR url,
+    audit-event id) so the auditor can correlate the override back to the
+    decision the operator disagreed with. Frozen cooldown_until in the
+    payload means later config changes do not retroactively shift past
+    windows — operators can tune cooldown_seconds without rewriting history.
+    Rolling cooldown (every override re-arms the timer) ensures repeated
+    overrides do not silently expire while the actor remains misaligned.
+  source:
+    cycle: "cycle-098-agent-network"
+    sprint: "Sprint 4 (L4 graduated-trust)"
+    rfc: "https://github.com/0xHoneyJar/loa/issues/656"
+    date: "2026-05-07"
+  tags:
+    - trust
+    - autonomous-systems
+    - audit-trail
+    - feedback-loop
+    - pattern
+  status: Active
+  challenges: []
+  lineage: null
+  superseded_by: null
+  related:
+    - graduated-trust
+
+- id: cooldown
+  term: Trust Cooldown
+  short: >-
+    A configurable window (default 7 days) during which a regular operator
+    grant is rejected after an auto-drop. Force-grant remains available as
+    an audit-logged exception. The cooldown ensures that a demotion is more
+    than a beat — the actor must re-earn trust through operator engagement
+    rather than through the operator forgetting.
+  context: >-
+    Without a cooldown, the operator-pressed "demote → re-promote" cycle
+    erases the demotion's signal value almost immediately. cycle-098 L4
+    enforces a configurable rest period before regular trust_grant can
+    re-raise the tier. Force-grant is intentionally available for incident
+    response — the operator should always have a final say — but it routes
+    through trust.force_grant (registered in protected-classes), captures
+    cooldown_remaining_seconds_at_grant for the auditor, and clears the
+    cooldown_until immediately upon firing. The contract is: cooldowns are
+    recoverable safety windows, not punitive sanctions; force-grants are
+    visible exceptions, not silent overrides.
+  source:
+    cycle: "cycle-098-agent-network"
+    sprint: "Sprint 4 (L4 graduated-trust)"
+    rfc: "https://github.com/0xHoneyJar/loa/issues/656"
+    date: "2026-05-07"
+  tags:
+    - trust
+    - autonomous-systems
+    - safety
+    - rate-limit
+    - pattern
+  status: Active
+  challenges: []
+  lineage: null
+  superseded_by: null
+  related:
+    - graduated-trust
+    - auto-drop

--- a/tests/integration/trust-chain-and-force-grant.bats
+++ b/tests/integration/trust-chain-and-force-grant.bats
@@ -187,7 +187,7 @@ PY
         trust_record_override "f" "m" "deep-name" "d-1" "override"
     # Mid-cooldown: 2026-05-04 is well before 2026-05-08 (auto_drop + 7d).
     LOA_TRUST_TEST_NOW="2026-05-04T00:00:00.000Z" \
-        run trust_grant "f" "m" "deep-name" "T2" --reason "emergency rerise" --operator "deep-name" --force
+        run trust_grant "f" "m" "deep-name" "T2" --reason "emergency rerise" --operator "operator-2" --force
     [[ "$status" -eq 0 ]] || {
         echo "$output"
         return 1
@@ -210,7 +210,7 @@ PY
     # cooldown_until = 2026-05-08T00:00:00Z. now = 2026-05-04T00:00:00Z.
     # remaining = 4 days = 345600 seconds.
     LOA_TRUST_TEST_NOW="2026-05-04T00:00:00.000Z" \
-        trust_grant "f" "m" "deep-name" "T2" --reason "emergency" --operator "deep-name" --force
+        trust_grant "f" "m" "deep-name" "T2" --reason "emergency" --operator "operator-2" --force
 
     local entry
     entry="$(grep -F '"event_type":"trust.force_grant"' "$LOA_TRUST_LEDGER_FILE" | head -n 1)"
@@ -223,7 +223,7 @@ PY
     source "$LIB"
     trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
     # Force-grant from T1 to T2, no cooldown active.
-    run trust_grant "f" "m" "deep-name" "T2" --reason "redundant force" --operator "deep-name" --force
+    run trust_grant "f" "m" "deep-name" "T2" --reason "redundant force" --operator "operator-2" --force
     [[ "$status" -eq 0 ]]
     local entry
     entry="$(grep -F '"event_type":"trust.force_grant"' "$LOA_TRUST_LEDGER_FILE" | head -n 1)"
@@ -238,13 +238,13 @@ PY
     [[ "$status" -eq 2 ]]
 }
 
-@test "FR-L4-8: --force on sealed ledger rejected" {
+@test "FR-L4-8: --force on sealed ledger rejected (exit 3)" {
     source "$LIB"
     cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
 {"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.disable","ts_utc":"2026-05-02T00:00:00.000Z","prev_hash":"GENESIS","payload":{"operator":"o","reason":"sealed","sealed_at":"2026-05-02T00:00:00.000Z"}}
 EOF
-    run trust_grant "f" "m" "deep-name" "T1" --reason "r" --operator "deep-name" --force
-    [[ "$status" -eq 1 ]]
+    run trust_grant "f" "m" "deep-name" "T1" --reason "r" --operator "operator-2" --force
+    [[ "$status" -eq 3 ]]
 }
 
 @test "FR-L4-8: trust.force_grant is registered in protected-classes taxonomy" {
@@ -285,4 +285,17 @@ EOF
     source "$LIB"
     run trust_auto_raise_check "f" "m" "deep-name" 'T1; rm -rf /'
     [[ "$status" -eq 2 ]]
+}
+
+@test "FR-L4-4: auto_raise_eligible does NOT silently raise the tier (informational only)" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    # Consult eligibility for T2 — must NOT ratchet tier from T1 to T2.
+    trust_auto_raise_check "f" "m" "deep-name" "T2"
+    run trust_query "f" "m" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+    # The auto_raise_eligible entry IS in the transition_history (audit trail)
+    # but did not affect the resolved tier.
+    echo "$output" | jq -e '[.transition_history[] | select(.transition_type == "auto_raise_eligible")] | length == 1' >/dev/null
 }

--- a/tests/integration/trust-chain-and-force-grant.bats
+++ b/tests/integration/trust-chain-and-force-grant.bats
@@ -173,6 +173,16 @@ PY
 
     run trust_verify_chain
     [[ "$status" -eq 0 ]]
+
+    # BB iter-1 F6 (confidence 0.85): verify recovery actually pulled the
+    # original committed content from git — not just re-hashed the tampered
+    # local file in place. The original entry's reason was "s1"; tamper made
+    # it "tampered". Post-recovery, "s1" must be restored.
+    grep -F '"reason":"s1"' "$LOA_TRUST_LEDGER_FILE"
+    if grep -F '"reason":"tampered"' "$LOA_TRUST_LEDGER_FILE" 2>/dev/null; then
+        echo "recovery left tampered content in place"
+        return 1
+    fi
 }
 
 # =============================================================================

--- a/tests/integration/trust-chain-and-force-grant.bats
+++ b/tests/integration/trust-chain-and-force-grant.bats
@@ -1,0 +1,288 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/trust-chain-and-force-grant.bats
+#
+# cycle-098 Sprint 4C — chain integrity (FR-L4-5), reconstruction (FR-L4-7),
+# force-grant exception (FR-L4-8), auto-raise stub (FR-L4-4).
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    LIB="$PROJECT_ROOT/.claude/scripts/lib/graduated-trust-lib.sh"
+    [[ -f "$LIB" ]] || skip "graduated-trust-lib.sh not present"
+
+    TEST_DIR="$(mktemp -d)"
+    TEST_TRUST_STORE="$TEST_DIR/trust-store.yaml"
+    cat > "$TEST_TRUST_STORE" <<'EOF'
+schema_version: "1.0"
+root_signature: { algorithm: ed25519, signer_pubkey: "", signed_at: "", signature: "" }
+keys: []
+revocations: []
+trust_cutoff: { default_strict_after: "2099-01-01T00:00:00Z" }
+EOF
+    export LOA_TRUST_STORE_FILE="$TEST_TRUST_STORE"
+
+    export LOA_TRUST_CONFIG_FILE="$TEST_DIR/.loa.config.yaml"
+    export LOA_TRUST_LEDGER_FILE="$TEST_DIR/trust-ledger.jsonl"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T0
+  tier_definitions:
+    T0: { description: "no" }
+    T1: { description: "ro" }
+    T2: { description: "routine" }
+    T3: { description: "full" }
+  transition_rules:
+    - { from: T0, to: T1, requires: operator_grant, id: T0_to_T1 }
+    - { from: T1, to: T2, requires: operator_grant, id: T1_to_T2 }
+    - { from: T2, to: T3, requires: operator_grant, id: T2_to_T3 }
+    - { from: T2, to: T1, via: auto_drop_on_override }
+  cooldown_seconds: 604800
+EOF
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_TRUST_STORE_FILE LOA_TRUST_CONFIG_FILE LOA_TRUST_LEDGER_FILE
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+# =============================================================================
+# FR-L4-5: trust_verify_chain
+# =============================================================================
+
+@test "FR-L4-5: empty/missing ledger -> trust_verify_chain exit 2" {
+    source "$LIB"
+    rm -f "$LOA_TRUST_LEDGER_FILE"
+    run trust_verify_chain
+    [[ "$status" -eq 2 ]]
+}
+
+@test "FR-L4-5: clean grant chain validates" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    run trust_verify_chain
+    [[ "$status" -eq 0 ]]
+}
+
+@test "FR-L4-5: tampering DETECTABLE — flipping a payload byte breaks verification" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    # Tamper: rewrite the first entry's reason field.
+    python3 - "$LOA_TRUST_LEDGER_FILE" <<'PY'
+import json, sys
+path = sys.argv[1]
+lines = open(path).read().splitlines()
+obj = json.loads(lines[0])
+obj["payload"]["reason"] = "tampered"
+lines[0] = json.dumps(obj, separators=(",", ":"))
+open(path, "w").write("\n".join(lines) + "\n")
+PY
+    run trust_verify_chain
+    [[ "$status" -ne 0 ]]
+}
+
+@test "FR-L4-5: tampering DETECTABLE — flipping a prev_hash byte breaks the chain" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    python3 - "$LOA_TRUST_LEDGER_FILE" <<'PY'
+import json, sys
+path = sys.argv[1]
+lines = open(path).read().splitlines()
+obj = json.loads(lines[1])
+ph = obj["prev_hash"]
+# Flip first hex character.
+flipped = ("0" if ph[0] != "0" else "1") + ph[1:]
+obj["prev_hash"] = flipped
+lines[1] = json.dumps(obj, separators=(",", ":"))
+open(path, "w").write("\n".join(lines) + "\n")
+PY
+    run trust_verify_chain
+    [[ "$status" -ne 0 ]]
+}
+
+# =============================================================================
+# FR-L4-7: trust_recover_chain (TRACKED log path)
+# =============================================================================
+
+@test "FR-L4-7: recovery on already-valid chain is a no-op (exit 0)" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    run trust_recover_chain
+    [[ "$status" -eq 0 ]]
+}
+
+@test "FR-L4-7: recovery from git history rebuilds tampered log (TRACKED-path)" {
+    source "$LIB"
+    # Create an isolated git repo to simulate the TRACKED log path.
+    cd "$TEST_DIR"
+    git init -q
+    git config user.email "test@test"
+    git config user.name "test"
+    mkdir -p subrepo/.run
+    cd subrepo
+    git init -q
+    git config user.email "test@test"
+    git config user.name "test"
+    export LOA_TRUST_LEDGER_FILE="$TEST_DIR/subrepo/.run/trust-ledger.jsonl"
+    cp "$LOA_TRUST_CONFIG_FILE" "$TEST_DIR/subrepo/.loa.config.yaml"
+    export LOA_TRUST_CONFIG_FILE="$TEST_DIR/subrepo/.loa.config.yaml"
+
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    git add .run/trust-ledger.jsonl .loa.config.yaml
+    git commit -q -m "initial trust-ledger"
+
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    git add .run/trust-ledger.jsonl
+    git commit -q -m "T2 grant"
+
+    # Tamper the local file.
+    python3 - "$LOA_TRUST_LEDGER_FILE" <<'PY'
+import json, sys
+path = sys.argv[1]
+lines = open(path).read().splitlines()
+obj = json.loads(lines[0])
+obj["payload"]["reason"] = "tampered"
+lines[0] = json.dumps(obj, separators=(",", ":"))
+open(path, "w").write("\n".join(lines) + "\n")
+PY
+
+    run trust_verify_chain
+    [[ "$status" -ne 0 ]]
+
+    run trust_recover_chain
+    [[ "$status" -eq 0 ]] || {
+        echo "$output"
+        cat "$LOA_TRUST_LEDGER_FILE" >&3 2>/dev/null || true
+        return 1
+    }
+
+    run trust_verify_chain
+    [[ "$status" -eq 0 ]]
+}
+
+# =============================================================================
+# FR-L4-8: trust_grant --force (force-grant exception)
+# =============================================================================
+
+@test "FR-L4-8: --force succeeds during cooldown; emits trust.force_grant" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    LOA_TRUST_TEST_NOW="2026-05-01T00:00:00.000Z" \
+        trust_record_override "f" "m" "deep-name" "d-1" "override"
+    # Mid-cooldown: 2026-05-04 is well before 2026-05-08 (auto_drop + 7d).
+    LOA_TRUST_TEST_NOW="2026-05-04T00:00:00.000Z" \
+        run trust_grant "f" "m" "deep-name" "T2" --reason "emergency rerise" --operator "deep-name" --force
+    [[ "$status" -eq 0 ]] || {
+        echo "$output"
+        return 1
+    }
+
+    grep -F '"event_type":"trust.force_grant"' "$LOA_TRUST_LEDGER_FILE"
+
+    # tier should now be T2 (force_grant cleared cooldown)
+    LOA_TRUST_TEST_NOW="2026-05-04T00:00:00.000Z" run trust_query "f" "m" "deep-name"
+    echo "$output" | jq -e '.tier == "T2"' >/dev/null
+    echo "$output" | jq -e '.in_cooldown_until == null' >/dev/null
+}
+
+@test "FR-L4-8: cooldown_remaining_seconds_at_grant accurately recorded" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    LOA_TRUST_TEST_NOW="2026-05-01T00:00:00.000Z" \
+        trust_record_override "f" "m" "deep-name" "d-1" "override"
+    # cooldown_until = 2026-05-08T00:00:00Z. now = 2026-05-04T00:00:00Z.
+    # remaining = 4 days = 345600 seconds.
+    LOA_TRUST_TEST_NOW="2026-05-04T00:00:00.000Z" \
+        trust_grant "f" "m" "deep-name" "T2" --reason "emergency" --operator "deep-name" --force
+
+    local entry
+    entry="$(grep -F '"event_type":"trust.force_grant"' "$LOA_TRUST_LEDGER_FILE" | head -n 1)"
+    echo "$entry" | jq -e '.payload.cooldown_remaining_seconds_at_grant == 345600' >/dev/null
+    echo "$entry" | jq -e '.payload.cooldown_until_at_grant == "2026-05-08T00:00:00.000Z"' >/dev/null
+    echo "$entry" | jq -e '.payload.reason == "emergency"' >/dev/null
+}
+
+@test "FR-L4-8: --force without active cooldown still emits trust.force_grant (with remaining=0)" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    # Force-grant from T1 to T2, no cooldown active.
+    run trust_grant "f" "m" "deep-name" "T2" --reason "redundant force" --operator "deep-name" --force
+    [[ "$status" -eq 0 ]]
+    local entry
+    entry="$(grep -F '"event_type":"trust.force_grant"' "$LOA_TRUST_LEDGER_FILE" | head -n 1)"
+    echo "$entry" | jq -e '.payload.cooldown_remaining_seconds_at_grant == 0' >/dev/null
+    echo "$entry" | jq -e '.payload.cooldown_until_at_grant == null' >/dev/null
+}
+
+@test "FR-L4-8: --force missing --reason -> exit 2" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    run trust_grant "f" "m" "deep-name" "T2" --operator "deep-name" --force
+    [[ "$status" -eq 2 ]]
+}
+
+@test "FR-L4-8: --force on sealed ledger rejected" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.disable","ts_utc":"2026-05-02T00:00:00.000Z","prev_hash":"GENESIS","payload":{"operator":"o","reason":"sealed","sealed_at":"2026-05-02T00:00:00.000Z"}}
+EOF
+    run trust_grant "f" "m" "deep-name" "T1" --reason "r" --operator "deep-name" --force
+    [[ "$status" -eq 1 ]]
+}
+
+@test "FR-L4-8: trust.force_grant is registered in protected-classes taxonomy" {
+    source "$LIB"
+    is_protected_class "trust.force_grant"
+}
+
+# =============================================================================
+# FR-L4-4: auto-raise stub
+# =============================================================================
+
+@test "FR-L4-4: trust_auto_raise_check returns eligibility_required (FU-3 deferral)" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    run trust_auto_raise_check "f" "m" "deep-name" "T2"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.stub_outcome == "eligibility_required"' >/dev/null
+    echo "$output" | jq -e '.current_tier == "T1"' >/dev/null
+    echo "$output" | jq -e '.next_tier == "T2"' >/dev/null
+}
+
+@test "FR-L4-4: trust_auto_raise_check emits trust.auto_raise_eligible audit event" {
+    source "$LIB"
+    trust_auto_raise_check "f" "m" "deep-name" "T1"
+    grep -F '"event_type":"trust.auto_raise_eligible"' "$LOA_TRUST_LEDGER_FILE"
+    local entry
+    entry="$(grep -F '"event_type":"trust.auto_raise_eligible"' "$LOA_TRUST_LEDGER_FILE" | head -n 1)"
+    echo "$entry" | jq -e '.payload.stub_outcome == "eligibility_required"' >/dev/null
+}
+
+@test "FR-L4-4: missing argument rejected with exit 2" {
+    source "$LIB"
+    run trust_auto_raise_check "f" "m" "deep-name"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "FR-L4-4: invalid tier rejected with exit 2" {
+    source "$LIB"
+    run trust_auto_raise_check "f" "m" "deep-name" 'T1; rm -rf /'
+    [[ "$status" -eq 2 ]]
+}

--- a/tests/integration/trust-concurrent-and-disable.bats
+++ b/tests/integration/trust-concurrent-and-disable.bats
@@ -152,7 +152,7 @@ teardown() {
     for i in 1 2; do
         ( source "$LIB"
           trust_grant "f" "m" "actor-B-$i" "T1" \
-              --reason "from-cli-$i" --operator "deep-name" --force >/dev/null 2>&1 || true
+              --reason "from-cli-$i" --operator "operator-2" --force >/dev/null 2>&1 || true
         ) &
         pids+=("$!")
     done
@@ -161,6 +161,34 @@ teardown() {
     run trust_verify_chain
     [[ "$status" -eq 0 ]] || {
         echo "$output"
+        return 1
+    }
+
+    # Per-event-type count pins (LOW-7 closure): verify no writes were dropped.
+    # 3 grants for actor-A-{1,2,3} (each is initial T0->T1 — independent triples)
+    local grants
+    grants="$(grep -F '"event_type":"trust.grant"' "$LOA_TRUST_LEDGER_FILE" | grep -cF '"actor-A-' || true)"
+    [[ "$grants" == "3" ]] || {
+        echo "expected 3 actor-A grants, got $grants"
+        return 1
+    }
+    # 3 force_grants for actor-B-{1,2} — all 3 race the same triples but only
+    # 2 unique actors, so the no-op detection caps at 2 successful force_grants.
+    local fgrants
+    fgrants="$(grep -F '"event_type":"trust.force_grant"' "$LOA_TRUST_LEDGER_FILE" | grep -cF '"actor-B-' || true)"
+    [[ "$fgrants" == "2" ]] || {
+        echo "expected 2 actor-B force_grants, got $fgrants"
+        return 1
+    }
+    # auto_drops for deep-name: T2->T1 + T1->T0 (the "any" rule isn't in this
+    # test's config so once at T0 the next override returns exit 3). 2 entries
+    # is the correct count given the 3-rule ladder; the 3rd writer is rejected
+    # for "no auto_drop_on_override rule for from='T0'", proving the misconfig
+    # path works under concurrency.
+    local drops
+    drops="$(grep -F '"event_type":"trust.auto_drop"' "$LOA_TRUST_LEDGER_FILE" | grep -cF '"actor":"deep-name"' || true)"
+    [[ "$drops" == "2" ]] || {
+        echo "expected 2 deep-name auto_drops (T2->T1 + T1->T0), got $drops"
         return 1
     }
 }
@@ -196,9 +224,9 @@ teardown() {
     [[ "$status" -eq 0 ]]
     grep -F '"event_type":"trust.disable"' "$LOA_TRUST_LEDGER_FILE"
 
-    # After seal: subsequent grants exit 1 (sealed); reads still work.
+    # After seal: subsequent grants exit 3 (sealed-ledger refusal); reads still work.
     run trust_grant "f" "m" "deep-name" "T2" --reason "after-seal" --operator "deep-name"
-    [[ "$status" -eq 1 ]]
+    [[ "$status" -eq 3 ]]
     run trust_query "f" "m" "deep-name"
     [[ "$status" -eq 0 ]]
     echo "$output" | jq -e '.tier == "T1"' >/dev/null

--- a/tests/integration/trust-concurrent-and-disable.bats
+++ b/tests/integration/trust-concurrent-and-disable.bats
@@ -1,0 +1,246 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/trust-concurrent-and-disable.bats
+#
+# cycle-098 Sprint 4D — concurrency safety (FR-L4-6: runtime + cron + CLI
+# flock-based serialization) and trust_disable seal semantics.
+#
+# The concurrency tests fork N parallel writers all aiming the same
+# (scope, capability, actor) triple and verify:
+#   - the chain remains valid (audit_verify_chain passes)
+#   - all transitions are recorded (no lost writes)
+#   - the resolved final tier is consistent regardless of dispatch order
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    LIB="$PROJECT_ROOT/.claude/scripts/lib/graduated-trust-lib.sh"
+    [[ -f "$LIB" ]] || skip "graduated-trust-lib.sh not present"
+
+    if ! command -v flock >/dev/null 2>&1; then
+        skip "flock not in PATH (concurrency tests require flock)"
+    fi
+
+    TEST_DIR="$(mktemp -d)"
+    TEST_TRUST_STORE="$TEST_DIR/trust-store.yaml"
+    cat > "$TEST_TRUST_STORE" <<'EOF'
+schema_version: "1.0"
+root_signature: { algorithm: ed25519, signer_pubkey: "", signed_at: "", signature: "" }
+keys: []
+revocations: []
+trust_cutoff: { default_strict_after: "2099-01-01T00:00:00Z" }
+EOF
+    export LOA_TRUST_STORE_FILE="$TEST_TRUST_STORE"
+
+    export LOA_TRUST_CONFIG_FILE="$TEST_DIR/.loa.config.yaml"
+    export LOA_TRUST_LEDGER_FILE="$TEST_DIR/trust-ledger.jsonl"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T0
+  tier_definitions:
+    T0: { description: "no" }
+    T1: { description: "ro" }
+    T2: { description: "routine" }
+    T3: { description: "full" }
+  transition_rules:
+    - { from: T0, to: T1, requires: operator_grant, id: T0_to_T1 }
+    - { from: T1, to: T2, requires: operator_grant, id: T1_to_T2 }
+    - { from: T2, to: T3, requires: operator_grant, id: T2_to_T3 }
+    - { from: T2, to: T1, via: auto_drop_on_override }
+    - { from: T3, to: T1, via: auto_drop_on_override }
+    - { from: T1, to: T0, via: auto_drop_on_override }
+  cooldown_seconds: 1   # short for tests; cooldown not the concurrency invariant
+EOF
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_TRUST_STORE_FILE LOA_TRUST_CONFIG_FILE LOA_TRUST_LEDGER_FILE
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+# =============================================================================
+# FR-L4-6: concurrent writes preserve chain integrity
+# =============================================================================
+
+@test "FR-L4-6: 8 parallel trust_grant writers (initial T0->T1) — chain remains valid" {
+    source "$LIB"
+    # First writer wins; others see the new state and reject as no-op (exit 3).
+    # The contract under test: NO chain corruption regardless of who wins.
+    local pids=()
+    for i in 1 2 3 4 5 6 7 8; do
+        ( source "$LIB"; trust_grant "scope-c" "cap-c" "actor-c" "T1" --reason "race$i" --operator "deep-name" >/dev/null 2>&1 || true ) &
+        pids+=("$!")
+    done
+    for p in "${pids[@]}"; do wait "$p" || true; done
+
+    # Exactly one trust.grant entry (the winner).
+    local n
+    n="$(grep -cF '"event_type":"trust.grant"' "$LOA_TRUST_LEDGER_FILE")"
+    [[ "$n" == "1" ]] || {
+        echo "expected 1 trust.grant entry, got $n"
+        return 1
+    }
+
+    # Chain valid.
+    run trust_verify_chain
+    [[ "$status" -eq 0 ]] || {
+        echo "chain verify failed after parallel writes:"
+        echo "$output"
+        cat "$LOA_TRUST_LEDGER_FILE" >&3 2>/dev/null || true
+        return 1
+    }
+
+    # Tier resolves to T1.
+    run trust_query "scope-c" "cap-c" "actor-c"
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+}
+
+@test "FR-L4-6: parallel writers across different (scope,cap,actor) — all complete; chain valid" {
+    source "$LIB"
+    local pids=()
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        ( source "$LIB"
+          trust_grant "scope-$i" "cap-$i" "actor-$i" "T1" \
+              --reason "parallel" --operator "deep-name" >/dev/null 2>&1
+        ) &
+        pids+=("$!")
+    done
+    for p in "${pids[@]}"; do wait "$p"; done
+
+    local n
+    n="$(grep -cF '"event_type":"trust.grant"' "$LOA_TRUST_LEDGER_FILE")"
+    [[ "$n" == "10" ]] || {
+        echo "expected 10 entries, got $n"
+        return 1
+    }
+    run trust_verify_chain
+    [[ "$status" -eq 0 ]]
+}
+
+@test "FR-L4-6: mixed grant + record_override + force_grant in parallel — chain valid" {
+    source "$LIB"
+    # Pre-populate to T2 so override has a tier to drop from.
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+
+    local pids=()
+    for i in 1 2 3; do
+        ( source "$LIB"
+          # Different actors so no false-positive collisions.
+          trust_grant "f" "m" "actor-A-$i" "T1" \
+              --reason "from-runtime-$i" --operator "deep-name" >/dev/null 2>&1 || true
+        ) &
+        pids+=("$!")
+    done
+    for i in 1 2 3; do
+        ( source "$LIB"
+          trust_record_override "f" "m" "deep-name" "decision-$i" "override-$i" >/dev/null 2>&1 || true
+        ) &
+        pids+=("$!")
+    done
+    for i in 1 2; do
+        ( source "$LIB"
+          trust_grant "f" "m" "actor-B-$i" "T1" \
+              --reason "from-cli-$i" --operator "deep-name" --force >/dev/null 2>&1 || true
+        ) &
+        pids+=("$!")
+    done
+    for p in "${pids[@]}"; do wait "$p"; done
+
+    run trust_verify_chain
+    [[ "$status" -eq 0 ]] || {
+        echo "$output"
+        return 1
+    }
+}
+
+# =============================================================================
+# trust_disable seal semantics
+# =============================================================================
+
+@test "trust_disable: missing --reason rejected with exit 2" {
+    source "$LIB"
+    run trust_disable --operator "deep-name"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "trust_disable: missing --operator rejected with exit 2" {
+    source "$LIB"
+    run trust_disable --reason "rotating"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "trust_disable: oversize reason rejected" {
+    source "$LIB"
+    local big
+    big="$(printf 'a%.0s' {1..5000})"
+    run trust_disable --reason "$big" --operator "deep-name"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "trust_disable: writes trust.disable event and seals the ledger" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    run trust_disable --reason "rotating" --operator "deep-name"
+    [[ "$status" -eq 0 ]]
+    grep -F '"event_type":"trust.disable"' "$LOA_TRUST_LEDGER_FILE"
+
+    # After seal: subsequent grants exit 1 (sealed); reads still work.
+    run trust_grant "f" "m" "deep-name" "T2" --reason "after-seal" --operator "deep-name"
+    [[ "$status" -eq 1 ]]
+    run trust_query "f" "m" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+}
+
+@test "trust_disable: re-disable on already-sealed ledger -> exit 3" {
+    source "$LIB"
+    trust_disable --reason "first" --operator "deep-name"
+    run trust_disable --reason "second" --operator "deep-name"
+    [[ "$status" -eq 3 ]]
+}
+
+@test "trust_disable: chain remains valid after seal" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    trust_disable --reason "rotate" --operator "deep-name"
+    run trust_verify_chain
+    [[ "$status" -eq 0 ]]
+}
+
+@test "trust_disable: shell-meta operator rejected (FR-L4-6 input pin)" {
+    source "$LIB"
+    run trust_disable --reason "r" --operator 'evil; rm -rf /'
+    [[ "$status" -eq 2 ]]
+}
+
+# =============================================================================
+# Lore + skill + CLAUDE.md presence (4D handoff invariants)
+# =============================================================================
+
+@test "4D handoff: graduated-trust SKILL.md exists" {
+    [[ -f "$PROJECT_ROOT/.claude/skills/graduated-trust/SKILL.md" ]]
+}
+
+@test "4D handoff: lore patterns.yaml contains graduated-trust + auto-drop + cooldown" {
+    grep -F 'id: graduated-trust' "$PROJECT_ROOT/grimoires/loa/lore/patterns.yaml"
+    grep -F 'id: auto-drop' "$PROJECT_ROOT/grimoires/loa/lore/patterns.yaml"
+    grep -F 'id: cooldown' "$PROJECT_ROOT/grimoires/loa/lore/patterns.yaml"
+}
+
+@test "4D handoff: CLAUDE.md has L4 Graduated-Trust Constraints section" {
+    grep -F 'L4 Graduated-Trust' "$PROJECT_ROOT/.claude/loa/CLAUDE.loa.md"
+    grep -F 'Graduated-Trust Constraints' "$PROJECT_ROOT/.claude/loa/CLAUDE.loa.md"
+}

--- a/tests/integration/trust-cypherpunk-remediation.bats
+++ b/tests/integration/trust-cypherpunk-remediation.bats
@@ -1,0 +1,333 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/trust-cypherpunk-remediation.bats
+#
+# cycle-098 Sprint 4 — remediation tests for the cypherpunk audit findings
+# (CRIT-1, CRIT-2, HIGH-1, HIGH-2, HIGH-3, HIGH-4, HIGH-6, MED-2, MED-3, MED-4).
+#
+# Each test exercises the attack the original review described and verifies
+# the patched lib refuses the attack (or honors the documented contract).
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    LIB="$PROJECT_ROOT/.claude/scripts/lib/graduated-trust-lib.sh"
+    [[ -f "$LIB" ]] || skip "graduated-trust-lib.sh not present"
+
+    TEST_DIR="$(mktemp -d)"
+    TEST_TRUST_STORE="$TEST_DIR/trust-store.yaml"
+    cat > "$TEST_TRUST_STORE" <<'EOF'
+schema_version: "1.0"
+root_signature: { algorithm: ed25519, signer_pubkey: "", signed_at: "", signature: "" }
+keys: []
+revocations: []
+trust_cutoff: { default_strict_after: "2099-01-01T00:00:00Z" }
+EOF
+    export LOA_TRUST_STORE_FILE="$TEST_TRUST_STORE"
+    export LOA_TRUST_CONFIG_FILE="$TEST_DIR/.loa.config.yaml"
+    export LOA_TRUST_LEDGER_FILE="$TEST_DIR/trust-ledger.jsonl"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T0
+  tier_definitions:
+    T0: { description: "no" }
+    T1: { description: "ro" }
+    T2: { description: "routine" }
+    T3: { description: "full" }
+  transition_rules:
+    - { from: T0, to: T1, requires: operator_grant, id: T0_to_T1 }
+    - { from: T1, to: T2, requires: operator_grant, id: T1_to_T2 }
+    - { from: T2, to: T3, requires: operator_grant, id: T2_to_T3 }
+    - { from: T2, to: T1, via: auto_drop_on_override }
+    - { from: T3, to: T1, via: auto_drop_on_override }
+    - { from: T1, to: T0, via: auto_drop_on_override }
+  cooldown_seconds: 604800
+EOF
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW LOA_TRUST_TEST_MODE
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_TRUST_STORE_FILE LOA_TRUST_CONFIG_FILE LOA_TRUST_LEDGER_FILE
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW LOA_TRUST_TEST_MODE
+}
+
+# =============================================================================
+# CRIT-1: seal bypass via terminal [CHAIN-BROKEN] marker
+# =============================================================================
+
+@test "CRIT-1: sealed ledger followed by [CHAIN-BROKEN] marker is correctly detected as sealed" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.disable","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"operator":"o","reason":"sealed","sealed_at":"2026-05-01T00:00:00.000Z"}}
+[CHAIN-BROKEN at=2026-05-02T00:00:00.000Z primitive=L4]
+EOF
+    # Pre-fix: tail|jq saw a marker line, returned "" event_type, sealed=false
+    # Post-fix: scan all non-marker lines for trust.disable, sealed=true
+    if ! _l4_ledger_is_sealed "$LOA_TRUST_LEDGER_FILE"; then
+        echo "FAIL: marker after seal hid the seal"
+        return 1
+    fi
+    # Subsequent grants must reject (exit 3).
+    run trust_grant "f" "m" "deep-name" "T1" --reason "post-seal" --operator "deep-name"
+    [[ "$status" -eq 3 ]]
+}
+
+@test "CRIT-1: sealed ledger followed by [CHAIN-RECOVERED ...] marker is sealed" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.disable","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"operator":"o","reason":"sealed","sealed_at":"2026-05-01T00:00:00.000Z"}}
+[CHAIN-GAP-RECOVERED-FROM-GIT commit=abc123]
+[CHAIN-RECOVERED source=git_history commit=abc123]
+EOF
+    _l4_ledger_is_sealed "$LOA_TRUST_LEDGER_FILE"
+    run trust_record_override "f" "m" "deep-name" "decision-x" "post-seal override"
+    [[ "$status" -eq 3 ]]
+}
+
+# =============================================================================
+# CRIT-2: cooldown_until forgery — clamp to [ts_utc, ts_utc + max_cooldown_seconds]
+# =============================================================================
+
+@test "CRIT-2: forged cooldown_until far-future is clamped to ts_utc + max_cooldown_seconds" {
+    source "$LIB"
+    # Inject an auto_drop entry with cooldown_until = year 9999 (DoS attempt).
+    # max_cooldown_seconds=7776000 (90d). ts_utc=2026-05-01 -> clamp to 2026-07-30.
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-04-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"f","capability":"m","actor":"deep-name","from_tier":null,"to_tier":"T2","operator":"deep-name","reason":"r"}}
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.auto_drop","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"x","payload":{"scope":"f","capability":"m","actor":"deep-name","from_tier":"T2","to_tier":"T1","decision_id":"d-1","reason":"override","cooldown_until":"9999-12-31T23:59:59.000Z","cooldown_seconds":604800}}
+EOF
+    LOA_TRUST_TEST_MODE=1 LOA_TRUST_TEST_NOW="2026-06-01T00:00:00.000Z" \
+        run trust_query "f" "m" "deep-name"
+    [[ "$status" -eq 0 ]]
+    # in_cooldown_until is clamped to 2026-07-30 (90d from auto_drop ts_utc).
+    local until
+    until="$(echo "$output" | jq -r '.in_cooldown_until')"
+    [[ "$until" == "2026-07-30T00:00:00.000Z" ]] || {
+        echo "expected clamp to 2026-07-30, got: $until"
+        return 1
+    }
+}
+
+@test "CRIT-2: forged cooldown_until in the past (epoch) is clamped to ts_utc (cannot pre-expire)" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-04-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"f","capability":"m","actor":"deep-name","from_tier":null,"to_tier":"T2","operator":"deep-name","reason":"r"}}
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.auto_drop","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"x","payload":{"scope":"f","capability":"m","actor":"deep-name","from_tier":"T2","to_tier":"T1","decision_id":"d-1","reason":"override","cooldown_until":"1970-01-01T00:00:00.000Z","cooldown_seconds":604800}}
+EOF
+    # Now=2026-05-02 — clamped cooldown ends at ts_utc=2026-05-01, so already
+    # expired; in_cooldown_until is null (cooldown over). Attacker DID NOT
+    # nullify cooldown beyond what they could already do (the actual cooldown
+    # starts at the auto_drop ts_utc and lasts at least 0 seconds — clamp to
+    # ts_utc means "cooldown was zero seconds" which is the safest the lib
+    # can guarantee for a forged past timestamp).
+    LOA_TRUST_TEST_MODE=1 LOA_TRUST_TEST_NOW="2026-05-02T00:00:00.000Z" \
+        run trust_query "f" "m" "deep-name"
+    [[ "$status" -eq 0 ]]
+    # in_cooldown_until is null because clamped value (2026-05-01) < now.
+    echo "$output" | jq -e '.in_cooldown_until == null' >/dev/null
+}
+
+@test "CRIT-2: legitimate cooldown_until (within max ceiling) is honored" {
+    source "$LIB"
+    LOA_TRUST_TEST_MODE=1 LOA_TRUST_TEST_NOW="2026-05-01T00:00:00.000Z" \
+        trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    LOA_TRUST_TEST_MODE=1 LOA_TRUST_TEST_NOW="2026-05-01T00:00:00.000Z" \
+        trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    LOA_TRUST_TEST_MODE=1 LOA_TRUST_TEST_NOW="2026-05-01T00:00:00.000Z" \
+        trust_record_override "f" "m" "deep-name" "d-1" "override"
+    # cooldown=604800s=7d, ts=2026-05-01, until=2026-05-08 -> within 90d cap, honored.
+    LOA_TRUST_TEST_MODE=1 LOA_TRUST_TEST_NOW="2026-05-04T00:00:00.000Z" \
+        run trust_query "f" "m" "deep-name"
+    local until
+    until="$(echo "$output" | jq -r '.in_cooldown_until')"
+    [[ "$until" == "2026-05-08T00:00:00.000Z" ]]
+}
+
+# =============================================================================
+# HIGH-1: walk_ledger filters marker lines + bubbles parse errors
+# =============================================================================
+
+@test "HIGH-1: trust_query handles ledger with [CHAIN-BROKEN] markers gracefully" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"f","capability":"m","actor":"deep-name","from_tier":null,"to_tier":"T1","operator":"deep-name","reason":"r"}}
+[CHAIN-BROKEN at=2026-05-02T00:00:00.000Z primitive=L4]
+EOF
+    run trust_query "f" "m" "deep-name"
+    [[ "$status" -eq 0 ]]
+    # Tier should be T1 from the valid entry; markers are filtered.
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+    echo "$output" | jq -e '.transition_history | length == 1' >/dev/null
+}
+
+# =============================================================================
+# HIGH-2: chain-integrity required for writes
+# =============================================================================
+
+@test "HIGH-2: trust_grant refuses to append on broken chain (multi-entry tamper)" {
+    source "$LIB"
+    # Single-entry tamper isn't detectable by chain-walk (entry 0's prev_hash
+    # is always GENESIS); need at least 2 entries so the prev_hash linkage
+    # exists and breaks under tamper.
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    python3 - "$LOA_TRUST_LEDGER_FILE" <<'PY'
+import json, sys
+path = sys.argv[1]
+lines = open(path).read().splitlines()
+obj = json.loads(lines[0])
+obj["payload"]["reason"] = "tampered"
+lines[0] = json.dumps(obj, separators=(",", ":"))
+open(path, "w").write("\n".join(lines) + "\n")
+PY
+    run trust_grant "f" "m" "deep-name" "T3" --reason "should-refuse" --operator "deep-name"
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"chain integrity broken"* ]] || [[ "$output" == *"trust_recover_chain"* ]]
+}
+
+@test "HIGH-2: trust_record_override refuses to append on broken chain" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    python3 - "$LOA_TRUST_LEDGER_FILE" <<'PY'
+import json, sys
+path = sys.argv[1]
+lines = open(path).read().splitlines()
+obj = json.loads(lines[0])
+obj["payload"]["reason"] = "tampered"
+lines[0] = json.dumps(obj, separators=(",", ":"))
+open(path, "w").write("\n".join(lines) + "\n")
+PY
+    run trust_record_override "f" "m" "deep-name" "d-1" "should-refuse"
+    [[ "$status" -eq 1 ]]
+}
+
+# =============================================================================
+# HIGH-3: _l4_enabled gates writes
+# =============================================================================
+
+@test "HIGH-3: trust_grant refuses to write when graduated_trust.enabled=false" {
+    source "$LIB"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: false
+  default_tier: T0
+  tier_definitions: { T0: {}, T1: {} }
+  transition_rules:
+    - { from: T0, to: T1, requires: operator_grant }
+EOF
+    run trust_grant "f" "m" "deep-name" "T1" --reason "r" --operator "deep-name"
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"graduated_trust.enabled"* ]]
+}
+
+@test "HIGH-3: trust_record_override refuses to write when L4 disabled" {
+    source "$LIB"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: false
+EOF
+    run trust_record_override "f" "m" "deep-name" "d-1" "r"
+    [[ "$status" -eq 1 ]]
+}
+
+@test "HIGH-3: trust_disable refuses to write when L4 disabled" {
+    source "$LIB"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: false
+EOF
+    run trust_disable --reason "r" --operator "deep-name"
+    [[ "$status" -eq 1 ]]
+}
+
+@test "HIGH-3: trust_query is NOT gated on _l4_enabled (read still works)" {
+    source "$LIB"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: false
+EOF
+    run trust_query "f" "m" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T0"' >/dev/null
+}
+
+# =============================================================================
+# HIGH-6: --force requires --operator distinct from actor
+# =============================================================================
+
+@test "HIGH-6: --force without --operator is rejected" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    run trust_grant "f" "m" "deep-name" "T2" --reason "force-without-op" --force
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"--operator"* ]]
+}
+
+@test "HIGH-6: --force with operator==actor is rejected" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    run trust_grant "f" "m" "deep-name" "T2" --reason "self-force" --operator "deep-name" --force
+    [[ "$status" -eq 2 ]]
+    [[ "$output" == *"distinct from actor"* ]]
+}
+
+@test "HIGH-6: --force with distinct --operator succeeds" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    run trust_grant "f" "m" "deep-name" "T2" --reason "ok-force" --operator "operator-2" --force
+    [[ "$status" -eq 0 ]]
+}
+
+# =============================================================================
+# MED-2: reason rejects JSONL field substrings + control bytes
+# =============================================================================
+
+@test "MED-2: reason containing event_type substring is rejected (grep-injection defense)" {
+    source "$LIB"
+    run trust_grant "f" "m" "deep-name" "T1" --reason 'foo "event_type": "bar"' --operator "deep-name"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "MED-2: reason containing newline is rejected" {
+    source "$LIB"
+    run trust_grant "f" "m" "deep-name" "T1" --reason $'line1\nline2' --operator "deep-name"
+    [[ "$status" -eq 2 ]]
+}
+
+# =============================================================================
+# MED-3: decision_id rejects HTML/markdown injection
+# =============================================================================
+
+@test "MED-3: decision_id with angle brackets is rejected" {
+    source "$LIB"
+    trust_grant "f" "m" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "f" "m" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    run trust_record_override "f" "m" "deep-name" '<script>alert(1)</script>' "override"
+    [[ "$status" -eq 2 ]]
+}
+
+# =============================================================================
+# MED-4: LOA_TRUST_TEST_NOW gated to test mode
+# =============================================================================
+
+@test "MED-4: LOA_TRUST_TEST_NOW outside test mode is ignored" {
+    source "$LIB"
+    # Unset BATS_TEST_DIRNAME to simulate non-test env; LOA_TRUST_TEST_MODE not set
+    local now
+    now="$(BATS_TEST_DIRNAME='' LOA_TRUST_TEST_NOW='1970-01-01T00:00:00.000Z' _l4_now_iso8601)"
+    [[ "$now" != "1970-01-01T00:00:00.000Z" ]]
+    # When TEST_MODE=1 is explicitly set, override IS honored
+    now="$(LOA_TRUST_TEST_MODE=1 BATS_TEST_DIRNAME='' LOA_TRUST_TEST_NOW='1970-01-01T00:00:00.000Z' _l4_now_iso8601)"
+    [[ "$now" == "1970-01-01T00:00:00.000Z" ]]
+}

--- a/tests/integration/trust-cypherpunk-remediation.bats
+++ b/tests/integration/trust-cypherpunk-remediation.bats
@@ -327,6 +327,14 @@ EOF
     local now
     now="$(BATS_TEST_DIRNAME='' LOA_TRUST_TEST_NOW='1970-01-01T00:00:00.000Z' _l4_now_iso8601)"
     [[ "$now" != "1970-01-01T00:00:00.000Z" ]]
+    # F1 (BB iter-1): pin to a current-ish ISO date prefix rather than just
+    # "any non-epoch value" — this catches the case where the lib accidentally
+    # starts honoring a forged value of a different shape.
+    [[ "$now" == "20"* ]] || {
+        echo "expected ISO date starting with '20', got: $now"
+        return 1
+    }
+    [[ "$now" == *T*Z ]]
     # When TEST_MODE=1 is explicitly set, override IS honored
     now="$(LOA_TRUST_TEST_MODE=1 BATS_TEST_DIRNAME='' LOA_TRUST_TEST_NOW='1970-01-01T00:00:00.000Z' _l4_now_iso8601)"
     [[ "$now" == "1970-01-01T00:00:00.000Z" ]]

--- a/tests/integration/trust-grant-and-override.bats
+++ b/tests/integration/trust-grant-and-override.bats
@@ -148,7 +148,7 @@ teardown() {
     trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
     trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "step2" --operator "deep-name"
     trust_record_override "flatline" "merge_main" "deep-name" "decision-x" "override"
-    run trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "rerise" --force --operator "deep-name"
+    run trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "rerise" --force --operator "operator-2"
     [[ "$status" -eq 0 ]]
     grep -F '"event_type":"trust.force_grant"' "$LOA_TRUST_LEDGER_FILE"
 }
@@ -164,13 +164,13 @@ teardown() {
     echo "$entry" | jq -e '.payload.transition_rule_id == "T0_to_T1"' >/dev/null
 }
 
-@test "trust_grant: ledger sealed -> rejected with exit 1" {
+@test "trust_grant: ledger sealed -> rejected with exit 3 (transition rejected)" {
     source "$LIB"
     cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
 {"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.disable","ts_utc":"2026-05-02T00:00:00.000Z","prev_hash":"GENESIS","payload":{"operator":"o","reason":"sealed","sealed_at":"2026-05-02T00:00:00.000Z"}}
 EOF
     run trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "r" --operator "deep-name"
-    [[ "$status" -eq 1 ]]
+    [[ "$status" -eq 3 ]]
 }
 
 # =============================================================================

--- a/tests/integration/trust-grant-and-override.bats
+++ b/tests/integration/trust-grant-and-override.bats
@@ -1,0 +1,315 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/trust-grant-and-override.bats
+#
+# cycle-098 Sprint 4B — FR-L4-2 (only configured transitions allowed) and
+# FR-L4-3 (recordOverride auto-drop + cooldown enforced).
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    LIB="$PROJECT_ROOT/.claude/scripts/lib/graduated-trust-lib.sh"
+    [[ -f "$LIB" ]] || skip "graduated-trust-lib.sh not present"
+
+    TEST_DIR="$(mktemp -d)"
+    TEST_TRUST_STORE="$TEST_DIR/trust-store.yaml"
+    cat > "$TEST_TRUST_STORE" <<'EOF'
+schema_version: "1.0"
+root_signature: { algorithm: ed25519, signer_pubkey: "", signed_at: "", signature: "" }
+keys: []
+revocations: []
+trust_cutoff: { default_strict_after: "2099-01-01T00:00:00Z" }
+EOF
+    export LOA_TRUST_STORE_FILE="$TEST_TRUST_STORE"
+
+    export LOA_TRUST_CONFIG_FILE="$TEST_DIR/.loa.config.yaml"
+    export LOA_TRUST_LEDGER_FILE="$TEST_DIR/trust-ledger.jsonl"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T0
+  tier_definitions:
+    T0: { description: "no autonomy" }
+    T1: { description: "read-only" }
+    T2: { description: "routine" }
+    T3: { description: "full" }
+  transition_rules:
+    - from: T0
+      to: T1
+      requires: operator_grant
+      id: T0_to_T1
+    - from: T1
+      to: T2
+      requires: operator_grant
+      id: T1_to_T2
+    - from: T2
+      to: T3
+      requires: operator_grant
+      id: T2_to_T3
+    - from: T2
+      to: T1
+      via: auto_drop_on_override
+    - from: T3
+      to: T1
+      via: auto_drop_on_override
+    - from: any
+      to_lower: true
+      via: auto_drop_on_override
+  cooldown_seconds: 604800
+EOF
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_TRUST_STORE_FILE LOA_TRUST_CONFIG_FILE LOA_TRUST_LEDGER_FILE
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+# =============================================================================
+# FR-L4-2: trust_grant — only configured transitions allowed
+# =============================================================================
+
+@test "FR-L4-2: initial T0->T1 grant succeeds (matches T0_to_T1 rule)" {
+    source "$LIB"
+    run trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "alignment-validated" --operator "deep-name"
+    [[ "$status" -eq 0 ]] || {
+        echo "$output"
+        return 1
+    }
+    [[ -f "$LOA_TRUST_LEDGER_FILE" ]]
+    grep -F '"event_type":"trust.grant"' "$LOA_TRUST_LEDGER_FILE"
+
+    run trust_query "flatline" "merge_main" "deep-name"
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+}
+
+@test "FR-L4-2: arbitrary jump T0->T3 is REJECTED (no rule matches)" {
+    source "$LIB"
+    run trust_grant "flatline" "merge_main" "deep-name" "T3" --reason "yolo" --operator "deep-name"
+    [[ "$status" -eq 3 ]]
+    [[ ! -f "$LOA_TRUST_LEDGER_FILE" ]] || {
+        if grep -F '"event_type":"trust.grant"' "$LOA_TRUST_LEDGER_FILE" 2>/dev/null; then
+            echo "trust.grant emitted despite rejection"
+            return 1
+        fi
+    }
+}
+
+@test "FR-L4-2: chained T0->T1->T2 grants both succeed" {
+    source "$LIB"
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "step2" --operator "deep-name"
+    run trust_query "flatline" "merge_main" "deep-name"
+    echo "$output" | jq -e '.tier == "T2"' >/dev/null
+    echo "$output" | jq -e '.transition_history | length == 2' >/dev/null
+}
+
+@test "FR-L4-2: re-granting current tier is rejected (no-op)" {
+    source "$LIB"
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    run trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "again" --operator "deep-name"
+    [[ "$status" -eq 3 ]]
+}
+
+@test "trust_grant: missing --reason rejected with exit 2" {
+    source "$LIB"
+    run trust_grant "flatline" "merge_main" "deep-name" "T1" --operator "deep-name"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "trust_grant: missing positional rejected with exit 2" {
+    source "$LIB"
+    run trust_grant "flatline" "merge_main" "deep-name" --reason "r" --operator "o"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "trust_grant: oversize reason rejected" {
+    source "$LIB"
+    local big
+    big="$(printf 'a%.0s' {1..5000})"
+    run trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "$big" --operator "deep-name"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "trust_grant: --force returns 99 in 4B (Sprint 4C wires the path)" {
+    source "$LIB"
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    trust_record_override "flatline" "merge_main" "deep-name" "decision-x" "override"
+    run trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "rerise" --force --operator "deep-name"
+    [[ "$status" -eq 99 ]]
+}
+
+@test "trust_grant: writes payload that matches trust-grant schema (jq shape)" {
+    source "$LIB"
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "validated" --operator "deep-name"
+    local entry
+    entry="$(grep -F '"event_type":"trust.grant"' "$LOA_TRUST_LEDGER_FILE" | head -n 1)"
+    echo "$entry" | jq -e '.payload.scope == "flatline"' >/dev/null
+    echo "$entry" | jq -e '.payload.from_tier == null' >/dev/null
+    echo "$entry" | jq -e '.payload.to_tier == "T1"' >/dev/null
+    echo "$entry" | jq -e '.payload.transition_rule_id == "T0_to_T1"' >/dev/null
+}
+
+@test "trust_grant: ledger sealed -> rejected with exit 1" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.disable","ts_utc":"2026-05-02T00:00:00.000Z","prev_hash":"GENESIS","payload":{"operator":"o","reason":"sealed","sealed_at":"2026-05-02T00:00:00.000Z"}}
+EOF
+    run trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "r" --operator "deep-name"
+    [[ "$status" -eq 1 ]]
+}
+
+# =============================================================================
+# FR-L4-3: trust_record_override — auto-drop + cooldown enforced
+# =============================================================================
+
+@test "FR-L4-3: override drops T2->T1 per explicit rule" {
+    source "$LIB"
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "step2" --operator "deep-name"
+    run trust_record_override "flatline" "merge_main" "deep-name" "decision-1" "panel decision overridden"
+    [[ "$status" -eq 0 ]] || {
+        echo "$output"
+        return 1
+    }
+    run trust_query "flatline" "merge_main" "deep-name"
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+    echo "$output" | jq -e '.in_cooldown_until != null' >/dev/null
+}
+
+@test "FR-L4-3: cooldown blocks regular trust_grant" {
+    source "$LIB"
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "step2" --operator "deep-name"
+    trust_record_override "flatline" "merge_main" "deep-name" "decision-1" "override"
+    # Cooldown active; T1 -> T2 grant should be blocked.
+    run trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "rerise" --operator "deep-name"
+    [[ "$status" -eq 3 ]]
+    [[ "$output" == *"cooldown"* ]]
+}
+
+@test "FR-L4-3: cooldown_until = ts + cooldown_seconds (precise math)" {
+    source "$LIB"
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "step2" --operator "deep-name"
+    LOA_TRUST_TEST_NOW="2026-05-01T00:00:00.000Z" \
+        trust_record_override "flatline" "merge_main" "deep-name" "decision-1" "override"
+    local entry
+    entry="$(grep -F '"event_type":"trust.auto_drop"' "$LOA_TRUST_LEDGER_FILE" | head -n 1)"
+    # Payload's cooldown_until should be 2026-05-01 + 7d = 2026-05-08T00:00:00.000Z.
+    echo "$entry" | jq -e '.payload.cooldown_until == "2026-05-08T00:00:00.000Z"' >/dev/null
+    echo "$entry" | jq -e '.payload.cooldown_seconds == 604800' >/dev/null
+}
+
+@test "FR-L4-3: re-override during cooldown is allowed (rolling cooldown)" {
+    source "$LIB"
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "step2" --operator "deep-name"
+    LOA_TRUST_TEST_NOW="2026-05-01T00:00:00.000Z" \
+        trust_record_override "flatline" "merge_main" "deep-name" "decision-1" "override-1"
+    LOA_TRUST_TEST_NOW="2026-05-02T00:00:00.000Z" \
+        run trust_record_override "flatline" "merge_main" "deep-name" "decision-2" "override-2"
+    [[ "$status" -eq 0 ]]
+    # Two auto_drop entries.
+    [[ "$(grep -cF '"event_type":"trust.auto_drop"' "$LOA_TRUST_LEDGER_FILE")" == "2" ]]
+}
+
+@test "FR-L4-3: missing decision_id rejected with exit 2" {
+    source "$LIB"
+    run trust_record_override "flatline" "merge_main" "deep-name" "" "reason"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "FR-L4-3: decision_id with shell metacharacter rejected" {
+    source "$LIB"
+    run trust_record_override "flatline" "merge_main" "deep-name" 'd-1$EVIL`whoami`' "reason"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "FR-L4-3: when no auto_drop rule configured -> exit 3" {
+    source "$LIB"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T0
+  tier_definitions:
+    T0: { description: "no" }
+    T1: { description: "y" }
+  transition_rules:
+    - from: T0
+      to: T1
+      requires: operator_grant
+EOF
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    run trust_record_override "flatline" "merge_main" "deep-name" "d-1" "override"
+    [[ "$status" -eq 3 ]]
+    [[ "$output" == *"auto_drop_on_override"* ]]
+}
+
+@test "FR-L4-3: 'any/to_lower:true' rule resolves drop_to=default_tier when no explicit rule" {
+    source "$LIB"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T0
+  tier_definitions:
+    T0: { description: "no" }
+    T1: { description: "y" }
+  transition_rules:
+    - from: T0
+      to: T1
+      requires: operator_grant
+    - from: any
+      to_lower: true
+      via: auto_drop_on_override
+EOF
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    run trust_record_override "flatline" "merge_main" "deep-name" "d-1" "override"
+    [[ "$status" -eq 0 ]]
+    run trust_query "flatline" "merge_main" "deep-name"
+    echo "$output" | jq -e '.tier == "T0"' >/dev/null
+}
+
+@test "FR-L4-3: oversize reason rejected" {
+    source "$LIB"
+    local big
+    big="$(printf 'a%.0s' {1..5000})"
+    run trust_record_override "flatline" "merge_main" "deep-name" "d-1" "$big"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "FR-L4-3: ledger sealed -> override rejected with exit 3" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.disable","ts_utc":"2026-05-02T00:00:00.000Z","prev_hash":"GENESIS","payload":{"operator":"o","reason":"sealed","sealed_at":"2026-05-02T00:00:00.000Z"}}
+EOF
+    run trust_record_override "flatline" "merge_main" "deep-name" "d-1" "override"
+    [[ "$status" -eq 3 ]]
+}
+
+# =============================================================================
+# Hash-chain shape: 4B emits with audit_emit, so chain hashes must be valid.
+# =============================================================================
+
+@test "trust_grant + trust_record_override produce valid prev_hash chain" {
+    source "$LIB"
+    source "$PROJECT_ROOT/.claude/scripts/audit-envelope.sh"
+    trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "s1" --operator "deep-name"
+    trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "s2" --operator "deep-name"
+    trust_record_override "flatline" "merge_main" "deep-name" "d-1" "override"
+    run audit_verify_chain "$LOA_TRUST_LEDGER_FILE"
+    [[ "$status" -eq 0 ]] || {
+        echo "audit_verify_chain rejected the chain produced by trust_grant + trust_record_override"
+        echo "$output"
+        return 1
+    }
+}

--- a/tests/integration/trust-grant-and-override.bats
+++ b/tests/integration/trust-grant-and-override.bats
@@ -140,12 +140,17 @@ teardown() {
     [[ "$status" -eq 2 ]]
 }
 
-@test "trust_grant: --force returns 99 in 4B (Sprint 4C wires the path)" {
+@test "trust_grant: --force routes to trust.force_grant (Sprint 4C wired)" {
+    # Pinned at 4B: --force was a stub returning 99. Sprint 4C activated the
+    # real path; this test documents the transition. The detailed exception
+    # behavior is covered by tests/integration/trust-chain-and-force-grant.bats.
     source "$LIB"
     trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "step1" --operator "deep-name"
+    trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "step2" --operator "deep-name"
     trust_record_override "flatline" "merge_main" "deep-name" "decision-x" "override"
-    run trust_grant "flatline" "merge_main" "deep-name" "T1" --reason "rerise" --force --operator "deep-name"
-    [[ "$status" -eq 99 ]]
+    run trust_grant "flatline" "merge_main" "deep-name" "T2" --reason "rerise" --force --operator "deep-name"
+    [[ "$status" -eq 0 ]]
+    grep -F '"event_type":"trust.force_grant"' "$LOA_TRUST_LEDGER_FILE"
 }
 
 @test "trust_grant: writes payload that matches trust-grant schema (jq shape)" {

--- a/tests/integration/trust-query-default-tier.bats
+++ b/tests/integration/trust-query-default-tier.bats
@@ -1,0 +1,277 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/trust-query-default-tier.bats
+#
+# cycle-098 Sprint 4A — FR-L4-1: First query for any (scope, capability, actor)
+# returns default_tier.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    LIB="$PROJECT_ROOT/.claude/scripts/lib/graduated-trust-lib.sh"
+
+    [[ -f "$LIB" ]] || skip "graduated-trust-lib.sh not present"
+
+    TEST_DIR="$(mktemp -d)"
+    TEST_TRUST_STORE="$TEST_DIR/trust-store.yaml"
+    cat > "$TEST_TRUST_STORE" <<'EOF'
+schema_version: "1.0"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: ""
+  signed_at: ""
+  signature: ""
+keys: []
+revocations: []
+trust_cutoff:
+  default_strict_after: "2099-01-01T00:00:00Z"
+EOF
+    export LOA_TRUST_STORE_FILE="$TEST_TRUST_STORE"
+
+    export LOA_TRUST_CONFIG_FILE="$TEST_DIR/.loa.config.yaml"
+    export LOA_TRUST_LEDGER_FILE="$TEST_DIR/trust-ledger.jsonl"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T0
+  tier_definitions:
+    T0:
+      description: "no autonomy"
+    T1:
+      description: "read-only"
+    T2:
+      description: "routine mutations"
+    T3:
+      description: "full"
+  transition_rules:
+    - from: T0
+      to: T1
+      requires: operator_grant
+  cooldown_seconds: 604800
+EOF
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_TRUST_STORE_FILE LOA_TRUST_CONFIG_FILE LOA_TRUST_LEDGER_FILE
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+# =============================================================================
+# FR-L4-1 happy path: empty ledger → default_tier
+# =============================================================================
+
+@test "FR-L4-1: empty ledger -> trust_query returns default_tier" {
+    source "$LIB"
+    run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T0"' >/dev/null
+    echo "$output" | jq -e '.transition_history == []' >/dev/null
+    echo "$output" | jq -e '.in_cooldown_until == null' >/dev/null
+    echo "$output" | jq -e '.auto_raise_eligible == false' >/dev/null
+}
+
+@test "FR-L4-1: empty ledger + custom default_tier -> returns custom default" {
+    source "$LIB"
+    cat > "$LOA_TRUST_CONFIG_FILE" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T1
+EOF
+    run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+}
+
+@test "FR-L4-1: missing ledger file (first install) -> returns default_tier" {
+    source "$LIB"
+    rm -f "$LOA_TRUST_LEDGER_FILE"
+    run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T0"' >/dev/null
+}
+
+@test "FR-L4-1: response shape carries scope/capability/actor verbatim" {
+    source "$LIB"
+    run trust_query "core/auth" "rotate_credentials" "alice@example"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.scope == "core/auth"' >/dev/null
+    echo "$output" | jq -e '.capability == "rotate_credentials"' >/dev/null
+    echo "$output" | jq -e '.actor == "alice@example"' >/dev/null
+}
+
+# =============================================================================
+# Input validation: bad input rejected with exit 2
+# =============================================================================
+
+@test "trust_query: missing argument -> exit 2" {
+    source "$LIB"
+    run trust_query "scope-only"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "trust_query: shell metacharacter in scope -> exit 2" {
+    source "$LIB"
+    run trust_query 'scope$EVIL' "merge_main" "deep-name"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "trust_query: dot-dot in actor -> exit 2 (charclass-bypass defense)" {
+    source "$LIB"
+    run trust_query "scope" "capability" "deep-name/../etc/passwd"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "trust_query: URL-shape in actor -> exit 2 (#761 pattern)" {
+    source "$LIB"
+    run trust_query "scope" "capability" "https://leak.example/secret"
+    [[ "$status" -eq 2 ]]
+}
+
+# =============================================================================
+# Ledger walking: pre-existing entries projected into transition_history
+# =============================================================================
+
+@test "trust_query: pre-existing trust.grant entry surfaces in transition_history" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":null,"to_tier":"T1","operator":"deep-name","reason":"alignment-validated"}}
+EOF
+    run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+    echo "$output" | jq -e '.transition_history | length == 1' >/dev/null
+    echo "$output" | jq -e '.transition_history[0].transition_type == "initial"' >/dev/null
+    echo "$output" | jq -e '.transition_history[0].to_tier == "T1"' >/dev/null
+}
+
+@test "trust_query: only entries matching scope/capability/actor included" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":null,"to_tier":"T1","operator":"deep-name","reason":"r"}}
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-05-01T01:00:00.000Z","prev_hash":"x","payload":{"scope":"deploy","capability":"prod","actor":"deep-name","from_tier":null,"to_tier":"T2","operator":"deep-name","reason":"r"}}
+EOF
+    run trust_query "flatline" "merge_main" "deep-name"
+    echo "$output" | jq -e '.transition_history | length == 1' >/dev/null
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+
+    run trust_query "deploy" "prod" "deep-name"
+    echo "$output" | jq -e '.transition_history | length == 1' >/dev/null
+    echo "$output" | jq -e '.tier == "T2"' >/dev/null
+}
+
+@test "trust_query: cooldown derived from auto_drop event when within window" {
+    source "$LIB"
+    # auto_drop at 2026-05-01; cooldown 7d -> 2026-05-08; now is 2026-05-03 (within)
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-04-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":null,"to_tier":"T2","operator":"deep-name","reason":"r"}}
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.auto_drop","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"x","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":"T2","to_tier":"T1","decision_id":"d-1","reason":"override","cooldown_until":"2026-05-08T00:00:00.000Z","cooldown_seconds":604800}}
+EOF
+    LOA_TRUST_TEST_NOW="2026-05-03T00:00:00.000Z" run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T1"' >/dev/null
+    # in_cooldown_until is the auto_drop's ts + cooldown_seconds (computed by lib)
+    echo "$output" | jq -e '.in_cooldown_until != null' >/dev/null
+}
+
+@test "trust_query: cooldown null when window has elapsed" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-04-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":null,"to_tier":"T2","operator":"deep-name","reason":"r"}}
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.auto_drop","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"x","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":"T2","to_tier":"T1","decision_id":"d-1","reason":"override","cooldown_until":"2026-05-08T00:00:00.000Z","cooldown_seconds":604800}}
+EOF
+    LOA_TRUST_TEST_NOW="2026-06-01T00:00:00.000Z" run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.in_cooldown_until == null' >/dev/null
+}
+
+@test "trust_query: force_grant clears cooldown" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-04-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":null,"to_tier":"T2","operator":"deep-name","reason":"r"}}
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.auto_drop","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"x","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":"T2","to_tier":"T1","decision_id":"d-1","reason":"override","cooldown_until":"2026-05-08T00:00:00.000Z","cooldown_seconds":604800}}
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.force_grant","ts_utc":"2026-05-02T00:00:00.000Z","prev_hash":"y","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":"T1","to_tier":"T2","operator":"deep-name","reason":"emergency","cooldown_remaining_seconds_at_grant":518400,"cooldown_until_at_grant":"2026-05-08T00:00:00.000Z"}}
+EOF
+    LOA_TRUST_TEST_NOW="2026-05-03T00:00:00.000Z" run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T2"' >/dev/null
+    echo "$output" | jq -e '.in_cooldown_until == null' >/dev/null
+}
+
+@test "trust_query: TrustResponse schema validates" {
+    if ! command -v ajv >/dev/null 2>&1; then
+        skip "ajv not installed"
+    fi
+    source "$LIB"
+    run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    local resp_file
+    resp_file="$(mktemp)"
+    printf '%s' "$output" > "$resp_file"
+    run ajv validate \
+        -s "$PROJECT_ROOT/.claude/data/trajectory-schemas/trust-events/trust-response.schema.json" \
+        -d "$resp_file" --strict=false
+    rm -f "$resp_file"
+    [[ "$status" -eq 0 ]] || {
+        echo "ajv: $output"
+        return 1
+    }
+}
+
+# =============================================================================
+# Optional query event emission
+# =============================================================================
+
+@test "trust_query: LOA_TRUST_EMIT_QUERY_EVENTS=1 appends a trust.query entry" {
+    source "$LIB"
+    LOA_TRUST_EMIT_QUERY_EVENTS=1 run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    [[ -f "$LOA_TRUST_LEDGER_FILE" ]]
+    grep -F '"event_type":"trust.query"' "$LOA_TRUST_LEDGER_FILE"
+    # Ensure no stray query events when flag is OFF
+    rm -f "$LOA_TRUST_LEDGER_FILE"
+    run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    [[ ! -f "$LOA_TRUST_LEDGER_FILE" ]] || {
+        if grep -F '"event_type":"trust.query"' "$LOA_TRUST_LEDGER_FILE" 2>/dev/null; then
+            echo "trust.query emitted with flag off"
+            return 1
+        fi
+    }
+}
+
+# =============================================================================
+# Sealed ledger: reads still return last-known-tier per PRD §849
+# =============================================================================
+
+@test "trust_query: sealed ledger ([L4-DISABLED]) still returns last-known-tier" {
+    source "$LIB"
+    cat > "$LOA_TRUST_LEDGER_FILE" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"flatline","capability":"merge_main","actor":"deep-name","from_tier":null,"to_tier":"T2","operator":"deep-name","reason":"r"}}
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.disable","ts_utc":"2026-05-02T00:00:00.000Z","prev_hash":"x","payload":{"operator":"deep-name","reason":"sealed","sealed_at":"2026-05-02T00:00:00.000Z"}}
+EOF
+    run trust_query "flatline" "merge_main" "deep-name"
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.tier == "T2"' >/dev/null
+}
+
+# =============================================================================
+# Operator-identity gate
+# =============================================================================
+
+@test "trust_query: LOA_TRUST_REQUIRE_KNOWN_ACTOR=1 rejects unknown actor" {
+    source "$LIB"
+    # operator-identity needs OPERATORS.md; we rely on the existing one in the
+    # repo. With an obviously-fake actor, this should reject.
+    LOA_TRUST_REQUIRE_KNOWN_ACTOR=1 run trust_query "flatline" "merge_main" "definitely-not-an-operator-xyz123"
+    [[ "$status" -eq 2 ]]
+}

--- a/tests/unit/graduated-trust-lib-defaults.bats
+++ b/tests/unit/graduated-trust-lib-defaults.bats
@@ -1,0 +1,290 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/unit/graduated-trust-lib-defaults.bats
+#
+# cycle-098 Sprint 4A — config getters, validators, and defaults for the L4
+# graduated-trust library. Pre-trust_query plumbing.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    LIB="$PROJECT_ROOT/.claude/scripts/lib/graduated-trust-lib.sh"
+
+    [[ -f "$LIB" ]] || skip "graduated-trust-lib.sh not present"
+
+    # Use a private trust-store so audit_emit doesn't reach the real one.
+    TEST_DIR="$(mktemp -d)"
+    TEST_TRUST_STORE="$TEST_DIR/trust-store.yaml"
+    cat > "$TEST_TRUST_STORE" <<'EOF'
+schema_version: "1.0"
+root_signature:
+  algorithm: ed25519
+  signer_pubkey: ""
+  signed_at: ""
+  signature: ""
+keys: []
+revocations: []
+trust_cutoff:
+  default_strict_after: "2099-01-01T00:00:00Z"
+EOF
+    export LOA_TRUST_STORE_FILE="$TEST_TRUST_STORE"
+
+    # Per-test private config, ledger, etc.
+    TEST_CONFIG="$TEST_DIR/.loa.config.yaml"
+    TEST_LEDGER="$TEST_DIR/trust-ledger.jsonl"
+    export LOA_TRUST_CONFIG_FILE="$TEST_CONFIG"
+    export LOA_TRUST_LEDGER_FILE="$TEST_LEDGER"
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+teardown() {
+    if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+        find "$TEST_DIR" -type f -delete 2>/dev/null || true
+        find "$TEST_DIR" -type d -empty -delete 2>/dev/null || true
+    fi
+    unset LOA_TRUST_STORE_FILE LOA_TRUST_CONFIG_FILE LOA_TRUST_LEDGER_FILE
+    unset LOA_TRUST_DEFAULT_TIER LOA_TRUST_COOLDOWN_SECONDS
+    unset LOA_TRUST_REQUIRE_KNOWN_ACTOR LOA_TRUST_EMIT_QUERY_EVENTS
+    unset LOA_TRUST_TEST_NOW
+}
+
+# -----------------------------------------------------------------------------
+# Validators
+# -----------------------------------------------------------------------------
+
+@test "validator: rejects empty token" {
+    source "$LIB"
+    run _l4_validate_token "" "scope"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "validator: rejects shell metacharacter" {
+    source "$LIB"
+    for bad in 'a$b' 'a`b' 'a;b' 'a&b' 'a|b' 'a(b' 'a)b' 'a{b' 'a<b' 'a"b' "a'b"; do
+        run _l4_validate_token "$bad" "scope"
+        [[ "$status" -ne 0 ]] || {
+            echo "did not reject: $bad"
+            return 1
+        }
+    done
+}
+
+@test "validator: rejects whitespace and control bytes" {
+    source "$LIB"
+    for bad in 'a b' $'a\tb' $'a\nb' $'a\rb'; do
+        run _l4_validate_token "$bad" "scope"
+        [[ "$status" -ne 0 ]] || {
+            echo "did not reject (whitespace/control)"
+            return 1
+        }
+    done
+}
+
+@test "validator: rejects '..' (charclass dot-dot bypass defense)" {
+    source "$LIB"
+    run _l4_validate_token "scope..pwn" "scope"
+    [[ "$status" -ne 0 ]]
+    run _l4_validate_token ".." "scope"
+    [[ "$status" -ne 0 ]]
+    run _l4_validate_token "a/../b" "scope"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "validator: rejects URL-shape (cycle-099 #761 pattern)" {
+    source "$LIB"
+    run _l4_validate_token "http://example.com/scope" "scope"
+    [[ "$status" -ne 0 ]]
+    run _l4_validate_token "//pasted-leak" "scope"
+    [[ "$status" -ne 0 ]]
+    run _l4_validate_token "?q=secret" "scope"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "validator: accepts canonical scope/capability/actor" {
+    source "$LIB"
+    for ok in 'flatline' 'merge_main' 'deep-name' 'core/auth' 'agent.deploy' 'org:repo'; do
+        run _l4_validate_token "$ok" "scope"
+        [[ "$status" -eq 0 ]] || {
+            echo "should have accepted: $ok"
+            return 1
+        }
+    done
+}
+
+@test "validator: rejects oversize token (>256 chars)" {
+    source "$LIB"
+    local big
+    big="$(printf 'a%.0s' {1..300})"
+    run _l4_validate_token "$big" "scope"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "tier validator: accepts T0/T1/T2/T3 + custom names; rejects shell metas" {
+    source "$LIB"
+    for ok in T0 T1 T2 T3 trusted apprentice; do
+        run _l4_validate_tier "$ok" "tier"
+        [[ "$status" -eq 0 ]]
+    done
+    for bad in 'T0;rm' 'T0$' '' '  '; do
+        run _l4_validate_tier "$bad" "tier"
+        [[ "$status" -ne 0 ]]
+    done
+}
+
+# -----------------------------------------------------------------------------
+# Config getters
+# -----------------------------------------------------------------------------
+
+@test "config: default_tier falls back to T0 when not configured" {
+    source "$LIB"
+    cat > "$TEST_CONFIG" <<'EOF'
+graduated_trust:
+  enabled: true
+EOF
+    run _l4_get_default_tier
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "T0" ]]
+}
+
+@test "config: default_tier honors operator config" {
+    source "$LIB"
+    cat > "$TEST_CONFIG" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T1
+EOF
+    run _l4_get_default_tier
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "T1" ]]
+}
+
+@test "config: default_tier env override beats operator config" {
+    source "$LIB"
+    cat > "$TEST_CONFIG" <<'EOF'
+graduated_trust:
+  enabled: true
+  default_tier: T1
+EOF
+    LOA_TRUST_DEFAULT_TIER="T2" run _l4_get_default_tier
+    [[ "$output" == "T2" ]]
+}
+
+@test "config: cooldown_seconds defaults to 7 days (604800)" {
+    source "$LIB"
+    cat > "$TEST_CONFIG" <<'EOF'
+graduated_trust:
+  enabled: true
+EOF
+    run _l4_get_cooldown_seconds
+    [[ "$output" == "604800" ]]
+}
+
+@test "config: cooldown_seconds honors operator config" {
+    source "$LIB"
+    cat > "$TEST_CONFIG" <<'EOF'
+graduated_trust:
+  enabled: true
+  cooldown_seconds: 3600
+EOF
+    run _l4_get_cooldown_seconds
+    [[ "$output" == "3600" ]]
+}
+
+@test "config: cooldown_seconds rejects non-integer (falls back to default)" {
+    source "$LIB"
+    cat > "$TEST_CONFIG" <<'EOF'
+graduated_trust:
+  enabled: true
+  cooldown_seconds: "abc; rm -rf /"
+EOF
+    run _l4_get_cooldown_seconds
+    # Stderr-error logged AND fallback printed; assert the stdout line.
+    echo "$output" | grep -qx "604800"
+}
+
+@test "config: tier_definitions returns JSON object (or {} when missing)" {
+    source "$LIB"
+    cat > "$TEST_CONFIG" <<'EOF'
+graduated_trust:
+  enabled: true
+  tier_definitions:
+    T0:
+      description: "no autonomy"
+    T1:
+      description: "read-only"
+EOF
+    run _l4_get_tier_definitions
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.T0.description == "no autonomy"' >/dev/null
+    echo "$output" | jq -e '.T1.description == "read-only"' >/dev/null
+}
+
+@test "config: transition_rules returns JSON array (or [] when missing)" {
+    source "$LIB"
+    cat > "$TEST_CONFIG" <<'EOF'
+graduated_trust:
+  enabled: true
+  transition_rules:
+    - from: T0
+      to: T1
+      requires: operator_grant
+EOF
+    run _l4_get_transition_rules
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e 'length == 1' >/dev/null
+    echo "$output" | jq -e '.[0].from == "T0"' >/dev/null
+}
+
+@test "_l4_enabled: false when config absent" {
+    source "$LIB"
+    rm -f "$TEST_CONFIG"
+    if _l4_enabled; then
+        echo "should be disabled when config missing"
+        return 1
+    fi
+}
+
+@test "_l4_enabled: true when graduated_trust.enabled=true" {
+    source "$LIB"
+    cat > "$TEST_CONFIG" <<'EOF'
+graduated_trust:
+  enabled: true
+EOF
+    _l4_enabled
+}
+
+# -----------------------------------------------------------------------------
+# Sealing detection
+# -----------------------------------------------------------------------------
+
+@test "sealing: empty/missing ledger returns not-sealed" {
+    source "$LIB"
+    rm -f "$TEST_LEDGER"
+    if _l4_ledger_is_sealed "$TEST_LEDGER"; then
+        echo "missing ledger should not be sealed"
+        return 1
+    fi
+}
+
+@test "sealing: last entry trust.disable returns sealed" {
+    source "$LIB"
+    cat > "$TEST_LEDGER" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"s","capability":"c","actor":"a","from_tier":null,"to_tier":"T1","operator":"o","reason":"r"}}
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.disable","ts_utc":"2026-05-02T00:00:00.000Z","prev_hash":"abc","payload":{"operator":"o","reason":"sealed","sealed_at":"2026-05-02T00:00:00.000Z"}}
+EOF
+    _l4_ledger_is_sealed "$TEST_LEDGER"
+}
+
+@test "sealing: last entry NOT trust.disable returns not-sealed" {
+    source "$LIB"
+    cat > "$TEST_LEDGER" <<'EOF'
+{"schema_version":"1.1.0","primitive_id":"L4","event_type":"trust.grant","ts_utc":"2026-05-01T00:00:00.000Z","prev_hash":"GENESIS","payload":{"scope":"s","capability":"c","actor":"a","from_tier":null,"to_tier":"T1","operator":"o","reason":"r"}}
+EOF
+    if _l4_ledger_is_sealed "$TEST_LEDGER"; then
+        echo "single non-disable entry should not be sealed"
+        return 1
+    fi
+}

--- a/tests/unit/trust-events-schemas.bats
+++ b/tests/unit/trust-events-schemas.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/unit/trust-events-schemas.bats
+#
+# cycle-098 Sprint 4A — schema-registry tests for L4 graduated-trust events.
+#
+# Pins the schema files at .claude/data/trajectory-schemas/trust-events/ and
+# verifies each is valid JSON Schema 2020-12 and validates a representative
+# happy-path payload. Defense for #708 F-007 pattern (per-event-type schema
+# registry + drift-resistance).
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    SCHEMA_DIR="$PROJECT_ROOT/.claude/data/trajectory-schemas/trust-events"
+
+    [[ -d "$SCHEMA_DIR" ]] || skip "trust-events schema dir missing"
+}
+
+@test "trust-events: schema directory contains expected event schemas" {
+    for f in trust-query trust-grant trust-auto-drop trust-force-grant trust-auto-raise-eligible trust-disable; do
+        [[ -f "$SCHEMA_DIR/${f}.payload.schema.json" ]] || {
+            echo "missing schema: ${f}.payload.schema.json"
+            return 1
+        }
+    done
+}
+
+@test "trust-events: trust-response.schema.json exists and is valid JSON" {
+    local f="$SCHEMA_DIR/trust-response.schema.json"
+    [[ -f "$f" ]]
+    jq empty "$f"
+}
+
+@test "trust-events: every schema is valid JSON" {
+    for f in "$SCHEMA_DIR"/*.json; do
+        jq empty "$f" || {
+            echo "not valid JSON: $f"
+            return 1
+        }
+    done
+}
+
+@test "trust-events: every payload schema declares draft 2020-12" {
+    for f in "$SCHEMA_DIR"/*.payload.schema.json; do
+        local declared
+        declared="$(jq -r '."$schema"' "$f")"
+        [[ "$declared" == "https://json-schema.org/draft/2020-12/schema" ]] || {
+            echo "wrong \$schema in $f: $declared"
+            return 1
+        }
+    done
+}
+
+@test "trust-events: every schema sets additionalProperties=false (typo guard)" {
+    for f in "$SCHEMA_DIR"/*.json; do
+        # NOTE: jq's `//` triggers on `false` AND null, so use `has` + raw value.
+        local present v
+        present="$(jq -r 'has("additionalProperties") | tostring' "$f")"
+        [[ "$present" == "true" ]] || {
+            echo "additionalProperties missing in $f"
+            return 1
+        }
+        v="$(jq -r '.additionalProperties | tostring' "$f")"
+        [[ "$v" == "false" ]] || {
+            echo "additionalProperties not false in $f (got $v)"
+            return 1
+        }
+    done
+}
+
+@test "trust-events: trust-grant payload validates a happy-path sample" {
+    if ! command -v ajv >/dev/null 2>&1; then
+        skip "ajv not installed"
+    fi
+    local sample
+    sample="$(jq -nc '{
+        scope: "flatline",
+        capability: "merge_main",
+        actor: "deep-name",
+        from_tier: "T0",
+        to_tier: "T1",
+        operator: "deep-name",
+        reason: "validated initial alignment"
+    }')"
+    local sample_file
+    sample_file="$(mktemp)"
+    printf '%s' "$sample" > "$sample_file"
+    run ajv validate -s "$SCHEMA_DIR/trust-grant.payload.schema.json" -d "$sample_file" --strict=false
+    rm -f "$sample_file"
+    [[ "$status" -eq 0 ]] || {
+        echo "ajv output: $output"
+        return 1
+    }
+}
+
+@test "trust-events: trust-auto-drop payload validates a happy-path sample" {
+    if ! command -v ajv >/dev/null 2>&1; then
+        skip "ajv not installed"
+    fi
+    local sample sample_file
+    sample="$(jq -nc '{
+        scope: "flatline",
+        capability: "merge_main",
+        actor: "deep-name",
+        from_tier: "T2",
+        to_tier: "T1",
+        decision_id: "panel-decision-2026-05-07-abc123",
+        reason: "operator override on panel decision",
+        cooldown_until: "2026-05-14T10:00:00.000Z",
+        cooldown_seconds: 604800
+    }')"
+    sample_file="$(mktemp)"
+    printf '%s' "$sample" > "$sample_file"
+    run ajv validate -s "$SCHEMA_DIR/trust-auto-drop.payload.schema.json" -d "$sample_file" --strict=false
+    rm -f "$sample_file"
+    [[ "$status" -eq 0 ]] || {
+        echo "ajv output: $output"
+        return 1
+    }
+}
+
+@test "trust-events: trust-force-grant payload requires cooldown_remaining_seconds_at_grant" {
+    if ! command -v ajv >/dev/null 2>&1; then
+        skip "ajv not installed"
+    fi
+    local sample sample_file
+    sample="$(jq -nc '{
+        scope: "flatline",
+        capability: "merge_main",
+        actor: "deep-name",
+        from_tier: "T1",
+        to_tier: "T2",
+        operator: "deep-name",
+        reason: "emergency override"
+    }')"
+    sample_file="$(mktemp)"
+    printf '%s' "$sample" > "$sample_file"
+    run ajv validate -s "$SCHEMA_DIR/trust-force-grant.payload.schema.json" -d "$sample_file" --strict=false
+    rm -f "$sample_file"
+    [[ "$status" -ne 0 ]] || {
+        echo "expected validation failure (missing cooldown_remaining_seconds_at_grant)"
+        return 1
+    }
+}
+
+@test "trust-events: trust-auto-raise-eligible stub_outcome enum locked to eligibility_required" {
+    local schema
+    schema="$SCHEMA_DIR/trust-auto-raise-eligible.payload.schema.json"
+    local enum_json
+    enum_json="$(jq -c '.properties.stub_outcome.enum' "$schema")"
+    [[ "$enum_json" == '["eligibility_required"]' ]]
+}
+
+@test "trust-events: trust-disable payload requires operator+reason+sealed_at" {
+    if ! command -v ajv >/dev/null 2>&1; then
+        skip "ajv not installed"
+    fi
+    local sample sample_file
+    sample="$(jq -nc '{
+        operator: "deep-name",
+        reason: "rotating ledger",
+        sealed_at: "2026-05-07T12:00:00.000Z"
+    }')"
+    sample_file="$(mktemp)"
+    printf '%s' "$sample" > "$sample_file"
+    run ajv validate -s "$SCHEMA_DIR/trust-disable.payload.schema.json" -d "$sample_file" --strict=false
+    rm -f "$sample_file"
+    [[ "$status" -eq 0 ]] || {
+        echo "ajv output: $output"
+        return 1
+    }
+}


### PR DESCRIPTION
## Summary

Implements the cycle-098 Sprint 4 deliverable: L4 graduated-trust per-(scope, capability, actor) trust ledger. All 8 ACs (FR-L4-1..8) covered. Composes-with audit envelope (1A) + signing (1B) + protected-class router (1B) + operator-identity (1B). 4-slice pattern (4A/4B/4C/4D), one bundled PR.

**Commits**:
- 4A: schemas + lib skeleton + `trust_query` (FR-L4-1)
- 4B: `trust_grant` + `trust_record_override` + cooldown (FR-L4-2 + FR-L4-3)
- 4C: chain integrity + git-history reconstruction + `--force` + auto-raise stub (FR-L4-4 + FR-L4-5 + FR-L4-7 + FR-L4-8)
- 4D: `trust_disable` seal + concurrent-write tests + skill + lore + CLAUDE.md (FR-L4-6)

**114 new tests; 0 regressions across 60-test audit-envelope suite.**

## Composition

- 1A audit envelope: `audit_emit` + `audit_verify_chain` + `audit_recover_chain`
- 1B signing: honored when `LOA_AUDIT_SIGNING_KEY_ID` is set
- 1B protected-class-router: `trust.force_grant` already in taxonomy
- 1B operator-identity: `LOA_TRUST_REQUIRE_KNOWN_ACTOR=1` enforces OPERATORS.md gate
- H1 signing-fixtures: not required for this sprint (signing is opt-in)

## Pre-existing bug fixed

`_audit_recover_from_git` previously used `basename(log_path)` as the git pathspec, failing for logs in subdirectories (e.g., `.run/trust-ledger.jsonl`). Sprint 1 callers happened not to exercise the recovery path. Sprint 4 began exercising it via `trust_recover_chain` and surfaced the bug. Fix: resolve the repo root via `rev-parse --show-toplevel`, canonicalize the log path, compute the repo-relative path, and use it for both `git log` and `git show`.

## Acceptance criteria

| FR | Test |
|----|------|
| FR-L4-1 | tests/integration/trust-query-default-tier.bats — 17 tests |
| FR-L4-2 | tests/integration/trust-grant-and-override.bats — 21 tests |
| FR-L4-3 | tests/integration/trust-grant-and-override.bats — see same |
| FR-L4-4 | tests/integration/trust-chain-and-force-grant.bats — 4 stub tests |
| FR-L4-5 | tests/integration/trust-chain-and-force-grant.bats — 4 verify tests |
| FR-L4-6 | tests/integration/trust-concurrent-and-disable.bats — 3 concurrency tests |
| FR-L4-7 | tests/integration/trust-chain-and-force-grant.bats — 2 reconstruct tests |
| FR-L4-8 | tests/integration/trust-chain-and-force-grant.bats — 6 force-grant tests |

Plus:
- 10 schema-pin tests (`tests/unit/trust-events-schemas.bats`)
- 21 validator + config-getter tests (`tests/unit/graduated-trust-lib-defaults.bats`)
- 7 trust_disable seal tests
- 3 4D handoff invariant tests (skill / lore / CLAUDE.md presence)

## Test plan
- [x] All 114 new tests pass locally (bats)
- [x] All 60 audit-envelope regression tests pass
- [ ] CI green
- [ ] Bridgebuilder kaironic convergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs: cycle-098 PRD §FR-L4 (#656), SDD §1.4.2 + §5.6