### PR TITLE
fix(cycle-098): follow-up #776 — L6 strict test-mode gate + hook wiring + LOW polish

### DIFF
--- a/.claude/scripts/lib/structured-handoff-lib.sh
+++ b/.claude/scripts/lib/structured-handoff-lib.sh
@@ -55,20 +55,17 @@ _LOA_HANDOFF_FINGERPRINT_HISTORY="${_LOA_HANDOFF_REPO_ROOT}/.run/machine-fingerp
 _LOA_HANDOFF_CROSS_HOST_STAGING="${_LOA_HANDOFF_REPO_ROOT}/.run/handoff-events.cross-host-staging.jsonl"
 
 # -----------------------------------------------------------------------------
-# Sprint 6E (cypherpunk remediation CYP-F1/F3/F4): test-mode gate.
-# Env-var overrides for the security-critical paths (fingerprint guardrail,
-# operator verification, audit log destination, schema mode) are honored
-# ONLY when running under bats OR when LOA_HANDOFF_TEST_MODE=1 is set with a
-# bats-detected ancestor. Production paths emit a stderr WARN and ignore.
-# Mirrors L4 graduated-trust-lib.sh:432-440 + cycle-099 sprint-1B fix.
+# Test-mode gate. cycle-098 follow-up #776 (CRIT-1 inheritance from sprint-7
+# cypherpunk review): require BOTH `LOA_HANDOFF_TEST_MODE=1` AND a robust
+# bats marker. Earlier draft permitted bypass via `BATS_TMPDIR` alone (any
+# developer-leaked env or nested tooling could flip production into
+# test-mode). Same regression-of-an-already-closed-pattern as cycle-099 #761
+# (L4) and L7 sprint-7 CRIT-1. Strict form below; do not "or" the clauses.
 # -----------------------------------------------------------------------------
 _handoff_test_mode_active() {
-    if [[ -n "${BATS_TEST_DIRNAME:-}" ]] || [[ -n "${BATS_TMPDIR:-}" ]]; then
-        return 0
-    fi
-    if [[ "${LOA_HANDOFF_TEST_MODE:-0}" == "1" ]] && [[ -n "${BATS_TEST_DIRNAME:-${BATS_TMPDIR:-}}" ]]; then
-        return 0
-    fi
+    [[ "${LOA_HANDOFF_TEST_MODE:-0}" == "1" ]] || return 1
+    [[ -n "${BATS_TEST_FILENAME:-}" ]] && return 0
+    [[ -n "${BATS_VERSION:-}" ]] && return 0
     return 1
 }
 

--- a/.claude/scripts/soul-validate.sh
+++ b/.claude/scripts/soul-validate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# =============================================================================
+# soul-validate.sh — discoverable CLI entry for L7 SOUL.md validation.
+#
+# cycle-098 follow-up #776 (optimist LOW-3 closure): the canonical operator
+# CLI ships at .claude/skills/soul-identity-doc/resources/soul-validate.sh
+# but that path is deeply nested. This shim is the discoverable alias —
+# invoke it from a top-level scripts directory that operators routinely
+# add to PATH.
+#
+# Usage:
+#   .claude/scripts/soul-validate.sh <path> [--strict|--warn]
+#   .claude/scripts/soul-validate.sh --help
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# scripts → .claude → REPO_ROOT
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TARGET="${REPO_ROOT}/.claude/skills/soul-identity-doc/resources/soul-validate.sh"
+
+if [[ ! -f "$TARGET" ]]; then
+    echo "soul-validate: canonical CLI not found at $TARGET" >&2
+    exit 7
+fi
+
+exec "$TARGET" "$@"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -456,6 +456,18 @@
             "command": ".claude/scripts/check-updates.sh --notify",
             "async": true,
             "once": true
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start/loa-l6-surface-handoffs.sh",
+            "async": true,
+            "once": true
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start/loa-l7-surface-soul.sh",
+            "async": true,
+            "once": true
           }
         ]
       }

--- a/tests/integration/cycle-098-cross-primitive-l7.bats
+++ b/tests/integration/cycle-098-cross-primitive-l7.bats
@@ -22,8 +22,9 @@ setup() {
 
     TEST_DIR="$(mktemp -d)"
     export LOA_TRUST_STORE_FILE="$TEST_DIR/no-such-trust-store.yaml"
-    # cycle-098 sprint-7 cypherpunk CRIT-1 closure.
+    # cycle-098 sprint-7 + follow-up #776 strict test-mode gates.
     export LOA_SOUL_TEST_MODE=1
+    export LOA_HANDOFF_TEST_MODE=1
     export LOA_SOUL_LOG="$TEST_DIR/soul-events.jsonl"
     export LOA_HANDOFF_LOG="$TEST_DIR/handoff-events.jsonl"
     export LOA_HANDOFF_VERIFY_OPERATORS=0

--- a/tests/integration/soul-identity-7a.bats
+++ b/tests/integration/soul-identity-7a.bats
@@ -515,9 +515,15 @@ BODY
 
 @test "T-AUDIT-2 (FR-L7) soul_emit validates payload against soul-surface schema" {
     # Missing required 'outcome' field → schema rejection.
+    # cycle-098 follow-up #776 (BB iter-1 LOW-1 / opt LOW-1 closure):
+    # tighten exit-code assertion to match SDD §6.1 grid (2 = validation).
+    # Earlier `-ne 0` accepted any non-zero, hiding regressions where
+    # soul_emit failed for an unrelated reason (jq, fs perms, etc.).
     local bad_payload='{"file_path":"SOUL.md","schema_version":"1.0","schema_mode":"strict","identity_for":"this-repo"}'
     run soul_emit "soul.surface" "$bad_payload"
-    [[ "$status" -ne 0 ]]
+    [[ "$status" -eq 2 ]] || { echo "expected validation exit 2, got $status: $output"; false; }
+    [[ "$output" == *"outcome"* ]] || [[ "$output" == *"schema"* ]] || \
+        { echo "expected schema/outcome reason in output: $output"; false; }
 }
 
 @test "T-AUDIT-3 _audit_primitive_id_for_log returns L7 for soul-events*" {

--- a/tests/integration/structured-handoff-6a.bats
+++ b/tests/integration/structured-handoff-6a.bats
@@ -24,6 +24,7 @@ setup() {
     export LOA_TRUST_STORE_FILE="$TEST_DIR/no-such-trust-store.yaml"
 
     # Audit log dir + path under TEST_DIR.
+    export LOA_HANDOFF_TEST_MODE=1
     export LOA_HANDOFF_LOG="$TEST_DIR/handoff-events.jsonl"
 
     # Sprint 6B: bypass OPERATORS.md verification for 6A schema/id/atomic tests.

--- a/tests/integration/structured-handoff-6b.bats
+++ b/tests/integration/structured-handoff-6b.bats
@@ -21,6 +21,7 @@ setup() {
     mkdir -p "$HANDOFFS_DIR"
 
     export LOA_TRUST_STORE_FILE="$TEST_DIR/no-such-trust-store.yaml"
+    export LOA_HANDOFF_TEST_MODE=1
     export LOA_HANDOFF_LOG="$TEST_DIR/handoff-events.jsonl"
     export LOA_HANDOFF_VERIFY_OPERATORS=1
     # Default mode strict; tests override per-case via LOA_HANDOFF_SCHEMA_MODE.

--- a/tests/integration/structured-handoff-6c.bats
+++ b/tests/integration/structured-handoff-6c.bats
@@ -20,6 +20,7 @@ setup() {
     mkdir -p "$HANDOFFS_DIR"
 
     export LOA_TRUST_STORE_FILE="$TEST_DIR/no-such-trust-store.yaml"
+    export LOA_HANDOFF_TEST_MODE=1
     export LOA_HANDOFF_LOG="$TEST_DIR/handoff-events.jsonl"
     export LOA_HANDOFF_VERIFY_OPERATORS=0
     # Sprint 6D: bypass same-machine guardrail (6C exercises surfacing only).

--- a/tests/integration/structured-handoff-6d.bats
+++ b/tests/integration/structured-handoff-6d.bats
@@ -19,6 +19,7 @@ setup() {
     mkdir -p "$HANDOFFS_DIR"
 
     export LOA_TRUST_STORE_FILE="$TEST_DIR/no-such-trust-store.yaml"
+    export LOA_HANDOFF_TEST_MODE=1
     export LOA_HANDOFF_LOG="$TEST_DIR/handoff-events.jsonl"
     export LOA_HANDOFF_VERIFY_OPERATORS=0
 

--- a/tests/integration/structured-handoff-6e.bats
+++ b/tests/integration/structured-handoff-6e.bats
@@ -27,6 +27,9 @@ setup() {
     mkdir -p "$HANDOFFS_DIR"
 
     export LOA_TRUST_STORE_FILE="$TEST_DIR/no-such-trust-store.yaml"
+    # cycle-098 follow-up #776 (CRIT-1 inheritance from sprint-7 cypherpunk):
+    # strict test-mode gate requires opt-in flag + bats marker.
+    export LOA_HANDOFF_TEST_MODE=1
     export LOA_HANDOFF_LOG="$TEST_DIR/handoff-events.jsonl"
     export LOA_HANDOFF_VERIFY_OPERATORS=0
     export LOA_HANDOFF_DISABLE_FINGERPRINT=1

--- a/tests/integration/structured-handoff-followup-776.bats
+++ b/tests/integration/structured-handoff-followup-776.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/structured-handoff-followup-776.bats
+#
+# cycle-098 follow-up #776 — pin the L6 strict test-mode gate.
+# Mirrors the L7 sprint-7 CRIT-1 closure (tests/integration/
+# soul-identity-7-remediation.bats:CRIT-1) for the L6 primitive.
+#
+# Pre-fix: `_handoff_test_mode_active` permitted bypass via `BATS_TMPDIR`
+# alone (any developer-leaked env or nested tooling could flip production
+# into test-mode). Same dead-code-clause regression as L4 cycle-099 #761
+# and L7 sprint-7 CRIT-1.
+#
+# Post-fix: strict gate requires BOTH `LOA_HANDOFF_TEST_MODE=1` AND a
+# robust bats marker (`BATS_TEST_FILENAME` or `BATS_VERSION`).
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    LIB="$PROJECT_ROOT/.claude/scripts/lib/structured-handoff-lib.sh"
+    [[ -f "$LIB" ]] || skip "structured-handoff-lib.sh not present"
+}
+
+@test "CRIT-1 BATS_TMPDIR alone does NOT activate L6 test-mode (was a bypass pre-fix)" {
+    bash -c '
+        unset BATS_TEST_DIRNAME BATS_TEST_FILENAME BATS_VERSION LOA_HANDOFF_TEST_MODE
+        export BATS_TMPDIR=/tmp
+        # shellcheck source=/dev/null
+        source "'"$LIB"'"
+        if _handoff_test_mode_active; then
+            echo "BYPASS: BATS_TMPDIR alone activated test-mode"; exit 1
+        fi
+        exit 0
+    '
+}
+
+@test "CRIT-1 LOA_HANDOFF_TEST_MODE alone (no bats marker) does NOT activate L6 test-mode" {
+    bash -c '
+        unset BATS_TEST_DIRNAME BATS_TEST_FILENAME BATS_VERSION BATS_TMPDIR
+        export LOA_HANDOFF_TEST_MODE=1
+        # shellcheck source=/dev/null
+        source "'"$LIB"'"
+        if _handoff_test_mode_active; then
+            echo "BYPASS: LOA_HANDOFF_TEST_MODE alone activated test-mode"; exit 1
+        fi
+        exit 0
+    '
+}
+
+@test "CRIT-1 only BOTH LOA_HANDOFF_TEST_MODE=1 + BATS marker activates L6 test-mode" {
+    bash -c '
+        unset BATS_TEST_DIRNAME BATS_TMPDIR
+        export LOA_HANDOFF_TEST_MODE=1 BATS_VERSION=1.10.0
+        # shellcheck source=/dev/null
+        source "'"$LIB"'"
+        _handoff_test_mode_active || { echo "FAIL: legitimate test-mode rejected"; exit 1; }
+        exit 0
+    '
+}
+
+@test "CRIT-1 production-mode env override emits stderr WARN and is ignored" {
+    bash -c '
+        unset BATS_TEST_DIRNAME BATS_TEST_FILENAME BATS_VERSION BATS_TMPDIR LOA_HANDOFF_TEST_MODE
+        # shellcheck source=/dev/null
+        source "'"$LIB"'"
+        # Lib has set -euo pipefail; disable -e so we can capture the
+        # expected non-zero return from _handoff_check_env_override.
+        set +e
+        out="$(_handoff_check_env_override LOA_HANDOFF_LOG /tmp/poison.jsonl 2>&1)"
+        rc=$?
+        set -e
+        if [[ "$rc" -ne 1 ]]; then
+            echo "production override accepted (rc=$rc): $out"; exit 1
+        fi
+        if [[ "$out" != *"WARNING"* ]]; then
+            echo "production override silently ignored (no WARN): $out"; exit 1
+        fi
+    '
+}


### PR DESCRIPTION
Closes #776.

## Summary

cycle-098 sprint-7 follow-up: closes the L6 inheritance items + selected LOW polish from the dual-review of PR #775. Cosmetic LOWs that don't pin invariants are explicitly listed as deferred at the bottom.

## L6 inheritance closures (high-impact)

| Item | Pre | Post |
|---|---|---|
| **CRIT-1 strict test-mode gate** | `_handoff_test_mode_active` permitted bypass via `BATS_TMPDIR` alone — same dead-code clause that L7 sprint-7 closed | Requires BOTH `LOA_HANDOFF_TEST_MODE=1` AND a robust bats marker (`BATS_TEST_FILENAME` or `BATS_VERSION`); all 5 L6 bats files updated; 4 new regression tests pin the truth table |
| **HIGH-2 hook wiring** | `loa-l6-surface-handoffs.sh` + `loa-l7-surface-soul.sh` shipped as scripts but were not auto-registered in `.claude/settings.json` | Both wired in `SessionStart` array with `"once": true` — `enabled: true` now actually triggers surfacing |

## LOW polish closures (cosmetic)

- **cyp LOW-1 / opt LOW-1**: T-AUDIT-2 exit-code precision (`-ne 0` → `-eq 2` + substring on reason)
- **opt LOW-3**: CLI shim discoverability — new top-level shim at `.claude/scripts/soul-validate.sh`

## Tests

- 10/10 test files green (5 L6 + 4 L7 + 1 cross-primitive + 1 new L6 follow-up)
- L6 90 pre-existing + 4 new = 94
- L7 74 pre-existing
- 0 regressions

## Deferred (non-blocking)

- **opt LOW-2** stderr/stdout convention in `soul_validate` — would require API-shape change
- **opt LOW-4** FR-L7-5 single-fire export side-effect pin — hook-runner-specific
- **BB iter-1 F1/F2** control-byte test alternate-paths — invariant IS pinned via YAML-decode path

## Test plan

- [ ] CI green (Shell Tests pre-existing flakes admin-merged-through per RESUMPTION.md)
- [ ] Admin-squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)