### PR TITLE
fix(cheval): #774 — typed connection-loss classification + operator-facing strings

### DIFF
--- a/.claude/adapters/cheval.py
+++ b/.claude/adapters/cheval.py
@@ -62,6 +62,7 @@ EXIT_CODES = {
     "RATE_LIMITED": 1,
     "PROVIDER_UNAVAILABLE": 1,
     "RETRIES_EXHAUSTED": 1,
+    "CONNECTION_LOST": 1,  # Issue #774: typed transient transport failure
     "INVALID_INPUT": 2,
     "INVALID_CONFIG": 2,
     "NATIVE_RUNTIME_REQUIRED": 2,
@@ -442,7 +443,21 @@ def cmd_invoke(args: argparse.Namespace) -> int:
         print(_error_json(e.code, str(e), retryable=True), file=sys.stderr)
         return EXIT_CODES["PROVIDER_UNAVAILABLE"]
     except RetriesExhaustedError as e:
-        print(_error_json(e.code, str(e)), file=sys.stderr)
+        # Issue #774: surface typed failure_class when the underlying retries
+        # exhausted on a ConnectionLostError. Sanitization: only the typed
+        # class name, transport class name, and request size are surfaced —
+        # raw body, headers, and auth values stay scoped inside the adapter.
+        extra: Dict[str, Any] = {}
+        if e.context.get("last_error_class") == "ConnectionLostError":
+            last_ctx = e.context.get("last_error_context") or {}
+            extra["failure_class"] = "PROVIDER_DISCONNECT"
+            if last_ctx.get("transport_class"):
+                extra["transport_class"] = last_ctx["transport_class"]
+            if last_ctx.get("request_size_bytes") is not None:
+                extra["request_size_bytes"] = last_ctx["request_size_bytes"]
+            if last_ctx.get("provider"):
+                extra["provider"] = last_ctx["provider"]
+        print(_error_json(e.code, str(e), **extra), file=sys.stderr)
         return EXIT_CODES["RETRIES_EXHAUSTED"]
     except ChevalError as e:
         print(_error_json(e.code, str(e), retryable=e.retryable), file=sys.stderr)

--- a/.claude/adapters/loa_cheval/providers/base.py
+++ b/.claude/adapters/loa_cheval/providers/base.py
@@ -14,6 +14,7 @@ from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
     ConfigError,
+    ConnectionLostError,
     ContextTooLargeError,
     ModelConfig,
     ProviderConfig,
@@ -69,9 +70,30 @@ def http_post(
             write=30.0,
             pool=10.0,
         )
-        resp = httpx.post(url, headers=headers, content=encoded, timeout=timeout)
+        # Issue #774: classify connection-loss exceptions as ConnectionLostError
+        # so the retry layer can route them with provider-aware semantics
+        # rather than dropping them into the bare `except Exception:` arm.
+        # Sanitization: only the transport class name and request size are
+        # attached; raw body, headers, and auth are NEVER carried on the
+        # exception (they remain in the local `encoded`/`headers` scope).
+        try:
+            resp = httpx.post(url, headers=headers, content=encoded, timeout=timeout)
+        except (
+            httpx.RemoteProtocolError,
+            httpx.ReadError,
+            httpx.WriteError,
+            httpx.ConnectError,
+            httpx.PoolTimeout,
+            httpx.ProtocolError,
+        ) as exc:
+            raise ConnectionLostError(
+                transport_class=type(exc).__name__,
+                request_size_bytes=len(encoded),
+                message=f"{type(exc).__name__}: {exc}",
+            ) from exc
         return resp.status_code, resp.json()
     else:
+        import http.client
         import urllib.request
         import urllib.error
 
@@ -93,7 +115,29 @@ def http_post(
                 return e.code, json.loads(resp_body)
             except json.JSONDecodeError:
                 return e.code, {"error": {"message": resp_body}}
+        except http.client.RemoteDisconnected as e:
+            # Issue #774: urllib branch parity with the httpx branch above.
+            raise ConnectionLostError(
+                transport_class="urllib.RemoteDisconnected",
+                request_size_bytes=len(encoded),
+                message=f"RemoteDisconnected: {e}",
+            ) from e
         except urllib.error.URLError as e:
+            # Server-disconnect / connection-reset shapes surface as URLError
+            # with reasons like ConnectionResetError, BrokenPipeError, etc.
+            reason_repr = repr(e.reason) if hasattr(e, "reason") else str(e)
+            disconnect_markers = (
+                "ConnectionReset",
+                "BrokenPipe",
+                "Connection aborted",
+                "Server disconnected",
+            )
+            if any(m in reason_repr for m in disconnect_markers):
+                raise ConnectionLostError(
+                    transport_class="urllib.URLError",
+                    request_size_bytes=len(encoded),
+                    message=f"URLError: {reason_repr}",
+                ) from e
             return 503, {"error": {"message": "URLError: %s" % e.reason}}
         except socket.timeout:
             return 504, {"error": {"message": "Request timed out"}}

--- a/.claude/adapters/loa_cheval/providers/retry.py
+++ b/.claude/adapters/loa_cheval/providers/retry.py
@@ -17,6 +17,7 @@ from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
     ChevalError,
+    ConnectionLostError,
     ProviderUnavailableError,
     RateLimitError,
     RetriesExhaustedError,
@@ -150,6 +151,10 @@ def invoke_with_retry(
     total_attempts = 0
     provider_switches = 0
     last_error: Optional[str] = None
+    # Issue #774: track the typed exception alongside the string so the
+    # final RetriesExhaustedError can carry structured failure metadata
+    # (used by cheval.py to emit `failure_class: PROVIDER_DISCONNECT`).
+    last_typed_error: Optional[ChevalError] = None
 
     for attempt in range(max_retries + 1):
         # Global attempt budget check
@@ -216,6 +221,38 @@ def invoke_with_retry(
             # Provider unavailable — no retry on same provider, move on
             break
 
+        except ConnectionLostError as e:
+            # Issue #774: classify httpx connection-loss as a typed transient.
+            # Pre-fix, the underlying httpx.RemoteProtocolError landed in the
+            # bare `except Exception:` arm below and produced the misleading
+            # "Unexpected error from %s" log line plus an operator pointer to
+            # `--per-call-max-tokens 4096` — a remedy that is a no-op against
+            # the cheval.py default of 4096 (issue body, sub-issue 3).
+            #
+            # The remediation hint here MUST NOT recommend that flag.
+            latency_ms = int((time.monotonic() - start) * 1000)
+            metrics_hook.record_attempt(adapter.provider, False, latency_ms)
+            _record_failure(adapter.provider, config)
+            last_error = str(e)
+            last_typed_error = e
+
+            logger.warning(
+                "Connection lost from %s after %dB request "
+                "(transport=%s, attempt %d/%d) — likely server-side disconnect "
+                "on long prompt. Tip: --per-call-max-tokens has no effect on "
+                "this failure mode (cheval default=4096). See issue #774.",
+                adapter.provider,
+                e.request_size_bytes or 0,
+                e.transport_class or "unknown",
+                attempt + 1,
+                max_retries + 1,
+            )
+
+            # Transient: retry with exponential backoff (counts against budget)
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
+                time.sleep(delay)
+
         except ChevalError:
             # Non-retryable errors propagate immediately
             raise
@@ -235,7 +272,21 @@ def invoke_with_retry(
                 delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
                 time.sleep(delay)
 
+    # Issue #774: surface typed metadata when the last error was a typed
+    # ConnectionLostError so cheval.py can emit failure_class on stderr.
+    last_error_class: Optional[str] = None
+    last_error_context: Optional[Dict[str, Any]] = None
+    if isinstance(last_typed_error, ConnectionLostError):
+        last_error_class = "ConnectionLostError"
+        last_error_context = {
+            "provider": last_typed_error.provider or adapter.provider,
+            "transport_class": last_typed_error.transport_class,
+            "request_size_bytes": last_typed_error.request_size_bytes,
+        }
+
     raise RetriesExhaustedError(
         total_attempts=total_attempts,
         last_error=last_error,
+        last_error_class=last_error_class,
+        last_error_context=last_error_context,
     )

--- a/.claude/adapters/loa_cheval/types.py
+++ b/.claude/adapters/loa_cheval/types.py
@@ -207,10 +207,84 @@ class ContextTooLargeError(ChevalError):
 
 
 class RetriesExhaustedError(ChevalError):
-    """All retry/fallback attempts exhausted."""
+    """All retry/fallback attempts exhausted.
 
-    def __init__(self, total_attempts: int, last_error: Optional[str] = None):
-        super().__init__("RETRIES_EXHAUSTED", f"Failed after {total_attempts} attempts: {last_error or 'unknown'}", retryable=False, context={"total_attempts": total_attempts})
+    Carries optional typed metadata on `context.last_error_class` and
+    `context.last_error_context` so downstream error formatters (cheval.py
+    JSON-error output) can surface a typed `failure_class` (e.g.
+    PROVIDER_DISCONNECT for ConnectionLostError per issue #774) without
+    parsing the message string.
+    """
+
+    def __init__(
+        self,
+        total_attempts: int,
+        last_error: Optional[str] = None,
+        last_error_class: Optional[str] = None,
+        last_error_context: Optional[Dict[str, Any]] = None,
+    ):
+        ctx: Dict[str, Any] = {"total_attempts": total_attempts}
+        if last_error_class:
+            ctx["last_error_class"] = last_error_class
+        if last_error_context:
+            ctx["last_error_context"] = last_error_context
+        super().__init__(
+            "RETRIES_EXHAUSTED",
+            f"Failed after {total_attempts} attempts: {last_error or 'unknown'}",
+            retryable=False,
+            context=ctx,
+        )
+
+
+class ConnectionLostError(ChevalError):
+    """Transport-layer connection lost mid-flight (issue #774).
+
+    Catches the family of httpx exceptions
+    (RemoteProtocolError / ReadError / WriteError / ConnectError /
+    PoolTimeout / ProtocolError) and the urllib equivalents
+    (http.client.RemoteDisconnected, urllib.error.URLError,
+    socket.timeout) that share the operator-facing failure shape:
+    "Server disconnected without sending a response."
+
+    Sibling of `ProviderUnavailableError` — NOT a subclass — because the
+    retry semantics differ. ProviderUnavailableError moves on to the next
+    provider in the chain; ConnectionLostError counts against the
+    per-provider retry budget (transient on long prompts; the real
+    workaround is upstream — streaming or HTTP/1.1 — and is deferred per
+    /bug scope to /plan).
+
+    Carries typed context (provider, transport_class, request_size_bytes)
+    so cheval.py can surface `failure_class: PROVIDER_DISCONNECT` in
+    JSON-error stderr without parsing the message string. Sanitization:
+    transport class and size are safe to log; raw body / headers / auth
+    are NEVER attached.
+    """
+
+    def __init__(
+        self,
+        provider: str = "",
+        transport_class: str = "",
+        request_size_bytes: Optional[int] = None,
+        message: Optional[str] = None,
+    ):
+        msg = message or (
+            f"Connection lost from {provider or 'provider'} "
+            f"(transport={transport_class or 'unknown'}, "
+            f"request_size_bytes={request_size_bytes if request_size_bytes is not None else 'unknown'})"
+        )
+        super().__init__(
+            "CONNECTION_LOST",
+            msg,
+            retryable=True,
+            context={
+                "provider": provider,
+                "transport_class": transport_class,
+                "request_size_bytes": request_size_bytes,
+            },
+        )
+        self.provider = provider
+        self.transport_class = transport_class
+        self.request_size_bytes = request_size_bytes
 
 
 class ConfigError(ChevalError):

--- a/.claude/adapters/tests/test_connection_lost_classification.py
+++ b/.claude/adapters/tests/test_connection_lost_classification.py
@@ -1,0 +1,308 @@
+"""Test ConnectionLostError classification — issue #774.
+
+Reproduces the bug where httpx connection-loss exceptions
+(`RemoteProtocolError("Server disconnected without sending a response")`,
+`ReadError`, `ConnectError`, `WriteError`, `ProtocolError`, `PoolTimeout`)
+fall into the bare `except Exception:` arm in
+`loa_cheval/providers/retry.py:223`, producing the operator-misleading
+"Unexpected error from anthropic" log line and the proven-ineffective
+`--per-call-max-tokens 4096` recommendation in operator-facing strings.
+
+Pre-fix: bare exception arm catches httpx errors generically.
+Post-fix: typed `ConnectionLostError` propagates; `cheval.py` surfaces
+`failure_class: "PROVIDER_DISCONNECT"` in JSON-error stderr; remediation
+hint correctly notes that `--per-call-max-tokens` does not address this
+failure mode.
+
+Test strategy: three focused tests, one per layer (transport / retry / CLI).
+Mirrors `test_cheval_exception_scoping.py` style for the CLI test.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from loa_cheval.types import (
+    ConnectionLostError,
+    RetriesExhaustedError,
+)
+
+# httpx is a runtime dependency of the adapter; the real package is required
+# to construct the typed exception classes the test mocks against.
+httpx = pytest.importorskip("httpx")
+
+import cheval  # type: ignore[import-not-found]
+from loa_cheval.providers import base as providers_base
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — Transport layer (http_post)
+# ---------------------------------------------------------------------------
+
+def test_http_post_classifies_remote_protocol_error_as_connection_lost():
+    """`http_post` must catch httpx.RemoteProtocolError and re-raise as
+    `ConnectionLostError` carrying provider, transport_class, and
+    request_size_bytes. Pre-fix: httpx error propagates bare; post-fix: typed.
+    """
+    # Force httpx branch (not urllib fallback)
+    providers_base._HTTP_CLIENT = "httpx"
+
+    with patch("httpx.post") as mock_post:
+        mock_post.side_effect = httpx.RemoteProtocolError(
+            "Server disconnected without sending a response"
+        )
+
+        with pytest.raises(ConnectionLostError) as exc_info:
+            providers_base.http_post(
+                url="https://api.anthropic.com/v1/messages",
+                headers={"x-api-key": "dummy"},
+                body={"model": "claude-opus-4-7", "messages": []},
+                connect_timeout=10.0,
+                read_timeout=120.0,
+            )
+
+    err = exc_info.value
+    # Provider is not embedded by http_post (it's transport-layer-agnostic);
+    # provider attribution happens at the adapter layer where http_post is
+    # called from. http_post sets transport_class + request_size_bytes only.
+    assert err.transport_class == "RemoteProtocolError"
+    assert err.request_size_bytes is not None and err.request_size_bytes > 0
+    assert "Server disconnected" in str(err) or "RemoteProtocolError" in str(err)
+
+
+def test_http_post_classifies_read_error_as_connection_lost():
+    """`http_post` must also classify httpx.ReadError as ConnectionLostError
+    (sibling case; same operator-facing failure mode)."""
+    providers_base._HTTP_CLIENT = "httpx"
+
+    with patch("httpx.post") as mock_post:
+        mock_post.side_effect = httpx.ReadError("read mid-flight")
+
+        with pytest.raises(ConnectionLostError) as exc_info:
+            providers_base.http_post(
+                url="https://api.openai.com/v1/chat/completions",
+                headers={"authorization": "Bearer dummy"},
+                body={"model": "gpt-5.5-pro", "messages": []},
+            )
+
+    assert exc_info.value.transport_class == "ReadError"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — Retry layer (invoke_with_retry)
+# ---------------------------------------------------------------------------
+
+def test_retry_propagates_connection_lost_through_retries_exhausted():
+    """When `adapter.complete()` raises `ConnectionLostError` repeatedly,
+    `invoke_with_retry` must:
+    - count it against the retry budget (transient classification)
+    - NOT fall into the bare `except Exception:` arm (no "Unexpected error" log)
+    - on exhaustion, raise `RetriesExhaustedError` carrying typed metadata
+      (`last_error_class` / `last_error_context`) so cheval.py can surface
+      `failure_class: PROVIDER_DISCONNECT` in JSON-error output.
+    """
+    from loa_cheval.providers.retry import invoke_with_retry
+    from loa_cheval.types import CompletionRequest
+
+    fake_adapter = MagicMock()
+    fake_adapter.provider = "anthropic"
+    fake_adapter.complete.side_effect = ConnectionLostError(
+        provider="anthropic",
+        transport_class="RemoteProtocolError",
+        request_size_bytes=42000,
+    )
+
+    request = CompletionRequest(
+        messages=[{"role": "user", "content": "test"}],
+        model="claude-opus-4-7",
+        max_tokens=4096,
+    )
+
+    fake_config = {
+        "providers": {"anthropic": {"type": "anthropic"}},
+        "retry": {"max_retries": 2, "max_total_attempts": 6, "base_delay_seconds": 0.0},
+    }
+
+    # Patch circuit-breaker IO + sleep to keep test hermetic and fast
+    with patch("loa_cheval.providers.retry._record_failure"), \
+         patch("loa_cheval.providers.retry._record_success"), \
+         patch("loa_cheval.providers.retry._check_circuit_breaker", return_value="CLOSED"), \
+         patch("loa_cheval.providers.retry.time.sleep"):
+        with pytest.raises(RetriesExhaustedError) as exc_info:
+            invoke_with_retry(
+                adapter=fake_adapter,
+                request=request,
+                config=fake_config,
+            )
+
+    err = exc_info.value
+    # The typed metadata must be carried on the exception so cheval.py
+    # can surface failure_class without parsing strings.
+    assert err.context.get("last_error_class") == "ConnectionLostError", (
+        f"Expected last_error_class='ConnectionLostError' on the typed "
+        f"RetriesExhaustedError context, got context={err.context!r}"
+    )
+    last_ctx = err.context.get("last_error_context") or {}
+    assert last_ctx.get("provider") == "anthropic"
+    assert last_ctx.get("transport_class") == "RemoteProtocolError"
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — CLI layer (cheval.cmd_invoke)
+# ---------------------------------------------------------------------------
+
+def _make_args() -> object:
+    """Construct a minimal valid argparse.Namespace for cmd_invoke()."""
+    args = types.SimpleNamespace()
+    args.agent = "flatline-reviewer"
+    args.input = None
+    args.prompt = "test prompt"
+    args.system = None
+    args.model = None
+    args.max_tokens = 4096
+    args.output_format = "text"
+    args.json_errors = True
+    args.timeout = 30
+    args.include_thinking = False
+    args.async_mode = False
+    args.poll_id = None
+    args.cancel_id = None
+    args.dry_run = False
+    args.print_config = False
+    args.validate_bindings = False
+    return args
+
+
+def test_cmd_invoke_emits_failure_class_provider_disconnect(capsys):
+    """When invoke_with_retry raises RetriesExhaustedError with typed
+    last_error_class='ConnectionLostError', cheval.cmd_invoke must emit a
+    JSON error on stderr that includes `failure_class: "PROVIDER_DISCONNECT"`
+    plus sanitized typed context (transport_class + request_size_bytes).
+    NO request body, headers, or auth values may appear in the output.
+    """
+    fake_resolved = MagicMock(provider="anthropic", model_id="claude-opus-4-7")
+    fake_binding = MagicMock(temperature=0.7)
+    fake_provider_cfg = MagicMock()
+    fake_adapter = MagicMock()
+
+    fake_config = {
+        "providers": {
+            "anthropic": {
+                "type": "anthropic",
+                "endpoint": "https://api.anthropic.com/v1/messages",
+                "auth": "dummy",
+                "models": {"claude-opus-4-7": {"capabilities": ["chat"], "context_window": 200000}},
+            },
+        },
+        "feature_flags": {"metering": False},
+    }
+
+    typed_exhausted = RetriesExhaustedError(
+        total_attempts=3,
+        last_error="ConnectionLostError: Server disconnected without sending a response",
+        last_error_class="ConnectionLostError",
+        last_error_context={
+            "provider": "anthropic",
+            "transport_class": "RemoteProtocolError",
+            "request_size_bytes": 42000,
+        },
+    )
+
+    with patch.object(cheval, "load_config", return_value=(fake_config, {})), \
+         patch.object(cheval, "resolve_execution", return_value=(fake_binding, fake_resolved)), \
+         patch.object(cheval, "_build_provider_config", return_value=fake_provider_cfg), \
+         patch.object(cheval, "get_adapter", return_value=fake_adapter), \
+         patch("loa_cheval.providers.retry.invoke_with_retry") as mock_retry:
+
+        mock_retry.side_effect = typed_exhausted
+
+        args = _make_args()
+        exit_code = cheval.cmd_invoke(args)
+
+    captured = capsys.readouterr()
+
+    assert exit_code == cheval.EXIT_CODES["RETRIES_EXHAUSTED"]
+
+    # Find the JSON line on stderr
+    json_line = None
+    for line in captured.err.splitlines():
+        line = line.strip()
+        if line.startswith("{") and "RETRIES_EXHAUSTED" in line:
+            json_line = line
+            break
+    assert json_line is not None, (
+        f"Expected RETRIES_EXHAUSTED JSON on stderr; stderr was:\n{captured.err}"
+    )
+
+    payload = json.loads(json_line)
+    assert payload.get("failure_class") == "PROVIDER_DISCONNECT", (
+        f"Expected failure_class='PROVIDER_DISCONNECT' in JSON-error stderr, "
+        f"got payload={payload!r}"
+    )
+    # Sanitization: typed-context fields surfaced without sensitive payload
+    assert payload.get("transport_class") == "RemoteProtocolError"
+    assert payload.get("request_size_bytes") == 42000
+    # No raw body/headers/auth
+    assert "x-api-key" not in captured.err
+    assert "Bearer" not in captured.err
+
+
+def test_cmd_invoke_does_not_recommend_per_call_max_tokens(capsys):
+    """Operator-facing JSON-error output for PROVIDER_DISCONNECT must NOT
+    suggest the proven-ineffective `--per-call-max-tokens 4096` remedy
+    (cheval.py defaults to 4096 already, so the recommendation was a no-op).
+    """
+    fake_resolved = MagicMock(provider="anthropic", model_id="claude-opus-4-7")
+    fake_binding = MagicMock(temperature=0.7)
+    fake_provider_cfg = MagicMock()
+    fake_adapter = MagicMock()
+
+    fake_config = {
+        "providers": {
+            "anthropic": {
+                "type": "anthropic",
+                "endpoint": "https://api.anthropic.com/v1/messages",
+                "auth": "dummy",
+                "models": {"claude-opus-4-7": {"capabilities": ["chat"], "context_window": 200000}},
+            },
+        },
+        "feature_flags": {"metering": False},
+    }
+
+    typed_exhausted = RetriesExhaustedError(
+        total_attempts=3,
+        last_error="ConnectionLostError: Server disconnected without sending a response",
+        last_error_class="ConnectionLostError",
+        last_error_context={
+            "provider": "anthropic",
+            "transport_class": "RemoteProtocolError",
+            "request_size_bytes": 42000,
+        },
+    )
+
+    with patch.object(cheval, "load_config", return_value=(fake_config, {})), \
+         patch.object(cheval, "resolve_execution", return_value=(fake_binding, fake_resolved)), \
+         patch.object(cheval, "_build_provider_config", return_value=fake_provider_cfg), \
+         patch.object(cheval, "get_adapter", return_value=fake_adapter), \
+         patch("loa_cheval.providers.retry.invoke_with_retry") as mock_retry:
+
+        mock_retry.side_effect = typed_exhausted
+        args = _make_args()
+        cheval.cmd_invoke(args)
+
+    captured = capsys.readouterr()
+
+    # The misleading recommendation MUST NOT appear in stderr for the
+    # PROVIDER_DISCONNECT failure class (cheval.py default already = 4096).
+    assert "--per-call-max-tokens 4096" not in captured.err, (
+        f"cheval CLI surfaced the proven-ineffective `--per-call-max-tokens 4096` "
+        f"recommendation for PROVIDER_DISCONNECT (issue #774). stderr:\n{captured.err}"
+    )

--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -75,8 +75,12 @@ DEFAULT_MODEL_TIMEOUT=120
 
 # Issue #675 (sub-issue 4): per-call max_tokens override. Empty = use the
 # downstream default (cheval.py's default 4096 / model-adapter.sh's hardcoded
-# 4096). Anthropic disconnects ~60s for max_tokens > 4096 on prompts ≥100KB —
-# operators can lower this knob for large-document reviews.
+# 4096). Historical (#675): Anthropic disconnected ~60s for max_tokens > 4096
+# on very large prompts; operators could lower this knob for large-document
+# reviews. NOTE (#774): the disconnect failure mode now manifests at much
+# smaller doc sizes (~38KB observed) and on OpenAI as well. Lowering the
+# knob is a no-op against `failure_class=PROVIDER_DISCONNECT` — the flag is
+# preserved for back-compat only.
 PER_CALL_MAX_TOKENS=""
 
 # State tracking
@@ -1103,13 +1107,26 @@ run_phase1() {
 
     if [[ $failed -gt 0 ]]; then
         log "Warning: $failed of $total_calls Phase 1 calls failed (degraded mode)"
-        # Log stderr from failed calls for diagnosis
+        # Issue #774: count failed calls whose stderr carries the typed
+        # `failure_class=PROVIDER_DISCONNECT` JSON marker emitted by cheval.py.
+        # When ≥1 such call appears, surface a single tip line that points
+        # operators at the right diagnosis (NOT --per-call-max-tokens 4096,
+        # which is a no-op against the disconnect failure mode).
+        local disconnect_count=0
         for label in "${failed_labels[@]}"; do
             local stderr_file="$TEMP_DIR/${label}-stderr.log"
             if [[ -s "$stderr_file" ]]; then
+                # Match the JSON-error shape literally: '"failure_class":"PROVIDER_DISCONNECT"'
+                # (with arbitrary whitespace inside the JSON object).
+                if grep -q '"failure_class"[[:space:]]*:[[:space:]]*"PROVIDER_DISCONNECT"' "$stderr_file" 2>/dev/null; then
+                    disconnect_count=$((disconnect_count + 1))
+                fi
                 log "  $label stderr: $(head -5 "$stderr_file")"
             fi
         done
+        if [[ $disconnect_count -gt 0 ]]; then
+            log "tip: $disconnect_count of $failed failed calls had failure_class=PROVIDER_DISCONNECT — see issue #774. The --per-call-max-tokens flag does NOT address this failure mode (cheval default already=4096)."
+        fi
     fi
 
     # Aggregate costs
@@ -1368,9 +1385,14 @@ Options:
   --budget <cents>       Cost budget in cents (default: 300 = \$3.00)
   --per-call-max-tokens <N>
                          Override max_tokens passed to each model invocation.
-                         Use 4096 for documents ≥100KB to avoid Anthropic
-                         API server-side disconnect ~60s on large prompts
-                         (issue #675). When unset, downstream defaults apply
+                         Preserved for backward compat with issue #675.
+                         NOTE: does NOT address failure_class=PROVIDER_DISCONNECT
+                         (issue #774) — both the Anthropic AND OpenAI cheval
+                         paths fail on long-prompt requests with the typed
+                         transport error; the gemini path is unaffected.
+                         cheval.py default is already 4096, so passing 4096
+                         is a no-op against the disconnect failure mode.
+                         When unset, downstream defaults apply
                          (cheval.py: 4096; model-adapter.sh: 4096).
   --json                 Output as JSON
   -h, --help             Show this help
@@ -1493,9 +1515,10 @@ main() {
                 ;;
             --per-call-max-tokens)
                 # Issue #675 (sub-issue 4): operator override for downstream
-                # max_tokens. Anthropic disconnects ~60s for max_tokens > 4096
-                # on prompts ≥100KB; lower this knob to 4096 to work around
-                # the server-side cutoff for large-document reviews.
+                # max_tokens. Preserved for back-compat. NOTE (#774): does NOT
+                # address `failure_class=PROVIDER_DISCONNECT` — cheval default
+                # is already 4096, so passing 4096 is a no-op against the
+                # disconnect failure mode (Anthropic + OpenAI cheval paths).
                 PER_CALL_MAX_TOKENS="$2"
                 shift 2
                 ;;
@@ -1557,16 +1580,18 @@ main() {
         exit 1
     fi
 
-    # Issue #675 (sub-issue 2 + 4): warn when prompt size is in the Anthropic
-    # 60s-disconnect danger zone and the operator has not lowered max_tokens.
-    # Anthropic API drops streamed responses ~60s for max_tokens > 4096 on
-    # prompts ≥100KB (server-side cutoff, reproduced across HTTP/1.1 + HTTP/2 +
-    # httpx + curl). Workaround: --per-call-max-tokens 4096.
+    # Issue #774: warn when prompt size is in the cheval connection-loss
+    # danger zone. Empirical break point in the issue reporter's run was
+    # ~38KB on Anthropic + OpenAI (Gemini unaffected — control case). The
+    # threshold here (30KB) gives an 8KB safety margin under the observed
+    # break point. The disconnect manifests as `failure_class=PROVIDER_DISCONNECT`
+    # in cheval JSON-error stderr; the workaround is upstream (streaming or
+    # HTTP/1.1 forcing) and is deferred per /bug scope to /plan.
     local doc_bytes doc_kb
     doc_bytes=$(wc -c < "$doc" 2>/dev/null || echo 0)
     doc_kb=$(( (doc_bytes + 512) / 1024 ))   # round to nearest KB
-    if [[ "$doc_bytes" -gt 102400 && -z "${PER_CALL_MAX_TOKENS:-}" ]]; then
-        echo "WARNING: Document size ${doc_kb} KB; recommend \`--per-call-max-tokens 4096\` to avoid Anthropic 60s server-side disconnect" >&2
+    if [[ "$doc_bytes" -gt 30720 ]]; then
+        echo "WARNING: Document size ${doc_kb} KB; long prompts may trip the cheval connection-loss path on Anthropic + OpenAI. See issue #774 if Phase 1 reports failure_class=PROVIDER_DISCONNECT. The --per-call-max-tokens flag does NOT address this failure mode." >&2
     fi
 
     # Validate orchestrator mode

--- a/grimoires/loa/NOTES.md
+++ b/grimoires/loa/NOTES.md
@@ -1128,3 +1128,38 @@ The pre-existing `grimoires/loa/prd.md` and `sdd.md` describe **cycle-098 Agent-
 - Grounding: 91.4% PRD, 95.2% SDD (target >80% met)
 - 0 hallucinations detected in self-audit
 - 15 gaps catalogued for human resolution
+
+## 2026-05-08 — cycle-100 PRD opened (jailbreak corpus)
+
+- **Cycle**: cycle-100-jailbreak-corpus (parallel to cycle-099-model-registry which remains active)
+- **PRD path**: `grimoires/loa/cycles/cycle-100-jailbreak-corpus/prd.md`
+- **Scope**: corpus + bats/pytest runner + GH Actions CI gate; Layer-5 tool-call resolver + BB-append-handler + telemetry deferred to cycle-101+
+- **Directory**: unified `tests/red-team/jailbreak/` (per RESUMPTION.md vs SDD's two-path nomenclature)
+- **Count target**: ≥50 (SDD floor) / ~100 aspiration; "open / emerges from sources" per operator
+- **Schema**: standard (id + category + title + payload + expected_outcome + defense_layer + source_citation + severity + status[+suppression_reason])
+- **Sources**: OWASP LLM Top 10 + DAN + Anthropic + cycle-098 PoCs (regression replay)
+- **Multi-turn**: in scope (thin Python replay harness over `sanitize_for_session_start`)
+- **Patterns lifted from `~/.claude/skills/`**: dcg (registry-driven catalog), ubs (categorized findings + suppression-with-justification), cc-hooks (exit-code discipline), testing-fuzzing (corpus seed/minimize + differential oracle), multi-pass-bug-hunting (4-pass runner organization), slb (severity tier model)
+- **Open follow-ups before /architect**: (1) confirm path-filter list for FR-6 with actual file globs reviewed against current cycle-099 work; (2) decide if Sprint 1 ships 20-vector seed or 5-vector smoke first
+
+## 2026-05-08 — cycle-100 PAUSED; pivoting to fix #774
+
+- **Cycle-100 state**: PRD + SDD shipped; Flatline review on SDD returned `degraded` due to issue #774 (Server disconnected on 38KB docs across both Anthropic + OpenAI; Gemini unaffected)
+- **#774 status**: OPEN, filed 2026-05-07 by external reporter. Documented `--per-call-max-tokens 4096` workaround DID NOT help in our reproduction (same 3-of-6 failure pattern persisted: opus-skeptic, gpt-review, gpt-skeptic dropped; opus-review + gemini-* succeeded). Reporter's hypothesis: "the failure mechanism isn't max_tokens-driven and the help text mis-attributes the cause"
+- **Operator decision**: pause cycle-100; treat #774 as /bug. Cycle-100 /sprint-plan resumes after Flatline is reliable
+- **Resume path**: after #774 ships, run `/flatline-review sdd` against `grimoires/loa/cycles/cycle-100-jailbreak-corpus/sdd.md`, integrate findings, then `/sprint-plan`
+
+## 2026-05-08 — sprint-bug-142 IMPLEMENTED (issue #774)
+
+- **Branch**: `fix/issue-774-cheval-disconnect-classification`
+- **Files**: 5 mod + 2 new (~570 LOC added). pytest 833 green (1 pre-existing unrelated fail confirmed via `git stash` on main); bats 5/5 green.
+- **Three-layer fix**: types.py adds `ConnectionLostError` + extends `RetriesExhaustedError`; base.py wraps `httpx.post` (+ urllib parity); retry.py adds typed `except ConnectionLostError` arm; cheval.py emits `failure_class: PROVIDER_DISCONNECT` JSON-error; orchestrator help + warn (30KB threshold) + degraded-mode tip rewritten.
+- **Implementation report**: `grimoires/loa/a2a/sprint-bug-142/reviewer.md` (full AC walk + verification steps).
+- **Next**: `/review-sprint sprint-bug-142` then `/audit-sprint sprint-bug-142` — OR commit+PR if operator wants to ship without local cycle gates.
+
+## 2026-05-08 — sprint-bug-142 AUDIT APPROVED
+
+- **Verdict**: APPROVED - LETS FUCKING GO (security audit clean: 0 CRIT, 0 HIGH, 0 MED, 0 LOW; 1 INFORMATIONAL non-blocking)
+- **COMPLETED marker**: `grimoires/loa/a2a/sprint-bug-142/COMPLETED`
+- **Reports**: `auditor-sprint-feedback.md` (canonical) + mirror at `audits/2026-05-08/SECURITY-AUDIT-REPORT.md`
+- **Ready to commit + open PR against #774**

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -21,26 +21,26 @@
         {
           "local_id": 2,
           "global_id": 53,
-          "label": "Bridgebuilder Findings \u2014 Excellence Hardening",
+          "label": "Bridgebuilder Findings — Excellence Hardening",
           "status": "completed"
         },
         {
           "local_id": 3,
           "global_id": 54,
-          "label": "CI Hardening \u2014 Bridge Iteration 2",
+          "label": "CI Hardening — Bridge Iteration 2",
           "status": "completed"
         },
         {
           "local_id": 4,
           "global_id": 55,
-          "label": "CI Integrity \u2014 Bridge Iteration 3",
+          "label": "CI Integrity — Bridge Iteration 3",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-037",
-      "label": "Bridgebuilder Deep Review \u2014 Architectural Fixes",
+      "label": "Bridgebuilder Deep Review — Architectural Fixes",
       "status": "archived",
       "created": "2026-02-24T08:40:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -58,7 +58,7 @@
     },
     {
       "id": "cycle-038",
-      "label": "Organizational Memory Sovereignty \u2014 Three-Zone State Architecture",
+      "label": "Organizational Memory Sovereignty — Three-Zone State Architecture",
       "status": "archived",
       "created": "2026-02-24T21:00:00Z",
       "archived": "2026-02-25T12:00:00Z",
@@ -106,7 +106,7 @@
     },
     {
       "id": "cycle-039",
-      "label": "Two-Pass Bridge Review \u2014 Decouple Convergence from Enrichment",
+      "label": "Two-Pass Bridge Review — Decouple Convergence from Enrichment",
       "status": "archived",
       "created": "2026-02-25T12:30:00Z",
       "archived": "2026-02-26T00:00:00Z",
@@ -123,19 +123,19 @@
         {
           "local_id": 2,
           "global_id": 64,
-          "label": "Excellence Hardening \u2014 Bridge Iteration 2",
+          "label": "Excellence Hardening — Bridge Iteration 2",
           "status": "completed"
         },
         {
           "local_id": 3,
           "global_id": 65,
-          "label": "Final Polish \u2014 Bridge Iteration 3",
+          "label": "Final Polish — Bridge Iteration 3",
           "status": "completed"
         },
         {
           "local_id": 4,
           "global_id": 66,
-          "label": "Metacognition \u2014 Confidence-Weighted Enrichment",
+          "label": "Metacognition — Confidence-Weighted Enrichment",
           "status": "completed"
         },
         {
@@ -147,32 +147,32 @@
         {
           "local_id": 6,
           "global_id": 68,
-          "label": "Ecosystem Context Integration \u2014 Pass 0 Prototype",
+          "label": "Ecosystem Context Integration — Pass 0 Prototype",
           "status": "completed"
         },
         {
           "local_id": 7,
           "global_id": 69,
-          "label": "Enrichment Pipeline Ergonomics \u2014 Schema-First Architecture",
+          "label": "Enrichment Pipeline Ergonomics — Schema-First Architecture",
           "status": "completed"
         },
         {
           "local_id": 8,
           "global_id": 70,
-          "label": "Pass 1 Convergence Cache \u2014 Cost Intelligence",
+          "label": "Pass 1 Convergence Cache — Cost Intelligence",
           "status": "completed"
         },
         {
           "local_id": 9,
           "global_id": 71,
-          "label": "Dynamic Ecosystem Context \u2014 From Static Hints to Living Memory",
+          "label": "Dynamic Ecosystem Context — From Static Hints to Living Memory",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-040",
-      "label": "Multi-Model Adversarial Review Upgrade \u2014 GPT-5.3-Codex + Gemini Tertiary",
+      "label": "Multi-Model Adversarial Review Upgrade — GPT-5.3-Codex + Gemini Tertiary",
       "status": "archived",
       "created": "2026-02-26T00:00:00Z",
       "archived": "2026-02-26T14:00:00Z",
@@ -189,14 +189,14 @@
         {
           "local_id": 2,
           "global_id": 73,
-          "label": "Bug Fix \u2014 Scoring Engine 3-Model Tertiary Cross-Scoring",
+          "label": "Bug Fix — Scoring Engine 3-Model Tertiary Cross-Scoring",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-041",
-      "label": "Vision-Aware Planning \u2014 Creative Agency for AI Peers",
+      "label": "Vision-Aware Planning — Creative Agency for AI Peers",
       "status": "archived",
       "created": "2026-02-26T14:00:00Z",
       "archived": "2026-02-26T18:00:00Z",
@@ -207,7 +207,7 @@
         {
           "local_id": 1,
           "global_id": 74,
-          "label": "Foundation \u2014 Schema, Library, Query, Shadow Mode",
+          "label": "Foundation — Schema, Library, Query, Shadow Mode",
           "status": "completed"
         },
         {
@@ -226,7 +226,7 @@
     },
     {
       "id": "cycle-042",
-      "label": "Vision Activation \u2014 From Infrastructure to Living Memory",
+      "label": "Vision Activation — From Infrastructure to Living Memory",
       "status": "archived",
       "created": "2026-02-26T18:00:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -253,7 +253,7 @@
         {
           "local_id": 4,
           "global_id": 80,
-          "label": "Excellence Hardening \u2014 Bridgebuilder Findings",
+          "label": "Excellence Hardening — Bridgebuilder Findings",
           "status": "completed"
         }
       ],
@@ -292,7 +292,7 @@
     },
     {
       "id": "cycle-044",
-      "label": "Bridgebuilder Design Review \u2014 Pre-Implementation Architectural Intelligence",
+      "label": "Bridgebuilder Design Review — Pre-Implementation Architectural Intelligence",
       "status": "archived",
       "created": "2026-02-28T00:00:00Z",
       "archived": "2026-02-28T07:00:00Z",
@@ -322,7 +322,7 @@
     },
     {
       "id": "cycle-045",
-      "label": "Review Pipeline Hardening \u2014 Gemini Activation, Orchestrator Wiring, Red Team Post-Implementation",
+      "label": "Review Pipeline Hardening — Gemini Activation, Orchestrator Wiring, Red Team Post-Implementation",
       "status": "archived",
       "created": "2026-02-28T03:00:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -352,7 +352,7 @@
     },
     {
       "id": "cycle-046",
-      "label": "Bridgebuilder Constellation \u2014 From Pipeline to Deliberation",
+      "label": "Bridgebuilder Constellation — From Pipeline to Deliberation",
       "status": "archived",
       "created": "2026-02-28T04:30:00Z",
       "archived": "2026-02-28T06:30:00Z",
@@ -369,7 +369,7 @@
         {
           "local_id": 2,
           "global_id": 91,
-          "label": "Deliberative Council \u2014 Prior Findings Integration",
+          "label": "Deliberative Council — Prior Findings Integration",
           "status": "completed"
         },
         {
@@ -388,7 +388,7 @@
     },
     {
       "id": "cycle-047",
-      "label": "Compassionate Excellence \u2014 Bridgebuilder Deep Review Integration",
+      "label": "Compassionate Excellence — Bridgebuilder Deep Review Integration",
       "status": "archived",
       "created": "2026-02-28T06:30:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -424,7 +424,7 @@
     },
     {
       "id": "cycle-048",
-      "label": "Community Feedback \u2014 Review Pipeline Hardening",
+      "label": "Community Feedback — Review Pipeline Hardening",
       "status": "active",
       "created": "2026-02-28T08:50:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -433,7 +433,7 @@
         {
           "local_id": 1,
           "global_id": 98,
-          "label": "Foundation \u2014 Curl Guard, Error Surfacing, YAML Regex",
+          "label": "Foundation — Curl Guard, Error Surfacing, YAML Regex",
           "status": "planned"
         },
         {
@@ -458,7 +458,7 @@
     },
     {
       "id": "cycle-bug-20260418-i553-cb632b",
-      "label": "Bug Fix \u2014 agent: Plan blocks Write in /architect and /sprint-plan",
+      "label": "Bug Fix — agent: Plan blocks Write in /architect and /sprint-plan",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/553",
@@ -479,7 +479,7 @@
     },
     {
       "id": "cycle-bug-20260418-i549-1aaa93",
-      "label": "Bug Fix \u2014 Shell Tests 20+ pre-existing failures on main (5 clusters)",
+      "label": "Bug Fix — Shell Tests 20+ pre-existing failures on main (5 clusters)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/549",
@@ -498,7 +498,7 @@
     },
     {
       "id": "cycle-bug-20260418-i555-5560f6",
-      "label": "Bug Fix \u2014 Silent data loss via git stash -k / git stash pop",
+      "label": "Bug Fix — Silent data loss via git stash -k / git stash pop",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/555",
@@ -518,7 +518,7 @@
     },
     {
       "id": "cycle-bug-20260418-i545-e2c781",
-      "label": "Bug Fix \u2014 Spiral REVIEW gate fix-loop + quality_gate recovery (#545 + #546)",
+      "label": "Bug Fix — Spiral REVIEW gate fix-loop + quality_gate recovery (#545 + #546)",
       "type": "bugfix",
       "status": "active",
       "source_issues": [
@@ -542,7 +542,7 @@
     },
     {
       "id": "cycle-bug-20260418-i548-a2460c",
-      "label": "Bug Fix \u2014 vision-011 + cycle-082 deferred gates bundle (#548)",
+      "label": "Bug Fix — vision-011 + cycle-082 deferred gates bundle (#548)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/548",
@@ -558,7 +558,7 @@
     },
     {
       "id": "cycle-bug-20260418-i563-39dbdf",
-      "label": "Bug Fix \u2014 tripwire-handler rollback precheck misses untracked-only changes",
+      "label": "Bug Fix — tripwire-handler rollback precheck misses untracked-only changes",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/563",
@@ -571,7 +571,7 @@
     },
     {
       "id": "cycle-bug-20260418-i568-740715",
-      "label": "Bug Fix \u2014 spiral.task not exported to dispatch subprocess",
+      "label": "Bug Fix — spiral.task not exported to dispatch subprocess",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/568",
@@ -584,7 +584,7 @@
     },
     {
       "id": "cycle-bug-20260418-i570-83c0b5",
-      "label": "Bug Fix \u2014 spiral-harness hardcoded 300s planning timeouts",
+      "label": "Bug Fix — spiral-harness hardcoded 300s planning timeouts",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/570",
@@ -597,7 +597,7 @@
     },
     {
       "id": "cycle-bug-20260418-i573-cb3351",
-      "label": "Bug Fix \u2014 Flatline model allowlist hygiene & graceful degradation (#573+#574)",
+      "label": "Bug Fix — Flatline model allowlist hygiene & graceful degradation (#573+#574)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/573",
@@ -637,13 +637,13 @@
         {
           "local_id": "3A",
           "global_id": 116,
-          "label": "Health-Probe Core \u2014 KEYSTONE part 1 (T2.2)",
+          "label": "Health-Probe Core — KEYSTONE part 1 (T2.2)",
           "status": "merged"
         },
         {
           "local_id": "3B",
           "global_id": 117,
-          "label": "Health-Probe Resilience+CI+Integration+Runbook \u2014 KEYSTONE part 2 (T2.2)",
+          "label": "Health-Probe Resilience+CI+Integration+Runbook — KEYSTONE part 2 (T2.2)",
           "status": "merged"
         },
         {
@@ -685,7 +685,7 @@
     },
     {
       "id": "cycle-bug-20260428-i637-20ddd6",
-      "label": "Bug Fix \u2014 bridgebuilder-dist-smoke CI lane fails because workflow does not run npm ci (#637)",
+      "label": "Bug Fix — bridgebuilder-dist-smoke CI lane fails because workflow does not run npm ci (#637)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/637",
@@ -698,7 +698,7 @@
     },
     {
       "id": "cycle-095-model-currency",
-      "label": "Model Currency \u2014 gpt-5.5 + Haiku 4.5 + Gemini 3 + cost guardrails",
+      "label": "Model Currency — gpt-5.5 + Haiku 4.5 + Gemini 3 + cost guardrails",
       "status": "archived",
       "created": "2026-04-29T20:30:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -760,7 +760,7 @@
     },
     {
       "id": "cycle-bug-20260502-i669-55150d",
-      "label": "Bug Fix \u2014 post-merge automation: orchestrator scripts ship without an invoking workflow template",
+      "label": "Bug Fix — post-merge automation: orchestrator scripts ship without an invoking workflow template",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/669",
@@ -781,7 +781,7 @@
     },
     {
       "id": "cycle-098-agent-network",
-      "label": "Agent-Network Operation Primitives (L1-L7) \u2014 operator-absent network operation",
+      "label": "Agent-Network Operation Primitives (L1-L7) — operator-absent network operation",
       "status": "archived",
       "created": "2026-05-03T03:02:37.318627Z",
       "prd": "grimoires/loa/prd.md",
@@ -857,13 +857,13 @@
         }
       ],
       "shipped_at": "2026-05-04",
-      "ship_note": "COMPLETE \u2014 L1-L7 all SHIPPED on main. Sprint timeline: Sprint 1 (#693, L1+cross-cutting), 1.5 (#697 hardening), 2 (#705, L2 cost-budget), 3 (#712, L3 scheduled-cycle), H1+H2 (#716, #717 signed-mode + observer), /bug #711 (#718 gpt-review hook), 4 (#764, L4 graduated-trust), 5 (#767, L5 cross-repo-status), 6 (#771, L6 structured-handoff), 7 (#775, L7 soul-identity-doc) + follow-up #778 (L6 inheritance: strict test-mode gate + hook wiring). Cycle-098 cumulative tests on main: 760+. See archive at grimoires/loa/archive/2026-05-08-cycle-098-agent-network-l1-l7-complete/.",
+      "ship_note": "COMPLETE — L1-L7 all SHIPPED on main. Sprint timeline: Sprint 1 (#693, L1+cross-cutting), 1.5 (#697 hardening), 2 (#705, L2 cost-budget), 3 (#712, L3 scheduled-cycle), H1+H2 (#716, #717 signed-mode + observer), /bug #711 (#718 gpt-review hook), 4 (#764, L4 graduated-trust), 5 (#767, L5 cross-repo-status), 6 (#771, L6 structured-handoff), 7 (#775, L7 soul-identity-doc) + follow-up #778 (L6 inheritance: strict test-mode gate + hook wiring). Cycle-098 cumulative tests on main: 760+. See archive at grimoires/loa/archive/2026-05-08-cycle-098-agent-network-l1-l7-complete/.",
       "archived": "2026-05-07T19:11:07Z",
       "archive_path": "grimoires/loa/archive/2026-05-08-cycle-098-agent-network-l1-l7-complete"
     },
     {
       "id": "cycle-bug-20260503-i674-84adf8",
-      "label": "Bug Fix \u2014 post-merge + post-PR pipeline reliability bundle (#674, #634, #633, #676)",
+      "label": "Bug Fix — post-merge + post-PR pipeline reliability bundle (#674, #634, #633, #676)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/674",
@@ -882,7 +882,7 @@
     },
     {
       "id": "cycle-bug-20260504-i636-cb9b6d",
-      "label": "Bug Fix \u2014 T2+T3 hardening bundle (#636+#681+#687+#691+#692)",
+      "label": "Bug Fix — T2+T3 hardening bundle (#636+#681+#687+#691+#692)",
       "type": "bugfix",
       "status": "active",
       "source_issues": [
@@ -960,9 +960,22 @@
         "wall_clock_weeks_low": 5,
         "wall_clock_weeks_high": 6
       }
+    },
+    {
+      "id": "cycle-bug-20260507-i774-e898cd",
+      "label": "Bug Fix — Flatline orchestrator drops 3-of-6 model calls on 38KB docs",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/774",
+      "created_at": "2026-05-07T20:15:02Z",
+      "sprints": [
+        "sprint-bug-142"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260507-i774-e898cd/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260507-i774-e898cd/sprint.md"
     }
   ],
-  "global_sprint_counter": 141,
+  "global_sprint_counter": 142,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -1025,7 +1038,7 @@
     },
     {
       "id": "cycle-bug-20260502-i668-3b9765",
-      "label": "Bug Fix \u2014 Post-merge classifier silently classifies cycle PRs as other (#668)",
+      "label": "Bug Fix — Post-merge classifier silently classifies cycle PRs as other (#668)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/668",
@@ -1038,7 +1051,7 @@
     },
     {
       "id": "cycle-bug-20260502-i665-3962d9",
-      "label": "Bug Fix \u2014 post-pr Bridgebuilder MEDIUMs auto-triage to log_only without operator visibility (#665)",
+      "label": "Bug Fix — post-pr Bridgebuilder MEDIUMs auto-triage to log_only without operator visibility (#665)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/665",
@@ -1051,7 +1064,7 @@
     },
     {
       "id": "cycle-bug-20260502-i664-653da7",
-      "label": "Bug Fix \u2014 post-pr-state.sh update-phase rejects bridgebuilder_review (#664)",
+      "label": "Bug Fix — post-pr-state.sh update-phase rejects bridgebuilder_review (#664)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/664",
@@ -1064,7 +1077,7 @@
     },
     {
       "id": "cycle-bug-20260502-i663-ec337e",
-      "label": "Bug Fix \u2014 post-pr-orchestrator passes invalid --phase pr to flatline-orchestrator (#663)",
+      "label": "Bug Fix — post-pr-orchestrator passes invalid --phase pr to flatline-orchestrator (#663)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/663",
@@ -1077,7 +1090,7 @@
     },
     {
       "id": "cycle-bug-20260502-i661-cd5f4f",
-      "label": "Bug Fix \u2014 Defensive diagnostic for beads_rust 0.2.1 migration error (#661)",
+      "label": "Bug Fix — Defensive diagnostic for beads_rust 0.2.1 migration error (#661)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/661",
@@ -1090,7 +1103,7 @@
     },
     {
       "id": "cycle-bug-20260502-i660-dd4514",
-      "label": "Bug Fix \u2014 mount-submodule.sh BSD realpath portability + silent reconcile exit (#660)",
+      "label": "Bug Fix — mount-submodule.sh BSD realpath portability + silent reconcile exit (#660)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/660",
@@ -1103,7 +1116,7 @@
     },
     {
       "id": "cycle-bug-20260503-i675-ceb96f",
-      "label": "Bug Fix \u2014 model-adapter large-payload hardening (cheval/httpx HTTP/2 disconnect on 137KB+ payloads, Anthropic 60s timeout, #675)",
+      "label": "Bug Fix — model-adapter large-payload hardening (cheval/httpx HTTP/2 disconnect on 137KB+ payloads, Anthropic 60s timeout, #675)",
       "type": "bugfix",
       "status": "completed",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/675",
@@ -1119,7 +1132,7 @@
     },
     {
       "id": "cycle-bug-20260503-i697-475b02",
-      "label": "Bug Fix \u2014 post-merge automation: gt_regen arg mismatch + CHANGELOG cross-scope leak (#697)",
+      "label": "Bug Fix — post-merge automation: gt_regen arg mismatch + CHANGELOG cross-scope leak (#697)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/697",
@@ -1134,7 +1147,7 @@
   "bugfixes": [
     {
       "id": "cycle-bug-20260428-i640-1cc190",
-      "label": "Bug Fix \u2014 /mount writes stale framework_version: 0.6.0 (THIRD recurrence #640)",
+      "label": "Bug Fix — /mount writes stale framework_version: 0.6.0 (THIRD recurrence #640)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/640",

--- a/tests/integration/flatline-orchestrator-disconnect-hint.bats
+++ b/tests/integration/flatline-orchestrator-disconnect-hint.bats
@@ -3,79 +3,126 @@
 #
 # Verifies that the help text, the size-warn threshold, and the degraded-mode
 # tip handler all match the reality of `failure_class=PROVIDER_DISCONNECT`:
-#   - Help text drops the "≥100KB" threshold and names BOTH Anthropic + OpenAI
-#   - Size warning fires above 30KB (not the old 100KB) and points operators
-#     at issue #774, not the proven-ineffective `--per-call-max-tokens 4096`
-#     remedy
-#   - The degraded-mode tip only surfaces when ≥1 failed call carries
-#     the `failure_class: "PROVIDER_DISCONNECT"` JSON marker
+#   - Help text drops the "≥100KB" threshold AND names BOTH Anthropic + OpenAI
+#   - Size warning fires above 30KB (not the old 100KB) with a single canonical
+#     warning phrase pinned by these tests
+#   - --per-call-max-tokens flag is preserved (back-compat) at the parser layer,
+#     not just in --help text
 #
 # Hermetic: no real network, no real cheval, no real model-invoke binary.
+#
+# BB-iter-1 remediation (2026-05-08): assertion specificity tightened per
+# F1-size-warning-disjunction (MED) + F1-help-text-contract (LOW) +
+# F3-threshold-not-validated (LOW) + F4-back-compat-flag-acceptance (LOW).
+# Degraded-mode tip emission path (F2-degraded-tip-untested LOW) remains
+# uncovered here; it requires stub-failed-call orchestrator state which
+# adds non-trivial complexity. Tracked as #774-followup.
+
+# Canonical warning phrase the orchestrator emits at the 30KB threshold.
+# Pinning ONE canonical string (not an OR over substrings) per BB F1.
+readonly CANONICAL_WARN="long prompts may trip the cheval connection-loss path"
 
 setup() {
     SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
     ORCHESTRATOR="$PROJECT_ROOT/.claude/scripts/flatline-orchestrator.sh"
+
+    # Per-test scratch dir — created in setup so teardown can clean even if
+    # the test body fails mid-assertion. Mode 700 to avoid tmp leakage on
+    # multi-user hosts. PID + bats-test-name suffix avoids collisions across
+    # parallel runs.
+    local slug
+    slug=$(echo "${BATS_TEST_NAME:-test}" | tr -c 'A-Za-z0-9_' '_')
+    SCRATCH="$PROJECT_ROOT/.run/disconnect-hint-test-$$-$slug"
+    mkdir -p "$SCRATCH"
+    chmod 700 "$SCRATCH"
+}
+
+teardown() {
+    [[ -n "${SCRATCH:-}" && -d "$SCRATCH" ]] && rm -rf "$SCRATCH"
 }
 
 # ---- Help text ------------------------------------------------------------
 
-@test "help text references issue #774 and OpenAI" {
+@test "help text names BOTH Anthropic and OpenAI and references issue #774" {
     run bash "$ORCHESTRATOR" --help
     [ "$status" -eq 0 ]
-    [[ "$output" == *"issue #774"* ]]
+    # Per BB F1-help-text-contract: the header promised three things and
+    # the body must check all three (Anthropic + OpenAI + issue link).
+    [[ "$output" == *"Anthropic"* ]]
     [[ "$output" == *"OpenAI"* ]]
+    [[ "$output" == *"issue #774"* ]]
 }
 
-@test "help text drops the misleading >=100KB threshold from per-call-max-tokens guidance" {
+@test "help text --per-call-max-tokens stanza explicitly states it does NOT address PROVIDER_DISCONNECT" {
     run bash "$ORCHESTRATOR" --help
     [ "$status" -eq 0 ]
-    # Allowed: comments may mention ≥100KB historically. Operator-facing
-    # `--per-call-max-tokens` help block must NOT recommend lowering at 100KB.
-    # We assert by checking the help-stanza for the negation phrase.
-    [[ "$output" == *"does NOT address failure_class=PROVIDER_DISCONNECT"* ]] || \
-    [[ "$output" == *"does NOT address"*"PROVIDER_DISCONNECT"* ]]
+    # Pin the precise contract phrase rather than a redundant OR.
+    [[ "$output" == *"does NOT address failure_class=PROVIDER_DISCONNECT"* ]]
+}
+
+@test "help text --per-call-max-tokens stanza drops the old 'use 4096' lowering recommendation" {
+    run bash "$ORCHESTRATOR" --help
+    [ "$status" -eq 0 ]
+    # The historical operator pointer was "Use 4096 for documents ≥100KB".
+    # That phrase MUST NOT appear in the operator-facing help block — its
+    # presence means the misleading remedy guidance is back. (Comments
+    # elsewhere in the file may still reference 100KB historically; the
+    # --help output is the operator surface and must be clean.)
+    [[ "$output" != *"Use 4096 for documents"* ]]
+    [[ "$output" != *"≥100KB"* ]]
 }
 
 # ---- Size warning threshold (30KB instead of 100KB) -----------------------
 
-@test "size warning fires on a 38KB document" {
-    # Fixture must live inside PROJECT_ROOT (orchestrator's path-traversal
-    # gate rejects out-of-tree docs). Use a per-test scratch dir.
-    local scratch="$PROJECT_ROOT/.run/jailbreak-corpus-test-$$"
-    mkdir -p "$scratch"
-    local fixture="$scratch/big.md"
+@test "size warning fires on a 38KB document with the canonical warning phrase" {
+    local fixture="$SCRATCH/big.md"
     # Create a 38KB document (matches the issue reporter's break point)
     head -c 39064 < /dev/zero | tr '\0' 'a' > "$fixture"
 
     run bash "$ORCHESTRATOR" --doc "$fixture" --phase prd --dry-run 2>&1
-    rm -rf "$scratch"
-
-    # Expect the new warning string to surface
-    [[ "$output" == *"failure_class=PROVIDER_DISCONNECT"* ]] || \
-    [[ "$output" == *"long prompts may trip the cheval connection-loss path"* ]] || \
-    [[ "$output" == *"issue #774"* ]]
+    [ "$status" -eq 0 ]
+    # Pin to ONE canonical phrase (BB F1-size-warning-disjunction). The OR
+    # over three substrings was masking regressions because "issue #774"
+    # also leaked through unrelated help-text bleed-through.
+    [[ "$output" == *"$CANONICAL_WARN"* ]]
 }
 
-@test "size warning is silent on a 5KB document" {
-    local scratch="$PROJECT_ROOT/.run/jailbreak-corpus-test-$$"
-    mkdir -p "$scratch"
-    local fixture="$scratch/small.md"
+@test "size warning is silent below the 30KB threshold (5KB document)" {
+    local fixture="$SCRATCH/small.md"
     head -c 5120 < /dev/zero | tr '\0' 'a' > "$fixture"
 
     run bash "$ORCHESTRATOR" --doc "$fixture" --phase prd --dry-run 2>&1
-    rm -rf "$scratch"
-
-    # Below the 30KB threshold the warning must not appear
-    [[ "$output" != *"long prompts may trip the cheval connection-loss path"* ]]
+    [ "$status" -eq 0 ]
+    # Per BB F3-threshold-not-validated: exclude ALL warning identifiers
+    # below the threshold, not just the canonical phrase. A drift in the
+    # warning string would otherwise leak through this assertion.
+    [[ "$output" != *"$CANONICAL_WARN"* ]]
+    [[ "$output" != *"failure_class=PROVIDER_DISCONNECT"* ]]
 }
 
 # ---- per-call-max-tokens flag preserved (back-compat) ---------------------
 
-@test "--per-call-max-tokens flag is preserved (back-compat)" {
+@test "--per-call-max-tokens flag is documented in help" {
     run bash "$ORCHESTRATOR" --help
     [ "$status" -eq 0 ]
-    # The flag must still be documented; operators who used it for the
-    # historical #675 remedy must continue to be able to set it.
     [[ "$output" == *"--per-call-max-tokens"* ]]
+}
+
+@test "--per-call-max-tokens flag is accepted by argument parser" {
+    # Per BB F4-back-compat-flag-acceptance: documenting the flag in --help
+    # is necessary but not sufficient — operators need it to actually parse.
+    # Drive the parser by passing the flag with a 5KB doc + --dry-run; if
+    # the parser had been removed, the orchestrator would error with
+    # "Unknown option" and exit non-zero before reaching dry-run.
+    local fixture="$SCRATCH/probe.md"
+    head -c 5120 < /dev/zero | tr '\0' 'a' > "$fixture"
+
+    run bash "$ORCHESTRATOR" --doc "$fixture" --phase prd \
+        --per-call-max-tokens 4096 --dry-run 2>&1
+    [ "$status" -eq 0 ]
+    # The "Unknown option" sentinel comes from the orchestrator's argv
+    # parser when an arg is unrecognized. Its absence proves the flag
+    # is wired through to the parser, not just the help string.
+    [[ "$output" != *"Unknown option: --per-call-max-tokens"* ]]
 }

--- a/tests/integration/flatline-orchestrator-disconnect-hint.bats
+++ b/tests/integration/flatline-orchestrator-disconnect-hint.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# Issue #774 — flatline-orchestrator operator-facing strings.
+#
+# Verifies that the help text, the size-warn threshold, and the degraded-mode
+# tip handler all match the reality of `failure_class=PROVIDER_DISCONNECT`:
+#   - Help text drops the "≥100KB" threshold and names BOTH Anthropic + OpenAI
+#   - Size warning fires above 30KB (not the old 100KB) and points operators
+#     at issue #774, not the proven-ineffective `--per-call-max-tokens 4096`
+#     remedy
+#   - The degraded-mode tip only surfaces when ≥1 failed call carries
+#     the `failure_class: "PROVIDER_DISCONNECT"` JSON marker
+#
+# Hermetic: no real network, no real cheval, no real model-invoke binary.
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    ORCHESTRATOR="$PROJECT_ROOT/.claude/scripts/flatline-orchestrator.sh"
+}
+
+# ---- Help text ------------------------------------------------------------
+
+@test "help text references issue #774 and OpenAI" {
+    run bash "$ORCHESTRATOR" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"issue #774"* ]]
+    [[ "$output" == *"OpenAI"* ]]
+}
+
+@test "help text drops the misleading >=100KB threshold from per-call-max-tokens guidance" {
+    run bash "$ORCHESTRATOR" --help
+    [ "$status" -eq 0 ]
+    # Allowed: comments may mention ≥100KB historically. Operator-facing
+    # `--per-call-max-tokens` help block must NOT recommend lowering at 100KB.
+    # We assert by checking the help-stanza for the negation phrase.
+    [[ "$output" == *"does NOT address failure_class=PROVIDER_DISCONNECT"* ]] || \
+    [[ "$output" == *"does NOT address"*"PROVIDER_DISCONNECT"* ]]
+}
+
+# ---- Size warning threshold (30KB instead of 100KB) -----------------------
+
+@test "size warning fires on a 38KB document" {
+    # Fixture must live inside PROJECT_ROOT (orchestrator's path-traversal
+    # gate rejects out-of-tree docs). Use a per-test scratch dir.
+    local scratch="$PROJECT_ROOT/.run/jailbreak-corpus-test-$$"
+    mkdir -p "$scratch"
+    local fixture="$scratch/big.md"
+    # Create a 38KB document (matches the issue reporter's break point)
+    head -c 39064 < /dev/zero | tr '\0' 'a' > "$fixture"
+
+    run bash "$ORCHESTRATOR" --doc "$fixture" --phase prd --dry-run 2>&1
+    rm -rf "$scratch"
+
+    # Expect the new warning string to surface
+    [[ "$output" == *"failure_class=PROVIDER_DISCONNECT"* ]] || \
+    [[ "$output" == *"long prompts may trip the cheval connection-loss path"* ]] || \
+    [[ "$output" == *"issue #774"* ]]
+}
+
+@test "size warning is silent on a 5KB document" {
+    local scratch="$PROJECT_ROOT/.run/jailbreak-corpus-test-$$"
+    mkdir -p "$scratch"
+    local fixture="$scratch/small.md"
+    head -c 5120 < /dev/zero | tr '\0' 'a' > "$fixture"
+
+    run bash "$ORCHESTRATOR" --doc "$fixture" --phase prd --dry-run 2>&1
+    rm -rf "$scratch"
+
+    # Below the 30KB threshold the warning must not appear
+    [[ "$output" != *"long prompts may trip the cheval connection-loss path"* ]]
+}
+
+# ---- per-call-max-tokens flag preserved (back-compat) ---------------------
+
+@test "--per-call-max-tokens flag is preserved (back-compat)" {
+    run bash "$ORCHESTRATOR" --help
+    [ "$status" -eq 0 ]
+    # The flag must still be documented; operators who used it for the
+    # historical #675 remedy must continue to be able to set it.
+    [[ "$output" == *"--per-call-max-tokens"* ]]
+}


### PR DESCRIPTION
## Summary

Three-layer fix for issue #774 — `Server disconnected without sending a response` failure mode that dropped 3-of-6 Phase 1 model calls in the flatline orchestrator at common (~38KB) document sizes on both Anthropic and OpenAI cheval paths. The documented `--per-call-max-tokens 4096` workaround was a no-op because cheval.py's default is already 4096.

- **Transport layer**: wraps `httpx.post` and the urllib fallback with typed `ConnectionLostError` classification (6 httpx exception classes + urllib parity for `RemoteDisconnected` / disconnect-shape `URLError`)
- **Retry layer**: new `except ConnectionLostError` arm before the bare `except Exception`; transient classification with corrective remediation hint
- **CLI layer**: `cheval.py` emits `failure_class: "PROVIDER_DISCONNECT"` + sanitized typed fields (`transport_class`, `request_size_bytes`, `provider`) in JSON-error stderr — no body/headers/auth surfaced
- **Operator-facing strings**: `flatline-orchestrator.sh` help text + warn threshold (30KB, down from 100KB) + degraded-mode tip rewritten to point at #774 instead of the proven-ineffective flag

## Test plan

- [x] Failing pytest landed first (`test_connection_lost_classification.py`); confirmed `ImportError: cannot import name 'ConnectionLostError'` pre-fix
- [x] 5 new pytest functions across transport / retry / CLI / sanitization layers — all green post-fix
- [x] Sibling regression test from #675 (`test_cheval_exception_scoping.py`) — no regression
- [x] Full pytest suite: 833 pass, 3 skipped, 1 pre-existing failure (`test_validate_bindings_includes_new_agents`) confirmed PRE-EXISTING on main via `git stash` baseline (unconnected to #774)
- [x] 5 new bats integration tests (`tests/integration/flatline-orchestrator-disconnect-hint.bats`) — help text + warn threshold + flag preservation
- [ ] CI green (this PR's run)
- [ ] After merge: re-run `/flatline-review` against the deferred `cycle-100-jailbreak-corpus/sdd.md` to verify the fix unblocks the Phase 1 review path

## Out of scope (deferred to /plan)

- Streaming refactor for Anthropic + OpenAI adapters (SDD §4.2.5 forbids streaming in MVP)
- Forcing httpx to HTTP/1.1 globally
- `flatline-orchestrator.sh --reset-breakers` operator gap-closer
- Auto-retry-with-reduced-input on `failure_class: PROVIDER_DISCONNECT`

## Notes for reviewer

- The cheval.py `RetriesExhaustedError` constructor signature gained two optional kwargs (`last_error_class`, `last_error_context`) for typed metadata. Backward-compatible — existing 2-arg callers keep working unchanged.
- `ConnectionLostError` is a sibling of `ProviderUnavailableError`, NOT a subclass — different retry semantics (per-provider retry-with-backoff vs move-to-next-provider-in-chain).
- `ledger.json` diff is noisy (484 lines) due to incidental Unicode normalization (`—` → `—`) by the `/bug` skill that registered the bugfix cycle. Logically equivalent JSON; the actual new entry is at the bottom.
- The `--no-verify` on this commit is per the hardened pre-commit hook's explicit diagnostic instruction for upstream beads_rust 0.2.1 migration bug (tracked separately as #661).

Closes #774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)