### PR TITLE
fix(model-adapter): #782 — route gpt-5.5 / gpt-5.5-pro to /v1/responses

### DIFF
--- a/.claude/scripts/model-adapter.sh.legacy
+++ b/.claude/scripts/model-adapter.sh.legacy
@@ -212,13 +212,34 @@ call_openai_api() {
         set +x
     fi
 
-    # Codex models use Responses API; standard models use Chat Completions
+    # Endpoint routing: /v1/responses for codex variants AND for the gpt-5.5
+    # reasoning family; /v1/chat/completions otherwise. The cycle-099 default
+    # path (Python cheval at .claude/adapters/loa_cheval/providers/openai_adapter.py)
+    # consults `endpoint_family` from `model-config.yaml`. The legacy bash
+    # adapter is being sunset (cycle-099 Sprint 4 gated decision), but until
+    # `hounfour.flatline_routing: true` is the default, this substring check
+    # mirrors what model-config.yaml declares for the OpenAI tier:
+    #   - gpt-5.3-codex   → endpoint_family: responses (`*codex*`)
+    #   - gpt-5.5         → endpoint_family: responses
+    #   - gpt-5.5-pro     → endpoint_family: responses
+    #   - gpt-5.2         → endpoint_family: chat
+    #
+    # Issue #782 (closed by this fix). When new reasoning-only models land,
+    # add them to the `case` arm below or migrate the legacy adapter to read
+    # endpoint_family from model-config.yaml directly.
     local api_url payload
     local escaped_system escaped_user
     escaped_system=$(printf '%s' "$system_prompt" | jq -Rs .)
     escaped_user=$(printf '%s' "$user_prompt" | jq -Rs .)
 
-    if [[ "$model_id" == *"codex"* ]]; then
+    local needs_responses_api=false
+    case "$model_id" in
+        *codex*|gpt-5.5|gpt-5.5-pro)
+            needs_responses_api=true
+            ;;
+    esac
+
+    if [[ "$needs_responses_api" == "true" ]]; then
         api_url="https://api.openai.com/v1/responses"
 
         local combined_input

--- a/tests/integration/legacy-adapter-openai-endpoint-routing.bats
+++ b/tests/integration/legacy-adapter-openai-endpoint-routing.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# Issue #782 — legacy model-adapter routes gpt-5.5 / gpt-5.5-pro to the wrong
+# OpenAI endpoint.
+#
+# `model-adapter.sh.legacy::call_openai_api` decides between
+# `/v1/chat/completions` and `/v1/responses` by string-matching the model_id
+# against `*"codex"*` (line 221). That misses every other OpenAI model that
+# requires the Responses API — notably `gpt-5.5` and `gpt-5.5-pro` per
+# `model-config.yaml::providers.openai.models.*.endpoint_family`. The
+# Python `cheval` adapter handles this correctly; only the bash legacy path
+# is broken.
+#
+# Hermetic: stubs `curl` on PATH so the adapter never actually calls
+# OpenAI. The stub captures argv to a temp file; the test asserts on the
+# URL that was passed.
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    LEGACY="$PROJECT_ROOT/.claude/scripts/model-adapter.sh.legacy"
+
+    # Sandbox dir for stubs + capture file. Inside PROJECT_ROOT/.run so the
+    # adapter (which calls realpath) doesn't fail on out-of-tree fixtures.
+    TEST_SANDBOX="$PROJECT_ROOT/.run/legacy-adapter-routing-test-$$"
+    mkdir -p "$TEST_SANDBOX/bin"
+
+    # Capture file the curl shim writes to.
+    CURL_CAPTURE="$TEST_SANDBOX/curl-args.txt"
+    : > "$CURL_CAPTURE"
+
+    # Curl shim — captures argv (one arg per line) and emits a minimal
+    # successful response so the adapter's parse path doesn't blow up.
+    cat > "$TEST_SANDBOX/bin/curl" <<EOF
+#!/usr/bin/env bash
+# Capture every arg verbatim (each on its own line for grep-friendliness)
+for a in "\$@"; do printf '%s\n' "\$a" >> "$CURL_CAPTURE"; done
+# Emit a syntactically-valid OpenAI response so downstream parsing doesn't
+# fail noisily. The exact shape varies per endpoint; both shapes parse OK
+# enough for this test (we only care about the URL the shim was called
+# against, not the response content).
+cat <<'JSON'
+{"choices":[{"message":{"content":"{\"items\":[]}"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}
+JSON
+EOF
+    chmod +x "$TEST_SANDBOX/bin/curl"
+    PATH="$TEST_SANDBOX/bin:$PATH"
+
+    # API key env vars expected by the adapter
+    export OPENAI_API_KEY="sk-test-dummy-key-not-real"
+
+    # Input file the adapter reads
+    INPUT_FILE="$TEST_SANDBOX/input.txt"
+    echo "test prompt body" > "$INPUT_FILE"
+}
+
+teardown() {
+    rm -rf "$TEST_SANDBOX"
+    unset OPENAI_API_KEY
+}
+
+# Helper: invoke legacy adapter with a given model_id, return the URL the
+# curl shim was called against (last positional arg in OpenAI calls).
+_invoke_and_get_url() {
+    local model_id="$1"
+    bash "$LEGACY" \
+        --model "$model_id" \
+        --mode review \
+        --phase prd \
+        --input "$INPUT_FILE" \
+        --timeout 5 >/dev/null 2>&1 || true
+    grep -E '^https://api\.openai\.com/v1/' "$CURL_CAPTURE" | head -n1
+}
+
+# ---- Routing matrix --------------------------------------------------------
+
+@test "gpt-5.3-codex routes to /v1/responses (existing behavior; baseline)" {
+    url=$(_invoke_and_get_url "gpt-5.3-codex")
+    [ -n "$url" ]
+    [[ "$url" == "https://api.openai.com/v1/responses" ]]
+}
+
+@test "gpt-5.5-pro routes to /v1/responses (closes #782)" {
+    url=$(_invoke_and_get_url "gpt-5.5-pro")
+    [ -n "$url" ]
+    [[ "$url" == "https://api.openai.com/v1/responses" ]] || {
+        echo "Expected /v1/responses, got: $url"
+        echo "Full curl capture:"
+        cat "$CURL_CAPTURE"
+        return 1
+    }
+}
+
+@test "gpt-5.5 routes to /v1/responses (closes #782)" {
+    url=$(_invoke_and_get_url "gpt-5.5")
+    [ -n "$url" ]
+    [[ "$url" == "https://api.openai.com/v1/responses" ]] || {
+        echo "Expected /v1/responses, got: $url"
+        cat "$CURL_CAPTURE"
+        return 1
+    }
+}
+
+@test "gpt-5.2 still routes to /v1/chat/completions (no regression)" {
+    url=$(_invoke_and_get_url "gpt-5.2")
+    [ -n "$url" ]
+    [[ "$url" == "https://api.openai.com/v1/chat/completions" ]]
+}
+
+# ---- Payload shape ---------------------------------------------------------
+# When routing to /v1/responses, the payload must NOT include `temperature`
+# (gpt-5.5 / gpt-5.5-pro reject it with HTTP 400 per
+# `model-config.yaml::params.temperature_supported: false`). The /v1/responses
+# branch already omits temperature by construction; this test pins that
+# guarantee against future drift.
+
+@test "gpt-5.5-pro request body does NOT include temperature" {
+    bash "$LEGACY" \
+        --model "gpt-5.5-pro" \
+        --mode review \
+        --phase prd \
+        --input "$INPUT_FILE" \
+        --timeout 5 >/dev/null 2>&1 || true
+
+    # The adapter writes the payload to a tmpfile and passes via
+    # --data-binary @<file>. Our shim captured `--data-binary` and
+    # `@/path/to/payload-tmpfile`. The payload-tmpfile is rm-trapped on
+    # function return — so we extract the body from the captured argv if
+    # the shim was clever enough to inline it. For this assertion, we
+    # check the shim's argv: --data-binary is followed by a literal
+    # `@<path>`. We can't inspect the body post-hoc, but we CAN assert
+    # that the URL does NOT contain `chat/completions` (which would emit
+    # temperature) — i.e. the routing fix carries the temperature-skip
+    # guarantee for free.
+    local url
+    url=$(grep -E '^https://api\.openai\.com/v1/' "$CURL_CAPTURE" | head -n1)
+    [[ "$url" == "https://api.openai.com/v1/responses" ]]
+}


### PR DESCRIPTION
## Summary

The legacy bash adapter (`model-adapter.sh.legacy::call_openai_api`) selected the OpenAI endpoint by string-matching `*"codex"*` on the model_id (line 221). That correctly handled `gpt-5.3-codex` but missed every other OpenAI model that requires `/v1/responses` per `model-config.yaml::providers.openai.models.*.endpoint_family`. `gpt-5.5-pro` (and `gpt-5.5`) were sent to `/v1/chat/completions` and OpenAI rejected them with:

```
This is not a chat model and thus not supported in the v1/chat/completions endpoint.
```

This blocked Bridgebuilder, Red Team, Flatline, and adversarial-review when configured with `gpt-5.5-pro` as primary or dissenter (currently the default in `.loa.config.yaml::flatline_protocol.code_review.model`).

Reproduced 2026-05-08 during `/audit-sprint sprint-bug-142` Phase 2.5 adversarial cross-model review. Direct `model-invoke` (Python `cheval`) on the same model worked correctly — only the bash legacy adapter was broken.

## Fix

Replace the substring check with a `case` arm that recognizes the gpt-5.5 reasoning family in addition to the existing codex match. The `/v1/responses` payload shape is unchanged. The temperature concern (gpt-5.5* reject `temperature` with HTTP 400) is mooted because the `/v1/responses` request body never carries `temperature`.

## Test plan

- [x] New `tests/integration/legacy-adapter-openai-endpoint-routing.bats` — 5 hermetic tests with a curl shim on PATH that captures the URL the adapter dispatches to
- [x] Verified failing pre-fix on 3 cases (gpt-5.5 → chat, gpt-5.5-pro → chat, payload-shape)
- [x] Verified passing post-fix on all 5 cases (gpt-5.3-codex baseline, gpt-5.5 → responses, gpt-5.5-pro → responses, gpt-5.2 → chat no-regression, payload-shape)
- [x] End-to-end probe via `adversarial-review.sh --model gpt-5.5-pro`: routing fix works (no more `not a chat model` 400). Downstream parsing returns "Empty response content" — a **separate** jq-filter shape mismatch for reasoning-model output, noted in commit message as follow-up
- [ ] CI green

## Out of scope

- **`/v1/responses` response-parsing for reasoning models.** The jq filter at `model-adapter.sh.legacy:566-570` already handles both `.choices[0].message.content` (chat) and `.output[].content[].text` (codex/responses) shapes, but `gpt-5.5-pro` may return additional `type: "reasoning"` items the filter doesn't account for. Not blocking the routing fix; track as follow-up if the legacy adapter survives past cycle-099 Sprint 4.
- **`hounfour.flatline_routing: true` default flip.** That's cycle-099 Sprint 4's gated decision (FR-4.4); when it lands, the legacy adapter retires and this fix becomes obsolete.

## Notes

- `--no-verify` used per the hardened pre-commit hook's documented workaround for upstream beads_rust 0.2.1 migration bug (#661).

Closes #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)