### PR TITLE
fix(semver-bump): handle prerelease tags (vX.Y.Z-{alpha,beta,rc}.N)

### DIFF
--- a/.claude/scripts/semver-bump.sh
+++ b/.claude/scripts/semver-bump.sh
@@ -51,10 +51,25 @@ declare -A BUMP_PRIORITY=(
 # Version Utilities
 # =============================================================================
 
-# Get current version from the latest git tag matching v*.*.*
+# Get current version from the latest git tag matching either:
+#   - vX.Y.Z          (release)
+#   - vX.Y.Z-PRE.N    (prerelease, where PRE ∈ {alpha, beta, rc})
+#
+# Both shapes are returned to the caller; bump_version() handles the kind
+# difference. Pre-1.0 projects that ship through a prerelease cadence (e.g.
+# v2.0.0-alpha.7) need this to compute "next version" correctly — without
+# the prerelease branch, the strict vX.Y.Z glob silently misses every
+# alpha/beta/rc tag and the post-merge orchestrator skips tag/CHANGELOG/
+# release entirely.
 get_version_from_tag() {
   local tag
-  tag=$(git -C "$PROJECT_ROOT" tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname 2>/dev/null | head -1)
+  # `tag -l` accepts multiple patterns; combine release + prerelease shapes,
+  # then filter by precise regex (the glob is permissive — matches strings
+  # like "v1.2.3-foo" too).
+  tag=$(git -C "$PROJECT_ROOT" tag -l 'v[0-9]*.[0-9]*.[0-9]*' 'v[0-9]*.[0-9]*.[0-9]*-*' \
+    --sort=-v:refname 2>/dev/null \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$' \
+    | head -1)
   if [[ -n "$tag" ]]; then
     echo "${tag#v}"
     return 0
@@ -76,21 +91,48 @@ get_version_from_changelog() {
   return 1
 }
 
-# Bump a version string by type
+# Bump a version string by type. Handles two shapes:
+#
+#   1. Release  X.Y.Z          → bump per `bump` arg (major/minor/patch)
+#   2. Prerelease X.Y.Z-PRE.N  → increment N (PRE ∈ {alpha, beta, rc})
+#
+# Prerelease bumping is type-agnostic by design: while a project is on a
+# prerelease cadence (e.g. 2.0.0-alpha.N), conventional-commit signal
+# (feat/fix/etc.) does not warrant a major/minor/patch flip — the project
+# is still pre-1.0-of-this-major. Promotion out of prerelease (alpha → beta,
+# rc → release) is operator-driven and out of scope for this bump path.
+#
+# Validate version format (M-05) — accept either release or prerelease.
 bump_version() {
   local current="$1" bump="$2"
-  # Validate version format (M-05)
-  if ! [[ "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "ERROR: Invalid version format: $current" >&2
-    return 1
+  local prerelease_re='^([0-9]+)\.([0-9]+)\.([0-9]+)-(alpha|beta|rc)\.([0-9]+)$'
+  local release_re='^([0-9]+)\.([0-9]+)\.([0-9]+)$'
+
+  if [[ "$current" =~ $prerelease_re ]]; then
+    local major="${BASH_REMATCH[1]}"
+    local minor="${BASH_REMATCH[2]}"
+    local patch="${BASH_REMATCH[3]}"
+    local pre_kind="${BASH_REMATCH[4]}"
+    local pre_num="${BASH_REMATCH[5]}"
+    echo "${major}.${minor}.${patch}-${pre_kind}.$((pre_num + 1))"
+    return 0
   fi
-  IFS='.' read -r major minor patch <<< "$current"
-  case "$bump" in
-    major) echo "$((major + 1)).0.0" ;;
-    minor) echo "${major}.$((minor + 1)).0" ;;
-    patch) echo "${major}.${minor}.$((patch + 1))" ;;
-    *) echo "ERROR: Unknown bump type: $bump" >&2; return 1 ;;
-  esac
+
+  if [[ "$current" =~ $release_re ]]; then
+    local major="${BASH_REMATCH[1]}"
+    local minor="${BASH_REMATCH[2]}"
+    local patch="${BASH_REMATCH[3]}"
+    case "$bump" in
+      major) echo "$((major + 1)).0.0" ;;
+      minor) echo "${major}.$((minor + 1)).0" ;;
+      patch) echo "${major}.${minor}.$((patch + 1))" ;;
+      *) echo "ERROR: Unknown bump type: $bump" >&2; return 1 ;;
+    esac
+    return 0
+  fi
+
+  echo "ERROR: Invalid version format: $current" >&2
+  return 1
 }
 
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.137.2] — 2026-05-07
+
 ## [1.130.0] — 2026-05-06 — Model-registry consolidation, agent-network audit infrastructure, subscription-auth headless adapters
 
 This is a **named milestone release** that bundles 41 incremental tags (v1.110.0 → v1.129.1) into one operator-facing version. Three architectural shifts ship together:
@@ -1037,6 +1039,8 @@ Full convergence trajectory: `grimoires/loa/a2a/trajectory/bridge-triage-2026-04
 - ATK-011: Blocks `unset LOA_TEAM_MEMBER` and `env -u` privilege escalation in Agent Teams
 
 ## [Unreleased]
+
+## [1.137.2] — 2026-05-07
 
 ## [1.94.0] — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.137.2] — 2026-05-07
+### Fixed
+
+- `semver-bump.sh` now recognizes prerelease tags (`vX.Y.Z-{alpha,beta,rc}.N`)
+  and increments the prerelease counter type-agnostically when the project
+  is on a prerelease cadence. Previously the strict release-only tag glob
+  silently skipped every prerelease tag, causing the post-merge orchestrator
+  to no-op the tag/CHANGELOG/release phases for any project shipping
+  through alpha/beta/rc cycles. Operators no longer need to manually tag
+  prerelease bumps. (#785)
 
 ## [1.130.0] — 2026-05-06 — Model-registry consolidation, agent-network audit infrastructure, subscription-auth headless adapters
 
@@ -1039,8 +1047,6 @@ Full convergence trajectory: `grimoires/loa/a2a/trajectory/bridge-triage-2026-04
 - ATK-011: Blocks `unset LOA_TEAM_MEMBER` and `env -u` privilege escalation in Agent Teams
 
 ## [Unreleased]
-
-## [1.137.2] — 2026-05-07
 
 ## [1.94.0] — 2026-04-17
 

--- a/tests/unit/semver-bump.bats
+++ b/tests/unit/semver-bump.bats
@@ -389,3 +389,205 @@ EOF
     current=$(echo "$output" | jq -r '.current')
     [ "$current" = "1.2.0" ]
 }
+
+# =============================================================================
+# Prerelease Tag Tests (alpha/beta/rc)
+# =============================================================================
+#
+# Pre-1.0 projects (or major-version cadences shipping through prereleases)
+# tag with `vX.Y.Z-alpha.N` / `vX.Y.Z-beta.N` / `vX.Y.Z-rc.N`. The
+# release-only glob in get_version_from_tag() previously skipped these,
+# silently breaking downstream post-merge automation (no current version
+# resolved → empty next → semver phase exit 0 with empty result → tag/
+# CHANGELOG/release phases skipped). These tests pin the prerelease path.
+
+@test "semver-bump: detects prerelease tag (alpha)" {
+    skip_if_deps_missing
+
+    make_commit "initial"
+    make_tag "2.0.0-alpha.7"
+    make_commit "feat: post-alpha-7 work"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local current
+    current=$(echo "$output" | jq -r '.current')
+    [ "$current" = "2.0.0-alpha.7" ]
+}
+
+@test "semver-bump: detects prerelease tag (beta)" {
+    skip_if_deps_missing
+
+    make_commit "initial"
+    make_tag "1.5.0-beta.2"
+    make_commit "fix: post-beta-2 work"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local current
+    current=$(echo "$output" | jq -r '.current')
+    [ "$current" = "1.5.0-beta.2" ]
+}
+
+@test "semver-bump: detects prerelease tag (rc)" {
+    skip_if_deps_missing
+
+    make_commit "initial"
+    make_tag "3.0.0-rc.1"
+    make_commit "feat: post-rc-1 work"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local current
+    current=$(echo "$output" | jq -r '.current')
+    [ "$current" = "3.0.0-rc.1" ]
+}
+
+@test "semver-bump: prerelease bump increments prerelease number on feat commit" {
+    skip_if_deps_missing
+
+    make_commit "initial"
+    make_tag "2.0.0-alpha.7"
+    make_commit "feat: add new feature during alpha"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local next
+    next=$(echo "$output" | jq -r '.next')
+    [ "$next" = "2.0.0-alpha.8" ]
+}
+
+@test "semver-bump: prerelease bump increments prerelease number on fix commit" {
+    skip_if_deps_missing
+
+    make_commit "initial"
+    make_tag "2.0.0-alpha.7"
+    make_commit "fix: patch something during alpha"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local next
+    next=$(echo "$output" | jq -r '.next')
+    [ "$next" = "2.0.0-alpha.8" ]
+}
+
+@test "semver-bump: prerelease bump is type-agnostic — major commit also increments prerelease N" {
+    skip_if_deps_missing
+
+    make_commit "initial"
+    make_tag "2.0.0-alpha.7"
+    make_commit "feat!: breaking change during alpha"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local next
+    next=$(echo "$output" | jq -r '.next')
+    # While on prerelease, conventional-commit type does not warrant
+    # major/minor/patch flip — project is still pre-1.0-of-this-major.
+    # Promotion (alpha → beta, rc → release) is operator-driven.
+    [ "$next" = "2.0.0-alpha.8" ]
+}
+
+@test "semver-bump: prerelease bump for beta increments beta number" {
+    skip_if_deps_missing
+
+    make_commit "initial"
+    make_tag "1.5.0-beta.9"
+    make_commit "fix: post-beta-9"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local next
+    next=$(echo "$output" | jq -r '.next')
+    [ "$next" = "1.5.0-beta.10" ]
+}
+
+@test "semver-bump: prerelease bump for rc increments rc number" {
+    skip_if_deps_missing
+
+    make_commit "initial"
+    make_tag "3.0.0-rc.1"
+    make_commit "fix: post-rc-1"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local next
+    next=$(echo "$output" | jq -r '.next')
+    [ "$next" = "3.0.0-rc.2" ]
+}
+
+@test "semver-bump: release bump still works for plain X.Y.Z (no regression)" {
+    skip_if_deps_missing
+
+    # Defense regression: VULN-002-style fix should not break release-only
+    # path. This test re-runs the canonical "feat → minor bump" case to
+    # confirm the bump_version() refactor is additive.
+    make_commit "initial"
+    make_tag "1.0.0"
+    make_commit "feat: minor bump"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local next
+    next=$(echo "$output" | jq -r '.next')
+    [ "$next" = "1.1.0" ]
+}
+
+@test "semver-bump: malformed prerelease tag (missing .N suffix) rejected by version regex" {
+    skip_if_deps_missing
+
+    # The grep regex in get_version_from_tag() requires the prerelease
+    # to have an explicit numeric suffix. A bare `v1.0.0-alpha` (no .N)
+    # is matched neither by the strict regex nor by the prerelease regex,
+    # so get_version_from_tag returns 1 (no version source) — the script
+    # falls back to changelog or fails cleanly.
+    make_commit "initial"
+    git -C "$TEST_REPO" tag -a "v1.0.0-alpha" -m "malformed prerelease"
+    make_commit "feat: post-malformed"
+
+    run "$TEST_SCRIPT" --from-tag
+    # Either exit 2 (no version source) OR fall back to changelog (which
+    # is also empty in this fixture, also exit 2). Behavior must NOT
+    # silently accept the malformed tag and produce empty/garbage next.
+    [ "$status" -ne 0 ]
+}
+
+@test "semver-bump: picks latest version-sorted prerelease across alpha.N range" {
+    skip_if_deps_missing
+
+    make_commit "initial"
+    make_tag "2.0.0-alpha.1"
+    make_commit "c2"
+    make_tag "2.0.0-alpha.2"
+    make_commit "c3"
+    make_tag "2.0.0-alpha.10"
+    make_commit "feat: post-alpha-10"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local current
+    current=$(echo "$output" | jq -r '.current')
+    # Version-aware sort: alpha.10 > alpha.2 > alpha.1 (NOT lexicographic).
+    [ "$current" = "2.0.0-alpha.10" ]
+}
+
+@test "semver-bump: picks latest tag when release and prerelease coexist" {
+    skip_if_deps_missing
+
+    # Mixed history: project shipped v1.x stable, then started v2 prerelease
+    # cadence. The post-merge orchestrator should pick the latest tag by
+    # version sort regardless of prerelease vs release shape.
+    make_commit "initial"
+    make_tag "1.5.0"
+    make_commit "c2"
+    make_tag "2.0.0-alpha.1"
+    make_commit "c3"
+    make_tag "2.0.0-alpha.5"
+    make_commit "feat: post-alpha-5"
+
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    local current
+    current=$(echo "$output" | jq -r '.current')
+    [ "$current" = "2.0.0-alpha.5" ]
+}


### PR DESCRIPTION
## Summary

`semver-bump.sh` silently skipped post-merge automation (tag/CHANGELOG/release phases) for any Loa project shipping through a prerelease cadence. The release-only tag glob and version regex couldn't recognize `vX.Y.Z-alpha.N` / `vX.Y.Z-beta.N` / `vX.Y.Z-rc.N` tags, so `get_version_from_tag()` returned empty → `semver-bump.sh` exited 0 with empty next version → orchestrator interpreted "no version" as a no-op and skipped the rest of the pipeline.

Operators were forced to manually tag + cut releases on every prerelease cycle.

## What this PR changes

Two surgical fixes to `.claude/scripts/semver-bump.sh` plus a prerelease bump strategy:

### 1. `get_version_from_tag()` — accept prerelease shapes

```bash
# Before — strict release-only glob; missed every prerelease tag
tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1

# After — paired glob + precise regex post-filter
tag -l 'v[0-9]*.[0-9]*.[0-9]*' 'v[0-9]*.[0-9]*.[0-9]*-*' --sort=-v:refname \
  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$' \
  | head -1
```

### 2. `bump_version()` — two-branch validator

Refactored from strict release-only regex to a two-branch validator:

- **Prerelease** `X.Y.Z-PRE.N` → increment N (PRE-kind preserved)
- **Release** `X.Y.Z` → existing major/minor/patch logic

### 3. Prerelease bump strategy: type-agnostic

While a project is on prerelease cadence (e.g. `2.0.0-alpha.7`), conventional-commit signal (`feat:` / `fix:` / `feat!:` etc.) does NOT warrant major/minor/patch flip — the project is still pre-1.0-of-this-major. Every conventional commit increments the prerelease number; promotion (`alpha → beta → rc → release`) is operator-driven and out of scope for the automated bump path.

## Test surface

12 new bats cases in `tests/unit/semver-bump.bats`:

| Coverage | Tests |
|---|---|
| **Detection** | alpha / beta / rc tag shapes |
| **Bump** | prerelease N increment on feat / fix / breaking; per-kind preservation (alpha→alpha, beta→beta, rc→rc) |
| **Regression** | release-only path unchanged after refactor |
| **Edge cases** | malformed prerelease (no `.N` suffix) rejected; version-aware sort handles `alpha.10 > alpha.2` correctly; latest-tag selection with mixed release+prerelease history |

All 34 tests pass (22 existing + 12 new); `tests/unit/semver-bump-downstream.bats` also clean.

## Checklist

- [x] Commits are clean and focused (single fix commit)
- [x] No sensitive data in commits
- [x] DCO sign-off present
- [x] Tests pass (34/34 bats)
- [x] No regression in existing release-only path

## Out of scope

- **Promotion path** (alpha → beta → rc → release): operator-driven; this PR only handles the within-prerelease-cadence increment. A `--promote=beta` flag could be added later if Loa workflows need automated promotion, but the current bug is the silent skip; promotion is a separate concern.
- **CHANGELOG header detection for prereleases** (`get_version_from_changelog()`): CHANGELOG conventions typically don't carry prerelease entries (releases consolidate alphas), so the changelog fallback is left release-only. Can revisit if a downstream operator needs it.

## Why now

A downstream Loa user encountered the silent-skip pattern across 4 consecutive prerelease cuts before the cause was identified. The fix is small, fully tested, and unblocks any project on a prerelease cadence — the cost of leaving this in is operator-toil multiplied by every prerelease cycle.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>