### PR TITLE
fix(bridgebuilder): Node 20 Happy Eyeballs IPv4 handshake timeout — closes #827 / KF-001

### DIFF
--- a/.claude/skills/bridgebuilder-review/resources/entry.sh
+++ b/.claude/skills/bridgebuilder-review/resources/entry.sh
@@ -27,5 +27,52 @@ if [[ -f .env.local ]]; then
   set -a; source .env.local; set +a
 fi
 
+# Happy Eyeballs autoselection-attempt-timeout (cycle-102 sprint-1E / KF-001 fix).
+#
+# Node 20+ undici fetch uses RFC 8305 Happy Eyeballs to race concurrent IPv6 +
+# IPv4 connection attempts. The default --network-family-autoselection-attempt-
+# timeout is 250ms — when an attempt does not complete a TCP handshake within
+# that window, Node aborts it and aggregates the failure. On networks where
+# IPv4 TCP handshake to specific provider endpoints (api.anthropic.com,
+# generativelanguage.googleapis.com) routinely takes >250ms (common with
+# slow-but-reachable IPv4 paths through DDoS protection layers like Cloudflare),
+# the attempt is killed before TCP completes and Node reports
+# `TypeError: fetch failed; cause=AggregateError [ETIMEDOUT]`. This presented
+# as full bridgebuilder degradation across 3 invocations on PR #826 (KF-001
+# in grimoires/loa/known-failures.md), with anthropic + google failing while
+# openai succeeded — openai's faster IPv4 path completed inside 250ms.
+#
+# Bumping the autoselection-attempt-timeout to 5000ms gives each connection
+# attempt enough time to complete the TCP+TLS handshake on slow-but-reachable
+# IPv4 paths. Effects:
+#   - Users with working IPv6: no slowdown — IPv6 wins fast; autoselection
+#     completes in tens of milliseconds. The 5000ms is a CEILING, not a delay.
+#   - Users with broken IPv6 (EADDRNOTAVAIL or no v6 stack): autoselection
+#     waits up to 5s for IPv4 to complete the handshake. Real-world IPv4
+#     handshakes complete in 1-3s on this class of network.
+#   - Users with both broken: waits 5s before declaring failure (vs 250ms
+#     previously). Acceptable for the rare full-network-outage case.
+#
+# Honors existing NODE_OPTIONS (appends rather than overwrites) so operators
+# who set their own NODE_OPTIONS don't get clobbered. The flag has been
+# available since Node 18.18 / 20.0 — covered by the engines.node >=20.0.0
+# pin in package.json. Set LOA_BB_DISABLE_FAMILY_TIMEOUT_FIX=1 to opt out.
+#
+# Diagnostic evidence (commit message of this patch references upstream issue):
+#   - Direct curl to api.anthropic.com IPv4 succeeds in 0.9-3s
+#   - Python httpx (cheval.py) succeeds against all 3 providers
+#   - Node fetch fails with: sub-error[0] ETIMEDOUT IPv4-addr,
+#     sub-error[1] EADDRNOTAVAIL IPv6-addr (no v6 stack)
+#   - With --network-family-autoselection-attempt-timeout=5000: Node
+#     fetch returns HTTP 401 (correct auth-failure response) instantly.
+#
+# Upstream issue: https://github.com/0xHoneyJar/loa/issues/827
+# Node CLI ref:   https://nodejs.org/api/cli.html#--network-family-autoselection-attempt-timeoutms
+if [[ -z "${LOA_BB_DISABLE_FAMILY_TIMEOUT_FIX:-}" ]]; then
+  if [[ "${NODE_OPTIONS:-}" != *"--network-family-autoselection-attempt-timeout"* ]]; then
+    export NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS} }--network-family-autoselection-attempt-timeout=5000"
+  fi
+fi
+
 # Run compiled TypeScript via Node (no npx tsx — SKP-002)
 exec node "${SKILL_DIR}/dist/main.js" "$@"

--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -55,7 +55,7 @@ actually tried, not just what someone *said* was tried.
 
 | ID | Status | Feature | Recurrence |
 |----|--------|---------|------------|
-| [KF-001](#kf-001-bridgebuilder-cross-model-provider-network-failures-non-openai) | OPEN (STRUCTURAL — upstream filed) | bridgebuilder cross-model dissent | 3 |
+| [KF-001](#kf-001-bridgebuilder-cross-model-provider-network-failures-non-openai) | RESOLVED 2026-05-10 (Node 20 Happy Eyeballs autoselection-attempt-timeout) | bridgebuilder cross-model dissent | 3 |
 | [KF-002](#kf-002-adversarial-reviewsh-empty-content-on-review-type-prompts-at-scale) | DEGRADED-ACCEPTED | adversarial-review.sh review-type | 3 |
 | [KF-003](#kf-003-gpt-55-pro-empty-content-on-27k-input-reasoning-class-prompts) | RESOLVED (model swap) | flatline_protocol code review | 1 |
 | [KF-004](#kf-004-validate_finding-silent-rejection-of-dissenter-payloads) | OPEN (upstream filed) | adversarial-review.sh validation pipeline | ≥4 |
@@ -66,7 +66,40 @@ actually tried, not just what someone *said* was tried.
 
 ## KF-001: bridgebuilder cross-model provider network failures (non-OpenAI)
 
-**Status**: OPEN — STRUCTURAL (upstream filed)
+**Status**: RESOLVED 2026-05-10 (root cause identified, patch landed in `.claude/skills/bridgebuilder-review/resources/entry.sh`)
+
+### Resolution
+
+Diagnosed root cause: Node 20+ undici fetch's RFC 8305 Happy Eyeballs uses a
+default `--network-family-autoselection-attempt-timeout=250ms`. On networks
+where the IPv4 TCP handshake to specific provider endpoints takes >250ms
+(common with Cloudflare/Cloud DDoS-protected anthropic + google endpoints),
+Node aborts the IPv4 attempt before the handshake completes and reports
+`TypeError: fetch failed; cause=AggregateError`. Curl, Python httpx, and
+other HTTP clients don't have this issue because they use sequential or
+longer-timeout connection logic. OpenAI's faster IPv4 path completed
+inside 250ms which is why it kept working while anthropic + google failed.
+
+Patch: bump the timeout to 5000ms via `NODE_OPTIONS` in `entry.sh`. Honors
+existing operator NODE_OPTIONS (appends rather than overwrites). Set
+`LOA_BB_DISABLE_FAMILY_TIMEOUT_FIX=1` to opt out.
+
+Diagnostic evidence (preserved here for future agents):
+- Direct curl to `api.anthropic.com` IPv4 (160.79.104.10) succeeds with HTTP 404 in 0.9-3s
+- Python httpx via cheval.py succeeds against all 3 providers (got "Pong!" from claude-opus-4.7, "pong" from gemini-3.1-pro)
+- Node raw `fetch()` fails with: `sub-error[0]: ETIMEDOUT 160.79.104.10:443`, `sub-error[1]: EADDRNOTAVAIL 2607:6bc0::10:443`
+- Operator's machine has NO local IPv6 stack (`ip -6 addr show` returns empty)
+- With `--network-family-autoselection-attempt-timeout=5000`: Node fetch returns HTTP 401 (correct auth-failure response) immediately
+
+Future agents observing similar fetch failures in OTHER Node-based skills
+should check whether those skills also need the same NODE_OPTIONS fix.
+The pattern is upstream-known: any Node 20+ undici fetch on networks
+with slow-but-reachable IPv4 paths will hit this.
+
+(Original entry preserved below for the trail.)
+---
+
+**Original Status**: OPEN — STRUCTURAL (upstream filed)
 **Feature**: `/bridgebuilder` cross-model dissent (`anthropic` + `google` providers via `.claude/skills/bridgebuilder-review/resources/adapters/`)
 **Symptom**: Both `anthropic/claude-opus-4-7` and `google/gemini-3.1-pro-preview` fail with `TypeError: fetch failed; cause=AggregateError` (Anthropic) and `cause=SocketError: other side closed` (Google) across all 3 retry attempts. OpenAI/`gpt-5.5-pro` succeeds. BB falls back to "stats-only summary" because the enrichment writer (also Anthropic) fails the same way. Headline reports `N findings — X consensus, Y disputed` but the consensus scoring runs over a single model's output. The pattern persisted across 3 independent BB invocations within ~60 min wall-clock on the same PR + machine; not a transient provider outage.
 **First observed**: 2026-05-10 (cycle-102 sprint-1D BB iter-1 on PR #826)
@@ -82,6 +115,8 @@ actually tried, not just what someone *said* was tried.
 | 2026-05-10 04:20Z | iter-1 normal invocation | DID NOT WORK — anthropic + google 3/3 attempts failed; openai succeeded (7616 in / 21198 out) | run `bridgebuilder-20260510T042044-3f1c` / PR #826 comment 4414476 |
 | 2026-05-10 04:35Z | iter-2 after 7-min gap + mitigation commit `6bfcae21` | DID NOT WORK — same failure mode; openai succeeded (8752 in / 15629 out) | run `bridgebuilder-20260510T043516-5fb8` / PR #826 comment 4414587 |
 | 2026-05-10 05:11Z | iter-3 after 36-min gap + framing-correction commit `a9591b28` (operator-requested retry to get all 3 models) | DID NOT WORK — same failure mode; openai succeeded (30067 in / 3069 out — note different output size from same model on same PR) | run `bridgebuilder-20260510T051139-fe00` |
+| 2026-05-10 ~06:30Z | Diagnostic sprint: direct curl + Python httpx + raw Node fetch + AggregateError sub-error inspection | ROOT CAUSE IDENTIFIED — Node 20 Happy Eyeballs autoselection-attempt-timeout=250ms killing IPv4 handshake before TCP completes | this entry's "Resolution" section |
+| 2026-05-10 ~06:35Z | Patch entry.sh to set `NODE_OPTIONS=--network-family-autoselection-attempt-timeout=5000` | RESOLVED — Node fetch reaches anthropic + google instantly; HTTP 401 / 400 responses received | this entry's "Resolution" section |
 
 ### Reading guide
 


### PR DESCRIPTION
## Summary

Closes #827 and resolves KF-001 (full diagnostic + resolution in `grimoires/loa/known-failures.md`).

**Root cause:** Node 20+ undici fetch's RFC 8305 Happy Eyeballs uses a default `--network-family-autoselection-attempt-timeout=250ms`. On networks where IPv4 TCP handshake to specific provider endpoints (api.anthropic.com, generativelanguage.googleapis.com) takes >250ms — common with Cloudflare/Cloud DDoS protection layers — Node aborts the IPv4 attempt before the handshake completes and reports `TypeError: fetch failed; cause=AggregateError`.

**Why OpenAI kept working when Anthropic + Google failed:** OpenAI's faster IPv4 path completes inside the 250ms window. Anthropic + Google have slower DDoS-protected paths that don't.

**Why curl + Python httpx kept working:** Different HTTP clients with different connection logic. Curl's Happy Eyeballs and Python httpx's sequential fallback both have longer/no autoselection timeout.

## Diagnostic evidence

```
curl https://api.anthropic.com/        → HTTP 404 in 0.9-3s (IPv4 reachable)
python3 cheval.py --model claude-opus-4.7 → "Pong! 🏓 How can I help you today?"
python3 cheval.py --model gemini-3.1-pro  → "pong"
node fetch(...)                          → AggregateError:
  [0] ETIMEDOUT 160.79.104.10:443 (IPv4 attempt killed at 250ms)
  [1] EADDRNOTAVAIL 2607:6bc0::10:443 (no local IPv6 stack)
ip -6 addr show                          → empty (no IPv6 configured)

# After fix:
NODE_OPTIONS="--network-family-autoselection-attempt-timeout=5000" \
  node fetch(...)                        → HTTP 401 (correct auth-failure response)
```

## Patch

`.claude/skills/bridgebuilder-review/resources/entry.sh` exports `NODE_OPTIONS` to bump the timeout to 5000ms before `exec node`:

- Honors existing `NODE_OPTIONS` (appends, doesn't overwrite)
- Avoids double-set if operator already passed the same flag
- `LOA_BB_DISABLE_FAMILY_TIMEOUT_FIX=1` opt-out for users who want original Node default
- 5000ms is a CEILING not a delay — users with working IPv6 see no slowdown (IPv6 wins fast); users with broken IPv6 see normal 1-3s IPv4 handshake; users with both broken see 5s failure (acceptable for rare full-outage case)

## Why this is the right fix layer

Three alternatives considered:

| Alternative | Verdict |
|-------------|---------|
| Patch each TS adapter (`anthropic.ts`, `google.ts`, `openai.ts`) to set `dispatcher` with `family: 4` | Invasive: 3 files + recompile dist + parity-test all adapters. Rejected. |
| Operator-side IPv6 fix (configure local IPv6 stack) | Out of agent's hands; doesn't help users without operator IPv6 expertise. |
| `NODE_OPTIONS` in entry.sh | Single-line change; fixes the bug class for ALL fetches in the BB process; opt-out env var preserves operator control. **Selected.** |

## What unblocks

The framework's BB cross-model dissent has been degraded since the cycle-102 model swap landed (KF-002 → cycle-102 sprint-1B T1B.4). With BB cross-model fixed, the framework can:

- Run real cross-model consensus on PR reviews (not single-model headlines that look like consensus)
- Trust REFRAME-class plateau calls (vision-024 substrate-speaks-twice pattern requires ≥2 models)
- Unblock substrate work in cycle-102+ (Sprint 1E and beyond can rely on BB)

## Test plan

- [x] Diagnostic verified: Node fetch with the new NODE_OPTIONS returns HTTP 401 from anthropic, HTTP 400 from google
- [x] Cross-runtime parity preserved (no other adapters touched)
- [ ] CI checks (BATS Tests + Shell Tests etc.) — expected pre-existing main failures only (KF-005 / KF-006)
- [ ] **End-to-end: run `/bridgebuilder --pr <this-pr-#>` after merge and verify all 3 providers complete** — the fix-against-itself pattern proves the patch works on a real BB invocation

## Closes

- Closes #827 (KF-001 root cause + fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)