### PR TITLE
fix(adversarial-review): rejected-finding sidecar — closes KF-004 / #814

### DIFF
--- a/.claude/scripts/adversarial-review.sh
+++ b/.claude/scripts/adversarial-review.sh
@@ -247,6 +247,76 @@ validate_finding() {
   ' > /dev/null 2>&1
 }
 
+# cycle-102 sprint-1F (#814 / KF-004 closure): companion to validate_finding
+# that returns a specific reject reason on stdout. Used by the rejection
+# sidecar so operators triaging "0 findings + N silent rejections" can see
+# WHY each payload was dropped without re-running the dissenter.
+#
+# Returns empty string on stdout if valid; first-failing-rule reason if not.
+# Mirrors validate_finding's rule order so the boolean fast-path stays the
+# canonical truth and the reason path is diagnostic-only.
+_validate_finding_reason() {
+  local finding="$1"
+  local type="$2"
+
+  local valid_severities
+  if [[ "$type" == "review" ]]; then
+    valid_severities='["BLOCKING","ADVISORY"]'
+  else
+    valid_severities='["CRITICAL","HIGH","MEDIUM","LOW"]'
+  fi
+  local valid_categories='["injection","authz","data-loss","null-safety","concurrency","type-error","resource-leak","error-handling","spec-violation","performance","secrets","xss","ssrf","deserialization","crypto","info-disclosure","rate-limiting","input-validation","config","other"]'
+
+  echo "$finding" | jq -r --argjson sevs "$valid_severities" --argjson cats "$valid_categories" '
+    if (.id // null) == null or (.id | type) != "string" then
+      "missing-or-non-string-id"
+    elif (.severity // null) == null then
+      "missing-severity"
+    elif ((.severity | IN($sevs[])) | not) then
+      "severity-not-in-enum (got: \(.severity // "null"))"
+    elif (.category // null) == null then
+      "missing-category"
+    elif ((.category | IN($cats[])) | not) then
+      "category-not-in-enum (got: \(.category // "null"))"
+    elif (.description // null) == null or (.description | type) != "string" or (.description | length) == 0 then
+      "missing-or-empty-description"
+    elif (.failure_mode // null) == null or (.failure_mode | type) != "string" or (.failure_mode | length) == 0 then
+      "missing-or-empty-failure_mode"
+    else
+      ""
+    end
+  ' 2>/dev/null
+}
+
+# cycle-102 sprint-1F (#814 / KF-004 closure): write a rejected-finding entry
+# to the per-sprint sidecar JSONL. One entry per rejected finding, append-only
+# within a single process_findings invocation. Schema:
+#   {ts_utc, sprint_id, type, model, index, reject_reason, payload}
+# Caller MUST have ensured the sidecar parent dir exists and (optionally)
+# truncated the file at the start of process_findings.
+_write_rejected_sidecar() {
+  local sidecar_path="$1"
+  local finding="$2"
+  local reject_reason="$3"
+  local index="$4"
+  local sprint_id="$5"
+  local type="$6"
+  local model="$7"
+
+  [[ -n "$sidecar_path" ]] || return 0
+
+  jq -nc \
+    --argjson f "$finding" \
+    --arg r "${reject_reason:-unknown-reason}" \
+    --argjson idx "$index" \
+    --arg sid "$sprint_id" \
+    --arg t "$type" \
+    --arg m "$model" \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{ts_utc: $ts, sprint_id: $sid, type: $t, model: $m, index: $idx, reject_reason: $r, payload: $f}' \
+    >> "$sidecar_path" 2>/dev/null || true
+}
+
 # =============================================================================
 # Anchor Validation Pipeline (SDD Section 5)
 # =============================================================================
@@ -594,8 +664,29 @@ process_findings() {
   fi
 
   # STATE 4: Populated findings — validate and process
+  #
+  # cycle-102 sprint-1F (#814 / KF-004 closure): rejected-finding sidecar.
+  # When validate_finding rejects a payload, the payload is preserved in
+  # `adversarial-rejected-${type}.jsonl` alongside the main output. This
+  # closes the silent-rejection observability gap that vision-024 named as
+  # the third consensus-classification failure mode and that the operator's
+  # suspicion-lens interjections caught manually across cycle-102.
+  #
+  # Sidecar is truncated at start of every process_findings invocation
+  # (idempotent within a single run; multiple runs on the same sprint do
+  # NOT accumulate). Disable via LOA_ADVERSARIAL_REJECT_SIDECAR_DISABLE=1
+  # (env opt-out for environments that can't write the sidecar).
+  local rejected_sidecar=""
+  if [[ -z "${LOA_ADVERSARIAL_REJECT_SIDECAR_DISABLE:-}" ]]; then
+    local rej_dir="$PROJECT_ROOT/grimoires/loa/a2a/${sprint_id}"
+    mkdir -p "$rej_dir" 2>/dev/null || true
+    rejected_sidecar="$rej_dir/adversarial-rejected-${type}.jsonl"
+    : > "$rejected_sidecar" 2>/dev/null || rejected_sidecar=""
+  fi
+
   local validated_findings="[]"
   local i=0
+  local rejected_count=0
   while [[ $i -lt $finding_count ]]; do
     local finding
     finding=$(echo "$parsed" | jq ".findings[$i]")
@@ -606,10 +697,19 @@ process_findings() {
       validated=$(validate_anchor "$finding" "$type" "$diff_files")
       validated_findings=$(echo "$validated_findings" | jq --argjson f "$validated" '. + [$f]')
     else
-      log "Rejected invalid finding at index $i"
+      local reject_reason
+      reject_reason=$(_validate_finding_reason "$finding" "$type")
+      log "Rejected invalid finding at index $i: ${reject_reason:-unknown-reason}"
+      _write_rejected_sidecar "$rejected_sidecar" "$finding" "$reject_reason" "$i" "$sprint_id" "$type" "$model"
+      rejected_count=$((rejected_count + 1))
     fi
     i=$((i + 1))
   done
+
+  # cycle-102 sprint-1F: surface aggregate rejection count in the main
+  # output's metadata so consumers (operator, /audit-sprint, BB triage) see
+  # the rejection signal without needing to grep stderr or open the sidecar.
+  # The sidecar path is also surfaced for one-jump triage.
 
   # Extract token/cost metadata from model-adapter response
   local tokens_in tokens_out cost latency
@@ -618,15 +718,26 @@ process_findings() {
   cost=$(echo "$raw_response" | jq -r '.cost_usd // 0')
   latency=$(echo "$raw_response" | jq -r '.latency_ms // 0')
 
+  # Compute relative path to sidecar from PROJECT_ROOT (cleaner for downstream
+  # logs / triage). Empty string when sidecar disabled.
+  local rejected_sidecar_rel=""
+  if [[ -n "$rejected_sidecar" ]]; then
+    rejected_sidecar_rel="${rejected_sidecar#"$PROJECT_ROOT/"}"
+  fi
+
   jq -n \
     --argjson findings "$validated_findings" \
     --arg type "$type" --arg model "$model" --arg sid "$sprint_id" \
     --arg ts "$timestamp" \
     --argjson ti "$tokens_in" --argjson to "$tokens_out" \
     --argjson cost "$cost" --argjson lat "$latency" \
+    --argjson rejc "$rejected_count" \
+    --arg rejs "$rejected_sidecar_rel" \
     '{findings: $findings, metadata: {type: $type, model: $model, sprint_id: $sid,
       timestamp: $ts, tokens_input: $ti, tokens_output: $to, cost_usd: $cost,
-      latency_ms: $lat, status: "reviewed", degraded: false}}'
+      latency_ms: $lat, status: "reviewed", degraded: false,
+      rejected_count: $rejc,
+      rejected_sidecar: (if $rejs == "" then null else $rejs end)}}'
 }
 
 # =============================================================================

--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -58,7 +58,7 @@ actually tried, not just what someone *said* was tried.
 | [KF-001](#kf-001-bridgebuilder-cross-model-provider-network-failures-non-openai) | RESOLVED 2026-05-10 (Node 20 Happy Eyeballs autoselection-attempt-timeout) | bridgebuilder cross-model dissent | 3 |
 | [KF-002](#kf-002-adversarial-reviewsh-empty-content-on-review-type-prompts-at-scale) | DEGRADED-ACCEPTED | adversarial-review.sh review-type | 3 |
 | [KF-003](#kf-003-gpt-55-pro-empty-content-on-27k-input-reasoning-class-prompts) | RESOLVED (model swap) | flatline_protocol code review | 1 |
-| [KF-004](#kf-004-validate_finding-silent-rejection-of-dissenter-payloads) | OPEN (upstream filed) | adversarial-review.sh validation pipeline | ≥4 |
+| [KF-004](#kf-004-validate_finding-silent-rejection-of-dissenter-payloads) | RESOLVED 2026-05-10 (sidecar dump landed; #814 mitigation shipped) | adversarial-review.sh validation pipeline | ≥4 |
 | [KF-005](#kf-005-beads_rust-021-migration-blocks-task-tracking) | DEGRADED-ACCEPTED | beads_rust task tracking | many |
 | [KF-006](#kf-006-t114-migrate-model-config-v2-schema-rejects-max_output_tokens) | OPEN | T1.14 migrate-model-config v2 schema | every PR since dd54fe9c |
 | [KF-007](#kf-007-red-team-pipeline-hardcoded-single-model-evaluator-vestigial-config) | RESOLVED 2026-05-10 (multi-model evaluator) | red team pipeline hardcoded single-model evaluator | n/a — resolved in same session as discovery |
@@ -212,7 +212,29 @@ provider, not at our integration.
 
 ## KF-004: validate_finding silent rejection of dissenter payloads
 
-**Status**: OPEN (upstream filed)
+**Status**: RESOLVED 2026-05-10 (rejected-finding sidecar landed; suspicion-lens automated)
+
+### Resolution
+
+Patched `.claude/scripts/adversarial-review.sh` with a per-sprint sidecar JSONL that captures every rejected dissenter payload alongside the canonical output:
+
+- **Sidecar path**: `grimoires/loa/a2a/${sprint_id}/adversarial-rejected-${type}.jsonl`
+- **Schema** (one entry per rejected finding):
+  ```json
+  {"ts_utc": "...", "sprint_id": "...", "type": "review|audit", "model": "...",
+   "index": <position-in-batch>, "reject_reason": "<why>", "payload": <the dropped finding>}
+  ```
+- **Reject reason** comes from new `_validate_finding_reason` companion function; possible values include `missing-or-non-string-id`, `missing-severity`, `severity-not-in-enum (got: PURPLE)`, `category-not-in-enum (got: sparkles)`, `missing-or-empty-description`, `missing-or-empty-failure_mode`
+- **Aggregate signal in main output**: `metadata.rejected_count` (integer) and `metadata.rejected_sidecar` (relative path or null) added to every `adversarial-{review,audit}.json`. Consumers see the rejection signal without needing to grep stderr
+- **Idempotent**: sidecar is truncated at start of every `process_findings` invocation; multiple runs on the same sprint do NOT accumulate entries
+- **Opt-out**: `LOA_ADVERSARIAL_REJECT_SIDECAR_DISABLE=1` for environments that can't write the sidecar
+
+The original cycle-102 manifest of this bug — 5 silent rejections during the Sprint 1D `/audit-sprint` adversarial-audit — would now produce `grimoires/loa/a2a/cycle-102-sprint-1D/adversarial-rejected-audit.jsonl` with 5 lines, each capturing the dissenter's actual payload + the reject reason. The operator suspicion-lens that we ran manually this session is now automatic.
+
+(Original entry preserved below.)
+---
+
+**Original Status**: OPEN (upstream filed)
 **Feature**: `.claude/scripts/adversarial-review.sh` validation pipeline
 **Symptom**: When adversarial-review.sh receives findings from the dissenter that don't conform to the strict schema (e.g., missing required field, out-of-enum severity, malformed `anchor_type`), the validator emits `[adversarial-review] Rejected invalid finding at index N` to stderr and **drops the payload entirely** — the rejected finding's content is unrecoverable. The output JSON shows fewer findings than the dissenter actually produced; the rejected payloads never reach the consensus scorer or the operator. Headline counts are misleadingly low.
 **First observed**: 2026-05-09 mid-session (caught by operator's "i am always suspicious when there are 0" interjection during BB iter-2 of sprint-1B PR #813)


### PR DESCRIPTION
## Summary

Closes #814 / KF-004. The `validate_finding` rejection branch in `adversarial-review.sh` silently dropped dissenter payloads that didn't match the strict schema. The "0 findings" / "low N findings" headlines on `adversarial-{review,audit}.json` carried authority the substrate didn't support — operators only caught the gap by manual suspicion-lens (per @janitooor's "i am suspicious when there are 0" pattern, surfaced ≥4 times across cycle-102).

This PR preserves the rejected payloads in a per-sprint sidecar JSONL so the suspicion-lens runs automatically.

## What changes

**Sidecar path**: `grimoires/loa/a2a/${sprint_id}/adversarial-rejected-${type}.jsonl`

**Schema** (one entry per rejected finding):
```json
{"ts_utc": "...", "sprint_id": "...", "type": "review|audit", "model": "...",
 "index": <position-in-batch>, "reject_reason": "<why>", "payload": <the dropped finding>}
```

**Reject reasons** come from new `_validate_finding_reason` companion to `validate_finding`. Mirrors `validate_finding`'s rule order so the boolean fast-path stays canonical truth and the reason path is diagnostic-only:
- `missing-or-non-string-id`
- `missing-severity`
- `severity-not-in-enum (got: <value>)`
- `missing-category`
- `category-not-in-enum (got: <value>)`
- `missing-or-empty-description`
- `missing-or-empty-failure_mode`

**Aggregate signal in main output** — added to every `adversarial-{review,audit}.json`:
- `metadata.rejected_count` (integer)
- `metadata.rejected_sidecar` (relative path or null)

So consumers (operator, `/audit-sprint`, BB triage, post-pr orchestrator) see the rejection signal without grepping stderr or opening the sidecar.

**Idempotent**: sidecar is truncated at start of every `process_findings` invocation; multiple runs on the same sprint do NOT accumulate entries.

**Opt-out**: `LOA_ADVERSARIAL_REJECT_SIDECAR_DISABLE=1` for environments that cannot write the sidecar.

## Smoke validation (local)

```
valid       VALID (no rejection)
bad_sev     REJECTED — severity-not-in-enum (got: PURPLE)
bad_cat     REJECTED — category-not-in-enum (got: sparkles)
no_desc     REJECTED — missing-or-empty-description
no_id       REJECTED — missing-or-non-string-id
```

## Pattern this exemplifies

Per vision-024 substrate-speaks-twice + the operator's interjection pattern: the framework's "0 findings" headline was a third consensus-classification failure mode (after single-model-Security-in-DISPUTED and demotion-by-relabel). The mitigation was operator-manual until tonight. This PR shifts it left — into the adversarial-review.sh substrate itself — so the suspicion-lens fires automatically on every invocation.

Cycle-102 sprint-1D's 5 silent rejections (documented in `grimoires/loa/a2a/cycle-102-sprint-1D/auditor-sprint-feedback.md`) would now produce a 5-line sidecar at:
  `grimoires/loa/a2a/cycle-102-sprint-1D/adversarial-rejected-audit.jsonl`

KF-004 in `grimoires/loa/known-failures.md` promoted to RESOLVED with full diagnostic preserved.

## Test plan

- [x] Bash syntax check
- [x] Smoke-validated `_validate_finding_reason` against 5 cases (1 valid + 4 distinct rejection reasons)
- [ ] CI checks (BATS Tests + Shell Tests etc.) — expected pre-existing main failures only (KF-005 / KF-006 / macOS bash 3.2 codegen)
- [ ] Operator can verify by running `/audit-sprint` on any PR post-merge — `metadata.rejected_count` will surface in the audit output

## Closes

- Closes #814 (KF-004 sidecar fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)