### PR TITLE
fix(cycle-102 sprint-1F): KF-006 — v2 schema permits max_output_tokens + max_input_tokens

### DIFF
--- a/.claude/data/schemas/model-config-v2.schema.json
+++ b/.claude/data/schemas/model-config-v2.schema.json
@@ -79,6 +79,16 @@
           "minimum": 1024,
           "description": "v2 minimum 1024 (SDD §3.1.1.1 unit test corpus). v1 entries below this fail post-migration validation with [MIGRATION-PRODUCED-INVALID-V2]."
         },
+        "max_output_tokens": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Per-model output budget cap. cycle-102 Sprint 1A T1.9 added this field to v1 model-config.yaml without bumping the v2 schema, causing every PR touching model-config to fail v2-validation as [MIGRATION-PRODUCED-INVALID-V2]: 'Additional properties are not allowed (max_output_tokens was unexpected)'. KF-006 closure (cycle-102 Sprint 1F)."
+        },
+        "max_input_tokens": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Empirically-observed safe input-size threshold. Distinct from context_window (advertised capacity) — this is the field-observed prompt size above which cheval's HTTP path on this provider disconnects (KF-002 layer 3 / Loa #774). Optional. cycle-102 Sprint 1F."
+        },
         "token_param": {"type": "string"},
         "endpoint_family": {
           "type": "string",

--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -60,7 +60,7 @@ actually tried, not just what someone *said* was tried.
 | [KF-003](#kf-003-gpt-55-pro-empty-content-on-27k-input-reasoning-class-prompts) | RESOLVED (model swap) | flatline_protocol code review | 1 |
 | [KF-004](#kf-004-validate_finding-silent-rejection-of-dissenter-payloads) | RESOLVED 2026-05-10 (sidecar dump landed; #814 mitigation shipped) | adversarial-review.sh validation pipeline | ≥4 |
 | [KF-005](#kf-005-beads_rust-021-migration-blocks-task-tracking) | DEGRADED-ACCEPTED | beads_rust task tracking | many |
-| [KF-006](#kf-006-t114-migrate-model-config-v2-schema-rejects-max_output_tokens) | OPEN | T1.14 migrate-model-config v2 schema | every PR since dd54fe9c |
+| [KF-006](#kf-006-t114-migrate-model-config-v2-schema-rejects-max_output_tokens) | RESOLVED 2026-05-10 (v2 schema modelEntry permits max_output_tokens + max_input_tokens) | T1.14 migrate-model-config v2 schema | every PR since dd54fe9c |
 | [KF-007](#kf-007-red-team-pipeline-hardcoded-single-model-evaluator-vestigial-config) | RESOLVED 2026-05-10 (multi-model evaluator) | red team pipeline hardcoded single-model evaluator | n/a — resolved in same session as discovery |
 
 ---
@@ -326,7 +326,12 @@ upstream and tracked. The markdown fallback is sufficient.
 
 ## KF-006: T1.14 migrate-model-config v2 schema rejects `max_output_tokens`
 
-**Status**: OPEN (CI-blocking on every PR touching model-config; pre-existing since cycle-102 sprint-1A merge)
+**Status**: RESOLVED 2026-05-10 (v2 schema modelEntry properties extended to include `max_output_tokens` + `max_input_tokens`; production-yaml smoke-migrates with exit 0; 3 new bats regression tests at `tests/integration/migrate-model-config.bats:M19.{1,2,3}`)
+
+(Original entry preserved below.)
+---
+
+**Original Status**: OPEN (CI-blocking on every PR touching model-config; pre-existing since cycle-102 sprint-1A merge)
 **Feature**: `tools/migrate-model-config.{sh,py}` smoke test step in workflow `T1.13 log-redactor + T1.14 migrate-model-config CLI`
 **Symptom**: The smoke step "Smoke test — migrate the production cycle-095 yaml" exits 78 with `MIGRATION-PRODUCED-INVALID-V2` errors for ~7 fields: `Additional properties are not allowed ('max_output_tokens' was unexpected)` on every model entry under `providers.{openai,anthropic,google}.models.*`. The migrator successfully translates v1 → v2 but the v2 schema validation step rejects the output because the schema doesn't list `max_output_tokens` as a known property.
 **First observed**: 2026-05-09 (cycle-102 sprint-1A merge of `dd54fe9c` — that commit added `max_output_tokens: 32000` per-model fields per T1.9, while the cycle-099 sprint-1E.a v2 schema did not extend to allow that field)
@@ -341,6 +346,7 @@ upstream and tracked. The markdown fallback is sufficient.
 |------|---------------|---------|----------|
 | 2026-05-09 | Sprint 1A T1.9 added `max_output_tokens` fields without bumping v2 schema | INTRODUCED THE REGRESSION | commit `dd54fe9c` |
 | 2026-05-10 | Sprint 1D PR #826 hit the same failure on T1.14 smoke step; cross-runtime T1.13 step itself passed 59/59 | OBSERVED — pre-existing not introduced | run `25621265130` / PR #826 |
+| 2026-05-10 | Extend v2 schema `modelEntry.properties` with `max_output_tokens` + `max_input_tokens`; add 3 bats regression tests (M19.1–M19.3) | RESOLVED — production-yaml smoke-migrates exit 0 | Sprint 1F PR (this entry) — `.claude/data/schemas/model-config-v2.schema.json` + `tests/integration/migrate-model-config.bats` |
 
 ### Reading guide
 

--- a/tests/integration/migrate-model-config.bats
+++ b/tests/integration/migrate-model-config.bats
@@ -679,3 +679,78 @@ EOF
     run "$PYTHON_BIN" "$CLI" "$bad_v2" -o "$OUT"
     [[ "$status" -eq 78 ]]
 }
+
+# ---------------------------------------------------------------------------
+# M19 — KF-006 regression coverage: max_output_tokens + max_input_tokens are
+#       valid v2 fields (cycle-102 Sprint 1F closure)
+# ---------------------------------------------------------------------------
+
+@test "M19.1 KF-006: max_output_tokens passes v2 validation on per-model entries" {
+    local v1="$WORK_DIR/v1-with-max-output.yaml"
+    cat > "$v1" <<'EOF'
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-5.5-pro:
+        capabilities: [chat, tools, function_calling, code]
+        context_window: 400000
+        endpoint_family: responses
+        max_output_tokens: 32000
+        token_param: max_completion_tokens
+EOF
+    run "$PYTHON_BIN" "$CLI" "$v1" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    # Field MUST be carried through unchanged (not stripped or archived)
+    _python_assert <<'EOF'
+import os
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open(os.environ["OUT"]) as f:
+    data = y.load(f)
+m = data["providers"]["openai"]["models"]["gpt-5.5-pro"]
+assert m["max_output_tokens"] == 32000, m
+# Must NOT be archived (the bug class would have routed the field there
+# in some buggy migrator variants)
+assert "max_output_tokens" not in (m.get("_archived_v1_fields") or {})
+EOF
+}
+
+@test "M19.2 KF-006: max_input_tokens passes v2 validation (Sprint 1F new field)" {
+    local v1="$WORK_DIR/v1-with-max-input.yaml"
+    cat > "$v1" <<'EOF'
+providers:
+  openai:
+    type: openai
+    endpoint: "https://api.openai.com/v1"
+    models:
+      gpt-5.5-pro:
+        capabilities: [chat]
+        context_window: 400000
+        endpoint_family: responses
+        max_output_tokens: 32000
+        max_input_tokens: 24000
+EOF
+    run "$PYTHON_BIN" "$CLI" "$v1" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    _python_assert <<'EOF'
+import os
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open(os.environ["OUT"]) as f:
+    data = y.load(f)
+m = data["providers"]["openai"]["models"]["gpt-5.5-pro"]
+assert m["max_input_tokens"] == 24000
+assert m["max_output_tokens"] == 32000
+EOF
+}
+
+@test "M19.3 KF-006: production model-config.yaml smoke-migrates without 78" {
+    # The exact failure class from KF-006: production yaml's
+    # max_output_tokens fields were rejected post-migration. With the
+    # schema bump, the production yaml should now smoke-migrate clean.
+    run "$PYTHON_BIN" "$CLI" "$PROJECT_ROOT/.claude/defaults/model-config.yaml" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"MIGRATION-PRODUCED-INVALID-V2"* ]]
+}


### PR DESCRIPTION
## Summary

Closes [KF-006](https://github.com/0xHoneyJar/loa/blob/main/grimoires/loa/known-failures.md#kf-006-t114-migrate-model-config-v2-schema-rejects-max_output_tokens). Extends the cycle-099 Sprint 1E.a v2 schema (`.claude/data/schemas/model-config-v2.schema.json`) `modelEntry.properties` to permit two integer fields:

- `max_output_tokens` — added to v1 by cycle-102 Sprint 1A T1.9 (commit dd54fe9c) without a v2 schema bump
- `max_input_tokens` — added to v1 by cycle-102 Sprint 1F (PR #838) for KF-002 layer 3 backstop

## Why this had to land

KF-006 was failing the `T1.13 log-redactor + T1.14 migrate-model-config CLI` workflow's smoke step on every PR that touched `model-config.yaml`. Per known-failures.md, the workflow reproduces the migration end-to-end against the production yaml; v2's `additionalProperties: false` rejected `max_output_tokens` with `[MIGRATION-PRODUCED-INVALID-V2]`. Operators routed it as "pre-existing main failure for merge purposes" but every cycle-102 PR carried the noise.

Production-yaml smoke now exits 0:

```
$ python .claude/scripts/loa-migrate-model-config.py \
    .claude/defaults/model-config.yaml -o /tmp/v2-smoke.yaml
[INFO] added schema_version: 2 (v1 → v2)
[INFO] renamed agents.translating-for-executives.model -> .default_tier (value 'cheap' is a tier-tag)
[INFO] renamed agents.jam-synthesizer.model -> .default_tier (value 'cheap' is a tier-tag)
exit: 0
```

## Test plan

- [x] 3 new bats tests at `tests/integration/migrate-model-config.bats:M19.{1,2,3}`:
  - **M19.1** — `max_output_tokens` carries through to valid v2; not archived
  - **M19.2** — `max_input_tokens` carries through (Sprint 1F new field)
  - **M19.3** — production yaml smoke-migrates without `MIGRATION-PRODUCED-INVALID-V2`
- [x] All 40 existing migrate bats green (37 prior + 3 new); no regressions

## Related

- Builds on PR #838 (KF-002 layer 3 backstop) which introduced `max_input_tokens` to the v1 schema.
- KF-006 entry flipped to RESOLVED with closing-evidence row in `grimoires/loa/known-failures.md`.

## Files

- `.claude/data/schemas/model-config-v2.schema.json` — `modelEntry.properties` extended
- `tests/integration/migrate-model-config.bats` — 3 new M19 regression tests
- `grimoires/loa/known-failures.md` — KF-006 RESOLVED + Attempts row

🤖 Generated with [Claude Code](https://claude.com/claude-code)