### PR TITLE
docs(cycle-102 sprint-1F): KF-005 — upgrade path to beads_rust 0.2.4

### DIFF
--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -59,7 +59,7 @@ actually tried, not just what someone *said* was tried.
 | [KF-002](#kf-002-adversarial-reviewsh-empty-content-on-review-type-prompts-at-scale) | MOSTLY-MITIGATED 2026-05-10 (text.format=text + provider fallback chain shipped; only Loa #774 connection-lost layer remains) | adversarial-review.sh review-type | 3 |
 | [KF-003](#kf-003-gpt-55-pro-empty-content-on-27k-input-reasoning-class-prompts) | RESOLVED (model swap) | flatline_protocol code review | 1 |
 | [KF-004](#kf-004-validate_finding-silent-rejection-of-dissenter-payloads) | RESOLVED 2026-05-10 (sidecar dump landed; #814 mitigation shipped) | adversarial-review.sh validation pipeline | ≥4 |
-| [KF-005](#kf-005-beads_rust-021-migration-blocks-task-tracking) | DEGRADED-ACCEPTED | beads_rust task tracking | many |
+| [KF-005](#kf-005-beads_rust-021-migration-blocks-task-tracking) | DEGRADED-ACCEPTED — fix available on crates.io as `beads_rust 0.2.4`; operator must `cargo install beads_rust` to land locally | beads_rust task tracking | many |
 | [KF-006](#kf-006-t114-migrate-model-config-v2-schema-rejects-max_output_tokens) | RESOLVED 2026-05-10 (v2 schema modelEntry permits max_output_tokens + max_input_tokens) | T1.14 migrate-model-config v2 schema | every PR since dd54fe9c |
 | [KF-007](#kf-007-red-team-pipeline-hardcoded-single-model-evaluator-vestigial-config) | RESOLVED 2026-05-10 (multi-model evaluator) | red team pipeline hardcoded single-model evaluator | n/a — resolved in same session as discovery |
 
@@ -297,7 +297,24 @@ again.
 
 ## KF-005: beads_rust 0.2.1 migration blocks task tracking
 
-**Status**: DEGRADED-ACCEPTED (markdown fallback)
+**Status**: DEGRADED-ACCEPTED (markdown fallback) — **fix available on crates.io as `beads_rust 0.2.4`; operator must `cargo install beads_rust` to upgrade locally**
+
+### Upgrade path (verified 2026-05-10)
+
+```bash
+cargo search beads_rust   # → 0.2.4 on crates.io
+br --version              # → br 0.2.1 (still installed locally)
+cargo install beads_rust  # operator action — upgrades user-scoped binary
+br --version              # should now report 0.2.4
+.claude/scripts/beads/beads-health.sh --json | jq .status  # should flip MIGRATION_NEEDED → HEALTHY
+```
+
+Loa #661 was closed upstream 2026-05-02; the schema-migration fix landed in 0.2.2 / 0.2.3 / 0.2.4. Local environments still on 0.2.1 will hit the same migration error documented below — the upstream fix is real, it just needs to be picked up via `cargo install`. If the upgrade does NOT fix the migration locally (i.e., 0.2.4 still hits the NOT NULL `dirty_issues.marked_at` error), file a fresh upstream issue with the new evidence — that would be a regression at the latest release.
+
+(Original entry preserved below.)
+---
+
+**Original Status**: DEGRADED-ACCEPTED (markdown fallback)
 **Feature**: `br` (beads_rust) sprint task lifecycle tracking
 **Symptom**: `br` commands (`br ready`, `br create`, `br update`, `br sync`) fail with `run_migrations failed: NOT NULL constraint failed: dirty_issues.marked_at`. `beads-health.sh --quick --json` returns `MIGRATION_NEEDED` status. SQLite schema migration cannot complete on existing local `.beads/` databases.
 **First observed**: 2026-04 (multiple cycles)
@@ -313,14 +330,22 @@ again.
 | various | `br migrate` / `br init` on existing database | DID NOT WORK — same migration error | NOTES.md cross-cycle |
 | various | Delete `.beads/` and re-initialize | DID NOT WORK in past cycles (operator may have tried more recently — verify before re-attempting) | — |
 | 2026-04+ | Markdown fallback per protocol | WORKS — ledger + reviewer.md + sprint.md checkboxes are sufficient SoT for sprint lifecycle | every cycle since 2026-04 |
+| 2026-05-10 | Verify upstream fix availability (P4.11 from cycle-102 session-9 handoff). `cargo search beads_rust` → 0.2.4 on crates.io; local install is 0.2.1 (3 patch versions behind). `br sync --import-only` on local 0.2.1 reproduces the original error. | UPGRADE PATH IDENTIFIED — operator must run `cargo install beads_rust` to land the upstream fix locally. Markdown fallback remains the safe bet until the upgrade is verified. | crates.io 0.2.4 / Loa #661 (closed 2026-05-02) |
 
 ### Reading guide
 
 Don't try to fix beads_rust mid-sprint. Use the markdown fallback;
 it's the documented protocol. Skill `<beads_workflow>` sections
-already handle the graceful-degradation path. If you find yourself
-spending more than 5 minutes diagnosing beads, stop — the bug is
-upstream and tracked. The markdown fallback is sufficient.
+already handle the graceful-degradation path. **2026-05-10 update**:
+the upstream fix landed in `beads_rust 0.2.2+`; if your local install
+is still 0.2.1, run `cargo install beads_rust` between sessions
+(operator action — touches `~/.cargo/bin/`) to land the fix. Don't do
+this mid-sprint — bin upgrades during agent runs can leave the agent
+in a stale binary-version state. If 0.2.4 still hits the migration
+error, treat as a regression and file a fresh upstream issue with
+new evidence. If you find yourself spending more than 5 minutes
+diagnosing beads, stop — the bug is upstream and tracked. The
+markdown fallback is sufficient.
 
 ---
 


### PR DESCRIPTION
## Summary

Per P4.11 from cycle-102 session-9 handoff: verifies that the upstream fix for Loa [#661](https://github.com/0xHoneyJar/loa/issues/661) is available on crates.io as `beads_rust 0.2.4`, and documents the operator-action upgrade path in `grimoires/loa/known-failures.md` KF-005.

## Background

Loa #661 (beads_rust 0.2.1 schema migration error) was closed upstream 2026-05-02 — but the operator's local environment still runs `br 0.2.1`, so the same `NOT NULL constraint failed: dirty_issues.marked_at` error continues to fire on every commit attempt and pre-commit beads sync. The session-9 handoff explicitly named this as a verification item:

> KF-005 / Loa #661 (beads_rust 0.2.1 migration). Closed upstream 2026-05-02 but the bug is still active in our env. Verify with a fresh `br sync --import-only` to see if upstream fix needs `cargo install beads_rust` to land locally.

## What this PR documents

- Top KF-005 index status now mentions the available upgrade path: `0.2.4 on crates.io`
- New "Upgrade path" subsection with the operator command + expected health-check transition (MIGRATION_NEEDED → HEALTHY)
- New Attempts row capturing the 2026-05-10 verification (crates.io 0.2.4 vs local 0.2.1 reproducing the original error)
- Reading guide updated with upgrade timing guidance ("don't upgrade mid-sprint" — bin upgrades during agent runs can leave the agent in a stale binary-version state)

The same evidence is posted as a comment on [Loa #661](https://github.com/0xHoneyJar/loa/issues/661#issuecomment-4415154276) so future verifications find it on the issue without re-discovering.

## What this PR does NOT do

- Does **not** run `cargo install beads_rust` — that's an operator-action because it touches `~/.cargo/bin/`. The PR documents the path; the operator runs the upgrade between sessions.
- Does **not** flip KF-005 status to RESOLVED — it remains DEGRADED-ACCEPTED until the operator verifies 0.2.4 actually fixes the migration locally. If 0.2.4 still hits the same error, that would be a regression at the latest release and warrants a fresh upstream issue.

## Files

- `grimoires/loa/known-failures.md` — KF-005 entry extended with upgrade-path evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)