### PR TITLE
feat(cycle-107): activate multi-model routing — flip flatline_routing default + verify live

### DIFF
--- a/.claude/loa/CLAUDE.loa.md
+++ b/.claude/loa/CLAUDE.loa.md
@@ -194,6 +194,33 @@ Multi-model adversarial review (Opus + GPT-5.2). HIGH_CONSENSUS auto-integrates,
 
 **Reference**: `.claude/loa/reference/flatline-reference.md`
 
+## Multi-Model Activation (v1.157.0 / cycle-107)
+
+The multi-model stabilization work shipped in cycle-104 (within-company fallback chains T2.5, voice-drop T2.8, MODELINV v1.1 envelope T2.6) routes through the `cheval.py` substrate. Activation is controlled by `hounfour.flatline_routing` in `.loa.config.yaml`.
+
+| Flag value | BB | Flatline | Red-team |
+|-----------|----|---------:|---------:|
+| `flatline_routing: true` (default post-cycle-107) | cheval | cheval | cheval |
+| `flatline_routing: false` (legacy rollback) | cheval (unconditional, BB always uses ChevalDelegateAdapter) | legacy model-adapter.sh.legacy (no chain-walk / voice-drop / MODELINV v1.1) | legacy |
+
+BB is unaffected by the flag — it has used `ChevalDelegateAdapter` unconditionally since cycle-103 PR #846. The flag only gates FL + RT.
+
+When `true`, all three consumers benefit from:
+- **Chain-walk**: cheval walks the within-company `fallback_chain` (e.g. gpt-5.5-pro → gpt-5.5 → gpt-5.3-codex → codex-headless) on retryable errors (EmptyContent, RateLimited, ProviderOutage, RetriesExhausted).
+- **Voice-drop**: when a voice's chain exhausts, flatline-orchestrator DROPS that voice from consensus instead of substituting another company's model. Audit log: `consensus.voice_dropped`.
+- **MODELINV v1.1 envelope**: emits per-invocation audit record at `.run/model-invoke.jsonl` with `final_model_id`, `transport`, `config_observed`, `models_failed[]`, `models_requested[]`.
+
+### Verification (cycle-107 sprint-1)
+
+Live evidence captured under operator config flatline_routing=true:
+- FL 3-model run: 549s, 3 voices' MODELINV envelopes recorded, chains populated, all primaries succeeded
+- RT review: 1 MODELINV envelope, cheval audit signature confirmed
+- BB: verified via cycle-104 sprint-3 T3.4 (4/4 trials at 297-539KB clean)
+
+### Rollback
+
+If a regression surfaces, flip `hounfour.flatline_routing: false` in `.loa.config.yaml` to revert FL + RT to the legacy model-adapter.sh.legacy path. BB unaffected.
+
 ## Invisible Prompt Enhancement (v1.17.0)
 
 Prompts automatically enhanced before skill execution. Silent, logged to trajectory.

--- a/.loa.config.yaml.example
+++ b/.loa.config.yaml.example
@@ -652,15 +652,22 @@ beads:
 # Architecture: SDD §4.1.2 (Config Schema), §4.2 (Routing), §4.5 (Metering)
 # Feature flags and metering — Hounfour Model-Heterogeneous Agent Routing
 hounfour:
-  # Top-level flag — controls whether Flatline uses Hounfour routing
-  # or the legacy direct-call path. Set to true when ready to migrate.
-  flatline_routing: false
+  # Top-level flag — controls whether Flatline + Red-team use cheval
+  # routing or the legacy direct-call path.
+  # cycle-107 (2026-05-12) flipped the default from false → true. Without
+  # cheval routing, the cycle-104 multi-model stabilization work (within-
+  # company chain-walk T2.5, voice-drop T2.8, MODELINV v1.1 envelope T2.6)
+  # is INERT for FL + RT. BB is unaffected — it uses ChevalDelegateAdapter
+  # unconditionally since cycle-103 PR #846.
+  # Rollback path: flip to false to restore the legacy model-adapter.sh.legacy
+  # behavior (no chain-walk, no voice-drop, no MODELINV v1.1).
+  flatline_routing: true
 
   # Per-subsystem feature flags (all default true — opt-out, not opt-in)
   feature_flags:
     google_adapter: true     # Enable Google provider adapter
     deep_research: true      # Enable Deep Research models (Interactions API)
-    flatline_routing: false   # Route Flatline through Hounfour
+    flatline_routing: true   # cycle-107: flipped — engages cheval chain-walk + voice-drop
     metering: true           # Enable BudgetEnforcer cost tracking
     thinking_traces: true    # Include thinking config in request bodies
     jam_geometry: false      # Enable Jam multi-model parallel review (opt-in)

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "active_cycle": "cycle-106-zone-hygiene",
+  "active_cycle": "cycle-107-multimodel-activation",
   "cycles": [
     {
       "id": "cycle-036",
@@ -1202,9 +1202,31 @@
           "tasks": 6
         }
       ]
+    },
+    {
+      "id": "cycle-107-multimodel-activation",
+      "label": "Multi-Model Activation + Live Verification",
+      "status": "in-progress",
+      "created": "2026-05-12T12:18:54Z",
+      "prd": "grimoires/loa/cycles/cycle-107-multimodel-activation/prd.md",
+      "sdd": "grimoires/loa/cycles/cycle-107-multimodel-activation/sdd.md",
+      "sprint_plan": "grimoires/loa/cycles/cycle-107-multimodel-activation/sprint.md",
+      "source_issues": [],
+      "predecessor_cycle": "cycle-106-zone-hygiene",
+      "cycle_folder": "grimoires/loa/cycles/cycle-107-multimodel-activation/",
+      "sprints": [
+        {
+          "local_id": 1,
+          "global_id": 158,
+          "label": "Flip + verify + document",
+          "status": "pending",
+          "scope": "SMALL",
+          "tasks": 8
+        }
+      ]
     }
   ],
-  "global_sprint_counter": 157,
+  "global_sprint_counter": 158,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -1388,5 +1410,5 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260428-i640-1cc190/sprint.md"
     }
   ],
-  "next_sprint_number": 158
+  "next_sprint_number": 159
 }


### PR DESCRIPTION
## Summary

Closes the honest gap identified during cycle-106 cleanup: cycle-104's multi-model stabilization (chain-walk T2.5, voice-drop T2.8, MODELINV v1.1 T2.6) was gated on `hounfour.flatline_routing`, which defaulted to `false`. With the flag off, **FL + RT bypassed cheval entirely** → cycle-104 work was INERT for them. Only BB benefited (always cheval-routed via cycle-103 PR #846).

This PR flips the default + documents activation + reports live verification.

## What changed

| File | Change |
|------|--------|
| `.loa.config.yaml.example` | `flatline_routing: false → true` (default) + inline rationale + rollback path |
| `.claude/loa/CLAUDE.loa.md` | New "Multi-Model Activation (v1.157.0 / cycle-107)" section |

## Live verification

Operator's local config has `flatline_routing: true` (gitignored change — documented in commit message).

| Task | Outcome |
|------|---------|
| T1.3 wiring smoke | `is_flatline_routing_enabled` → ENABLED |
| T1.4 live FL 3-model run | 549s, 3 voices' MODELINV envelopes captured, chains populated, all primaries succeeded |
| T1.5 live RT review | 1 MODELINV envelope, cheval audit signature confirmed, legacy NOT invoked |
| T1.6 live BB run | Pending — will trigger via BB self-review label after this PR opens |

## MODELINV envelope evidence (T1.4)

```jsonc
// secondary (OpenAI voice)
{
  "primitive_id": "MODELINV",
  "final_model_id": "openai:gpt-5.5-pro",
  "transport": "http",
  "models_requested": [
    "openai:gpt-5.5-pro",
    "openai:gpt-5.5",
    "openai:gpt-5.3-codex",
    "openai:codex-headless"
  ],
  "walked": false
}
```

Chain populated correctly. Primary succeeded → no walk needed. Voice-drop wiring is in place (cycle-104 sprint-2 T2.8) but only fires on chain-exhaustion which didn't happen this run.

## Cross-consumer matrix

| Consumer | Dispatch path | Multi-model active? | Verified live? |
|----------|---------------|---------------------|---------------|
| BB | ChevalDelegateAdapter (always) | yes | cycle-104 sprint-3 T3.4 (4/4 at 297-539KB) |
| FL | flatline-orchestrator → cheval (post-flag flip) | **yes** | **T1.4 this PR** |
| RT | adversarial-review → cheval (post-flag flip) | **yes** | **T1.5 this PR** |

## Rollback

If a regression surfaces, flip `hounfour.flatline_routing: false` in `.loa.config.yaml` to revert FL + RT to legacy `model-adapter.sh.legacy`. BB unaffected.

## AC closure

- [x] AC-1 flag flipped
- [x] AC-2 FL multi-model verified
- [x] AC-3 RT cheval-mode verified
- [ ] AC-4 BB 3-model consensus (post-merge)
- [x] AC-5 evidence doc (operator-local per cycle-106 zone hygiene)
- [x] AC-6 CLAUDE.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)