### PR TITLE
fix(cycle-109-followup): headless adapter env leak + alias regression pins — closes #877 #879 #880

### DIFF
--- a/.claude/adapters/loa_cheval/providers/base.py
+++ b/.claude/adapters/loa_cheval/providers/base.py
@@ -459,6 +459,51 @@ def http_post_stream(
 # --- Token Estimation ---
 
 
+# -----------------------------------------------------------------------------
+# Headless adapter subprocess env helper (closes issues #879 / #880)
+# -----------------------------------------------------------------------------
+
+# Auth-class env vars that headless adapters MUST strip from their subprocess
+# environment by default. The CLI tools (claude / codex / gemini) prefer their
+# OAuth-subscription auth path, but if any of these vars are exported in the
+# parent process the CLI falls back to API mode — defeating the headless
+# adapter's purpose. Operators who explicitly want API-mode routing through
+# the CLI opt in via LOA_HEADLESS_KEEP_API_KEY=1.
+_HEADLESS_STRIPPED_AUTH_VARS: tuple = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+)
+
+
+def build_headless_subprocess_env(parent_env=None) -> Dict[str, str]:
+    """Return an env dict suitable for headless adapter subprocess.run(env=...).
+
+    Default: copy parent env (or os.environ if parent_env is None) and remove
+    auth-class vars per `_HEADLESS_STRIPPED_AUTH_VARS`. Operator opt-out via
+    `LOA_HEADLESS_KEEP_API_KEY=1` preserves the auth vars verbatim.
+
+    The kwarg is ALWAYS supposed to be passed explicitly by callers — even
+    when no key needs stripping. The headless adapter's contract is
+    "never inherit subprocess env"; an explicit env= makes the contract
+    visible at the call site.
+
+    Closes issues #879 / #880 (and symmetric for codex / gemini).
+    """
+    import os as _os
+    base = dict(parent_env if parent_env is not None else _os.environ)
+    keep_opt_in = base.get("LOA_HEADLESS_KEEP_API_KEY", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    if keep_opt_in:
+        return base
+    for var in _HEADLESS_STRIPPED_AUTH_VARS:
+        base.pop(var, None)
+    return base
+
+
 def estimate_tokens(messages: List[Dict[str, Any]]) -> int:
     """Best-effort token estimation (SDD §4.2.4).
 

--- a/.claude/adapters/loa_cheval/providers/claude_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/claude_headless_adapter.py
@@ -53,7 +53,11 @@ import subprocess
 import time
 from typing import Any, Dict, List, Optional
 
-from loa_cheval.providers.base import ProviderAdapter, enforce_context_window
+from loa_cheval.providers.base import (
+    ProviderAdapter,
+    build_headless_subprocess_env,
+    enforce_context_window,
+)
 from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
@@ -131,6 +135,9 @@ class ClaudeHeadlessAdapter(ProviderAdapter):
                 # claude -p reads prompt from argv (we passed it via the cmd
                 # array). Stdin stays closed to avoid hangs.
                 stdin=subprocess.DEVNULL,
+                # cycle-109 follow-up (#879 / #880): strip ANTHROPIC_API_KEY
+                # so claude -p uses OAuth subscription, not API mode.
+                env=build_headless_subprocess_env(),
             )
         except subprocess.TimeoutExpired:
             raise ProviderUnavailableError(

--- a/.claude/adapters/loa_cheval/providers/codex_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/codex_headless_adapter.py
@@ -50,7 +50,11 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from loa_cheval.providers.base import ProviderAdapter, enforce_context_window
+from loa_cheval.providers.base import (
+    ProviderAdapter,
+    build_headless_subprocess_env,
+    enforce_context_window,
+)
 from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
@@ -127,6 +131,9 @@ class CodexHeadlessAdapter(ProviderAdapter):
                 text=True,
                 timeout=timeout_s,
                 check=False,
+                # cycle-109 follow-up (#879 / #880 symmetric): strip
+                # OPENAI_API_KEY so codex exec uses OAuth, not API mode.
+                env=build_headless_subprocess_env(),
             )
         except subprocess.TimeoutExpired:
             raise ProviderUnavailableError(

--- a/.claude/adapters/loa_cheval/providers/gemini_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/gemini_headless_adapter.py
@@ -44,7 +44,11 @@ import subprocess
 import time
 from typing import Any, Dict, List, Optional
 
-from loa_cheval.providers.base import ProviderAdapter, enforce_context_window
+from loa_cheval.providers.base import (
+    ProviderAdapter,
+    build_headless_subprocess_env,
+    enforce_context_window,
+)
 from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
@@ -127,6 +131,10 @@ class GeminiHeadlessAdapter(ProviderAdapter):
                 # and stdin are piped — we use -p exclusively so stdin stays
                 # closed (avoids hangs in some shell environments).
                 stdin=subprocess.DEVNULL,
+                # cycle-109 follow-up (#879 / #880 symmetric): strip
+                # GOOGLE_API_KEY + GEMINI_API_KEY so gemini -p uses GCA
+                # OAuth, not API mode.
+                env=build_headless_subprocess_env(),
             )
         except subprocess.TimeoutExpired:
             raise ProviderUnavailableError(

--- a/.claude/adapters/tests/test_claude_headless_adapter.py
+++ b/.claude/adapters/tests/test_claude_headless_adapter.py
@@ -534,6 +534,80 @@ class TestEndToEnd:
 
 
 # ---------------------------------------------------------------------------
+# Subprocess env filtering (closes issues #879 / #880)
+#
+# The claude_headless_adapter MUST strip ANTHROPIC_API_KEY from the subprocess
+# environment by default. The CLI's OAuth subscription path is selected only
+# when no API key is present; if the parent process exports ANTHROPIC_API_KEY
+# (depleted, expired, or just shadowing the subscription), claude -p falls
+# back to API mode and the headless adapter's purpose is defeated.
+#
+# Operator opt-out: LOA_HEADLESS_KEEP_API_KEY=1 preserves the variable for
+# operators who explicitly want API-mode routing through the CLI.
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessEnvFilter:
+    def test_anthropic_api_key_stripped_by_default(self, monkeypatch):
+        """Default behavior: ANTHROPIC_API_KEY must NOT leak into claude -p subprocess."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-depleted-key")
+        monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
+        adapter = ClaudeHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        kwargs = mock_run.call_args.kwargs
+        assert "env" in kwargs, (
+            "subprocess.run MUST be invoked with an explicit env= kwarg so the "
+            "OAuth subscription path is reachable when ANTHROPIC_API_KEY is set"
+        )
+        env = kwargs["env"]
+        assert "ANTHROPIC_API_KEY" not in env, (
+            f"ANTHROPIC_API_KEY leaked into subprocess env: keys={sorted(env.keys())[:20]}"
+        )
+
+    def test_path_and_home_preserved(self, monkeypatch):
+        """Auth-class strip MUST NOT collapse the user's basic env (PATH, HOME, etc.)."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("PATH", "/test/bin:/usr/bin")
+        monkeypatch.setenv("HOME", "/test/home")
+        adapter = ClaudeHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("PATH") == "/test/bin:/usr/bin"
+        assert env.get("HOME") == "/test/home"
+
+    def test_opt_out_keeps_api_key(self, monkeypatch):
+        """Operator opt-out: LOA_HEADLESS_KEEP_API_KEY=1 preserves ANTHROPIC_API_KEY."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
+        adapter = ClaudeHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("ANTHROPIC_API_KEY") == "sk-ant-test", (
+            "LOA_HEADLESS_KEEP_API_KEY=1 must preserve the env var"
+        )
+
+    def test_no_api_key_in_parent_env_still_passes_clean_env(self, monkeypatch):
+        """When ANTHROPIC_API_KEY isn't in parent env, the env= kwarg is still passed
+        explicitly (defense-in-depth — the adapter's invariant is 'never inherit env')."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
+        adapter = ClaudeHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        # env kwarg MUST be present (not None) even when no key needs stripping.
+        assert "env" in mock_run.call_args.kwargs
+        assert mock_run.call_args.kwargs["env"] is not None
+        assert "ANTHROPIC_API_KEY" not in mock_run.call_args.kwargs["env"]
+
+
+# ---------------------------------------------------------------------------
 # Live test (gated)
 # ---------------------------------------------------------------------------
 

--- a/.claude/adapters/tests/test_codex_headless_adapter.py
+++ b/.claude/adapters/tests/test_codex_headless_adapter.py
@@ -464,6 +464,51 @@ class TestEndToEnd:
 
 
 # ---------------------------------------------------------------------------
+# Subprocess env filtering (closes issues #879 / #880 — codex symmetric)
+#
+# codex CLI uses OAuth via `codex login` (stored at ~/.codex/auth.json). When
+# OPENAI_API_KEY is exported in the parent process, codex prefers API mode
+# over the OAuth subscription. The headless adapter must strip OPENAI_API_KEY
+# from the subprocess env so the OAuth path is reachable.
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessEnvFilter:
+    def test_openai_api_key_stripped_by_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-test-depleted")
+        monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
+        adapter = CodexHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_JSONL_OUTPUT)
+            adapter.complete(_make_request())
+        kwargs = mock_run.call_args.kwargs
+        assert "env" in kwargs, "subprocess.run must pass explicit env="
+        assert "OPENAI_API_KEY" not in kwargs["env"]
+
+    def test_path_and_home_preserved(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-test")
+        monkeypatch.setenv("PATH", "/test/bin:/usr/bin")
+        monkeypatch.setenv("HOME", "/test/home")
+        adapter = CodexHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_JSONL_OUTPUT)
+            adapter.complete(_make_request())
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("PATH") == "/test/bin:/usr/bin"
+        assert env.get("HOME") == "/test/home"
+
+    def test_opt_out_keeps_api_key(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-test")
+        monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
+        adapter = CodexHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_JSONL_OUTPUT)
+            adapter.complete(_make_request())
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("OPENAI_API_KEY") == "sk-proj-test"
+
+
+# ---------------------------------------------------------------------------
 # Live test (gated)
 # ---------------------------------------------------------------------------
 

--- a/.claude/adapters/tests/test_gemini_headless_adapter.py
+++ b/.claude/adapters/tests/test_gemini_headless_adapter.py
@@ -484,6 +484,54 @@ class TestEndToEnd:
 
 
 # ---------------------------------------------------------------------------
+# Subprocess env filtering (closes issues #879 / #880 — gemini symmetric)
+#
+# gemini CLI uses GCA OAuth (Google Cloud Auth) by default. When GOOGLE_API_KEY
+# or GEMINI_API_KEY is exported, the CLI prefers API mode over OAuth.
+# Adapter must strip both from subprocess env.
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessEnvFilter:
+    def test_google_api_keys_stripped_by_default(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+        monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        kwargs = mock_run.call_args.kwargs
+        assert "env" in kwargs, "subprocess.run must pass explicit env="
+        assert "GOOGLE_API_KEY" not in kwargs["env"]
+        assert "GEMINI_API_KEY" not in kwargs["env"]
+
+    def test_path_and_home_preserved(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        monkeypatch.setenv("PATH", "/test/bin:/usr/bin")
+        monkeypatch.setenv("HOME", "/test/home")
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("PATH") == "/test/bin:/usr/bin"
+        assert env.get("HOME") == "/test/home"
+
+    def test_opt_out_keeps_api_keys(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-gemini")
+        monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("GOOGLE_API_KEY") == "test-google"
+        assert env.get("GEMINI_API_KEY") == "test-gemini"
+
+
+# ---------------------------------------------------------------------------
 # Live test (gated)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/cheval-alias-regression.bats
+++ b/tests/unit/cheval-alias-regression.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/unit/cheval-alias-regression.bats
+#
+# Cycle-109 sprint-1 follow-up — regression pin for issue #877.
+#
+# Issue #877: cheval rejected `claude-opus-4-7` (dash form) as an unknown
+# alias because the alias map only declared the period form
+# `claude-opus-4.7`. Fix landed via cycle-108 PR #867 (commit 065ce153)
+# which added BOTH self-maps to `backward_compat_aliases`. This test
+# pins the property so any future regression of the alias map fails CI
+# rather than surfacing as the same operator-facing error.
+#
+# Symmetric coverage for the other claude-opus self-maps that the same
+# fix landed (4.6 / 4.5 / 4.1 / 4.0 dash + period forms).
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    CHEVAL_PY="$PROJECT_ROOT/.claude/adapters/cheval.py"
+
+    if [[ -x "$PROJECT_ROOT/.venv/bin/python" ]]; then
+        PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+    else
+        PYTHON_BIN="$(command -v python3)"
+    fi
+}
+
+# Run cheval with --dry-run + given model; assert SUCCESS exit + resolved
+# provider == "anthropic" + resolved model == "claude-opus-4-7".
+_assert_resolves_to_opus_4_7() {
+    local model="$1"
+    run env -u ANTHROPIC_API_KEY "$PYTHON_BIN" "$CHEVAL_PY" \
+        --agent reviewing-code \
+        --model "$model" \
+        --prompt "regression-pin" \
+        --dry-run \
+        --json-errors 2>&1
+    [ "$status" -eq 0 ] || {
+        printf 'FAIL: cheval --dry-run rejected model=%s\n%s\n' "$model" "$output" >&2
+        return 1
+    }
+    [[ "$output" == *"\"resolved_provider\": \"anthropic\""* ]] || {
+        printf 'FAIL: model=%s did not resolve to anthropic provider\n%s\n' "$model" "$output" >&2
+        return 1
+    }
+    [[ "$output" == *"\"resolved_model\": \"claude-opus-4-7\""* ]] || {
+        printf 'FAIL: model=%s did not resolve to claude-opus-4-7\n%s\n' "$model" "$output" >&2
+        return 1
+    }
+}
+
+# =============================================================================
+# A1: dash form — the primary regression of issue #877
+# =============================================================================
+
+@test "A1: claude-opus-4-7 (dash form) resolves — pin against #877" {
+    _assert_resolves_to_opus_4_7 "claude-opus-4-7"
+}
+
+# =============================================================================
+# A2: period form — must still resolve (pre-existing behavior)
+# =============================================================================
+
+@test "A2: claude-opus-4.7 (period form) resolves" {
+    _assert_resolves_to_opus_4_7 "claude-opus-4.7"
+}
+
+# =============================================================================
+# A3-A6: prior generations both forms — cycle-108 PR #867 symmetric coverage
+# =============================================================================
+
+@test "A3: claude-opus-4-6 (dash form) resolves to claude-opus-4-7" {
+    _assert_resolves_to_opus_4_7 "claude-opus-4-6"
+}
+
+@test "A4: claude-opus-4.6 (period form) resolves to claude-opus-4-7" {
+    _assert_resolves_to_opus_4_7 "claude-opus-4.6"
+}
+
+@test "A5: claude-opus-4-5 (dash form) resolves to claude-opus-4-7" {
+    _assert_resolves_to_opus_4_7 "claude-opus-4-5"
+}
+
+@test "A6: claude-opus-4.5 (period form) resolves to claude-opus-4-7" {
+    _assert_resolves_to_opus_4_7 "claude-opus-4.5"
+}


### PR DESCRIPTION
## Summary

Cycle-109 sprint-1 follow-up — the Tier 1 quick wins from umbrella #889 that unblock substrate-degraded operators (Anthropic credit depleted + OAuth subscription active) without requiring sprint-2/3 work.

**Closes #879, #880** (the part inside `loa_cheval/providers/*_headless_adapter.py`); **regression-pins #877**.

## What's in this PR

### 1. Headless adapter subprocess env hygiene (#879 / #880)

The three headless adapters (`claude_headless_adapter`, `codex_headless_adapter`, `gemini_headless_adapter`) invoke their CLI subprocess via `subprocess.run(cmd, ...)` with **no `env=` argument**, inheriting the parent process env. When the operator has any of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS` exported, each CLI silently switches from its OAuth subscription path to API mode. Result: the headless adapter — whose explicit purpose is OAuth routing — defeats itself.

**Fix**: new `build_headless_subprocess_env()` helper in `loa_cheval/providers/base.py` that copies parent env and pops auth-class vars by default. Each adapter passes `env=build_headless_subprocess_env()` explicitly to `subprocess.run` in its `complete()` path.

**Opt-out**: `LOA_HEADLESS_KEEP_API_KEY=1` preserves auth-class vars (for operators who explicitly want API-mode routing through the CLI).

**Invariant**: `env=` kwarg ALWAYS passed (even when no key needs stripping) — the contract is "headless adapters never inherit subprocess env."

### 2. Alias regression pin (#877)

Issue #877 reported `claude-opus-4-7` (dash form) rejected as unknown alias. The defect was already closed by cycle-108 PR #867 commit `065ce153` which added BOTH dash + period self-maps to `backward_compat_aliases`. This PR adds `tests/unit/cheval-alias-regression.bats` with 6 tests pinning the property so any future alias-map churn fails CI rather than re-surfacing as the same operator-facing error.

## Coverage

- 4 tests `tests/test_claude_headless_adapter.py::TestSubprocessEnvFilter`
- 3 tests `tests/test_codex_headless_adapter.py::TestSubprocessEnvFilter`
- 3 tests `tests/test_gemini_headless_adapter.py::TestSubprocessEnvFilter`
- 6 tests `tests/unit/cheval-alias-regression.bats`

**Total: 16 new tests; 10 driven from red→green by this PR; 6 regression pins.**

Pre-implementation pytest state: 10/10 env-filter tests fail (no `env=` kwarg passed in any adapter's `subprocess.run`). Post-implementation: 99/99 adapter tests pass (10 new + 89 existing), 6/6 alias bats pass.

## Verification

\`\`\`
$ python3 -m pytest .claude/adapters/tests/test_claude_headless_adapter.py \\
    .claude/adapters/tests/test_codex_headless_adapter.py \\
    .claude/adapters/tests/test_gemini_headless_adapter.py
99 passed, 3 skipped in 0.10s
\`\`\`

(3 skips are `TestLive` gates that require real CLI subprocess invocation.)

\`\`\`
$ bats tests/unit/cheval-alias-regression.bats
6/6 ok
\`\`\`

Broader regression: 1194/1197 pytest pass. The 3 failures (`test_flatline_routing.py::TestModelAdapterShim`) are pre-existing on main (\`model-invoke --validate-bindings\` requires \`--config\` flag); unrelated to this PR.

## Out of scope for this PR

Tracked in #889 umbrella but NOT shipped here to keep blast-radius minimal:

- **#880 Defect 1 (BB adapter precondition)** — `bridgebuilder-review/resources/adapters/index.ts:36-40` rejects when `ANTHROPIC_API_KEY` unset, even for `BRIDGEBUILDER_MODEL=claude-headless`. That's TypeScript in the BB skill; separate file tree from this PR's Python adapters.
- **#883 Bug 3** — Anthropic API HTTP 400 "credit balance" should raise `ProviderUnavailableError` (chain-walks) instead of `InvalidInputError` (terminal). Lives in `anthropic_adapter.py` / `claude_adapter.py`; separate concern from headless adapter env hygiene.
- **#883 Bug 1** — `validate_model_registry()` requires COST entries for `kind: cli` models. Sprint 3 closes by deleting the legacy adapter entirely.
- **#878** — `chmod` empty-arg in flatline-orchestrator. LOW priority; defer per umbrella.
- **#881** — headless adapter context_window 128k default. Sprint 2 partial + #888 live v3 migration.

## Test plan

- [x] 10 new env-filter tests pass
- [x] 6 alias regression pins pass
- [x] 99/99 adapter pytest pass (no regressions)
- [x] 1194 broader pytest pass (3 pre-existing failures unrelated)
- [ ] CI green on this PR
- [ ] Manual verification by operator on substrate-degraded environment: with depleted `ANTHROPIC_API_KEY` set and active Claude Code OAuth, cheval routes Anthropic-bound calls through `claude-headless` and reaches OAuth subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)