### PR TITLE
cycle-110 sprint-2b1: resolver dispatch_preference + auto-mode + MODELINV v1.4

### DIFF
--- a/.claude/adapters/loa_cheval/audit/modelinv.py
+++ b/.claude/adapters/loa_cheval/audit/modelinv.py
@@ -442,6 +442,17 @@ def emit_model_invoke_complete(
     # (SDD §5.4.4 / IMP-014). Populated when the streaming code path
     # observed (and possibly aborted via) one of the three thresholds.
     streaming_recovery: Optional[Dict[str, Any]] = None,
+    # Cycle-110 sprint-2b1 T2.8 — MODELINV v1.4 additive fields
+    # ([PRD:FR-3.4, FR-7.1], SDD §3.4). All optional — when ALL are None,
+    # the emitted envelope is shape-identical to v1.3. Operators reading v1.3
+    # envelopes tolerate unknown fields per the cycle-109 forward-compat
+    # contract; cycle-110 readers default absent fields to "http_api" /
+    # per_token / None.
+    auth_type_resolved: Optional[str] = None,
+    auth_type_selection_reason: Optional[str] = None,
+    auto_selection_inputs: Optional[Dict[str, Any]] = None,
+    auto_evaluation_timestamp: Optional[float] = None,
+    semaphore_exhausted: Optional[bool] = None,
 ) -> None:
     """Emit a model.invoke.complete envelope to the MODELINV audit chain.
 
@@ -596,6 +607,53 @@ def emit_model_invoke_complete(
         payload["chunked_review"] = dict(chunked_review)
     if streaming_recovery is not None:
         payload["streaming_recovery"] = dict(streaming_recovery)
+
+    # Cycle-110 sprint-2b1 T2.8 — MODELINV v1.4 additive fields.
+    # All four flow through the redactor at the end of this function (the
+    # redactor walks the dict recursively, so adding keys here does not
+    # require redaction-table changes). auth_type_resolved is validated
+    # against the closed enum at the call site (resolver), but we defense-
+    # in-depth re-validate here so a stale caller cannot smuggle bad values.
+    if auth_type_resolved is not None:
+        if auth_type_resolved not in ("headless", "http_api", "aws_iam"):
+            raise ValueError(
+                "emit_model_invoke_complete: auth_type_resolved must be one of "
+                f"('headless', 'http_api', 'aws_iam'), got {auth_type_resolved!r}"
+            )
+        payload["auth_type_resolved"] = auth_type_resolved
+    if auth_type_selection_reason is not None:
+        # Match dispatch_filter.SELECTION_REASONS enum.
+        if auth_type_selection_reason not in (
+            "explicit-dispatch_preference",
+            "auto-band-comparison",
+            "auto-cold-start-recommended_for",
+            "auto-cold-start-default-headless",
+        ):
+            raise ValueError(
+                "emit_model_invoke_complete: auth_type_selection_reason must "
+                "be one of {explicit-dispatch_preference, auto-band-comparison, "
+                "auto-cold-start-recommended_for, auto-cold-start-default-headless}, "
+                f"got {auth_type_selection_reason!r}"
+            )
+        payload["auth_type_selection_reason"] = auth_type_selection_reason
+    if auto_selection_inputs is not None:
+        # Defensive copy + shape check. C11 carry-in: must conform to SDD §3.4
+        # canonical example. Three required keys per the spec.
+        if not isinstance(auto_selection_inputs, dict):
+            raise ValueError(
+                "auto_selection_inputs must be a dict, got "
+                f"{type(auto_selection_inputs).__name__}"
+            )
+        # Defensive copy at top level + dict-coerce on the three sub-keys.
+        _aux: Dict[str, Any] = {}
+        for k in ("sample_n_per_bucket", "band_per_bucket", "success_rate_per_bucket"):
+            if k in auto_selection_inputs and auto_selection_inputs[k] is not None:
+                _aux[k] = dict(auto_selection_inputs[k])
+        payload["auto_selection_inputs"] = _aux
+    if auto_evaluation_timestamp is not None:
+        payload["auto_evaluation_timestamp"] = float(auto_evaluation_timestamp)
+    if semaphore_exhausted is not None:
+        payload["semaphore_exhausted"] = bool(semaphore_exhausted)
 
     # cycle-109 Sprint 2 T2.3 — verdict_quality pass-through (SDD §3.3.1 v1.3
     # additive). Schema additivity: only emit when caller supplied the dict.

--- a/.claude/adapters/loa_cheval/routing/chain_resolver.py
+++ b/.claude/adapters/loa_cheval/routing/chain_resolver.py
@@ -183,11 +183,20 @@ def _build_entry(
     adapter_kind: AdapterKind = kind_raw  # type: ignore[assignment]
 
     capabilities = frozenset(model_cfg.get("capabilities") or ())
+    # Cycle-110 sprint-2b1 (T2.6): propagate auth_type + dispatch_group from
+    # model-config into the resolved entry so downstream callers (auto-mode
+    # algorithm + envelope emitter + CB key derivation) read from one source.
+    # The loader already validated both fields at process start; the empty-
+    # string fallback is defensive for fixture/test paths that bypass loader.
+    auth_type = model_cfg.get("auth_type", "http_api") or "http_api"
+    dispatch_group = model_cfg.get("dispatch_group", "") or ""
     return ResolvedEntry(
         provider=model.provider,
         model_id=model.model_id,
         adapter_kind=adapter_kind,
         capabilities=capabilities,
+        auth_type=auth_type,
+        dispatch_group=dispatch_group,
     )
 
 

--- a/.claude/adapters/loa_cheval/routing/dispatch_filter.py
+++ b/.claude/adapters/loa_cheval/routing/dispatch_filter.py
@@ -1,0 +1,397 @@
+"""Cycle-110 sprint-2b1 — dispatch_preference filter + deterministic auto-mode.
+
+Sits between `chain_resolver.resolve()` (which builds the within-company
+fallback chain) and the cheval invocation loop. Filters the chain by
+`auth_type` according to the operator's `dispatch_preference` setting and,
+for `auto` mode, runs a deterministic band-comparison algorithm against
+windowed MODELINV success-rate stats.
+
+Public surface:
+- :func:`filter_chain_by_dispatch_preference` — given a `ResolvedChain` and
+  a resolved `dispatch_preference`, return a `(filtered_entries, reason)`
+  tuple. `reason` is one of the `auth_type_selection_reason` enum values
+  per [PRD:FR-3.4] / SDD §1.4.7.
+- :func:`run_auto_mode` — the deterministic algorithm for `dispatch_preference=auto`
+  (FR-3.3). Pure function on (chain, stats, config, current_time).
+
+Carry-in closures:
+- C1 (legacy MODELINV dispatch_group derivation) — `_derive_dispatch_group_from_stats`
+  reads from a per-process cache; missing entries → bucket dropped + WARNING.
+- C10 (auto_evaluation_timestamp) — `AutoResolution.evaluation_timestamp` field.
+- C11 (auto_selection_inputs canonical fixture) — `AutoResolution.selection_inputs`
+  shape matches the SDD §3.4 example verbatim.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from loa_cheval.routing.types import (
+    NoEligibleAdapterError,
+    ResolvedChain,
+    ResolvedEntry,
+)
+
+logger = logging.getLogger("loa_cheval.routing.dispatch_filter")
+
+
+# --- Constants ----------------------------------------------------------------
+
+# Dispatch_preference enum (matches advisor-strategy.schema.json)
+DISPATCH_HEADLESS = "headless"
+DISPATCH_HTTP_API = "http_api"
+DISPATCH_AUTO = "auto"
+DISPATCH_PREFERENCES = (DISPATCH_HEADLESS, DISPATCH_HTTP_API, DISPATCH_AUTO)
+
+# auth_type_selection_reason enum (matches MODELINV v1.4 §1.4.7).
+SELECTION_REASON_EXPLICIT = "explicit-dispatch_preference"
+SELECTION_REASON_AUTO_BAND = "auto-band-comparison"
+SELECTION_REASON_AUTO_RECOMMENDED = "auto-cold-start-recommended_for"
+SELECTION_REASON_AUTO_DEFAULT = "auto-cold-start-default-headless"
+SELECTION_REASONS = (
+    SELECTION_REASON_EXPLICIT,
+    SELECTION_REASON_AUTO_BAND,
+    SELECTION_REASON_AUTO_RECOMMENDED,
+    SELECTION_REASON_AUTO_DEFAULT,
+)
+
+# Auto-mode thresholds (SDD §5.2 v1.1)
+AUTO_MODE_SAMPLE_SIZE_MIN = 20           # N≥20 per bucket for warm comparison
+AUTO_MODE_RECENCY_WINDOW_SECONDS = 86400  # 24h
+AUTO_MODE_BAND_GREEN_MIN = 0.80           # ≥80% success → green
+AUTO_MODE_BAND_YELLOW_MIN = 0.50          # 50-80% → yellow
+
+# Cross-auth fallback per FR-1.4 — when dispatch_preference=http_api,
+# include aws_iam in the same "http-ish" bucket (Bedrock fits the
+# http_api-vs-headless dichotomy on the HTTP side).
+HTTP_API_LIKE_AUTH_TYPES = frozenset({"http_api", "aws_iam"})
+
+
+# --- Data types ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AutoResolution:
+    """Output of the auto-mode algorithm (FR-3.4 MODELINV v1.4 input).
+
+    All fields are JSON-serializable for direct inclusion in the
+    `auto_selection_inputs` MODELINV envelope field.
+    """
+
+    selected_auth_type: str  # "headless" | "http_api" | "aws_iam"
+    reason: str              # one of SELECTION_REASONS
+    evaluation_timestamp: float  # C10 — epoch seconds when auto-mode ran
+    sample_n_per_bucket: Dict[str, int] = field(default_factory=dict)
+    band_per_bucket: Dict[str, str] = field(default_factory=dict)
+    success_rate_per_bucket: Dict[str, float] = field(default_factory=dict)
+
+    def as_selection_inputs(self) -> Dict[str, Any]:
+        """Return the `auto_selection_inputs` MODELINV envelope sub-dict
+        (C11 canonical shape from SDD §3.4)."""
+        return {
+            "sample_n_per_bucket": dict(self.sample_n_per_bucket),
+            "band_per_bucket": dict(self.band_per_bucket),
+            "success_rate_per_bucket": dict(self.success_rate_per_bucket),
+        }
+
+
+# --- T2.6: dispatch_preference filter ----------------------------------------
+
+
+def _entry_matches_preference(
+    entry: ResolvedEntry,
+    dispatch_preference: str,
+) -> bool:
+    """Return True if `entry` matches the operator's dispatch_preference.
+
+    Semantics ([PRD:FR-3.1, FR-3.2]):
+    - `headless` → only entries with auth_type == "headless".
+    - `http_api` → entries with auth_type ∈ {"http_api", "aws_iam"}.
+    - `auto`     → match all entries (caller passes filtered chain post-auto).
+    """
+    if dispatch_preference == DISPATCH_HEADLESS:
+        return entry.auth_type == "headless"
+    if dispatch_preference == DISPATCH_HTTP_API:
+        return entry.auth_type in HTTP_API_LIKE_AUTH_TYPES
+    if dispatch_preference == DISPATCH_AUTO:
+        return True
+    raise ValueError(
+        f"dispatch_preference must be one of {DISPATCH_PREFERENCES}, "
+        f"got {dispatch_preference!r}"
+    )
+
+
+def filter_chain_by_dispatch_preference(
+    chain: ResolvedChain,
+    *,
+    dispatch_preference: str,
+    allow_cross_auth_fallback: bool,
+    auto_resolution: Optional[AutoResolution] = None,
+) -> Tuple[List[ResolvedEntry], str]:
+    """Apply the operator's dispatch_preference filter to a within-company chain.
+
+    Args:
+        chain: output of `chain_resolver.resolve()`. The within-company invariant
+            is already enforced.
+        dispatch_preference: one of `DISPATCH_PREFERENCES`. For `auto`, the caller
+            MUST also pass `auto_resolution` (the deterministic algorithm's output).
+        allow_cross_auth_fallback: when True AND the preferred-auth_type chain
+            is exhausted, append the other auth_type entries as fallback (FR-1.2).
+        auto_resolution: required when `dispatch_preference == "auto"`. Carries
+            the auto-mode algorithm's selected auth_type + reason.
+
+    Returns:
+        `(filtered_entries, auth_type_selection_reason)` per [PRD:FR-3.4].
+
+    Raises:
+        NoEligibleAdapterError: when filtering produces an empty chain AND
+            cross-auth fallback is disabled or also empty.
+        ValueError: on invalid dispatch_preference or missing auto_resolution.
+    """
+    if dispatch_preference not in DISPATCH_PREFERENCES:
+        raise ValueError(
+            f"dispatch_preference must be one of {DISPATCH_PREFERENCES}, "
+            f"got {dispatch_preference!r}"
+        )
+
+    if dispatch_preference == DISPATCH_AUTO:
+        if auto_resolution is None:
+            raise ValueError(
+                "filter_chain_by_dispatch_preference: dispatch_preference=auto "
+                "requires auto_resolution (run_auto_mode output)"
+            )
+        # Auto-mode resolves to a concrete auth_type; treat it as explicit
+        # downstream. The reason carries the auto sub-class.
+        effective_pref = (
+            DISPATCH_HEADLESS
+            if auto_resolution.selected_auth_type == "headless"
+            else DISPATCH_HTTP_API
+        )
+        reason = auto_resolution.reason
+    else:
+        effective_pref = dispatch_preference
+        reason = SELECTION_REASON_EXPLICIT
+
+    preferred: List[ResolvedEntry] = [
+        e for e in chain.entries if _entry_matches_preference(e, effective_pref)
+    ]
+
+    if preferred:
+        if allow_cross_auth_fallback:
+            # Append the non-preferred entries AFTER all preferred entries.
+            non_preferred = [
+                e for e in chain.entries
+                if not _entry_matches_preference(e, effective_pref)
+            ]
+            return preferred + non_preferred, reason
+        return preferred, reason
+
+    # Preferred bucket empty.
+    if allow_cross_auth_fallback:
+        # Fall back to the whole chain (within-company is the SDD invariant).
+        non_preferred = [
+            e for e in chain.entries
+            if not _entry_matches_preference(e, effective_pref)
+        ]
+        if non_preferred:
+            return non_preferred, reason
+
+    raise NoEligibleAdapterError(
+        primary_alias=chain.primary_alias,
+        headless_mode=chain.headless_mode,
+        reason=(
+            f"dispatch_preference={dispatch_preference!r} produced empty chain "
+            f"for {chain.primary_alias!r} (within-company entries: "
+            f"{[e.canonical + '|' + e.auth_type for e in chain.entries]}); "
+            f"allow_cross_auth_fallback={allow_cross_auth_fallback}"
+        ),
+    )
+
+
+# --- T2.7: deterministic auto-mode algorithm ---------------------------------
+
+
+def _classify_band(success_rate: float) -> str:
+    if success_rate >= AUTO_MODE_BAND_GREEN_MIN:
+        return "green"
+    if success_rate >= AUTO_MODE_BAND_YELLOW_MIN:
+        return "yellow"
+    return "red"
+
+
+def _bucket_stats_for_chain(
+    chain: ResolvedChain,
+    stats: Dict[Tuple[str, str], Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
+    """Aggregate per-auth_type stats across the entries of a chain.
+
+    Args:
+        chain: resolved chain whose entries all share dispatch_group.
+        stats: pre-computed per-(dispatch_group, auth_type) windowed stats:
+            {("anthropic-claude", "headless"): {"n": 124, "success_rate": 0.984},
+             ("anthropic-claude", "http_api"): {"n": 87, "success_rate": 0.862}, ...}
+
+    Returns:
+        {auth_type: {"n": int, "success_rate": float}, ...} for the auth_types
+        present in the chain. Buckets that have NO stats at all are omitted.
+    """
+    auth_types_in_chain = {e.auth_type for e in chain.entries}
+    # Pick a representative dispatch_group from the primary entry (within-
+    # company invariant ⇒ all entries share dispatch_group when populated).
+    dg = chain.entries[0].dispatch_group
+    out: Dict[str, Dict[str, Any]] = {}
+    for at in auth_types_in_chain:
+        key = (dg, at)
+        if key in stats:
+            out[at] = dict(stats[key])
+    return out
+
+
+def _select_with_margin(
+    bucket_stats: Dict[str, Dict[str, Any]],
+    *,
+    headless_margin_bps: int,
+) -> Optional[str]:
+    """Return the winning auth_type per the SDD §5.2 band-comparison + margin.
+
+    Returns None when no bucket has N >= AUTO_MODE_SAMPLE_SIZE_MIN.
+    """
+    warm = {
+        at: data for at, data in bucket_stats.items()
+        if data.get("n", 0) >= AUTO_MODE_SAMPLE_SIZE_MIN
+    }
+    if not warm:
+        return None
+
+    # Sort by success_rate descending; deterministic tie-break by auth_type
+    # name ascending (headless < http_api < aws_iam lexicographic — fine since
+    # the SDD's intent is "headless wins ties at the band-comparison layer").
+    ranked = sorted(
+        warm.items(),
+        key=lambda kv: (-kv[1].get("success_rate", 0.0), kv[0]),
+    )
+    top_at, top_data = ranked[0]
+    # Headless preference margin: if a headless bucket exists and is within
+    # `headless_margin_bps / 10000` of the top, headless wins.
+    if "headless" in warm and top_at != "headless":
+        head_rate = warm["headless"].get("success_rate", 0.0)
+        top_rate = top_data.get("success_rate", 0.0)
+        margin = headless_margin_bps / 10000.0
+        if (top_rate - head_rate) <= margin:
+            return "headless"
+    return top_at
+
+
+def run_auto_mode(
+    chain: ResolvedChain,
+    *,
+    stats: Dict[Tuple[str, str], Dict[str, Any]],
+    advisor_config: Optional[Dict[str, Any]] = None,
+    capability_evaluation: Optional[Dict[str, Any]] = None,
+    now: Optional[float] = None,
+) -> AutoResolution:
+    """Deterministic auto-mode resolution ([PRD:FR-3.3], SDD §5.2 v1.1).
+
+    Decision tree:
+      1. If any bucket in the chain has N >= AUTO_MODE_SAMPLE_SIZE_MIN, use the
+         band-comparison algorithm with headless_margin_bps preference.
+         Reason: auto-band-comparison.
+      2. Else (cold-start), if capability_evaluation.recommended_for hints
+         a specific auth_type, use that.
+         Reason: auto-cold-start-recommended_for.
+      3. Else, default to headless when the chain has a headless entry,
+         otherwise the first available auth_type.
+         Reason: auto-cold-start-default-headless.
+
+    The algorithm is a pure function on (chain, stats, advisor_config,
+    capability_evaluation, now) — same inputs ⇒ byte-identical AutoResolution.
+    FR-8.7 deterministic-replica test pins this.
+
+    Args:
+        chain: resolved within-company chain.
+        stats: per-(dispatch_group, auth_type) windowed stats. Empty dict in
+            tests / cold-start.
+        advisor_config: parsed advisor_strategy section. Used to read
+            `auto_mode.headless_margin_bps` (default 200).
+        capability_evaluation: capability-aware substrate evaluation from
+            the pre-flight gate (cycle-109 Sprint 1). Used for `recommended_for`
+            cold-start hint.
+        now: injected current time for tests; defaults to time.time().
+
+    Returns:
+        AutoResolution carrying selected auth_type + reason + per-bucket stats.
+    """
+    eval_ts = now if now is not None else time.time()
+    config = advisor_config or {}
+    auto_mode_cfg = config.get("auto_mode") or {}
+    headless_margin_bps = int(auto_mode_cfg.get("headless_margin_bps", 200))
+
+    bucket_stats = _bucket_stats_for_chain(chain, stats)
+
+    sample_n = {at: int(d.get("n", 0)) for at, d in bucket_stats.items()}
+    rates = {at: float(d.get("success_rate", 0.0)) for at, d in bucket_stats.items()}
+    bands = {at: _classify_band(r) for at, r in rates.items()}
+
+    # Phase 1: warm path — band-comparison.
+    warm_winner = _select_with_margin(bucket_stats, headless_margin_bps=headless_margin_bps)
+    if warm_winner is not None:
+        return AutoResolution(
+            selected_auth_type=warm_winner,
+            reason=SELECTION_REASON_AUTO_BAND,
+            evaluation_timestamp=eval_ts,
+            sample_n_per_bucket=sample_n,
+            band_per_bucket=bands,
+            success_rate_per_bucket=rates,
+        )
+
+    # Phase 2: cold-start recommended_for hint.
+    if capability_evaluation:
+        rec = capability_evaluation.get("recommended_for") or []
+        rec_auth_types = {r for r in rec if r in ("headless", "http_api", "aws_iam")}
+        # Pick the first chain entry whose auth_type is in rec_auth_types.
+        for entry in chain.entries:
+            if entry.auth_type in rec_auth_types:
+                return AutoResolution(
+                    selected_auth_type=entry.auth_type,
+                    reason=SELECTION_REASON_AUTO_RECOMMENDED,
+                    evaluation_timestamp=eval_ts,
+                    sample_n_per_bucket=sample_n,
+                    band_per_bucket=bands,
+                    success_rate_per_bucket=rates,
+                )
+
+    # Phase 3: cold-start default — prefer headless.
+    chain_auth_types = [e.auth_type for e in chain.entries]
+    default = "headless" if "headless" in chain_auth_types else chain_auth_types[0]
+    return AutoResolution(
+        selected_auth_type=default,
+        reason=SELECTION_REASON_AUTO_DEFAULT,
+        evaluation_timestamp=eval_ts,
+        sample_n_per_bucket=sample_n,
+        band_per_bucket=bands,
+        success_rate_per_bucket=rates,
+    )
+
+
+__all__ = [
+    "AUTO_MODE_BAND_GREEN_MIN",
+    "AUTO_MODE_BAND_YELLOW_MIN",
+    "AUTO_MODE_RECENCY_WINDOW_SECONDS",
+    "AUTO_MODE_SAMPLE_SIZE_MIN",
+    "AutoResolution",
+    "DISPATCH_AUTO",
+    "DISPATCH_HEADLESS",
+    "DISPATCH_HTTP_API",
+    "DISPATCH_PREFERENCES",
+    "HTTP_API_LIKE_AUTH_TYPES",
+    "SELECTION_REASONS",
+    "SELECTION_REASON_AUTO_BAND",
+    "SELECTION_REASON_AUTO_DEFAULT",
+    "SELECTION_REASON_AUTO_RECOMMENDED",
+    "SELECTION_REASON_EXPLICIT",
+    "filter_chain_by_dispatch_preference",
+    "run_auto_mode",
+]

--- a/.claude/adapters/loa_cheval/routing/dispatch_filter.py
+++ b/.claude/adapters/loa_cheval/routing/dispatch_filter.py
@@ -73,12 +73,21 @@ HTTP_API_LIKE_AUTH_TYPES = frozenset({"http_api", "aws_iam"})
 # --- Data types ---------------------------------------------------------------
 
 
+_VALID_AUTH_TYPES_FOR_RESOLUTION = ("headless", "http_api", "aws_iam")
+
+
 @dataclass(frozen=True)
 class AutoResolution:
     """Output of the auto-mode algorithm (FR-3.4 MODELINV v1.4 input).
 
     All fields are JSON-serializable for direct inclusion in the
     `auto_selection_inputs` MODELINV envelope field.
+
+    BB iter-1 #905 F-002 closure: `selected_auth_type` is validated against
+    the closed auth_type enum at construction. Previously, an invalid value
+    would silently collapse to http_api at filter-time, producing a MODELINV
+    envelope whose `auth_type_resolved` lied about which bucket the dispatch
+    actually traversed.
     """
 
     selected_auth_type: str  # "headless" | "http_api" | "aws_iam"
@@ -87,6 +96,19 @@ class AutoResolution:
     sample_n_per_bucket: Dict[str, int] = field(default_factory=dict)
     band_per_bucket: Dict[str, str] = field(default_factory=dict)
     success_rate_per_bucket: Dict[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.selected_auth_type not in _VALID_AUTH_TYPES_FOR_RESOLUTION:
+            raise ValueError(
+                "AutoResolution.selected_auth_type must be one of "
+                f"{_VALID_AUTH_TYPES_FOR_RESOLUTION}, got "
+                f"{self.selected_auth_type!r}"
+            )
+        if self.reason not in SELECTION_REASONS:
+            raise ValueError(
+                f"AutoResolution.reason must be one of {SELECTION_REASONS}, "
+                f"got {self.reason!r}"
+            )
 
     def as_selection_inputs(self) -> Dict[str, Any]:
         """Return the `auto_selection_inputs` MODELINV envelope sub-dict
@@ -111,6 +133,11 @@ def _entry_matches_preference(
     - `headless` → only entries with auth_type == "headless".
     - `http_api` → entries with auth_type ∈ {"http_api", "aws_iam"}.
     - `auto`     → match all entries (caller passes filtered chain post-auto).
+
+    BB iter-1 #905 F-002 NOTE: for `auto` mode, the caller MUST use
+    `_entry_matches_auto_resolved_auth_type` directly with the resolved
+    auth_type (not this function's binary preference enum) so aws_iam
+    selections route through aws_iam buckets, not the http_api collapse.
     """
     if dispatch_preference == DISPATCH_HEADLESS:
         return entry.auth_type == "headless"
@@ -122,6 +149,21 @@ def _entry_matches_preference(
         f"dispatch_preference must be one of {DISPATCH_PREFERENCES}, "
         f"got {dispatch_preference!r}"
     )
+
+
+def _entry_matches_auto_resolved_auth_type(
+    entry: ResolvedEntry,
+    resolved_auth_type: str,
+) -> bool:
+    """Exact-auth_type match used by auto-mode dispatch (F-002 closure).
+
+    Unlike `_entry_matches_preference`, this does NOT collapse aws_iam +
+    http_api into one HTTP-like bucket. Auto-mode selects a SPECIFIC
+    auth_type from the chain; the filter MUST honor that selection
+    exactly so the emitted `auth_type_resolved` matches the bucket the
+    dispatch actually traverses.
+    """
+    return entry.auth_type == resolved_auth_type
 
 
 def filter_chain_by_dispatch_preference(
@@ -163,17 +205,40 @@ def filter_chain_by_dispatch_preference(
                 "filter_chain_by_dispatch_preference: dispatch_preference=auto "
                 "requires auto_resolution (run_auto_mode output)"
             )
-        # Auto-mode resolves to a concrete auth_type; treat it as explicit
-        # downstream. The reason carries the auto sub-class.
-        effective_pref = (
-            DISPATCH_HEADLESS
-            if auto_resolution.selected_auth_type == "headless"
-            else DISPATCH_HTTP_API
-        )
+        # BB iter-1 #905 F-002 closure: auto-mode selects a SPECIFIC auth_type
+        # — do NOT collapse to the binary preference enum (which would route
+        # aws_iam selections through http_api buckets and produce a MODELINV
+        # `auth_type_resolved` mismatch with the bucket actually traversed).
+        # Match on the resolved auth_type verbatim.
+        resolved_at = auto_resolution.selected_auth_type
         reason = auto_resolution.reason
-    else:
-        effective_pref = dispatch_preference
-        reason = SELECTION_REASON_EXPLICIT
+        preferred: List[ResolvedEntry] = [
+            e for e in chain.entries
+            if _entry_matches_auto_resolved_auth_type(e, resolved_at)
+        ]
+        # Compute the non-preferred set for the xfb branch below using the
+        # same exact-match semantics — non-preferred = chain MINUS preferred.
+        non_preferred: List[ResolvedEntry] = [
+            e for e in chain.entries
+            if not _entry_matches_auto_resolved_auth_type(e, resolved_at)
+        ]
+        if preferred:
+            if allow_cross_auth_fallback:
+                return preferred + non_preferred, reason
+            return preferred, reason
+        if allow_cross_auth_fallback and non_preferred:
+            return non_preferred, reason
+        raise NoEligibleAdapterError(
+            primary_alias=chain.primary_alias,
+            headless_mode=chain.headless_mode,
+            reason=(
+                f"auto-mode resolved auth_type={resolved_at!r} produced "
+                f"empty chain for {chain.primary_alias!r}"
+            ),
+        )
+
+    effective_pref = dispatch_preference
+    reason = SELECTION_REASON_EXPLICIT
 
     preferred: List[ResolvedEntry] = [
         e for e in chain.entries if _entry_matches_preference(e, effective_pref)

--- a/.claude/adapters/loa_cheval/routing/types.py
+++ b/.claude/adapters/loa_cheval/routing/types.py
@@ -44,12 +44,22 @@ class ResolvedEntry:
 
     Immutable. Constructed only via chain_resolver.resolve() so that the
     within-company invariant and capability frozenset are enforced uniformly.
+
+    Cycle-110 sprint-2b1 (T2.6): adds `auth_type` + `dispatch_group` per-entry
+    metadata. Both default to "http_api" / "" for backward-compat with pre-
+    cycle-110 callers that build ResolvedEntry directly (tests). Production
+    callers always go through chain_resolver.resolve() which populates from
+    model-config.
     """
 
     provider: str  # e.g. "openai" / "anthropic" / "google"
     model_id: str  # e.g. "gpt-5.5-pro" or "codex-headless"
     adapter_kind: AdapterKind  # "http" or "cli"
     capabilities: FrozenSet[str]  # e.g. frozenset({"chat", "tools"})
+    # Cycle-110 additive fields (FR-2.3 propagation). Default-valued so legacy
+    # constructors don't break; chain_resolver populates from model-config.
+    auth_type: str = "http_api"
+    dispatch_group: str = ""
 
     def __post_init__(self) -> None:
         if self.adapter_kind not in ADAPTER_KINDS:
@@ -61,6 +71,15 @@ class ResolvedEntry:
             raise TypeError(
                 "ResolvedEntry.capabilities must be a frozenset (got "
                 f"{type(self.capabilities).__name__})"
+            )
+        # Cycle-110: validate auth_type. Tolerate empty dispatch_group at this
+        # layer — chain_resolver populates from model-config which is loader-
+        # validated. The default-empty path lets test fixtures keep working.
+        if self.auth_type not in ("headless", "http_api", "aws_iam"):
+            raise ValueError(
+                "ResolvedEntry.auth_type must be one of "
+                "('headless', 'http_api', 'aws_iam'), "
+                f"got {self.auth_type!r}"
             )
 
     @property

--- a/.claude/adapters/tests/test_dispatch_filter.py
+++ b/.claude/adapters/tests/test_dispatch_filter.py
@@ -268,6 +268,82 @@ class TestInvalidDispatchPreference:
             )
 
 
+class TestAutoModeAwsIamPreservation:
+    """BB iter-1 #905 F-002 closure: auto-mode selecting aws_iam must route
+    through aws_iam buckets, NOT collapse to http_api."""
+
+    def test_aws_iam_selected_uses_exact_aws_iam_filter(self):
+        bedrock_chain = _chain(
+            _entry("bedrock", "us.anthropic.claude-opus-4-7", "aws_iam",
+                   dispatch_group="bedrock-anthropic"),
+            _entry("bedrock", "us.anthropic.claude-sonnet-4-6", "aws_iam",
+                   dispatch_group="bedrock-anthropic"),
+        )
+        ar = AutoResolution(
+            selected_auth_type="aws_iam",
+            reason=SELECTION_REASON_AUTO_BAND,
+            evaluation_timestamp=1.0,
+        )
+        out, reason = filter_chain_by_dispatch_preference(
+            bedrock_chain, dispatch_preference=DISPATCH_AUTO,
+            allow_cross_auth_fallback=False, auto_resolution=ar,
+        )
+        assert all(e.auth_type == "aws_iam" for e in out)
+        assert reason == SELECTION_REASON_AUTO_BAND
+
+    def test_aws_iam_selected_does_NOT_pull_http_api_entries(self):
+        # Mixed chain: aws_iam selection must NOT pick up http_api entries
+        # (the pre-fix collapse would have).
+        mixed = _chain(
+            _entry("bedrock", "us.anthropic.claude-opus-4-7", "aws_iam",
+                   dispatch_group="bedrock-anthropic"),
+            _entry("bedrock", "us.anthropic.claude-sonnet-4-6", "http_api",
+                   dispatch_group="bedrock-anthropic"),
+        )
+        ar = AutoResolution(
+            selected_auth_type="aws_iam",
+            reason=SELECTION_REASON_AUTO_BAND,
+            evaluation_timestamp=1.0,
+        )
+        out, _ = filter_chain_by_dispatch_preference(
+            mixed, dispatch_preference=DISPATCH_AUTO,
+            allow_cross_auth_fallback=False, auto_resolution=ar,
+        )
+        # Only the aws_iam entry; http_api entry is NOT preferred under
+        # auto-mode aws_iam selection.
+        assert len(out) == 1
+        assert out[0].auth_type == "aws_iam"
+
+
+class TestAutoResolutionConstructionValidation:
+    """BB iter-1 #905 F-002 closure: AutoResolution validates at construction."""
+
+    def test_invalid_selected_auth_type_raises(self):
+        with pytest.raises(ValueError, match="selected_auth_type"):
+            AutoResolution(
+                selected_auth_type="subscription",  # not in enum
+                reason=SELECTION_REASON_AUTO_BAND,
+                evaluation_timestamp=1.0,
+            )
+
+    def test_invalid_reason_raises(self):
+        with pytest.raises(ValueError, match="reason"):
+            AutoResolution(
+                selected_auth_type="headless",
+                reason="bogus-reason",
+                evaluation_timestamp=1.0,
+            )
+
+    def test_all_three_valid_auth_types_construct(self):
+        for at in ("headless", "http_api", "aws_iam"):
+            ar = AutoResolution(
+                selected_auth_type=at,
+                reason=SELECTION_REASON_AUTO_BAND,
+                evaluation_timestamp=1.0,
+            )
+            assert ar.selected_auth_type == at
+
+
 # --- T2.7 coverage — auto-mode algorithm -------------------------------------
 
 

--- a/.claude/adapters/tests/test_dispatch_filter.py
+++ b/.claude/adapters/tests/test_dispatch_filter.py
@@ -1,0 +1,416 @@
+"""Cycle-110 sprint-2b1 T2.13 / T2.17 — dispatch_filter coverage.
+
+Tests `loa_cheval.routing.dispatch_filter`:
+- filter_chain_by_dispatch_preference (T2.6): 3 dispatch_preference × 3 chain
+  shapes × 2 cross-auth-fallback settings = 18 cells (FR-8.1 cell count).
+- run_auto_mode (T2.7): warm-path band comparison + cold-start branches +
+  margin tie-breaker.
+- AutoResolution.as_selection_inputs (C11 canonical shape).
+- Deterministic-replica test (T2.17 / FR-8.7): identical input → identical
+  AutoResolution.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from loa_cheval.routing.dispatch_filter import (  # noqa: E402
+    AUTO_MODE_SAMPLE_SIZE_MIN,
+    AutoResolution,
+    DISPATCH_AUTO,
+    DISPATCH_HEADLESS,
+    DISPATCH_HTTP_API,
+    SELECTION_REASON_AUTO_BAND,
+    SELECTION_REASON_AUTO_DEFAULT,
+    SELECTION_REASON_AUTO_RECOMMENDED,
+    SELECTION_REASON_EXPLICIT,
+    filter_chain_by_dispatch_preference,
+    run_auto_mode,
+)
+from loa_cheval.routing.types import (  # noqa: E402
+    NoEligibleAdapterError,
+    ResolvedChain,
+    ResolvedEntry,
+)
+
+
+# --- Fixtures ----------------------------------------------------------------
+
+
+def _entry(provider, model_id, auth_type, *, dispatch_group="anthropic-claude", adapter_kind="http"):
+    return ResolvedEntry(
+        provider=provider,
+        model_id=model_id,
+        adapter_kind=adapter_kind,
+        capabilities=frozenset(["chat"]),
+        auth_type=auth_type,
+        dispatch_group=dispatch_group,
+    )
+
+
+def _chain(*entries, primary_alias=None):
+    return ResolvedChain(
+        primary_alias=primary_alias or entries[0].model_id,
+        entries=tuple(entries),
+        headless_mode="prefer-api",
+        headless_mode_source="default",
+    )
+
+
+# Three canonical chain shapes for the 18-cell matrix.
+MIXED_CHAIN = _chain(
+    _entry("anthropic", "claude-headless", "headless", adapter_kind="cli"),
+    _entry("anthropic", "claude-opus-4-7", "http_api"),
+)
+HEADLESS_ONLY_CHAIN = _chain(
+    _entry("anthropic", "claude-headless", "headless", adapter_kind="cli"),
+)
+HTTP_API_ONLY_CHAIN = _chain(
+    _entry("anthropic", "claude-opus-4-7", "http_api"),
+    _entry("anthropic", "claude-opus-4-6", "http_api"),
+)
+
+
+# --- T2.6 coverage — 18 cells ------------------------------------------------
+
+
+class TestDispatchPreferenceMatrix:
+    """T2.13 / FR-8.1: 3 dispatch_preference × 3 chain shapes × 2 cross-auth
+    fallback settings = 18 cells. Each test row pins (preference, chain, xfb)
+    → expected outcome."""
+
+    # ---- dispatch_preference=headless (6 cells) ----
+
+    def test_headless_pref_mixed_chain_no_xfb(self):
+        out, reason = filter_chain_by_dispatch_preference(
+            MIXED_CHAIN, dispatch_preference=DISPATCH_HEADLESS,
+            allow_cross_auth_fallback=False,
+        )
+        assert [e.canonical for e in out] == ["anthropic:claude-headless"]
+        assert reason == SELECTION_REASON_EXPLICIT
+
+    def test_headless_pref_mixed_chain_with_xfb(self):
+        out, reason = filter_chain_by_dispatch_preference(
+            MIXED_CHAIN, dispatch_preference=DISPATCH_HEADLESS,
+            allow_cross_auth_fallback=True,
+        )
+        # Preferred (headless) first, then non-preferred (http_api) appended.
+        assert [e.canonical for e in out] == [
+            "anthropic:claude-headless", "anthropic:claude-opus-4-7",
+        ]
+        assert reason == SELECTION_REASON_EXPLICIT
+
+    def test_headless_pref_headless_only_chain_no_xfb(self):
+        out, _ = filter_chain_by_dispatch_preference(
+            HEADLESS_ONLY_CHAIN, dispatch_preference=DISPATCH_HEADLESS,
+            allow_cross_auth_fallback=False,
+        )
+        assert len(out) == 1 and out[0].auth_type == "headless"
+
+    def test_headless_pref_headless_only_chain_with_xfb(self):
+        out, _ = filter_chain_by_dispatch_preference(
+            HEADLESS_ONLY_CHAIN, dispatch_preference=DISPATCH_HEADLESS,
+            allow_cross_auth_fallback=True,
+        )
+        assert len(out) == 1 and out[0].auth_type == "headless"
+
+    def test_headless_pref_http_only_chain_no_xfb_raises(self):
+        with pytest.raises(NoEligibleAdapterError, match="dispatch_preference"):
+            filter_chain_by_dispatch_preference(
+                HTTP_API_ONLY_CHAIN, dispatch_preference=DISPATCH_HEADLESS,
+                allow_cross_auth_fallback=False,
+            )
+
+    def test_headless_pref_http_only_chain_with_xfb_falls_back(self):
+        out, _ = filter_chain_by_dispatch_preference(
+            HTTP_API_ONLY_CHAIN, dispatch_preference=DISPATCH_HEADLESS,
+            allow_cross_auth_fallback=True,
+        )
+        # Cross-auth fallback returns the http_api chain.
+        assert [e.auth_type for e in out] == ["http_api", "http_api"]
+
+    # ---- dispatch_preference=http_api (6 cells) ----
+
+    def test_http_pref_mixed_chain_no_xfb(self):
+        out, _ = filter_chain_by_dispatch_preference(
+            MIXED_CHAIN, dispatch_preference=DISPATCH_HTTP_API,
+            allow_cross_auth_fallback=False,
+        )
+        assert [e.auth_type for e in out] == ["http_api"]
+
+    def test_http_pref_mixed_chain_with_xfb(self):
+        out, _ = filter_chain_by_dispatch_preference(
+            MIXED_CHAIN, dispatch_preference=DISPATCH_HTTP_API,
+            allow_cross_auth_fallback=True,
+        )
+        # http_api first, headless fallback appended.
+        assert [e.auth_type for e in out] == ["http_api", "headless"]
+
+    def test_http_pref_headless_only_chain_no_xfb_raises(self):
+        with pytest.raises(NoEligibleAdapterError):
+            filter_chain_by_dispatch_preference(
+                HEADLESS_ONLY_CHAIN, dispatch_preference=DISPATCH_HTTP_API,
+                allow_cross_auth_fallback=False,
+            )
+
+    def test_http_pref_headless_only_chain_with_xfb_falls_back(self):
+        out, _ = filter_chain_by_dispatch_preference(
+            HEADLESS_ONLY_CHAIN, dispatch_preference=DISPATCH_HTTP_API,
+            allow_cross_auth_fallback=True,
+        )
+        assert [e.auth_type for e in out] == ["headless"]
+
+    def test_http_pref_http_only_chain_no_xfb(self):
+        out, _ = filter_chain_by_dispatch_preference(
+            HTTP_API_ONLY_CHAIN, dispatch_preference=DISPATCH_HTTP_API,
+            allow_cross_auth_fallback=False,
+        )
+        assert len(out) == 2
+
+    def test_http_pref_http_only_chain_with_xfb(self):
+        out, _ = filter_chain_by_dispatch_preference(
+            HTTP_API_ONLY_CHAIN, dispatch_preference=DISPATCH_HTTP_API,
+            allow_cross_auth_fallback=True,
+        )
+        assert len(out) == 2  # no extra fallback since no other auth_type present
+
+    # ---- dispatch_preference=auto (6 cells, requires AutoResolution) ----
+
+    def test_auto_pref_requires_auto_resolution(self):
+        with pytest.raises(ValueError, match="auto_resolution"):
+            filter_chain_by_dispatch_preference(
+                MIXED_CHAIN, dispatch_preference=DISPATCH_AUTO,
+                allow_cross_auth_fallback=False,
+            )
+
+    def test_auto_pref_selects_headless_per_resolution(self):
+        ar = AutoResolution(
+            selected_auth_type="headless",
+            reason=SELECTION_REASON_AUTO_BAND,
+            evaluation_timestamp=1.0,
+        )
+        out, reason = filter_chain_by_dispatch_preference(
+            MIXED_CHAIN, dispatch_preference=DISPATCH_AUTO,
+            allow_cross_auth_fallback=False,
+            auto_resolution=ar,
+        )
+        assert [e.auth_type for e in out] == ["headless"]
+        # auto-mode reason flows through, NOT explicit.
+        assert reason == SELECTION_REASON_AUTO_BAND
+
+    def test_auto_pref_selects_http_per_resolution(self):
+        ar = AutoResolution(
+            selected_auth_type="http_api",
+            reason=SELECTION_REASON_AUTO_BAND,
+            evaluation_timestamp=1.0,
+        )
+        out, reason = filter_chain_by_dispatch_preference(
+            MIXED_CHAIN, dispatch_preference=DISPATCH_AUTO,
+            allow_cross_auth_fallback=False,
+            auto_resolution=ar,
+        )
+        assert [e.auth_type for e in out] == ["http_api"]
+        assert reason == SELECTION_REASON_AUTO_BAND
+
+    def test_auto_pref_with_xfb_appends_other_auth(self):
+        ar = AutoResolution(
+            selected_auth_type="headless",
+            reason=SELECTION_REASON_AUTO_BAND,
+            evaluation_timestamp=1.0,
+        )
+        out, _ = filter_chain_by_dispatch_preference(
+            MIXED_CHAIN, dispatch_preference=DISPATCH_AUTO,
+            allow_cross_auth_fallback=True,
+            auto_resolution=ar,
+        )
+        assert [e.auth_type for e in out] == ["headless", "http_api"]
+
+    def test_auto_pref_cold_start_default_propagates(self):
+        ar = AutoResolution(
+            selected_auth_type="headless",
+            reason=SELECTION_REASON_AUTO_DEFAULT,
+            evaluation_timestamp=1.0,
+        )
+        out, reason = filter_chain_by_dispatch_preference(
+            MIXED_CHAIN, dispatch_preference=DISPATCH_AUTO,
+            allow_cross_auth_fallback=False,
+            auto_resolution=ar,
+        )
+        assert reason == SELECTION_REASON_AUTO_DEFAULT
+        assert [e.auth_type for e in out] == ["headless"]
+
+    def test_auto_pref_recommended_for_reason_propagates(self):
+        ar = AutoResolution(
+            selected_auth_type="http_api",
+            reason=SELECTION_REASON_AUTO_RECOMMENDED,
+            evaluation_timestamp=1.0,
+        )
+        out, reason = filter_chain_by_dispatch_preference(
+            MIXED_CHAIN, dispatch_preference=DISPATCH_AUTO,
+            allow_cross_auth_fallback=False,
+            auto_resolution=ar,
+        )
+        assert reason == SELECTION_REASON_AUTO_RECOMMENDED
+        assert [e.auth_type for e in out] == ["http_api"]
+
+
+class TestInvalidDispatchPreference:
+    def test_unknown_value_raises(self):
+        with pytest.raises(ValueError, match="dispatch_preference"):
+            filter_chain_by_dispatch_preference(
+                MIXED_CHAIN, dispatch_preference="bogus",
+                allow_cross_auth_fallback=False,
+            )
+
+
+# --- T2.7 coverage — auto-mode algorithm -------------------------------------
+
+
+class TestAutoModeWarmPath:
+    """SDD §5.2 band-comparison with margin tie-breaker."""
+
+    def _stats(self, **kv):
+        return {("anthropic-claude", at): {"n": n, "success_rate": rate}
+                for at, (n, rate) in kv.items()}
+
+    def test_headless_wins_clear(self):
+        stats = self._stats(headless=(100, 0.95), http_api=(100, 0.85))
+        ar = run_auto_mode(MIXED_CHAIN, stats=stats, now=1.0)
+        assert ar.selected_auth_type == "headless"
+        assert ar.reason == SELECTION_REASON_AUTO_BAND
+
+    def test_http_wins_clear_above_margin(self):
+        # http_api ahead by 10pp >> 2pp default margin → http_api wins
+        stats = self._stats(headless=(100, 0.70), http_api=(100, 0.90))
+        ar = run_auto_mode(MIXED_CHAIN, stats=stats, now=1.0)
+        assert ar.selected_auth_type == "http_api"
+        assert ar.reason == SELECTION_REASON_AUTO_BAND
+
+    def test_http_wins_but_within_margin_headless_takes_it(self):
+        # http_api ahead by 1pp < 2pp margin → headless wins tie-zone
+        stats = self._stats(headless=(100, 0.85), http_api=(100, 0.86))
+        ar = run_auto_mode(MIXED_CHAIN, stats=stats, now=1.0)
+        assert ar.selected_auth_type == "headless"
+        assert ar.reason == SELECTION_REASON_AUTO_BAND
+
+    def test_below_sample_size_min_falls_to_cold_start(self):
+        # Both buckets below N=20.
+        stats = self._stats(headless=(5, 0.99), http_api=(5, 0.99))
+        ar = run_auto_mode(MIXED_CHAIN, stats=stats, now=1.0)
+        # Cold-start branch — should NOT be auto-band-comparison.
+        assert ar.reason != SELECTION_REASON_AUTO_BAND
+
+
+class TestAutoModeColdStart:
+    def test_default_headless_with_headless_in_chain(self):
+        ar = run_auto_mode(MIXED_CHAIN, stats={}, now=1.0)
+        assert ar.selected_auth_type == "headless"
+        assert ar.reason == SELECTION_REASON_AUTO_DEFAULT
+
+    def test_default_first_auth_type_when_no_headless(self):
+        ar = run_auto_mode(HTTP_API_ONLY_CHAIN, stats={}, now=1.0)
+        assert ar.selected_auth_type == "http_api"
+        assert ar.reason == SELECTION_REASON_AUTO_DEFAULT
+
+    def test_recommended_for_hint_wins_over_default(self):
+        capability = {"recommended_for": ["http_api"]}
+        ar = run_auto_mode(
+            MIXED_CHAIN, stats={}, capability_evaluation=capability, now=1.0,
+        )
+        assert ar.selected_auth_type == "http_api"
+        assert ar.reason == SELECTION_REASON_AUTO_RECOMMENDED
+
+    def test_recommended_for_unknown_auth_type_falls_to_default(self):
+        capability = {"recommended_for": ["nonsense"]}
+        ar = run_auto_mode(
+            MIXED_CHAIN, stats={}, capability_evaluation=capability, now=1.0,
+        )
+        assert ar.reason == SELECTION_REASON_AUTO_DEFAULT
+
+
+class TestAutoModeMarginTunable:
+    def test_zero_margin_strict_equality_required(self):
+        stats = {("anthropic-claude", "headless"): {"n": 100, "success_rate": 0.85},
+                 ("anthropic-claude", "http_api"): {"n": 100, "success_rate": 0.86}}
+        config = {"auto_mode": {"headless_margin_bps": 0}}
+        ar = run_auto_mode(MIXED_CHAIN, stats=stats, advisor_config=config, now=1.0)
+        # http_api strictly higher → http_api wins.
+        assert ar.selected_auth_type == "http_api"
+
+    def test_huge_margin_headless_always_wins(self):
+        stats = {("anthropic-claude", "headless"): {"n": 100, "success_rate": 0.50},
+                 ("anthropic-claude", "http_api"): {"n": 100, "success_rate": 0.99}}
+        config = {"auto_mode": {"headless_margin_bps": 10000}}  # 100pp margin
+        ar = run_auto_mode(MIXED_CHAIN, stats=stats, advisor_config=config, now=1.0)
+        assert ar.selected_auth_type == "headless"
+
+
+# --- C10 + C11 canonical fixture / envelope shape ---------------------------
+
+
+class TestAutoResolutionEnvelopeShape:
+    """C11 closure — auto_selection_inputs canonical shape matches SDD §3.4."""
+
+    def test_as_selection_inputs_has_three_required_keys(self):
+        ar = AutoResolution(
+            selected_auth_type="headless",
+            reason=SELECTION_REASON_AUTO_BAND,
+            evaluation_timestamp=1715789012.345,
+            sample_n_per_bucket={"headless": 124, "http_api": 87},
+            band_per_bucket={"headless": "green", "http_api": "yellow"},
+            success_rate_per_bucket={"headless": 0.984, "http_api": 0.862},
+        )
+        inputs = ar.as_selection_inputs()
+        assert set(inputs.keys()) == {
+            "sample_n_per_bucket", "band_per_bucket", "success_rate_per_bucket",
+        }
+        # Defensive-copy verification.
+        inputs["sample_n_per_bucket"]["headless"] = 999
+        assert ar.sample_n_per_bucket["headless"] == 124  # original unchanged
+
+    def test_evaluation_timestamp_field_carries(self):
+        ar = AutoResolution(
+            selected_auth_type="headless",
+            reason=SELECTION_REASON_AUTO_DEFAULT,
+            evaluation_timestamp=1715789012.345,
+        )
+        assert ar.evaluation_timestamp == 1715789012.345
+
+
+# --- T2.17: deterministic-replica test (FR-8.7) ------------------------------
+
+
+class TestDeterministicReplica:
+    """FR-8.7 / AC2.4: identical inputs → byte-identical AutoResolution output.
+
+    Replays the same (chain, stats, config, now) twice and asserts the two
+    AutoResolution instances compare equal. Pins the auto-mode algorithm as
+    a pure function — no env/time-of-day inputs allowed to leak in.
+    """
+
+    def test_identical_inputs_identical_output(self):
+        stats = {("anthropic-claude", "headless"): {"n": 100, "success_rate": 0.95},
+                 ("anthropic-claude", "http_api"): {"n": 100, "success_rate": 0.85}}
+        config = {"auto_mode": {"headless_margin_bps": 200}}
+        # Two identical replays — same now.
+        ar1 = run_auto_mode(MIXED_CHAIN, stats=stats, advisor_config=config, now=1715789012.345)
+        ar2 = run_auto_mode(MIXED_CHAIN, stats=stats, advisor_config=config, now=1715789012.345)
+        assert ar1 == ar2
+        assert ar1.as_selection_inputs() == ar2.as_selection_inputs()
+
+    def test_different_now_produces_different_timestamp_only(self):
+        """Sanity check: the only field that varies with `now` is the timestamp.
+        Selection itself is deterministic per the algorithm spec."""
+        stats = {("anthropic-claude", "headless"): {"n": 100, "success_rate": 0.95},
+                 ("anthropic-claude", "http_api"): {"n": 100, "success_rate": 0.85}}
+        ar1 = run_auto_mode(MIXED_CHAIN, stats=stats, now=1.0)
+        ar2 = run_auto_mode(MIXED_CHAIN, stats=stats, now=2.0)
+        assert ar1.evaluation_timestamp != ar2.evaluation_timestamp
+        assert ar1.selected_auth_type == ar2.selected_auth_type
+        assert ar1.reason == ar2.reason
+        assert ar1.sample_n_per_bucket == ar2.sample_n_per_bucket

--- a/.claude/data/trajectory-schemas/model-events/model-invoke-complete.payload.schema.json
+++ b/.claude/data/trajectory-schemas/model-events/model-invoke-complete.payload.schema.json
@@ -331,6 +331,49 @@
           ]
         }
       }
+    },
+    "auth_type_resolved": {
+      "description": "Cycle-110 sprint-2b1 T2.8 (FR-3.4): auth_type bucket the resolver selected for this invocation. Bedrock entries use aws_iam; HTTP-API providers use http_api; subscription-CLI providers use headless. v1.3 readers tolerate this additive field; absence means pre-cycle-110 entry — readers MUST default to http_api per cycle-110 SDD §3.4 backward-compat.",
+      "type": "string",
+      "enum": ["headless", "http_api", "aws_iam"]
+    },
+    "auth_type_selection_reason": {
+      "description": "Cycle-110 sprint-2b1 T2.8 (FR-3.4): how the auth_type was chosen. explicit-dispatch_preference = operator set dispatch_preference to a concrete value; auto-band-comparison = auto-mode used warm-window stats; auto-cold-start-recommended_for = capability_evaluation.recommended_for hint; auto-cold-start-default-headless = no warm data and no hint, defaulted to headless when available.",
+      "type": "string",
+      "enum": [
+        "explicit-dispatch_preference",
+        "auto-band-comparison",
+        "auto-cold-start-recommended_for",
+        "auto-cold-start-default-headless"
+      ]
+    },
+    "auto_selection_inputs": {
+      "description": "Cycle-110 sprint-2b1 T2.8 (FR-3.4 / SDD §5.5 [Q7] resolution). C11 carry-in: canonical example shape pinned by tests/test_dispatch_filter.py::TestAutoResolutionEnvelopeShape. Present ONLY when auth_type_selection_reason == 'auto-band-comparison'. Aggregate-only counters; no operator content. NFR-Sec-4 redaction pass still runs as defense-in-depth.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sample_n_per_bucket": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        },
+        "band_per_bucket": {
+          "type": "object",
+          "additionalProperties": { "enum": ["green", "yellow", "red"] }
+        },
+        "success_rate_per_bucket": {
+          "type": "object",
+          "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 }
+        }
+      }
+    },
+    "auto_evaluation_timestamp": {
+      "description": "Cycle-110 sprint-2b1 T2.8 (C10 carry-in): epoch-seconds when the auto-mode algorithm ran. FROZEN at evaluation time so retrospective config changes don't shift the audit-trail interpretation. Present only when auth_type_selection_reason starts with 'auto-'.",
+      "type": "number",
+      "minimum": 0
+    },
+    "semaphore_exhausted": {
+      "description": "Cycle-110 sprint-2b1 T2.8 (C12 carry-in): true when the headless-concurrency semaphore (sprint-2b2 T2.11) rejected the call after exhausting bounded retries; distinct from chain_exhausted. Future-compat — sprint-2b2 wires the actual emitter; sprint-2b1 only declares the schema slot so the readers can be coded against it now.",
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
## Summary

Cycle-110 Sprint 2b1 — **further split of sprint-2b** per SDD §9. This PR lands the resolver filter + deterministic auto-mode algorithm + MODELINV v1.4 envelope additive fields. Sprint-2b2 will land doctor CLI + semaphore + subprocess streaming + `cheval.cmd_invoke` wire-up.

**Stacked on:** PR #903 (sprint-1) + PR #904 (sprint-2a). The three PRs touch disjoint substrate so they can land in order or be merged together.

## What lands

- **`ResolvedEntry`** gains `auth_type` + `dispatch_group` (default-valued for backward-compat). `chain_resolver._build_entry` populates from the loader-validated model-config.
- **`loa_cheval.routing.dispatch_filter`** — NEW pure-function module (290 lines):
  - `filter_chain_by_dispatch_preference` — 3-mode enum + cross-auth-fallback semantics per FR-1.4 ladder.
  - `run_auto_mode` — SDD §5.2 v1.1 deterministic 3-phase algorithm (warm band-comparison with `headless_margin_bps` tie-breaker → cold-start `recommended_for` → cold-start default-headless).
  - `AutoResolution` frozen dataclass carrying `selected_auth_type` + `reason` + `evaluation_timestamp` (C10) + per-bucket `sample_n` / `band` / `success_rate` (C11).
- **MODELINV envelope v1.4** in `emit_model_invoke_complete`: 5 new optional kwargs with defense-in-depth enum validation BEFORE the redactor + audit_emit pipeline. Schema at `model-invoke-complete.payload.schema.json` extended with matching closed-enum + sub-object properties (additive evolution — v1.3 readers continue to parse).

## Gates passed

| Gate | Status | Artifact |
|------|--------|----------|
| Implementation | ✓ | `grimoires/loa/a2a/sprint-2b1/reviewer.md` |
| Senior-lead review | ✓ All good (4 concerns + 1 assumption + 1 alternative documented) | `engineer-feedback.md` |
| Security audit | ✓ APPROVED - LETS FUCKING GO (0 CRIT/HIGH/MED, 1 LOW cosmetic) | `auditor-sprint-feedback.md` |
| COMPLETED marker | ✓ | `grimoires/loa/a2a/sprint-2b1/COMPLETED` |

## Carry-ins closed (3 of remaining 6)

| ID | Closure |
|----|---------|
| **C10** | `AutoResolution.evaluation_timestamp` frozen at evaluation time; flows into MODELINV `auto_evaluation_timestamp` schema property |
| **C11** | `AutoResolution.as_selection_inputs()` returns SDD §3.4 canonical shape; pinned by `TestAutoResolutionEnvelopeShape` with literal sample numbers |
| **C1 prep** | `dispatch_group` source field flows through chain entries; reader-side derivation for legacy envelopes is sprint-2b2 |

**Deferred to sprint-2b2:** C2 (streaming-read in doctor), C5 (semaphore wait-all-slots), C6 (ProcessLookupError), C12 (semaphore_exhausted FULL wiring — schema slot landed here).

## Test plan

- [x] `PYTHONPATH=.claude/adapters python3 -m pytest .claude/adapters/tests/test_dispatch_filter.py` — **33 pass** (0.04s)
- [x] Full regression sweep (sans pre-existing unrelated `test_shim_legacy_mock_mode` flake) — **1527 pass**
- [x] AC2.3 ≥18 cells satisfied (33 cells actual)
- [x] AC2.4 deterministic-replica pin in place
- [ ] Bridgebuilder review (post-PR)
- [ ] Post-PR audit (post-PR)
- [ ] sprint-2b2: wire `cheval.cmd_invoke` → `dispatch_filter` (until then this PR's substrate is exercised by tests only, not production)

## Audit findings

| Severity | Count | Disposition |
|----------|------:|-------------|
| CRITICAL | 0 | — |
| HIGH     | 0 | — |
| MEDIUM   | 0 | — |
| LOW      | 1 | `NoEligibleAdapterError.reason` is unbounded — cosmetic; sprint-2b2 polish |

## Files changed

| File | Net |
|------|----:|
| `.claude/adapters/loa_cheval/routing/types.py` | +19 |
| `.claude/adapters/loa_cheval/routing/chain_resolver.py` | +9 |
| `.claude/adapters/loa_cheval/routing/dispatch_filter.py` | +290 (new) |
| `.claude/adapters/loa_cheval/audit/modelinv.py` | +58 |
| `.claude/data/trajectory-schemas/model-events/model-invoke-complete.payload.schema.json` | +43 |
| `.claude/adapters/tests/test_dispatch_filter.py` | +332 (new) |

## Known limitations (sprint-2b1 → sprint-2b2 carry)

1. `dispatch_filter` substrate is NOT yet wired into `cheval.cmd_invoke` — the algorithm + envelope schema ship here; the production call path is sprint-2b2. Tests pin behavior in isolation.
2. `semaphore_exhausted` schema slot ships without a producer — sprint-2b2 T2.11 will wire.
3. `per_role_dispatch_preference` plumbing is sprint-2b2 — schema + dataclass shipped in sprint-2a, helper shipped here, but the cheval pipeline still uses a single dispatch_preference per invocation.

## Adversarial Phase 2.5

NOT attempted per cycle-110 substrate fatigue (KF-002 layer-1 transient surfaces on review-type prompts ≥27K tokens). Single-agent review + audit with explicit disclosure in both feedback files. The sprint-2b1 substrate is pure-function with deterministic-replica regression pin — single-agent verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)