### PR TITLE
fix(flatline): normalize skeptic concern envelope before consensus

### DIFF
--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -290,6 +290,30 @@ extract_json_content() {
     echo "$normalized"
 }
 
+# Normalize skeptic prepared JSON to the {"concerns":[...]} envelope expected
+# by scoring-engine.sh. Skeptic prompts request the object form, but some
+# adapters emit a bare top-level array of concern objects. scoring-engine's
+# `$skeptic_x[0].concerns` lookup then errors with
+#   jq: Cannot index array with string "concerns"
+# because --slurpfile wraps a bare-array file as [[{...}]], making $s[0] the
+# inner array. Caller writes the prepared file then calls this in-place.
+normalize_skeptic_envelope() {
+    local file="$1"
+    [[ -f "$file" ]] || return 0
+
+    local normalized
+    if normalized=$(jq -c '
+        if type == "object" then .
+        elif type == "array" then {concerns: .}
+        else {concerns: []}
+        end
+    ' "$file" 2>/dev/null) && [[ -n "$normalized" ]]; then
+        printf '%s\n' "$normalized" > "$file"
+    else
+        printf '%s\n' '{"concerns":[]}' > "$file"
+    fi
+}
+
 # Log to trajectory
 log_trajectory() {
     local event_type="$1"
@@ -1529,6 +1553,8 @@ run_consensus() {
 
     extract_json_content "$gpt_skeptic_file" '{"concerns":[]}' > "$gpt_skeptic_prepared"
     extract_json_content "$opus_skeptic_file" '{"concerns":[]}' > "$opus_skeptic_prepared"
+    normalize_skeptic_envelope "$gpt_skeptic_prepared"
+    normalize_skeptic_envelope "$opus_skeptic_prepared"
 
     # FR-3: Prepare tertiary scoring and skeptic files when available
     local tertiary_args=()
@@ -1557,6 +1583,7 @@ run_consensus() {
     if [[ -n "$tertiary_skeptic_file" && -s "$tertiary_skeptic_file" ]]; then
         local tertiary_skeptic_prepared="$TEMP_DIR/tertiary-skeptic-prepared.json"
         extract_json_content "$tertiary_skeptic_file" '{"concerns":[]}' > "$tertiary_skeptic_prepared"
+        normalize_skeptic_envelope "$tertiary_skeptic_prepared"
         tertiary_skeptic_args=(--skeptic-tertiary "$tertiary_skeptic_prepared")
         log "Including tertiary model skeptic concerns in consensus"
     fi

--- a/tests/unit/flatline-skeptic-envelope.bats
+++ b/tests/unit/flatline-skeptic-envelope.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# =============================================================================
+# flatline-skeptic-envelope.bats
+#
+# Regression test for the Flatline consensus-shape bug:
+#   jq: Cannot index array with string "concerns"
+#
+# Root cause: flatline-orchestrator.sh wrote skeptic prepared JSON in whatever
+# shape extract_json_content produced. scoring-engine.sh's
+# `$skeptic_x[0].concerns` access fails when the model emitted a bare
+# top-level array instead of {"concerns":[...]}.
+#
+# Fix: normalize_skeptic_envelope() in flatline-orchestrator.sh wraps bare
+# arrays into the object envelope before consensus runs.
+# =============================================================================
+
+setup() {
+    ORCH="$BATS_TEST_DIRNAME/../../.claude/scripts/flatline-orchestrator.sh"
+    [[ -f "$ORCH" ]] || skip "flatline-orchestrator.sh not present"
+    command -v jq >/dev/null 2>&1 || skip "jq not present"
+
+    WORK_DIR="$(mktemp -d)"
+    HELPER="$WORK_DIR/helper.sh"
+
+    # Extract just the function body (matches the pattern used in
+    # tests/unit/flatline-jq-construction.bats:T9).
+    awk '/^normalize_skeptic_envelope\(\)/,/^}$/' "$ORCH" > "$HELPER"
+    [[ -s "$HELPER" ]] || {
+        echo "normalize_skeptic_envelope() not found in orchestrator" >&2
+        return 1
+    }
+}
+
+teardown() {
+    [[ -n "${WORK_DIR:-}" && -d "$WORK_DIR" ]] && rm -rf "$WORK_DIR"
+    return 0
+}
+
+@test "object-shaped skeptic prepared JSON is preserved unchanged" {
+    local f="$WORK_DIR/skeptic-object.json"
+    cat > "$f" <<'JSON'
+{"concerns":[{"id":"c1","concern":"x","severity":"high","severity_score":700}]}
+JSON
+
+    run bash -c "source '$HELPER'; normalize_skeptic_envelope '$f'"
+    [ "$status" -eq 0 ]
+
+    # Envelope intact, concerns array intact, single concern preserved.
+    [[ "$(jq -r '.concerns | length' "$f")" == "1" ]]
+    [[ "$(jq -r '.concerns[0].id' "$f")" == "c1" ]]
+    [[ "$(jq -r '.concerns[0].severity_score' "$f")" == "700" ]]
+
+    # And the slurpfile access pattern scoring-engine uses now succeeds.
+    run jq --slurpfile s "$f" -n '$s[0].concerns | length'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "1" ]]
+}
+
+@test "bare-array skeptic prepared JSON is wrapped to {concerns:[...]}" {
+    local f="$WORK_DIR/skeptic-array.json"
+    cat > "$f" <<'JSON'
+[{"id":"c1","concern":"x","severity":"high","severity_score":700}]
+JSON
+
+    # Pre-fix reproduction: bare array breaks scoring-engine's $s[0].concerns.
+    run jq --slurpfile s "$f" -n '$s[0].concerns'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Cannot index array with string \"concerns\""* ]]
+
+    run bash -c "source '$HELPER'; normalize_skeptic_envelope '$f'"
+    [ "$status" -eq 0 ]
+
+    # Post-fix: envelope present, concerns array carries the original item.
+    [[ "$(jq -r 'type' "$f")" == "object" ]]
+    [[ "$(jq -r '.concerns | length' "$f")" == "1" ]]
+    [[ "$(jq -r '.concerns[0].id' "$f")" == "c1" ]]
+
+    # And the slurpfile access pattern scoring-engine uses now succeeds.
+    run jq --slurpfile s "$f" -n '$s[0].concerns | length'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "1" ]]
+}


### PR DESCRIPTION
## Summary

Fixes a Flatline consensus failure where skeptic outputs shaped as a bare JSON array caused `scoring-engine.sh` to fail with:

```text
jq: Cannot index array with string "concerns"
```

The scoring path expects skeptic payloads shaped as:

```json
{ "concerns": [...] }
```

During headless Flatline proofing, one model could produce or be extracted into a bare array:

```json
[ ...concern objects... ]
```

This PR normalizes that shape before consensus scoring.

## What changed

- Adds `normalize_skeptic_envelope()` in `.claude/scripts/flatline-orchestrator.sh`.
- Preserves object-shaped skeptic payloads unchanged.
- Wraps bare arrays as `{ "concerns": [...] }`.
- Applies normalization to prepared skeptic JSON files before scoring.
- Adds unit coverage in `tests/unit/flatline-skeptic-envelope.bats`.

## Validation

Locally validated:

```bash
bash -n .claude/scripts/flatline-orchestrator.sh
```

Manual jq/helper reproduction passed.

Cross-repo runtime proof in `~/loa-dev/loa-straylight` using Loa commit `33bd726`:

- `claude-headless` smoke passed.
- `codex-headless` smoke passed.
- Gemini CLI was reachable, but Gemini capacity was exhausted, so tertiary was disabled.
- Two-voice skip-consensus Flatline passed.
- Full two-voice Flatline consensus passed.
- The previous jq error disappeared.

Observed completion:

```text
Consensus: HIGH=4 DISPUTED=0 LOW=0 BLOCKERS=4
Flatline: 2-model (claude-headless + codex-headless)
Flatline Protocol complete. Cost: 0 cents.
```

## Scope

This is a narrow Flatline robustness fix only.

It does not:

- change provider/model routing,
- add new provider calls,
- touch `.env.local` or secrets,
- modify Straylight,
- modify Hounfour,
- change consensus semantics beyond accepting the already-observed bare-array skeptic shape.
