### PR TITLE
cycle-110: flip advisor_strategy.enabled=true to start 7-day window

### DIFF
--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -1,6 +1,46 @@
 # Loa Configuration
 # Active: Eval Sandbox (#277)
 
+# Cycle-110 sprint-2b2b1 (2026-05-15): advisor_strategy enabled per operator
+# instruction. Enables headless-first dispatch wire-up shipped in PRs
+# #903-#908. MODELINV envelopes now carry v1.4 fields
+# (auth_type_resolved + auth_type_selection_reason + auto_selection_inputs
+# + auto_evaluation_timestamp). Auto-mode runs with empty stats (cold-start)
+# until 7-day measurement window completes and sprint-3 wires the windowed
+# stats reader.
+#
+# Sprint-3 entry condition (cycle-110 PRD §M2.5): operator runs
+# `.claude/scripts/loa-substrate-doctor.sh` and attests OAuth state OK across
+# all three providers BEFORE flipping `dispatch_preference: headless`. Until
+# then, leaving as `auto` (default) lets cold-start path prefer headless
+# only when the chain has a headless entry.
+advisor_strategy:
+  schema_version: 2
+  enabled: true
+  # dispatch_preference defaults to "auto" per advisor-strategy.schema.json.
+  # Auto-mode falls to cold-start-default-headless (preferring headless
+  # when a chain has a headless entry) until warm stats accumulate.
+  # Operator may explicitly set "headless" or "http_api" per role here:
+  # per_role_dispatch_preference:
+  #   review: headless
+  #   audit: headless
+  #   planning: auto    # planning may want gpt-5.5-pro reasoning
+  # allow_cross_auth_fallback: null  # null → derive from FR-1.4 ladder
+  defaults:
+    planning: advisor
+    review: advisor
+    audit: advisor
+    implementation: advisor
+  tier_aliases:
+    advisor:
+      anthropic: claude-opus-4-7
+      openai: gpt-5.5-pro
+      google: gemini-3.1-pro-preview
+    executor:
+      anthropic: claude-sonnet-4-6
+      openai: gpt-5.3-codex
+      google: gemini-2.5-pro
+
 simstim:
   enabled: true
   bridgebuilder_design_review: true # Phase 3.5 gate — enabled for cycle-048


### PR DESCRIPTION
## Summary

Operator-authorized config flip (verbatim: "yes flip it true"). Enables the cycle-110 headless-first dispatch wire-up shipped in PRs #903–#908. Starts the cycle-110 PRD §M2.5 7-day measurement window — MODELINV v1.4 envelopes begin carrying \`auth_type_resolved\` + \`auth_type_selection_reason\` + \`auto_evaluation_timestamp\` on every cheval invocation from this commit forward.

## What this enables

- \`cheval.cmd_invoke\` reads \`advisor_strategy.dispatch_preference\` + per-role overrides + \`allow_cross_auth_fallback\` (from FR-1.4 ladder)
- \`dispatch_filter.run_auto_mode\` runs cold-start path until warm stats accumulate; default-headless when chain has a headless entry
- MODELINV v1.4 envelope fields now populated on every invocation

## Settings

```yaml
advisor_strategy:
  schema_version: 2
  enabled: true
  # dispatch_preference defaults to "auto"
  defaults:
    planning: advisor
    review: advisor    # NFR-Sec1 hard-pin
    audit: advisor     # NFR-Sec1 hard-pin
    implementation: advisor
  tier_aliases:
    advisor:
      anthropic: claude-opus-4-7
      openai: gpt-5.5-pro
      google: gemini-3.1-pro-preview
    executor:
      anthropic: claude-sonnet-4-6
      openai: gpt-5.3-codex
      google: gemini-2.5-pro
```

## Doctor baseline at flip time

| CLI | auth_state | Notes |
|-----|-----------|-------|
| codex-headless | ok | Clean status-command path |
| claude-headless | unknown | Budget=$0.001 too tight to round-trip (auth probably OK) |
| gemini-headless | unreachable | Timed out at 10s — FR-4.5 fallback latency overhead |

The unknown/unreachable probes are FR-4.5 no-op-dispatch fallback limitations the cycle-110 SDD §1.4.5 anticipated. Sprint-3 will tighten or document.

## Test plan

- [x] `python3 -c "from loa_cheval.config.advisor_strategy import load_advisor_strategy; ..."` confirms `enabled: True, dispatch_preference: auto, schema_version: 2`
- [x] Effective dispatch_preference + cross_auth_fallback resolve per FR-1.4 ladder

## Sprint-3 entry condition (cycle-110 PRD §M2.5)

1. Operator runs `.claude/scripts/loa-substrate-doctor.sh` to attest OAuth state OK across all three providers
2. 7-day measurement window observed (begins on merge of this PR)
3. Operator may flip `dispatch_preference: headless` per-role for the rollout phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)