### PR TITLE
test(bug-897): anti-regression pin for BB default alias resolution

### DIFF
--- a/tests/unit/bug-897-bb-default-alias-resolves.bats
+++ b/tests/unit/bug-897-bb-default-alias-resolves.bats
@@ -37,7 +37,7 @@ setup() {
 
 @test "bug-897-1: BB default model alias resolves via load_config()" {
     cd "$PROJECT_ROOT"
-    run python3 - <<PY
+    run env BB_DEFAULT_MODEL="$BB_DEFAULT_MODEL" python3 - <<'PY'
 import os, sys
 sys.path.insert(0, '.claude/adapters')
 from loa_cheval.config.loader import load_config
@@ -63,19 +63,36 @@ PY
 
 @test "bug-897-2: dot-form of the BB default resolves to the same target as the dash form" {
     cd "$PROJECT_ROOT"
-    run python3 - <<PY
-import os, sys
+    run env BB_DEFAULT_MODEL="$BB_DEFAULT_MODEL" python3 - <<'PY'
+import os, re, sys
 sys.path.insert(0, '.claude/adapters')
 from loa_cheval.config.loader import load_config
 cfg, _ = load_config()
 aliases = cfg.get('aliases', {}) or {}
 backcompat = cfg.get('backward_compat_aliases', {}) or {}
 dash = os.environ['BB_DEFAULT_MODEL']
-dot  = dash.replace('-', '.', 1) if '-' in dash else dash
-# Only compare when both forms exist; if the model name has no dash-form
-# variant in the registry, this assertion is vacuous (sonnet/haiku style).
+# BB #913 v4 fix (claude F-001 HIGH 0.97 — vacuous test): the v3 form
+# used `dash.replace('-', '.', 1)` which replaces the FIRST dash, so
+# 'claude-opus-4-7' became 'claude.opus-4-7' (wrong) instead of the
+# intended 'claude-opus-4.7'. The conditional `if dot in merged` then
+# silently skipped the assertion. Corrected substitution: target only
+# the trailing version-separator dash. Examples:
+#   claude-opus-4-7   → claude-opus-4.7
+#   claude-sonnet-4-6 → claude-sonnet-4.6
+#   gpt-5.5-pro       → unchanged (no trailing -\d+)
+dot = re.sub(r'-(\d+)$', r'.\1', dash)
 merged = {**backcompat, **aliases}
-if dot != dash and dot in merged:
+# BB #913 v4 fix (gpt F-002 MEDIUM 0.90 — conditional assertion): the
+# previous `if dot in merged: assert X` form silently passed when the
+# registry dropped the dot-form alias — the exact regression bug-897
+# was opened to close. When the dash/dot forms genuinely differ, the
+# dot form MUST be present AND resolve to the same target.
+if dot != dash:
+    assert dot in merged, (
+        f"BB default dot-form {dot!r} (derived from {dash!r}) missing from "
+        f"aliases / backward_compat_aliases — sample aliases: "
+        f"{sorted(aliases)[:10]}"
+    )
     assert merged[dash] == merged[dot], (
         f"alias divergence: dash form '{dash}'→{merged[dash]!r}  "
         f"dot form '{dot}'→{merged[dot]!r}"
@@ -96,12 +113,16 @@ PY
     # `aliases:` or `backward_compat_aliases:`. Anchors the path, not just
     # the key.
     cd "$PROJECT_ROOT"
-    run python3 - <<PY
-import os, sys, yaml
-# BB #913 review F-002 fix: match the sys.path setup tests 1+2 use, so
-# if pyyaml is ever vendored under .claude/adapters this test picks up
-# the same copy as the rest of the suite.
+    run env BB_DEFAULT_MODEL="$BB_DEFAULT_MODEL" python3 - <<'PY'
+import os, sys
+# BB #913 v4 (gpt F-001 MEDIUM 0.98 — sys.path ordering): sys.path
+# must be configured BEFORE `import yaml` for a vendored copy under
+# .claude/adapters to take effect. Otherwise the system pyyaml wins
+# and tests 1+2 (which do this in the right order via the imports
+# preceding the load_config call) end up using a different yaml lib
+# than test 3.
 sys.path.insert(0, '.claude/adapters')
+import yaml
 default = os.environ['BB_DEFAULT_MODEL']
 with open('.claude/defaults/model-config.yaml') as f:
     cfg = yaml.safe_load(f)

--- a/tests/unit/bug-897-bb-default-alias-resolves.bats
+++ b/tests/unit/bug-897-bb-default-alias-resolves.bats
@@ -57,10 +57,32 @@ PY
     [[ "$output" == *"OK"* ]]
 }
 
-@test "bug-897-3: bridgebuilder default model entry matches the resolved alias" {
-    # BB's generated config sets `claude-opus-4-7` as the default model.
-    # Pin that the YAML still declares it in either the live aliases
-    # map OR backward_compat_aliases.
-    run grep -E '^\s*claude-opus-4-7\s*:' "$PROJECT_ROOT/.claude/defaults/model-config.yaml"
+@test "bug-897-3: bridgebuilder default model lives in a loader-readable section" {
+    # BB #913 review (F-001 DISPUTED, 0.88 conf — drop-or-replace): the
+    # previous version grepped `^\s*claude-opus-4-7\s*:` against the raw
+    # YAML, which matches the key anywhere in the document tree (including
+    # a hypothetical `deprecations:` section the fold helper never reads).
+    # Replaced with a structural assertion that the alias lives in one of
+    # the two sections `_fold_backward_compat_aliases` actually consults:
+    # `aliases:` or `backward_compat_aliases:`. Anchors the path, not just
+    # the key.
+    cd "$PROJECT_ROOT"
+    run python3 - <<'PY'
+import yaml, sys
+with open('.claude/defaults/model-config.yaml') as f:
+    cfg = yaml.safe_load(f)
+in_aliases  = 'claude-opus-4-7' in (cfg.get('aliases') or {})
+in_backcompat = 'claude-opus-4-7' in (cfg.get('backward_compat_aliases') or {})
+assert in_aliases or in_backcompat, (
+    "claude-opus-4-7 not in aliases:{} or backward_compat_aliases:{} — "
+    "the fold helper at loader.py:573-606 won't see it. "
+    "Found 'claude-opus-4-7' present only in: {}".format(
+        [k for k, v in cfg.items()
+         if isinstance(v, dict) and 'claude-opus-4-7' in v]
+    )
+)
+print("OK")
+PY
     [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
 }

--- a/tests/unit/bug-897-bb-default-alias-resolves.bats
+++ b/tests/unit/bug-897-bb-default-alias-resolves.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/unit/bug-897-bb-default-alias-resolves.bats
+#
+# Bug #897 — anti-regression: bridgebuilder-review's default model alias
+# `claude-opus-4-7` (dash form) must resolve cleanly via cheval's
+# `load_config()` path. The original report claimed the alias was
+# rejected with `INVALID_CONFIG: Unknown alias`, but the bug was
+# already closed on main via the `_fold_backward_compat_aliases` fold
+# at `.claude/adapters/loa_cheval/config/loader.py:573-606` (cycle-095
+# Sprint 2). This test pins that contract so a future YAML edit can't
+# silently drop the dash-form alias and re-break BB Pass 1.
+#
+# Closes #897 (verification + anti-regression).
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    export PROJECT_ROOT
+}
+
+@test "bug-897-1: claude-opus-4-7 (dash form) resolves via load_config()" {
+    cd "$PROJECT_ROOT"
+    run python3 - <<'PY'
+import sys
+sys.path.insert(0, '.claude/adapters')
+from loa_cheval.config.loader import load_config
+cfg, _ = load_config()
+aliases = cfg.get('aliases', {})
+assert 'claude-opus-4-7' in aliases, \
+    f"claude-opus-4-7 missing from aliases — found: {sorted(aliases)[:20]}"
+assert aliases['claude-opus-4-7'] == 'anthropic:claude-opus-4-7', \
+    f"claude-opus-4-7 resolves to '{aliases['claude-opus-4-7']}', expected 'anthropic:claude-opus-4-7'"
+print("OK")
+PY
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "bug-897-2: claude-opus-4.7 (dot form) resolves to the same target as the dash form" {
+    cd "$PROJECT_ROOT"
+    run python3 - <<'PY'
+import sys
+sys.path.insert(0, '.claude/adapters')
+from loa_cheval.config.loader import load_config
+cfg, _ = load_config()
+aliases = cfg.get('aliases', {})
+assert 'claude-opus-4.7' in aliases, \
+    f"claude-opus-4.7 missing from aliases — found: {sorted(aliases)[:20]}"
+dash = aliases.get('claude-opus-4-7')
+dot  = aliases.get('claude-opus-4.7')
+assert dash == dot, f"alias divergence: dash→{dash!r} dot→{dot!r}"
+print("OK")
+PY
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "bug-897-3: bridgebuilder default model entry matches the resolved alias" {
+    # BB's generated config sets `claude-opus-4-7` as the default model.
+    # Pin that the YAML still declares it in either the live aliases
+    # map OR backward_compat_aliases.
+    run grep -E '^\s*claude-opus-4-7\s*:' "$PROJECT_ROOT/.claude/defaults/model-config.yaml"
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/bug-897-bb-default-alias-resolves.bats
+++ b/tests/unit/bug-897-bb-default-alias-resolves.bats
@@ -24,12 +24,28 @@ setup() {
     SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
     export PROJECT_ROOT
-    # Extract the BB default model from config.ts. The DEFAULTS block
-    # declares `model: "..."` — read it once and export so all three
-    # test bodies pin THIS value, not a stale literal.
-    BB_DEFAULT_MODEL="$(grep -oE 'model:\s*"[^"]+"' "$PROJECT_ROOT/.claude/skills/bridgebuilder-review/resources/config.ts" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+    # Extract the BB default model from config.ts.
+    # BB #913 v5 (F-001 MEDIUM — unanchored grep / test oracle correlation):
+    # the v3/v4 form `grep -oE 'model:\s*"..."' | head -1` matched the
+    # FIRST `model:` line in config.ts. Today line 165 happens to be in
+    # the DEFAULTS block, but a future edit that inserts a `model: "..."`
+    # earlier (a comment, another struct, a Zod schema default) would
+    # silently pin the wrong alias — making the anti-regression check
+    # correlated with the regression it's meant to detect.
+    # Fix: anchor on the `const DEFAULTS:` block with awk, then capture
+    # the first `model:` line WITHIN that block. `exit` stops at
+    # DEFAULTS.model and never sees later `model:` references.
+    BB_DEFAULT_MODEL="$(awk '
+        /^const DEFAULTS:[[:space:]]*BridgebuilderConfig[[:space:]]*=/{flag=1; next}
+        flag && /^\}/{flag=0; exit}
+        flag && /^[[:space:]]*model:[[:space:]]*"/{
+            match($0, /"[^"]+"/)
+            print substr($0, RSTART+1, RLENGTH-2)
+            exit
+        }
+    ' "$PROJECT_ROOT/.claude/skills/bridgebuilder-review/resources/config.ts")"
     [ -n "$BB_DEFAULT_MODEL" ] || {
-        echo "FATAL: could not extract DEFAULTS.model from config.ts" >&2
+        echo "FATAL: could not extract DEFAULTS.model from config.ts (anchored awk found no match in the DEFAULTS block)" >&2
         return 1
     }
     export BB_DEFAULT_MODEL

--- a/tests/unit/bug-897-bb-default-alias-resolves.bats
+++ b/tests/unit/bug-897-bb-default-alias-resolves.bats
@@ -3,13 +3,19 @@
 # tests/unit/bug-897-bb-default-alias-resolves.bats
 #
 # Bug #897 — anti-regression: bridgebuilder-review's default model alias
-# `claude-opus-4-7` (dash form) must resolve cleanly via cheval's
-# `load_config()` path. The original report claimed the alias was
-# rejected with `INVALID_CONFIG: Unknown alias`, but the bug was
-# already closed on main via the `_fold_backward_compat_aliases` fold
-# at `.claude/adapters/loa_cheval/config/loader.py:573-606` (cycle-095
+# (whatever DEFAULTS.model in config.ts declares, currently `claude-opus-4-7`)
+# must resolve cleanly via cheval's `load_config()` path. The original
+# report claimed the alias was rejected with `INVALID_CONFIG: Unknown
+# alias`, but the bug was already closed on main via the
+# `_fold_backward_compat_aliases` fold at
+# `.claude/adapters/loa_cheval/config/loader.py:573-606` (cycle-095
 # Sprint 2). This test pins that contract so a future YAML edit can't
-# silently drop the dash-form alias and re-break BB Pass 1.
+# silently drop the alias the BB tool actually uses by default.
+#
+# Note: the bats file reads the alias name from `config.ts` rather than
+# hardcoding it, so a future BB default-model change (e.g., bumping to
+# opus 4.8 or sonnet 5) will automatically pin the new alias instead of
+# leaving a stale check passing against an obsolete model name.
 #
 # Closes #897 (verification + anti-regression).
 # =============================================================================
@@ -18,46 +24,69 @@ setup() {
     SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
     PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
     export PROJECT_ROOT
+    # Extract the BB default model from config.ts. The DEFAULTS block
+    # declares `model: "..."` — read it once and export so all three
+    # test bodies pin THIS value, not a stale literal.
+    BB_DEFAULT_MODEL="$(grep -oE 'model:\s*"[^"]+"' "$PROJECT_ROOT/.claude/skills/bridgebuilder-review/resources/config.ts" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+    [ -n "$BB_DEFAULT_MODEL" ] || {
+        echo "FATAL: could not extract DEFAULTS.model from config.ts" >&2
+        return 1
+    }
+    export BB_DEFAULT_MODEL
 }
 
-@test "bug-897-1: claude-opus-4-7 (dash form) resolves via load_config()" {
+@test "bug-897-1: BB default model alias resolves via load_config()" {
     cd "$PROJECT_ROOT"
-    run python3 - <<'PY'
-import sys
+    run python3 - <<PY
+import os, sys
 sys.path.insert(0, '.claude/adapters')
 from loa_cheval.config.loader import load_config
 cfg, _ = load_config()
-aliases = cfg.get('aliases', {})
-assert 'claude-opus-4-7' in aliases, \
-    f"claude-opus-4-7 missing from aliases — found: {sorted(aliases)[:20]}"
-assert aliases['claude-opus-4-7'] == 'anthropic:claude-opus-4-7', \
-    f"claude-opus-4-7 resolves to '{aliases['claude-opus-4-7']}', expected 'anthropic:claude-opus-4-7'"
+aliases = cfg.get('aliases', {}) or {}
+backcompat = cfg.get('backward_compat_aliases', {}) or {}
+default = os.environ['BB_DEFAULT_MODEL']
+merged = {**backcompat, **aliases}
+assert default in merged, (
+    f"BB default '{default}' missing from aliases/backward_compat_aliases — "
+    f"sample aliases: {sorted(aliases)[:10]}, "
+    f"sample backcompat: {sorted(backcompat)[:10]}"
+)
+target = merged[default]
+assert target.startswith(('anthropic:', 'openai:', 'google:', 'bedrock:')), \
+    f"BB default '{default}' resolves to '{target}' — expected provider:model form"
+print("OK")
+PY
+    # OK-glob is intentional positive-control canary against accidental status=0 returns
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "bug-897-2: dot-form of the BB default resolves to the same target as the dash form" {
+    cd "$PROJECT_ROOT"
+    run python3 - <<PY
+import os, sys
+sys.path.insert(0, '.claude/adapters')
+from loa_cheval.config.loader import load_config
+cfg, _ = load_config()
+aliases = cfg.get('aliases', {}) or {}
+backcompat = cfg.get('backward_compat_aliases', {}) or {}
+dash = os.environ['BB_DEFAULT_MODEL']
+dot  = dash.replace('-', '.', 1) if '-' in dash else dash
+# Only compare when both forms exist; if the model name has no dash-form
+# variant in the registry, this assertion is vacuous (sonnet/haiku style).
+merged = {**backcompat, **aliases}
+if dot != dash and dot in merged:
+    assert merged[dash] == merged[dot], (
+        f"alias divergence: dash form '{dash}'→{merged[dash]!r}  "
+        f"dot form '{dot}'→{merged[dot]!r}"
+    )
 print("OK")
 PY
     [ "$status" -eq 0 ]
     [[ "$output" == *"OK"* ]]
 }
 
-@test "bug-897-2: claude-opus-4.7 (dot form) resolves to the same target as the dash form" {
-    cd "$PROJECT_ROOT"
-    run python3 - <<'PY'
-import sys
-sys.path.insert(0, '.claude/adapters')
-from loa_cheval.config.loader import load_config
-cfg, _ = load_config()
-aliases = cfg.get('aliases', {})
-assert 'claude-opus-4.7' in aliases, \
-    f"claude-opus-4.7 missing from aliases — found: {sorted(aliases)[:20]}"
-dash = aliases.get('claude-opus-4-7')
-dot  = aliases.get('claude-opus-4.7')
-assert dash == dot, f"alias divergence: dash→{dash!r} dot→{dot!r}"
-print("OK")
-PY
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"OK"* ]]
-}
-
-@test "bug-897-3: bridgebuilder default model lives in a loader-readable section" {
+@test "bug-897-3: BB default model lives in a loader-readable section of model-config.yaml" {
     # BB #913 review (F-001 DISPUTED, 0.88 conf — drop-or-replace): the
     # previous version grepped `^\s*claude-opus-4-7\s*:` against the raw
     # YAML, which matches the key anywhere in the document tree (including
@@ -67,19 +96,34 @@ PY
     # `aliases:` or `backward_compat_aliases:`. Anchors the path, not just
     # the key.
     cd "$PROJECT_ROOT"
-    run python3 - <<'PY'
-import yaml, sys
+    run python3 - <<PY
+import os, sys, yaml
+# BB #913 review F-002 fix: match the sys.path setup tests 1+2 use, so
+# if pyyaml is ever vendored under .claude/adapters this test picks up
+# the same copy as the rest of the suite.
+sys.path.insert(0, '.claude/adapters')
+default = os.environ['BB_DEFAULT_MODEL']
 with open('.claude/defaults/model-config.yaml') as f:
     cfg = yaml.safe_load(f)
-in_aliases  = 'claude-opus-4-7' in (cfg.get('aliases') or {})
-in_backcompat = 'claude-opus-4-7' in (cfg.get('backward_compat_aliases') or {})
+aliases_section = cfg.get('aliases') or {}
+backcompat_section = cfg.get('backward_compat_aliases') or {}
+in_aliases  = default in aliases_section
+in_backcompat = default in backcompat_section
+# BB #913 review F-001 fix (format-string mismatch): three positional {}
+# placeholders, three explicit .format() args. Without this the test's
+# own failure path raised IndexError instead of emitting the diagnostic.
+other_sections = [k for k, v in cfg.items()
+                  if isinstance(v, dict) and default in v
+                  and k not in ('aliases', 'backward_compat_aliases')]
 assert in_aliases or in_backcompat, (
-    "claude-opus-4-7 not in aliases:{} or backward_compat_aliases:{} — "
-    "the fold helper at loader.py:573-606 won't see it. "
-    "Found 'claude-opus-4-7' present only in: {}".format(
-        [k for k, v in cfg.items()
-         if isinstance(v, dict) and 'claude-opus-4-7' in v]
-    )
+    "{default!r} not in aliases ({a_sample}) or backward_compat_aliases "
+    "({b_sample}) — the fold helper at loader.py:573-606 won't see it. "
+    "Found {default!r} present only in: {other}"
+).format(
+    default=default,
+    a_sample=sorted(aliases_section)[:8],
+    b_sample=sorted(backcompat_section)[:8],
+    other=other_sections,
 )
 print("OK")
 PY


### PR DESCRIPTION
## Bug Fix: bridgebuilder-review default model alias `claude-opus-4-7` rejected by cheval

**Bug ID**: 20260515-i897-997d62
**Sprint**: sprint-bug-160
**Source**: /run --bug

### Summary

**Verification-only.** Bug #897 reported that `claude-opus-4-7` (dash form) was rejected by cheval with `INVALID_CONFIG: Unknown alias`. The alias **already resolves cleanly on current main** via the `_fold_backward_compat_aliases` path at `.claude/adapters/loa_cheval/config/loader.py:573-606` (landed cycle-095 Sprint 2). The reporter was on a pre-fold-backcompat Loa snapshot.

This PR adds a one-shot anti-regression test that pins the resolved-alias-table invariant, so a future YAML/loader edit cannot silently drop the entry and re-break BB Pass 1.

### Verification on current main

```python
from loa_cheval.config.loader import load_config
cfg, _ = load_config()
aliases = cfg.get('aliases', {})
print(aliases['claude-opus-4-7'])       # → anthropic:claude-opus-4-7
print(aliases['claude-opus-4.7'])       # → anthropic:claude-opus-4-7
```

### Confidence Signals

- Reproduction: weak (issue does not reproduce on current main)
- Test type: unit (bats, calling `python3` against live loader)
- Files changed: 1 (test-only)
- Lines changed: +66
- Risk level: low

### Test plan

- [x] `bats tests/unit/bug-897-bb-default-alias-resolves.bats` — 3/3 PASS
- [x] Live `load_config()` smoke verifies both dash and dot forms resolve cleanly
- [x] Independent smoke during review re-confirms

### Cross-model adversarial review

Intentionally skipped for this PR: change is 50 LOC of test code pinning an
existing contract (live smoke proves the invariant; no behavior change).
Cheval substrate health is verified by the parallel PR #912 (bug-898) clean
cross-model run. Documented decision in `grimoires/loa/a2a/bug-20260515-i897-997d62/engineer-feedback.md`.

### Artifacts

- Triage: `grimoires/loa/a2a/bug-20260515-i897-997d62/triage.md`
- Implementation report: `grimoires/loa/a2a/bug-20260515-i897-997d62/reviewer.md`
- Review feedback: `grimoires/loa/a2a/bug-20260515-i897-997d62/engineer-feedback.md`
- Security audit: `grimoires/loa/a2a/bug-20260515-i897-997d62/auditor-sprint-feedback.md`

### Status: READY FOR HUMAN REVIEW

Created by `/run --bug` autonomous mode. Closes #897 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)