### PR TITLE
docs(known-failures): KF-010 root cause + cycle-111 ledger + gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -284,3 +284,14 @@ grimoires/loa/ledger.json.bak*
 #   grimoires/loa/runbooks/           (framework-shipped runbooks)
 #   grimoires/loa/known-failures.md   (shared zone)
 #   grimoires/loa/ledger.json         (project sprint ledger)
+
+# Skill-run ephemeral output (cycle-099/108 reports; never load-bearing across sessions)
+grimoires/loa/consistency-report.md
+grimoires/loa/drift-report.md
+grimoires/loa/gaps.md
+grimoires/loa/governance-report.md
+grimoires/loa/trajectory-audit.md
+
+# Runtime session state (lockfiles + test output, regenerated per-session)
+.claude/scheduled_tasks.lock
+report.xml

--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -722,9 +722,9 @@ When future cycles want to benchmark a NEW dimension (not in cycle-108), reuse t
 **Feature**: bridgebuilder multi-model review — `google/gemini-3.1-pro-preview` voice via cheval-delegate subprocess
 **Symptom**: Every google voice invocation in a 6-PR concurrent BB sweep returned `cheval-delegate: process exceeded timeout=300000ms (signal=SIGTERM)`. The BB TS layer (`adapters/llm-google.ts` or equivalent) imposes a 300s SIGTERM on the cheval-delegate subprocess. Anthropic + OpenAI voices completed normally (anthropic 80-275s, openai 39-138s on same runs). Consensus scoring proceeds with 2/3 voices but verdict-quality envelope is DEGRADED per NFR-Rel-1. BB does NOT surface the degradation in the GitHub-posted review comment — the comment header lists all 3 INTENDED models without distinguishing which actually returned a verdict. Operators relying on the comment alone cannot tell quality is degraded.
 **First observed**: 2026-05-16 (cycle-110 BB sweep batch 5, run IDs `bridgebuilder-20260516T0721{19,26,33,40,46,53}-*`)
-**Recurrence count**: 6 (single batch, all 6 PRs in the sweep, all hitting exactly the 300s wall — pattern strongly suggests provider-side issue rather than client-side per-call latency variance)
-**Current workaround**: Treat any BB run missing a `google] Complete` log line as DEGRADED → do NOT auto-merge under operator-approval `Verdict quality NOT DEGRADED` clause. Re-run BB sequentially (not concurrent) if convergence is required; or accept 2-voice consensus and route the merge through human review.
-**Upstream issue**: not filed yet — needs investigation to distinguish (a) Google API throttling/slowness on concurrent reqs, (b) cheval google httpx-adapter hang, (c) BB's 300s timeout being too tight for current Gemini response latency.
+**Recurrence count**: 8 (6× concurrent batch 2026-05-16T0721Z + 2× sequential single-PR #920 + #912-anthropic 2026-05-16T1159Z — all hitting exactly the 300_000ms wall)
+**Current workaround**: Treat any BB run missing a `google] Complete` log line as DEGRADED → do NOT auto-merge under operator-approval `Verdict quality NOT DEGRADED` clause. Re-run BB sequentially (not concurrent) if convergence is required; or accept 2-voice consensus and route the merge through human review. **Note 2026-05-16 evening**: per upstream #921, the failure also hits Anthropic `claude-opus-4-7` on large diffs — the issue is NOT Google-specific, so even "2-voice consensus" can degrade to 1-voice if Anthropic also blows the 300s wall.
+**Upstream issue**: [#921](https://github.com/0xHoneyJar/loa/issues/921) (filed 2026-05-16 evening) — root cause is `deriveTimeoutMs` reasoning-class predicate at `.claude/skills/bridgebuilder-review/resources/core/multi-model-pipeline.ts:42-48` being OpenAI-only. The cycle-100 fix granted 1_800_000ms (30-min) budget to `gpt-*-pro` only; Anthropic Opus + Google Gemini-pro are also reasoning-class models that need the same budget but get the 300_000ms ceiling instead.
 **Related visions / lore**: KF-001 (different mechanism — Node 20 Happy Eyeballs at 250ms, resolved), KF-008 (different mechanism — Google SocketError on large bodies, resolved via cheval httpx). This is a NEW failure class: process-level subprocess timeout, not connection-level.
 
 ### Attempts
@@ -732,10 +732,22 @@ When future cycles want to benchmark a NEW dimension (not in cycle-108), reuse t
 | Date | What we tried | Outcome | Evidence |
 |------|---------------|---------|----------|
 | 2026-05-16 07:21Z | 6 BB invocations launched concurrently with 5s stagger across PRs #804/#885/#912/#913/#914/#917 | DID NOT WORK — all 6 google voices SIGTERM'd at 300s; anthropic+openai succeeded | `/tmp/bb-runs-5/pr-{804,885,912,913,914,917}.log`; GitHub comments timestamped 07:28Z on each PR |
+| 2026-05-16 11:59Z | Sequential single-PR BB on #920 (cycle-111 sprint-164 impl) | DID NOT WORK — **anthropic ALSO SIGTERM'd at 300_000ms** (245s budget broken on larger diff), google SIGTERM'd at 300_000ms, only openai/gpt-5.5-pro completed (244s; covered by cycle-100 reasoning-class extension). Operator authorized Amendment 4 (1-voice override, PR-scoped) and merged. | `/tmp/bb-runs-9/pr-920.log` |
+| 2026-05-16 evening | Root-cause investigation: direct Gemini API timing (3-10s healthy), cheval `_call_with_retry` analysis, BB-side `deriveTimeoutMs` audit | ROOT CAUSE IDENTIFIED — BB `deriveTimeoutMs` reasoning-class predicate is OpenAI-only (`^gpt-\d+(\.\d+)?-pro$`). Anthropic Opus + Google Gemini-pro fall into the 300_000ms ceiling despite being reasoning-class. Filed upstream #921 with fix proposal (extend predicate to multi-provider, or use capability-driven lookup against the model registry). | issue #921; `.claude/skills/bridgebuilder-review/resources/core/multi-model-pipeline.ts:42-48`; this entry's Upstream issue field |
 
 ### Reading guide
 
-When a BB sweep shows uniform `cheval-delegate: process exceeded timeout=300000ms` on the google voice across all PRs, treat as DEGRADED-voice batch-level and refuse auto-merge per the operator-approval doc's `Verdict quality NOT DEGRADED` clause. Don't retry the same batch — investigate the substrate first: (a) check Gemini API status / rate-limit posture, (b) run a single sequential BB and observe wall time, (c) examine cheval google adapter for hang patterns (similar to KF-008's pre-cheval-httpx era). The pattern is suspicious because all 6 hit exactly 300s — concurrent reqs from same key may be queueing server-side and timing out client-side together, not on individual call latency. **Do NOT increase BB's 300s timeout as a workaround** — that hides the underlying provider issue; instead, route batch-mode invocations through sequential queue or accept 2-voice consensus with explicit human gate.
+**Recurrence count 8 — STRUCTURAL. Root cause filed at upstream #921.** Do NOT
+retry BB cross-model on this machine until #921 lands. The 1/3-voice and
+2/3-voice operator-approval amendments are bridge measures, not solutions —
+the substrate fix is the `deriveTimeoutMs` predicate extension.
+
+When a BB sweep shows uniform `cheval-delegate: process exceeded timeout=300000ms` on the google voice across all PRs, OR Anthropic Opus on large diffs (>50K input tokens), it is the same root cause: reasoning-class models without the 30-min budget extension. Treat as DEGRADED-voice batch-level and refuse auto-merge per the operator-approval doc's `Verdict quality NOT DEGRADED` clause. **Do NOT increase BB's 300s timeout as a one-off workaround** — that hides the underlying scope-error in the predicate; instead, extend the predicate per #921 fix proposal, or route batch-mode invocations through sequential queue and accept 2-voice consensus with explicit human gate.
+
+Diagnostic disambiguation (preserved for future agents):
+- Direct Gemini call: small (6 tokens) = 3.5s; medium (5KB) = 10s — API healthy
+- BB run logs show exact `latencyMs=300000` on failing voices, `latencyMs=244794` on surviving gpt-5.5-pro (which has the 1_800_000ms extension)
+- The cycle-100 docstring at `multi-model-pipeline.ts:25-37` already explains the failure pattern: "model spends most of its budget on internal reasoning before emitting visible tokens." The fix was scoped to OpenAI; KF-010 is that same pattern resurfacing on the other two BB triad members.
 
 ---
 

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1300,6 +1300,15 @@
           "created": "2026-05-13T05:14:02Z"
         }
       ]
+    },
+    {
+      "id": "cycle-111-dcg-native-integration",
+      "label": "DCG pattern coverage native to Loa (side-cycle parallel to cycle-109)",
+      "status": "active",
+      "created_at": "2026-05-16T11:46:53Z",
+      "prd": "grimoires/loa/cycles/cycle-111-dcg-native-integration/prd.md",
+      "sdd": "grimoires/loa/cycles/cycle-111-dcg-native-integration/sdd.md",
+      "sprints": []
     }
   ],
   "global_sprint_counter": 158,


### PR DESCRIPTION
## Summary

Three small, related working-tree cleanups from the 2026-05-16 evening
investigation session.

### 1. KF-010 root cause update

`grimoires/loa/known-failures.md` — KF-010 (cheval-delegate google 300s timeout) entry updated to reflect the root-cause investigation findings:

- Recurrence count `6 → 8` (added sequential PR #920 SIGTERM + #912 Anthropic SIGTERM observations)
- Upstream issue field now links to **#921** (filed this session)
- Attempts table: 2 new rows (sequential #920 run; root-cause investigation summary)
- Reading guide rewritten — the failure mode is **broader than Google-only**: Anthropic Opus on large diffs hits the same 300_000ms wall

Root cause (per #921): the `deriveTimeoutMs` reasoning-class predicate at `.claude/skills/bridgebuilder-review/resources/core/multi-model-pipeline.ts:42-48` whitelists only OpenAI `gpt-*-pro` for the 1_800_000ms budget. Anthropic Opus + Google Gemini-pro fall into the 300s ceiling. The cycle-100 fix was scoped too narrowly.

### 2. cycle-111 ledger entry

`grimoires/loa/ledger.json` — adds the `cycle-111-dcg-native-integration` entry that `/sprint-plan` produced during cycle-111 execution but that PR #920 (the cycle-111 impl) did not include in its merge. Closes the ledger-sync gap so `/loa` / `/ledger` queries see cycle-111 in proper `active` state.

### 3. .gitignore additions

5 patterns added to silence the working-tree noise observed during this session:

| Path | Reason |
|------|--------|
| `grimoires/loa/consistency-report.md` | Skill-run ephemeral output |
| `grimoires/loa/drift-report.md` | Skill-run ephemeral output |
| `grimoires/loa/gaps.md` | Skill-run ephemeral output |
| `grimoires/loa/governance-report.md` | Skill-run ephemeral output |
| `grimoires/loa/trajectory-audit.md` | Skill-run ephemeral output |
| `.claude/scheduled_tasks.lock` | Per-session lockfile (PID + sessionId) |
| `report.xml` | Test runner output |

## Test plan

- [x] `git status` is clean of these patterns after the gitignore change
- [x] `cat grimoires/loa/known-failures.md` shows KF-010 with recurrence 8 + #921 link
- [x] `jq '.cycles[] | select(.id == "cycle-111-dcg-native-integration")' grimoires/loa/ledger.json` returns the new entry
- [ ] (manual) operator verifies KF-010 framing for accuracy

## References

- Upstream issue: #921 (KF-010 root cause + fix proposal)
- Operator-approval Amendment 4: `.run/bugs/operator-approval-2026-05-16-bb-merge.md`
- Session validation doc (P2 reject): `/tmp/executor-tier-validation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)