### PR TITLE
fix(kf011): LOA_ADVERSARIAL_DEBUG=1 raw-response capture (closes #930)

### DIFF
--- a/.claude/scripts/adversarial-review.sh
+++ b/.claude/scripts/adversarial-review.sh
@@ -688,6 +688,53 @@ process_findings() {
   findings_array=$(echo "$parsed" | jq -r '.findings // empty' 2>/dev/null || echo "")
   if [[ -z "$findings_array" ]]; then
     log "Malformed response: missing 'findings' key"
+
+    # KF-011 diagnostic capture (issue #930).
+    # When LOA_ADVERSARIAL_DEBUG=1, write the raw response body to a sidecar
+    # so future fixes can disambiguate between (a) prompt-schema drift,
+    # (b) parser brittleness on wrapped envelopes, (c) reasoning-class
+    # meta-commentary. Pipes through log-redactor for NFR-Sec-1.
+    # Default behavior (env unset) is unchanged — no observable change.
+    if [[ "${LOA_ADVERSARIAL_DEBUG:-0}" == "1" ]]; then
+      local debug_dir="$PROJECT_ROOT/grimoires/loa/a2a/${sprint_id}"
+      mkdir -p "$debug_dir" 2>/dev/null || true
+      # Slug the model name to a filesystem-safe form (provider:id has `:`).
+      # Use `__` so the namespace boundary stays visible in filenames
+      # (single `_` would be ambiguous with literal underscores in model ids).
+      local model_slug
+      model_slug=$(echo "$model" | sed 's|:|__|g; s|/|__|g')
+      # Slug colons out of the ISO timestamp too — `:` is illegal in
+      # filenames on Windows/FAT and confuses cross-platform tarball
+      # extraction. Replace with `-` for human readability.
+      local timestamp_slug
+      timestamp_slug=$(echo "$timestamp" | tr ':' '-')
+      local debug_file="$debug_dir/adversarial-debug-${model_slug}-${timestamp_slug}.txt"
+      local redactor="$PROJECT_ROOT/.claude/scripts/lib/log-redactor.sh"
+      {
+        echo "# KF-011 debug capture (LOA_ADVERSARIAL_DEBUG=1)"
+        echo "# model: $model"
+        echo "# sprint_id: $sprint_id"
+        echo "# type: $type"
+        echo "# timestamp: $timestamp"
+        echo "# ---"
+        echo "## raw_response (model-adapter envelope):"
+        echo "$raw_response"
+        echo ""
+        echo "## extracted content (.content field):"
+        echo "$content"
+        echo ""
+        echo "## parsed (post markdown-fence strip):"
+        echo "$parsed"
+      } | (
+        if [[ -x "$redactor" ]]; then
+          "$redactor"
+        else
+          cat
+        fi
+      ) > "$debug_file" 2>/dev/null || true
+      log "KF-011 debug: raw response captured to $debug_file"
+    fi
+
     jq -n \
       --arg type "$type" --arg model "$model" --arg sid "$sprint_id" \
       --arg ts "$timestamp" \

--- a/tests/unit/adversarial-review-kf-011-debug.bats
+++ b/tests/unit/adversarial-review-kf-011-debug.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Tests for adversarial-review.sh — KF-011 debug capture (issue #930).
+#
+# Verifies:
+#   - When LOA_ADVERSARIAL_DEBUG=1 AND status: malformed_response,
+#     a sidecar file is written to grimoires/loa/a2a/{sprint_id}/
+#   - When LOA_ADVERSARIAL_DEBUG unset (default), NO sidecar is written
+#   - When LOA_ADVERSARIAL_DEBUG=1 but response is well-formed (state: clean
+#     or populated), NO debug sidecar is written
+#   - The sidecar passes through log-redactor (NFR-Sec-1)
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    export PROJECT_ROOT
+    ADVERSARIAL_REVIEW="$PROJECT_ROOT/.claude/scripts/adversarial-review.sh"
+    TEST_DIR="${BATS_TEST_TMPDIR:-$(mktemp -d)}"
+
+    # Sandbox the sprint dir so we don't pollute the real grimoires tree.
+    # The sidecar is written under $PROJECT_ROOT/grimoires/loa/a2a/$sprint_id,
+    # so we override PROJECT_ROOT to a tmp tree for each test.
+    SANDBOX_ROOT="$TEST_DIR/sandbox"
+    mkdir -p "$SANDBOX_ROOT/.claude/scripts/lib"
+    # Copy the redactor so process_findings can find it under sandbox PROJECT_ROOT.
+    cp "$PROJECT_ROOT/.claude/scripts/lib/log-redactor.sh" "$SANDBOX_ROOT/.claude/scripts/lib/"
+    chmod +x "$SANDBOX_ROOT/.claude/scripts/lib/log-redactor.sh"
+
+    local saved_root="$PROJECT_ROOT"
+    source "$PROJECT_ROOT/.claude/scripts/lib-content.sh"
+    eval "$(sed 's/^main "\$@"/# main disabled for testing/' "$ADVERSARIAL_REVIEW")"
+
+    PROJECT_ROOT="$SANDBOX_ROOT"
+    export PROJECT_ROOT
+
+    SPRINT_ID="sprint-kf011-test"
+    SIDECAR_DIR="$SANDBOX_ROOT/grimoires/loa/a2a/$SPRINT_ID"
+}
+
+teardown() {
+    unset LOA_ADVERSARIAL_DEBUG
+}
+
+# Build a synthetic model-adapter envelope where the .content does NOT
+# contain a 'findings' key. process_findings should bucket this as
+# malformed_response.
+_malformed_envelope() {
+    jq -n '{
+        content: "Sorry, I cannot review this without more context. The review object should contain a list of issues but instead I will explain my reasoning.",
+        model: "openai:gpt-5.5-pro",
+        cost_cents: 12
+    }'
+}
+
+# Build a well-formed envelope.
+_well_formed_envelope() {
+    jq -n '{
+        content: "{\"findings\": []}",
+        model: "openai:gpt-5.5-pro",
+        cost_cents: 8
+    }'
+}
+
+# Build a well-formed envelope with populated findings.
+_populated_envelope() {
+    jq -n '{
+        content: "{\"findings\": [{\"id\": \"X\", \"severity\": \"MEDIUM\", \"category\": \"quality\", \"summary\": \"test\", \"detail\": \"test\", \"file\": \"foo.sh\", \"line\": 1, \"anchor\": \"echo hi\"}]}",
+        model: "openai:gpt-5.5-pro",
+        cost_cents: 8
+    }'
+}
+
+@test "KF-011 debug: LOA_ADVERSARIAL_DEBUG=1 + malformed → sidecar written" {
+    export LOA_ADVERSARIAL_DEBUG=1
+    raw=$(_malformed_envelope)
+
+    result=$(process_findings "$raw" "review" "openai:gpt-5.5-pro" "$SPRINT_ID" "0" "" 2>/dev/null)
+    status_val=$(echo "$result" | jq -r '.metadata.status' 2>/dev/null)
+    [ "$status_val" = "malformed_response" ]
+
+    # Sidecar must exist
+    [ -d "$SIDECAR_DIR" ]
+    sidecar_count=$( (ls -1 "$SIDECAR_DIR"/adversarial-debug-*.txt 2>/dev/null || true) | wc -l )
+    [ "$sidecar_count" -ge 1 ]
+}
+
+@test "KF-011 debug: LOA_ADVERSARIAL_DEBUG unset + malformed → NO sidecar" {
+    unset LOA_ADVERSARIAL_DEBUG
+    raw=$(_malformed_envelope)
+
+    result=$(process_findings "$raw" "review" "openai:gpt-5.5-pro" "$SPRINT_ID" "0" "" 2>/dev/null)
+    status_val=$(echo "$result" | jq -r '.metadata.status' 2>/dev/null)
+    [ "$status_val" = "malformed_response" ]
+
+    # NO debug sidecar should exist (the dir may exist from other sidecars,
+    # but no adversarial-debug-* file)
+    sidecar_count=$( (ls -1 "$SIDECAR_DIR"/adversarial-debug-*.txt 2>/dev/null || true) | wc -l )
+    [ "$sidecar_count" -eq 0 ]
+}
+
+@test "KF-011 debug: LOA_ADVERSARIAL_DEBUG=1 + well-formed empty → NO sidecar" {
+    export LOA_ADVERSARIAL_DEBUG=1
+    raw=$(_well_formed_envelope)
+
+    result=$(process_findings "$raw" "review" "openai:gpt-5.5-pro" "$SPRINT_ID" "0" "" 2>/dev/null)
+    status_val=$(echo "$result" | jq -r '.metadata.status' 2>/dev/null)
+    [ "$status_val" = "clean" ]
+
+    sidecar_count=$( (ls -1 "$SIDECAR_DIR"/adversarial-debug-*.txt 2>/dev/null || true) | wc -l )
+    [ "$sidecar_count" -eq 0 ]
+}
+
+@test "KF-011 debug: LOA_ADVERSARIAL_DEBUG=1 + populated findings → NO sidecar" {
+    export LOA_ADVERSARIAL_DEBUG=1
+    raw=$(_populated_envelope)
+
+    result=$(process_findings "$raw" "review" "openai:gpt-5.5-pro" "$SPRINT_ID" "0" "" 2>/dev/null)
+    # Status should be clean or some populated state — not malformed
+    status_val=$(echo "$result" | jq -r '.metadata.status' 2>/dev/null)
+    [ "$status_val" != "malformed_response" ]
+
+    sidecar_count=$( (ls -1 "$SIDECAR_DIR"/adversarial-debug-*.txt 2>/dev/null || true) | wc -l )
+    [ "$sidecar_count" -eq 0 ]
+}
+
+@test "KF-011 debug: sidecar applies log-redactor (no AKIA leak)" {
+    export LOA_ADVERSARIAL_DEBUG=1
+    # Inject an AKIA-shape secret into the malformed content. Log-redactor
+    # should scrub it before write.
+    fake_secret="AKIA1234567890ABCDEF"
+    raw=$(jq -n --arg secret "$fake_secret" '{
+        content: "I refuse to produce findings, but here is an AWS key for testing: \($secret)",
+        model: "openai:gpt-5.5-pro",
+        cost_cents: 5
+    }')
+
+    result=$(process_findings "$raw" "review" "openai:gpt-5.5-pro" "$SPRINT_ID" "0" "" 2>/dev/null)
+    status_val=$(echo "$result" | jq -r '.metadata.status' 2>/dev/null)
+    [ "$status_val" = "malformed_response" ]
+
+    sidecar=$(find "$SIDECAR_DIR" -name "adversarial-debug-*.txt" 2>/dev/null | head -1)
+    [ -n "$sidecar" ]
+    [ -f "$sidecar" ]
+    # AKIA-shape must NOT appear verbatim in the sidecar
+    if grep -q "$fake_secret" "$sidecar"; then
+        echo "REDACTION FAILURE: $fake_secret leaked into $sidecar"
+        cat "$sidecar"
+        false
+    fi
+    # And the redaction marker should be present
+    grep -q "REDACTED-AKIA" "$sidecar"
+}
+
+@test "KF-011 debug: filename slugs colon in model id" {
+    export LOA_ADVERSARIAL_DEBUG=1
+    raw=$(_malformed_envelope)
+
+    result=$(process_findings "$raw" "review" "openai:gpt-5.5-pro" "$SPRINT_ID" "0" "" 2>/dev/null)
+    [ -n "$result" ]
+
+    # No file should have a `:` in its name (sanitized to `__`)
+    bad_count=$( (ls -1 "$SIDECAR_DIR"/*:* 2>/dev/null || true) | wc -l )
+    [ "$bad_count" -eq 0 ]
+
+    # And the expected slug (provider__model_id) should be present
+    expected_slug_count=$( (ls -1 "$SIDECAR_DIR"/adversarial-debug-openai__gpt-5.5-pro-*.txt 2>/dev/null || true) | wc -l )
+    [ "$expected_slug_count" -ge 1 ]
+}


### PR DESCRIPTION
## Summary

Closes #930 (KF-011 diagnostic). Adds an opt-in raw-response capture to `adversarial-review.sh` so the next observation of `status: malformed_response` can be diagnosed against actual model output instead of metadata alone.

## Why

[KF-011](https://github.com/0xHoneyJar/loa/blob/main/grimoires/loa/known-failures.md#kf-011-adversarial-reviewsh-malformed_response-on-review-type-prompts-post-kf-002-closure) is structurally distinct from KF-002 (RESOLVED-STRUCTURAL via cycle-109 T4.10):

| | KF-002 | KF-011 |
|---|---|---|
| HTTP status | 200 | 200 |
| Response body | empty | non-empty |
| Parser fails because | nothing to parse | content does not contain `findings` key |
| cycle-109 T4.10 fixes apply | ✅ YES | ❌ NO |

Without the raw response body, we can't distinguish between three candidate root causes (prompt-schema drift, parser brittleness on wrapped envelopes, reasoning-class meta-commentary). Each has a different fix scope. **This patch is the diagnostic that unlocks all three fixes**; it ships nothing else.

## Behavior

```bash
# Default: nothing changes
.claude/scripts/adversarial-review.sh --type review ...

# Opt-in capture (one-shot diagnostic):
LOA_ADVERSARIAL_DEBUG=1 .claude/scripts/adversarial-review.sh --type review ...
# On malformed_response: writes
#   grimoires/loa/a2a/{sprint_id}/adversarial-debug-{model_slug}-{ts}.txt
# Otherwise: silent (no debug output for clean/populated states)
```

The sidecar contents:

```
# KF-011 debug capture (LOA_ADVERSARIAL_DEBUG=1)
# model: openai:gpt-5.5-pro
# sprint_id: sprint-166
# type: review
# timestamp: 2026-05-17T08:23:30Z
# ---
## raw_response (model-adapter envelope):
{"content": "...", "model": "openai:gpt-5.5-pro", ...}

## extracted content (.content field):
[whatever the model returned]

## parsed (post markdown-fence strip):
[same with ```json fences stripped]
```

## NFR-Sec-1 defense-in-depth

Sidecar passes through `lib/log-redactor.sh` before write — same pattern as `tools/model-economy-roll-up.sh` (cycle-112 sprint-166). Synthetic-AKIA test pins the redaction round-trip (test 5 of 6).

## Tests

| Test | Asserts |
|------|---------|
| 1 | `LOA_ADVERSARIAL_DEBUG=1` + malformed → sidecar written |
| 2 | env unset + malformed → NO sidecar (default behavior unchanged) |
| 3 | env=1 + well-formed empty → NO sidecar (only fires on malformed) |
| 4 | env=1 + populated findings → NO sidecar |
| 5 | sidecar applies log-redactor (no AKIA leak) |
| 6 | filename slugs colons (model id `:` and timestamp `:`) for cross-platform portability |

6/6 new tests pass. 69/69 existing `adversarial-review.bats` tests pass unchanged (regression check).

## Operator usage when KF-011 recurs

```bash
# Re-run a known-malformed adversarial review with the debug flag
LOA_ADVERSARIAL_DEBUG=1 .claude/scripts/adversarial-review.sh \
    --type review \
    --sprint-id sprint-NNN \
    --diff-file /tmp/diff.patch \
    --json

# Inspect the captured content
cat grimoires/loa/a2a/sprint-NNN/adversarial-debug-*.txt | less
```

Three sub-modes will be visually obvious from the captured content:
- **(a) prompt-schema drift**: the model's `.content` will be JSON but missing the `findings` key — the dissenter prompt isn't enforcing the envelope shape
- **(b) parser brittleness**: the model's `.content` will be JSON WITH findings but wrapped in another envelope (`{review: {findings: [...]}}` or `{result: {findings: [...]}}`)
- **(c) model behavior change**: the model's `.content` will be prose / refusal / meta-commentary — no JSON at all

The KF-011 entry's Reading guide documents the three sub-modes + their respective fix scopes. This PR enables the diagnostic that picks between them.

## Test plan

- [x] `bats tests/unit/adversarial-review-kf-011-debug.bats` → 6/6
- [x] `bats tests/unit/adversarial-review.bats` → 69/69 (no regressions)
- [x] Default behavior verified unchanged via test 2 (env unset, no sidecar)
- [x] NFR-Sec-1 redaction verified via test 5 (AKIA does not leak)
- [x] Cross-platform filename portability verified via test 6

## Follow-up after merge

On the next KF-011 recurrence, run with `LOA_ADVERSARIAL_DEBUG=1`, capture the content, choose the appropriate sub-mode fix. Update KF-011's Attempts table with the captured-content evidence as the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via cycle-112 follow-up.