### PR TITLE
fix(kf011-c): extend adversarial-review fallback chain to 4 voices (claude-headless)

### DIFF
--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -318,6 +318,14 @@ flatline_protocol:
     model: gpt-5.5-pro
     budget_cents: 200
     timeout_seconds: 600
+    # KF-011 sub-mode (c) mitigation (2026-05-17): Gemini-3.1-pro empty-content
+    # on review-type prompts post cycle-109 T4.10. Adding claude-headless as a
+    # 4th-line voice so quorum is reachable when Gemini is silent. KF-011
+    # sub-mode (b) resolved by parser fix in d9ec8cb5; this entry covers (c).
+    fallback_chain:
+      - gpt-5.5
+      - gemini-3.1-pro
+      - claude-headless
   security_audit:
     enabled: true
     # Same revert rationale as code_review (cycle-104 Sprint 2 T2.9).
@@ -325,6 +333,11 @@ flatline_protocol:
     model: gpt-5.5-pro
     budget_cents: 200
     timeout_seconds: 600
+    # KF-011 sub-mode (c) mitigation — same as code_review above.
+    fallback_chain:
+      - gpt-5.5
+      - gemini-3.1-pro
+      - claude-headless
   secret_scanning:
     patterns:
       - "AIzaSy[A-Za-z0-9_-]{33}"


### PR DESCRIPTION
## Summary

Mitigates KF-011 sub-mode (c) — Gemini-3.1-pro empty-content on review-type prompts — by extending the adversarial-review fallback chain to include `claude-headless` as a 4th-line voice.

Sub-mode (b) (OpenAI prose preamble + JSON) was closed in [PR #933](https://github.com/0xHoneyJar/loa/pull/933) (`d9ec8cb5`) via parser-side `raw_decode` extraction. This PR closes the route-around for sub-mode (c). The root-cause Gemini streaming-recovery investigation remains open (tracked in KF-011 §Reading guide §5).

## Captured evidence motivating this fix

From the 2026-05-17 diagnostic capture:
```
adversarial-debug-gemini-3.1-pro-2026-05-17T08-35-44Z.txt:
  raw_response.content: "" (empty string)
  raw_response.cost_usd: 0
  raw_response.tokens_output: 0
```

Gemini's adapter returned a clean HTTP 200 + zero-content envelope. cycle-109 T4.10's streaming-recovery should have aborted this with a typed exit, but per-provider gaps in the Gemini implementation let it through. Until that's investigated structurally, routing around with a 4th voice keeps consensus reachable.

## Effective fallback chain post-merge

| Position | Model | Notes |
|----------|-------|-------|
| primary  | gpt-5.5-pro | unchanged |
| 1st fall | gpt-5.5 | unchanged |
| 2nd fall | gemini-3.1-pro | unchanged |
| **3rd fall** | **claude-headless** | **NEW — KF-011-c mitigation** |

The same chain applies to `security_audit` (mirror of `code_review`).

## Why claude-headless

- Different provider family from gpt-5.5* and gemini-3.1-pro (cross-model dissent diversity)
- Already in the substrate catalog (`.claude/defaults/model-config.yaml:471`)
- Headless models bypass the reasoning-budget class that drives KF-002/KF-011 substrate fatigue
- Cost-cheap relative to Pro tier — appropriate as a last-line consensus voice

## No code changes required

The script's chain-construction logic at `.claude/scripts/adversarial-review.sh:1318-1352` already iterates `flatline_protocol.{type}.fallback_chain` arrays of arbitrary length (cycle-102 sprint-1F design). This PR is config-only.

## BB parser parity check (informational, not a fix)

Investigated whether bridgebuilder-review needs the same KF-011 fixes:

- **Sub-mode (b) prose preamble**: BB uses HTML-comment markers as the envelope contract (`<!-- bridge-findings-start --> \`\`\`json ... \`\`\` <!-- bridge-findings-end -->`). The regex at `multi-model-pipeline.ts:442-444` only matches the explicit-marker form, so prose preamble is structurally handled by the marker contract. **No fix needed**.
- **Sub-mode (c) Gemini empty-content**: BB's `multi-model-pipeline.ts:42-48` `deriveTimeoutMs` predicate covers reasoning-class Anthropic + Google + OpenAI (sprint-bug-165 / #921 / KF-010). The fallback chain extension here doesn't apply to BB's separate dispatch path. **Separate consideration if BB hits the same Gemini empty-content empirically.**

BB's marker-based design is actually stronger than adversarial-review's was — worth considering as the convergent design if future KF-011-class sub-modes emerge.

## Drift gate posture

`.loa.config.yaml::workload_tier_map` is unchanged. Verified via yq projection diff:
```bash
diff <(yq eval '.workload_tier_map' main:.loa.config.yaml) \
     <(yq eval '.workload_tier_map' .loa.config.yaml)
# (empty — subtree unchanged)
```

So the cycle-112 drift gate (introduced in PR #928) does NOT fire on this PR — no `Tier-Change-Evidence:` / `Operator-Approval:` trailer needed.

## Test plan

- [x] YAML parses (`yq eval '.flatline_protocol.code_review.fallback_chain'` returns the 3-entry list)
- [x] workload_tier_map subtree unchanged (drift gate clean)
- [x] No code changes — fallback chain logic at lines 1318-1352 already iterates arrays from `flatline_protocol.{type}.fallback_chain`

## Verification post-merge

When KF-011 sub-mode (c) recurs (next time Gemini returns empty), the script should:
1. Try gpt-5.5-pro → if prose-preamble: parser fix recovers → reviewed (most common path post-PR-#933)
2. If gpt-5.5-pro malformed: fall to gpt-5.5
3. If gpt-5.5 malformed: fall to gemini-3.1-pro → if empty: classify as malformed_response → continue
4. **NEW**: Fall to claude-headless → quorum reachable

## Follow-ups

1. KF-011 sub-mode (c) root cause: investigate Gemini adapter's streaming-recovery behavior on review-type prompts. Issue can be filed if Gemini empty-content recurs repeatedly (current recurrence count: 2 — once at sprint-166 review, once at this session's reproduction).
2. Convergent design: BB's marker-based envelope contract is the stronger pattern. Future KF-011-class observations may warrant migrating adversarial-review.sh to the same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via diagnostic-chain follow-up.