### PR TITLE
fix(#911): sha256_portable migration — close macOS portability gap across 38 framework scripts

### DIFF
--- a/.claude/scripts/adversarial-review.sh
+++ b/.claude/scripts/adversarial-review.sh
@@ -35,6 +35,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG_FILE="${CONFIG_FILE:-$PROJECT_ROOT/.loa.config.yaml}"
@@ -1011,9 +1015,9 @@ compute_finding_id() {
 
   if [[ "$anchor" == "no_anchor" ]]; then
     # No-anchor findings are always unique — include index to prevent collision
-    printf 'noanch:%s:%s' "$category" "$index" | sha256sum | cut -c1-8
+    printf 'noanch:%s:%s' "$category" "$index" | sha256_portable | cut -c1-8
   else
-    printf '%s:%s' "$anchor" "$category" | sha256sum | cut -c1-8
+    printf '%s:%s' "$anchor" "$category" | sha256_portable | cut -c1-8
   fi
 }
 

--- a/.claude/scripts/audit-envelope.sh
+++ b/.claude/scripts/audit-envelope.sh
@@ -63,6 +63,12 @@ _LOA_AUDIT_SCHEMA="${_LOA_AUDIT_REPO_ROOT}/data/trajectory-schemas/agent-network
 _LOA_AUDIT_JCS_LIB="${_LOA_AUDIT_REPO_ROOT}/../lib/jcs.sh"
 _LOA_AUDIT_SIGNING_HELPER="${_LOA_AUDIT_DIR}/lib/audit-signing-helper.py"
 
+# sprint-bug-172 / bug-911: compat-lib provides sha256_portable for the
+# _audit_sha256 helper below. python3 fallback at line ~157 stays as
+# defense-in-depth for hash-chain integrity when neither GNU sha256sum
+# nor BSD shasum is available.
+source "${_LOA_AUDIT_DIR}/compat-lib.sh"
+
 # Source JCS canonicalizer.
 # shellcheck source=../../lib/jcs.sh
 source "${_LOA_AUDIT_JCS_LIB}"
@@ -142,13 +148,13 @@ print(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
 
 # -----------------------------------------------------------------------------
 # _audit_sha256() — SHA-256 hex digest of stdin bytes.
-# Tries `sha256sum` (Linux) first, then `shasum -a 256` (macOS), then python3.
+# Delegates to compat-lib's sha256_portable (GNU sha256sum + BSD shasum dispatch).
+# Falls through to python3 as a last-resort defense-in-depth for hash-chain
+# integrity when neither GNU nor BSD shasum is available. sprint-bug-172.
 # -----------------------------------------------------------------------------
 _audit_sha256() {
-    if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum | awk '{print $1}'
-    elif command -v shasum >/dev/null 2>&1; then
-        shasum -a 256 | awk '{print $1}'
+    if [[ -n "${_COMPAT_SHA256_CMD:-}" ]]; then
+        sha256_portable | awk '{print $1}'
     else
         python3 -c '
 import hashlib, sys

--- a/.claude/scripts/beads-flatline-loop.sh
+++ b/.claude/scripts/beads-flatline-loop.sh
@@ -21,6 +21,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source bootstrap if available
@@ -129,7 +133,7 @@ count_beads() {
 # Get bead structure hash for change detection
 get_bead_hash() {
     if command -v br &>/dev/null; then
-        br list --json 2>/dev/null | jq -S '.' 2>/dev/null | sha256sum | cut -d' ' -f1
+        br list --json 2>/dev/null | jq -S '.' 2>/dev/null | sha256_portable | cut -d' ' -f1
     else
         echo "none"
     fi

--- a/.claude/scripts/butterfreezone-gen.sh
+++ b/.claude/scripts/butterfreezone-gen.sh
@@ -2178,7 +2178,7 @@ generate_ground_truth_meta() {
         content=$(extract_section_content "$document" "$section")
         if [[ -n "$content" ]]; then
             local hash
-            hash=$(printf '%s' "$content" | sha256sum | awk '{print $1}')
+            hash=$(printf '%s' "$content" | sha256_portable | awk '{print $1}')
             checksums="${checksums}
   ${section}: ${hash}"
         fi

--- a/.claude/scripts/cache-manager.sh
+++ b/.claude/scripts/cache-manager.sh
@@ -3,6 +3,10 @@
 # Part of the Loa framework's Recursive JIT Context System
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck source=lib/normalize-json.sh
@@ -122,8 +126,8 @@ check_dependencies() {
         missing+=("jq")
     fi
 
-    if ! command -v sha256sum &>/dev/null && ! command -v shasum &>/dev/null; then
-        missing+=("sha256sum or shasum")
+    if ! command -v sha256_portable &>/dev/null && ! command -v shasum &>/dev/null; then
+        missing+=("sha256_portable or shasum")
     fi
 
     if [[ ${#missing[@]} -gt 0 ]]; then
@@ -143,8 +147,8 @@ check_dependencies() {
 #######################################
 sha256_hash() {
     local input="$1"
-    if command -v sha256sum &>/dev/null; then
-        echo -n "$input" | sha256sum | cut -d' ' -f1
+    if command -v sha256_portable &>/dev/null; then
+        echo -n "$input" | sha256_portable | cut -d' ' -f1
     else
         echo -n "$input" | shasum -a 256 | cut -d' ' -f1
     fi

--- a/.claude/scripts/cache-manager.sh
+++ b/.claude/scripts/cache-manager.sh
@@ -126,8 +126,11 @@ check_dependencies() {
         missing+=("jq")
     fi
 
-    if ! command -v sha256_portable &>/dev/null && ! command -v shasum &>/dev/null; then
-        missing+=("sha256_portable or shasum")
+    # sprint-bug-172: sha256_portable is a compat-lib function; the underlying
+    # tool (GNU sha256sum or BSD shasum) availability is tracked in
+    # _COMPAT_SHA256_CMD at compat-lib source time.
+    if [[ -z "${_COMPAT_SHA256_CMD:-}" ]]; then
+        missing+=("GNU coreutils or BSD shasum (sha-256 tool)")
     fi
 
     if [[ ${#missing[@]} -gt 0 ]]; then
@@ -147,11 +150,8 @@ check_dependencies() {
 #######################################
 sha256_hash() {
     local input="$1"
-    if command -v sha256_portable &>/dev/null; then
-        echo -n "$input" | sha256_portable | cut -d' ' -f1
-    else
-        echo -n "$input" | shasum -a 256 | cut -d' ' -f1
-    fi
+    # sprint-bug-172: sha256_portable handles GNU/BSD/fail-loud dispatch.
+    echo -n "$input" | sha256_portable | cut -d' ' -f1
 }
 
 #######################################

--- a/.claude/scripts/check-loa.sh
+++ b/.claude/scripts/check-loa.sh
@@ -4,6 +4,10 @@
 # Exit codes: 0 = success, 1 = failure
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 VERSION_FILE=".loa-version.json"
 CHECKSUMS_FILE=".claude/checksums.json"
 CONFIG_FILE=".loa.config.yaml"
@@ -43,7 +47,7 @@ check_integrity() {
     [[ -z "$expected" || "$expected" == "null" ]] && continue
 
     if [[ -f "$file" ]]; then
-      local actual=$(sha256sum "$file" | cut -d' ' -f1)
+      local actual=$(sha256_portable "$file" | cut -d' ' -f1)
       if [[ "$expected" != "$actual" ]]; then
         fail "Tampered: $file"
         drift=true

--- a/.claude/scripts/compat-lib.sh
+++ b/.claude/scripts/compat-lib.sh
@@ -29,6 +29,7 @@
 #   make_temp          Portable mktemp with suffix support
 #   get_file_mtime     Portable file modification time (epoch seconds)
 #   find_sorted_by_time Portable find + sort by mtime (no -printf)
+#   sha256_portable    Portable SHA-256 hashing (handles GNU sha256sum vs BSD shasum)
 #
 # Environment:
 #   LOA_COMPAT_DEBUG=1   Enable debug output for platform detection
@@ -40,7 +41,7 @@ if [[ "${_COMPAT_LIB_LOADED:-}" == "true" ]]; then
 fi
 _COMPAT_LIB_LOADED=true
 
-_COMPAT_LIB_VERSION="1.1.0"
+_COMPAT_LIB_VERSION="1.2.0"
 
 # =============================================================================
 # Platform Detection (run once at source time)
@@ -87,6 +88,18 @@ if stat -c %Y / &>/dev/null 2>&1; then
   _COMPAT_STAT_STYLE="gnu"
 fi
 
+# Feature detection for GNU sha256sum vs BSD shasum -a 256
+# Prefers GNU sha256sum when both are available (deterministic, simpler dispatch).
+# Empty string means neither is available — sha256_portable will fail loud at
+# call time rather than at source time, so callers that don't need hashing can
+# still source the library.
+_COMPAT_SHA256_CMD=""
+if command -v sha256sum >/dev/null 2>&1; then
+  _COMPAT_SHA256_CMD="gnu"
+elif command -v shasum >/dev/null 2>&1; then
+  _COMPAT_SHA256_CMD="bsd"
+fi
+
 if [[ "${LOA_COMPAT_DEBUG:-}" == "1" ]]; then
   echo "[compat-lib] OS: $_COMPAT_OS" >&2
   echo "[compat-lib] sed: $_COMPAT_SED_STYLE" >&2
@@ -94,6 +107,7 @@ if [[ "${LOA_COMPAT_DEBUG:-}" == "1" ]]; then
   echo "[compat-lib] readlink -f: $_COMPAT_HAS_READLINK_F" >&2
   echo "[compat-lib] find -printf: $_COMPAT_HAS_FIND_PRINTF" >&2
   echo "[compat-lib] stat: $_COMPAT_STAT_STYLE" >&2
+  echo "[compat-lib] sha256: $_COMPAT_SHA256_CMD" >&2
 fi
 
 # =============================================================================
@@ -461,10 +475,57 @@ _date_to_epoch() {
 }
 
 # =============================================================================
+# sha256_portable - Portable SHA-256 hashing (sprint-bug-172 / bug-911)
+# =============================================================================
+#
+# GNU coreutils ships `sha256sum`; macOS ships `shasum -a 256` (Perl-based
+# from BSD's stock toolchain). Loa framework scripts that called raw
+# sha256sum silently produced empty hashes on macOS, cascading into
+# validation FAILs (e.g., butterfreezone-gen → butterfreezone-validate
+# returning 10/12 instead of 12/12 provenance tagged).
+#
+# Argv shape matches sha256sum exactly: pass file paths positionally, or
+# pipe content via stdin. Output format is byte-identical between GNU and
+# BSD (`<hex-hash>  <filename-or-dash>` with two spaces), so downstream
+# parsing via `awk '{print $1}'` or `cut -d' ' -f1` works unchanged.
+#
+# Arguments:
+#   Same as sha256sum: zero or more file paths. With no args, reads stdin.
+#
+# Exit codes:
+#   0    - hashing succeeded
+#   127  - neither sha256sum nor shasum found in PATH (fail loud, no silent
+#          empty-hash emission — that's exactly the bug #911 failure class)
+#   other - backend tool's own exit code (e.g., file-not-found from
+#           sha256sum/shasum)
+#
+# Usage:
+#   echo "content" | sha256_portable | awk '{print $1}'
+#   sha256_portable file.txt | cut -d' ' -f1
+#   sha256_portable a.txt b.txt c.txt  # multi-file form
+#
+sha256_portable() {
+  case "$_COMPAT_SHA256_CMD" in
+    gnu)
+      sha256sum "$@"
+      ;;
+    bsd)
+      shasum -a 256 "$@"
+      ;;
+    *)
+      echo "ERROR: sha256_portable: neither sha256sum (GNU) nor shasum (BSD) found in PATH" >&2
+      echo "       Install GNU coreutils (Linux: apt/yum/pacman 'coreutils'; macOS: 'brew install coreutils')" >&2
+      echo "       or Perl (macOS ships shasum from /usr/bin/shasum by default)." >&2
+      return 127
+      ;;
+  esac
+}
+
+# =============================================================================
 # Version
 # =============================================================================
 
-_COMPAT_LIB_VERSION="1.1.0"
+_COMPAT_LIB_VERSION="1.2.0"
 
 get_compat_lib_version() {
   echo "$_COMPAT_LIB_VERSION"

--- a/.claude/scripts/condense.sh
+++ b/.claude/scripts/condense.sh
@@ -125,11 +125,8 @@ check_dependencies() {
 #######################################
 sha256_hash() {
     local input="$1"
-    if command -v sha256_portable &>/dev/null; then
-        echo -n "$input" | sha256_portable | cut -d' ' -f1
-    else
-        echo -n "$input" | shasum -a 256 | cut -d' ' -f1
-    fi
+    # sprint-bug-172: sha256_portable handles GNU/BSD/fail-loud dispatch.
+    echo -n "$input" | sha256_portable | cut -d' ' -f1
 }
 
 #######################################

--- a/.claude/scripts/condense.sh
+++ b/.claude/scripts/condense.sh
@@ -3,6 +3,10 @@
 # Part of the Loa framework's Recursive JIT Context System
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Allow environment variable overrides for testing
@@ -121,8 +125,8 @@ check_dependencies() {
 #######################################
 sha256_hash() {
     local input="$1"
-    if command -v sha256sum &>/dev/null; then
-        echo -n "$input" | sha256sum | cut -d' ' -f1
+    if command -v sha256_portable &>/dev/null; then
+        echo -n "$input" | sha256_portable | cut -d' ' -f1
     else
         echo -n "$input" | shasum -a 256 | cut -d' ' -f1
     fi

--- a/.claude/scripts/constructs-lib.sh
+++ b/.claude/scripts/constructs-lib.sh
@@ -904,14 +904,10 @@ verify_content_hash() {
         return 1
     fi
 
-    # Calculate SHA256 (portable: works on Linux and macOS)
+    # sprint-bug-172: sha256_portable handles GNU/BSD/fail-loud dispatch.
     local actual_hash
-    if command -v sha256_portable &>/dev/null; then
-        # Linux
+    if [[ -n "${_COMPAT_SHA256_CMD:-}" ]]; then
         actual_hash=$(sha256_portable "$file" | cut -d' ' -f1)
-    elif command -v shasum &>/dev/null; then
-        # macOS
-        actual_hash=$(shasum -a 256 "$file" | cut -d' ' -f1)
     else
         print_warning "  No SHA256 tool available, skipping verification"
         return 0
@@ -940,10 +936,9 @@ calculate_file_hash() {
         return 1
     fi
 
-    if command -v sha256_portable &>/dev/null; then
+    # sprint-bug-172: sha256_portable handles GNU/BSD/fail-loud dispatch.
+    if [[ -n "${_COMPAT_SHA256_CMD:-}" ]]; then
         sha256_portable "$file" | cut -d' ' -f1
-    elif command -v shasum &>/dev/null; then
-        shasum -a 256 "$file" | cut -d' ' -f1
     else
         echo ""
         return 1

--- a/.claude/scripts/constructs-lib.sh
+++ b/.claude/scripts/constructs-lib.sh
@@ -22,6 +22,10 @@ set -euo pipefail
 #   $1 - Config key under registry section (e.g., "enabled", "default_url")
 #   $2 - Default value if key not found
 # Returns: Config value or default
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 get_registry_config() {
     local key="$1"
     local default="${2:-}"
@@ -902,9 +906,9 @@ verify_content_hash() {
 
     # Calculate SHA256 (portable: works on Linux and macOS)
     local actual_hash
-    if command -v sha256sum &>/dev/null; then
+    if command -v sha256_portable &>/dev/null; then
         # Linux
-        actual_hash=$(sha256sum "$file" | cut -d' ' -f1)
+        actual_hash=$(sha256_portable "$file" | cut -d' ' -f1)
     elif command -v shasum &>/dev/null; then
         # macOS
         actual_hash=$(shasum -a 256 "$file" | cut -d' ' -f1)
@@ -936,8 +940,8 @@ calculate_file_hash() {
         return 1
     fi
 
-    if command -v sha256sum &>/dev/null; then
-        sha256sum "$file" | cut -d' ' -f1
+    if command -v sha256_portable &>/dev/null; then
+        sha256_portable "$file" | cut -d' ' -f1
     elif command -v shasum &>/dev/null; then
         shasum -a 256 "$file" | cut -d' ' -f1
     else

--- a/.claude/scripts/flatline-manifest.sh
+++ b/.claude/scripts/flatline-manifest.sh
@@ -25,6 +25,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
@@ -220,7 +224,7 @@ create_manifest() {
     # Calculate document hash
     local doc_hash=""
     if [[ -f "$document" ]]; then
-        doc_hash=$(sha256sum "$document" | cut -d' ' -f1)
+        doc_hash=$(sha256_portable "$document" | cut -d' ' -f1)
     fi
 
     # Normalize document path

--- a/.claude/scripts/flatline-result-handler.sh
+++ b/.claude/scripts/flatline-result-handler.sh
@@ -28,6 +28,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
@@ -157,7 +161,7 @@ get_critical_percent() {
 calculate_hash() {
     local file="$1"
     if [[ -f "$file" ]]; then
-        sha256sum "$file" | cut -d' ' -f1
+        sha256_portable "$file" | cut -d' ' -f1
     else
         echo ""
     fi

--- a/.claude/scripts/flatline-rollback.sh
+++ b/.claude/scripts/flatline-rollback.sh
@@ -25,6 +25,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 RUNS_DIR="$PROJECT_ROOT/.flatline/runs"
@@ -83,7 +87,7 @@ log_trajectory() {
 calculate_hash() {
     local file="$1"
     if [[ -f "$file" ]]; then
-        sha256sum "$file" | cut -d' ' -f1
+        sha256_portable "$file" | cut -d' ' -f1
     else
         echo ""
     fi

--- a/.claude/scripts/flatline-snapshot.sh
+++ b/.claude/scripts/flatline-snapshot.sh
@@ -27,6 +27,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
@@ -163,7 +167,7 @@ ensure_snapshot_dir() {
 calculate_hash() {
     local file="$1"
     if [[ -f "$file" ]]; then
-        sha256sum "$file" | cut -d' ' -f1
+        sha256_portable "$file" | cut -d' ' -f1
     else
         echo ""
     fi

--- a/.claude/scripts/generate-constraints.sh
+++ b/.claude/scripts/generate-constraints.sh
@@ -49,7 +49,7 @@ compute_section_hash() {
   printf '%s' "$1" \
     | tr -d '\r' \
     | sed 's/[[:space:]]*$//' \
-    | sha256sum \
+    | sha256_portable \
     | cut -c1-16
 }
 

--- a/.claude/scripts/ground-truth-gen.sh
+++ b/.claude/scripts/ground-truth-gen.sh
@@ -114,8 +114,9 @@ check_dependencies() {
     missing=1
   fi
 
-  if ! command -v sha256_portable &>/dev/null && ! command -v shasum &>/dev/null; then
-    echo "ERROR: sha256_portable or shasum is required but not installed" >&2
+  # sprint-bug-172: sha256_portable backend availability tracked in _COMPAT_SHA256_CMD.
+  if [[ -z "${_COMPAT_SHA256_CMD:-}" ]]; then
+    echo "ERROR: GNU coreutils or BSD shasum (sha-256 tool) is required but not installed" >&2
     missing=1
   fi
 
@@ -128,14 +129,10 @@ check_dependencies() {
 # Helpers
 # =============================================================================
 
-# Cross-platform SHA-256
+# Cross-platform SHA-256 — sprint-bug-172: sha256_portable handles dispatch.
 compute_sha256() {
   local file="$1"
-  if command -v sha256_portable &>/dev/null; then
-    sha256_portable "$file" | awk '{print $1}'
-  elif command -v shasum &>/dev/null; then
-    shasum -a 256 "$file" | awk '{print $1}'
-  fi
+  sha256_portable "$file" | awk '{print $1}'
 }
 
 # Estimate tokens from word count (1 token ≈ 0.75 words)

--- a/.claude/scripts/ground-truth-gen.sh
+++ b/.claude/scripts/ground-truth-gen.sh
@@ -19,6 +19,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/bootstrap.sh"
 
@@ -110,8 +114,8 @@ check_dependencies() {
     missing=1
   fi
 
-  if ! command -v sha256sum &>/dev/null && ! command -v shasum &>/dev/null; then
-    echo "ERROR: sha256sum or shasum is required but not installed" >&2
+  if ! command -v sha256_portable &>/dev/null && ! command -v shasum &>/dev/null; then
+    echo "ERROR: sha256_portable or shasum is required but not installed" >&2
     missing=1
   fi
 
@@ -127,8 +131,8 @@ check_dependencies() {
 # Cross-platform SHA-256
 compute_sha256() {
   local file="$1"
-  if command -v sha256sum &>/dev/null; then
-    sha256sum "$file" | awk '{print $1}'
+  if command -v sha256_portable &>/dev/null; then
+    sha256_portable "$file" | awk '{print $1}'
   elif command -v shasum &>/dev/null; then
     shasum -a 256 "$file" | awk '{print $1}'
   fi

--- a/.claude/scripts/lib-route-table.sh
+++ b/.claude/scripts/lib-route-table.sh
@@ -39,6 +39,10 @@
 # It is designed to be sourced by other scripts.
 
 # Guard against double-sourcing
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 if [[ "${_LIB_ROUTE_TABLE_LOADED:-}" == "true" ]]; then
   return 0 2>/dev/null || true
 fi
@@ -632,7 +636,7 @@ log_route_table() {
   done
 
   local hash
-  hash=$(printf '%s' "$table_str" | sha256sum | cut -d' ' -f1)
+  hash=$(printf '%s' "$table_str" | sha256_portable | cut -d' ' -f1)
 
   log "[route-table] effective routes: ${table_str}"
   log "[route-table] hash: sha256:${hash:0:16}"

--- a/.claude/scripts/lib/hitl-jury-panel-lib.sh
+++ b/.claude/scripts/lib/hitl-jury-panel-lib.sh
@@ -39,6 +39,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/compat-lib.sh"
+
 if [[ "${_LOA_PANEL_LIB_SOURCED:-0}" == "1" ]]; then
     return 0 2>/dev/null || exit 0
 fi
@@ -102,7 +106,7 @@ panel_select() {
 
     # Compute seed = sha256(decision_id || context_hash) hex.
     local seed
-    seed=$(printf '%s%s' "$decision_id" "$context_hash" | sha256sum | awk '{print $1}')
+    seed=$(printf '%s%s' "$decision_id" "$context_hash" | sha256_portable | awk '{print $1}')
 
     # Compute index = seed-as-uint256 mod count (Python big-int).
     local index selected

--- a/.claude/scripts/log-handoff.sh
+++ b/.claude/scripts/log-handoff.sh
@@ -18,6 +18,10 @@ set -euo pipefail
 # Configuration
 # =============================================================================
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"
 readonly PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -111,7 +115,7 @@ get_file_checksum() {
     local full_path="$PROJECT_ROOT/$path"
 
     if [[ -f "$full_path" ]]; then
-        sha256sum "$full_path" 2>/dev/null | cut -d' ' -f1 || echo ""
+        sha256_portable "$full_path" 2>/dev/null | cut -d' ' -f1 || echo ""
     else
         echo ""
     fi

--- a/.claude/scripts/lore-promote.sh
+++ b/.claude/scripts/lore-promote.sh
@@ -29,6 +29,10 @@ shopt -s nullglob
 # Defaults
 # =============================================================================
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 QUEUE_PATH=".run/bridge-lore-candidates.jsonl"
 LORE_PATH="grimoires/loa/lore/patterns.yaml"
 JOURNAL_PATH=".run/lore-promote-journal.jsonl"
@@ -310,7 +314,7 @@ process_candidate() {
     context=$(extract_finding_field "$entry" "reasoning")
     [[ -z "$context" ]] && context=$(echo "$entry" | jq -r '.reasoning // ""')
     tags_json=$(echo "$entry" | jq -c '(.finding_content.tags // .tags // [])')
-    content_hash=$(echo "$entry" | sha256sum | cut -c1-64)
+    content_hash=$(echo "$entry" | sha256_portable | cut -c1-64)
 
     # Sanitize each field. On rejection, log + journal + return.
     local sterm sshort scontext rejection_reason=""

--- a/.claude/scripts/marker-utils.sh
+++ b/.claude/scripts/marker-utils.sh
@@ -12,6 +12,10 @@ set -euo pipefail
 
 # MED-001 FIX: Set restrictive umask for secure temp file creation
 # This ensures mktemp creates files with 600 permissions atomically
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 umask 077
 
 # =============================================================================
@@ -138,7 +142,7 @@ compute_hash() {
       ;;
   esac
 
-  echo -n "$content" | sha256sum | cut -d' ' -f1
+  echo -n "$content" | sha256_portable | cut -d' ' -f1
 }
 
 # Verify file hash matches marker

--- a/.claude/scripts/memory-sync.sh
+++ b/.claude/scripts/memory-sync.sh
@@ -16,6 +16,10 @@ set -euo pipefail
 # Configuration
 # =============================================================================
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/bootstrap.sh"
 
@@ -92,7 +96,7 @@ save_sync_state() {
 get_file_hash() {
     local file="$1"
     if [[ -f "$file" ]]; then
-        sha256sum "$file" 2>/dev/null | cut -c1-16
+        sha256_portable "$file" 2>/dev/null | cut -c1-16
     else
         echo "missing"
     fi

--- a/.claude/scripts/mermaid-url.sh
+++ b/.claude/scripts/mermaid-url.sh
@@ -37,6 +37,10 @@
 set -euo pipefail
 
 # Configuration
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 readonly DEFAULT_THEME="github"
 readonly DEFAULT_SERVICE_URL="https://agents.craft.do/mermaid"
 readonly DEFAULT_MODE="github"
@@ -328,7 +332,7 @@ render_local() {
 
     # Generate hash for unique filename
     local hash
-    hash=$(printf '%s' "$mermaid" | sha256sum | cut -c1-8)
+    hash=$(printf '%s' "$mermaid" | sha256_portable | cut -c1-8)
     local outfile="${output_dir}/diagram-${hash}.${format}"
 
     # Create temp file for input

--- a/.claude/scripts/migrate-state-layout.sh
+++ b/.claude/scripts/migrate-state-layout.sh
@@ -19,6 +19,10 @@
 set -uo pipefail
 
 # === Constants ===
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 VERSION_FILE="${PROJECT_ROOT}/.loa-version.json"
@@ -251,8 +255,8 @@ verify_copy() {
 
   # Deep check: sha256 checksums
   local source_checksums target_checksums
-  source_checksums=$(cd "$source_dir" && find . -type f -print0 | sort -z | xargs -0 sha256sum 2>/dev/null)
-  target_checksums=$(cd "$target_dir" && find . -type f -print0 | sort -z | xargs -0 sha256sum 2>/dev/null)
+  source_checksums=$(cd "$source_dir" && find . -type f -print0 | sort -z | xargs -0 sha256_portable 2>/dev/null)
+  target_checksums=$(cd "$target_dir" && find . -type f -print0 | sort -z | xargs -0 sha256_portable 2>/dev/null)
 
   if [[ "$source_checksums" != "$target_checksums" ]]; then
     warn "Checksum mismatch between source and target"

--- a/.claude/scripts/mount-loa.sh
+++ b/.claude/scripts/mount-loa.sh
@@ -1042,7 +1042,7 @@ generate_checksums() {
 
   local first=true
   while IFS= read -r -d '' file; do
-    local hash=$(sha256sum "$file" | cut -d' ' -f1)
+    local hash=$(sha256_portable "$file" | cut -d' ' -f1)
     local relpath="${file#./}"
     if [[ "$first" == "true" ]]; then
       first=false
@@ -1905,7 +1905,7 @@ Then re-run:
       local expected_hash actual_hash
       expected_hash=$(jq -r --arg f "$relpath" '.files[$f] // ""' "$CHECKSUMS_FILE" 2>/dev/null)
       if [[ -n "$expected_hash" && "$expected_hash" != "null" ]]; then
-        actual_hash=$(sha256sum "$file" | cut -d' ' -f1)
+        actual_hash=$(sha256_portable "$file" | cut -d' ' -f1)
         if [[ "$expected_hash" == "$actual_hash" ]]; then
           framework_files+=("$relpath")
         else

--- a/.claude/scripts/post-pr-audit.sh
+++ b/.claude/scripts/post-pr-audit.sh
@@ -19,6 +19,10 @@ set -euo pipefail
 # Configuration
 # ============================================================================
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly STATE_SCRIPT="${SCRIPT_DIR}/post-pr-state.sh"
 
@@ -105,7 +109,7 @@ finding_identity() {
   local identity_str="${category}|${rule_id}|${file}|${normalized_line}|${severity}"
 
   # Generate SHA256 and take first 16 chars
-  echo -n "$identity_str" | sha256sum | cut -c1-16
+  echo -n "$identity_str" | sha256_portable | cut -c1-16
 }
 
 # Check if finding identity is already known (circuit breaker)

--- a/.claude/scripts/post-pr-e2e.sh
+++ b/.claude/scripts/post-pr-e2e.sh
@@ -147,7 +147,7 @@ test_failure_identity() {
   local identity_str="${test_name}|${file}|${error_type}"
 
   # Generate SHA256 and take first 16 chars
-  echo -n "$identity_str" | sha256sum | cut -c1-16
+  echo -n "$identity_str" | sha256_portable | cut -c1-16
 }
 
 # Add failure identity to state

--- a/.claude/scripts/preflight.sh
+++ b/.claude/scripts/preflight.sh
@@ -8,6 +8,10 @@
 #   ./preflight.sh --integrity   # Run full integrity checks for ck operations
 
 # Check if a file exists
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 check_file_exists() {
     local path="$1"
     [ -f "$path" ]
@@ -226,7 +230,7 @@ run_integrity_checks() {
             EXPECTED_FINGERPRINT=$(jq -r '.binary_fingerprints.ck // ""' "${PROJECT_ROOT}/.loa-version.json")
             if [[ -n "${EXPECTED_FINGERPRINT}" ]] && [[ "${EXPECTED_FINGERPRINT}" != "null" ]]; then
                 CK_PATH=$(command -v ck)
-                ACTUAL_FINGERPRINT=$(sha256sum "${CK_PATH}" | awk '{print $1}')
+                ACTUAL_FINGERPRINT=$(sha256_portable "${CK_PATH}" | awk '{print $1}')
 
                 if [[ "${EXPECTED_FINGERPRINT}" != "${ACTUAL_FINGERPRINT}" ]]; then
                     echo "⚠️  ck binary fingerprint mismatch" >&2

--- a/.claude/scripts/proposal-generator.sh
+++ b/.claude/scripts/proposal-generator.sh
@@ -29,6 +29,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
@@ -492,7 +496,7 @@ generate_exchange_file() {
     # Generate learning exchange ID: LX-YYYYMMDD-hexhash
     local date_part hash_part learning_id
     date_part=$(date +%Y%m%d)
-    hash_part=$(printf '%s' "$id$title" | sha256sum | cut -c1-10)
+    hash_part=$(printf '%s' "$id$title" | sha256_portable | cut -c1-10)
     learning_id="LX-${date_part}-${hash_part}"
 
     # Run content through redact-export.sh

--- a/.claude/scripts/simstim-orchestrator.sh
+++ b/.claude/scripts/simstim-orchestrator.sh
@@ -29,6 +29,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/bootstrap.sh"
 
@@ -889,7 +893,7 @@ check_artifact_drift() {
 
             if [[ -f "$PROJECT_ROOT/$path" ]]; then
                 local current
-                current=$(sha256sum "$PROJECT_ROOT/$path" | cut -d' ' -f1)
+                current=$(sha256_portable "$PROJECT_ROOT/$path" | cut -d' ' -f1)
                 local stored_hash
                 stored_hash=$(echo "$stored" | sed 's/sha256://')
 

--- a/.claude/scripts/simstim-state.sh
+++ b/.claude/scripts/simstim-state.sh
@@ -32,6 +32,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 RUN_DIR="$PROJECT_ROOT/.run"
@@ -91,7 +95,7 @@ state_exists() {
 calculate_checksum() {
     local file="$1"
     if [[ -f "$file" ]]; then
-        sha256sum "$file" | cut -d' ' -f1
+        sha256_portable "$file" | cut -d' ' -f1
     else
         echo ""
     fi

--- a/.claude/scripts/spiral-evidence.sh
+++ b/.claude/scripts/spiral-evidence.sh
@@ -22,6 +22,10 @@
 # =============================================================================
 
 # Prevent double-sourcing
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 if [[ "${_SPIRAL_EVIDENCE_LOADED:-}" == "true" ]]; then
     return 0 2>/dev/null || exit 0
 fi
@@ -128,7 +132,7 @@ _verify_artifact() {
     fi
 
     local checksum
-    checksum=$(sha256sum "$artifact" | awk '{print $1}')
+    checksum=$(sha256_portable "$artifact" | awk '{print $1}')
 
     _record_action "$phase" "evidence-gate" "verified" "" "$checksum" "$artifact" "$bytes" 0 0 "OK"
 
@@ -166,7 +170,7 @@ _verify_flatline_output() {
     blockers=$(jq '.consensus_summary.blocker_count // 0' "$output")
 
     local checksum
-    checksum=$(sha256sum "$output" | awk '{print $1}')
+    checksum=$(sha256_portable "$output" | awk '{print $1}')
     _record_action "GATE_${phase}" "flatline-orchestrator" "multi_model_review" \
         "" "$checksum" "$output" "$(wc -c < "$output")" 0 0 "high=${high} blockers=${blockers}"
 
@@ -189,7 +193,7 @@ _verify_review_verdict() {
 
     if grep -qi "All good\|APPROVED" "$feedback"; then
         local checksum
-        checksum=$(sha256sum "$feedback" | awk '{print $1}')
+        checksum=$(sha256_portable "$feedback" | awk '{print $1}')
         _record_action "GATE_${phase}" "claude-opus" "verdict" "" "$checksum" "$feedback" \
             "$(wc -c < "$feedback")" 0 0 "APPROVED"
         return 0

--- a/.claude/scripts/spiral-harvest-adapter.sh
+++ b/.claude/scripts/spiral-harvest-adapter.sh
@@ -15,6 +15,10 @@
 # =============================================================================
 
 # Guard against double-source
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 [[ -n "${_SPIRAL_HARVEST_ADAPTER_LOADED:-}" ]] && return 0
 readonly _SPIRAL_HARVEST_ADAPTER_LOADED=1
 
@@ -60,7 +64,7 @@ emit_cycle_outcome_sidecar() {
     local reviewer_path="${cycle_dir}/reviewer.md"
     local auditor_path="${cycle_dir}/auditor-sprint-feedback.md"
     if [[ -f "$reviewer_path" && -f "$auditor_path" ]]; then
-        content_hash="\"sha256:$(cat "$reviewer_path" "$auditor_path" | sha256sum | cut -d' ' -f1)\""
+        content_hash="\"sha256:$(cat "$reviewer_path" "$auditor_path" | sha256_portable | cut -d' ' -f1)\""
     fi
 
     # Compute flatline signature if not provided
@@ -403,7 +407,7 @@ fallback_parse_markdown() {
     # Compute content hash
     local content_hash="null"
     if [[ -f "$reviewer_path" && -f "$auditor_path" ]]; then
-        content_hash="\"sha256:$(cat "$reviewer_path" "$auditor_path" | sha256sum | cut -d' ' -f1)\""
+        content_hash="\"sha256:$(cat "$reviewer_path" "$auditor_path" | sha256_portable | cut -d' ' -f1)\""
     fi
 
     local review_arg audit_arg
@@ -465,7 +469,7 @@ compute_flatline_signature() {
     # Concatenate and hash
     local input="${norm_review}\n${norm_audit}\n${norm_findings}\n${norm_content_hash}"
     local hash
-    hash=$(printf '%b' "$input" | sha256sum | cut -d' ' -f1)
+    hash=$(printf '%b' "$input" | sha256_portable | cut -d' ' -f1)
 
     echo "sha256:${hash}"
 }

--- a/.claude/scripts/tests/test-workspace-cleanup.bats
+++ b/.claude/scripts/tests/test-workspace-cleanup.bats
@@ -15,6 +15,10 @@
 # =============================================================================
 
 # Setup and teardown
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/compat-lib.sh"
+
 setup() {
     # Create temporary test directory
     export TEST_DIR=$(mktemp -d)
@@ -372,13 +376,13 @@ EOF
 
     local content="unique test content $(date +%s)"
     echo "$content" > grimoires/loa/prd.md
-    local original_sum=$(sha256sum grimoires/loa/prd.md | cut -d' ' -f1)
+    local original_sum=$(sha256_portable grimoires/loa/prd.md | cut -d' ' -f1)
 
     run bash "$SCRIPT" --grimoire grimoires/loa --yes
     [ "$status" -eq 0 ]
 
     local archive_dir=$(find grimoires/loa/archive -maxdepth 1 -type d -name "20*" | head -1)
-    local archived_sum=$(sha256sum "$archive_dir/prd.md" | cut -d' ' -f1)
+    local archived_sum=$(sha256_portable "$archive_dir/prd.md" | cut -d' ' -f1)
 
     [ "$original_sum" = "$archived_sum" ]
 }

--- a/.claude/scripts/tests/test_memory.sh
+++ b/.claude/scripts/tests/test_memory.sh
@@ -7,6 +7,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MEMORY_WRITER="$(dirname "$SCRIPT_DIR")/../hooks/memory-writer.sh"
 MEMORY_QUERY="$(dirname "$SCRIPT_DIR")/memory-query.sh"
@@ -70,7 +74,7 @@ teardown() {
 create_test_observation() {
     local type="${1:-discovery}"
     local summary="${2:-Test observation}"
-    local id="obs-$(date +%s)-$(echo "$summary" | sha256sum | cut -c1-8)"
+    local id="obs-$(date +%s)-$(echo "$summary" | sha256_portable | cut -c1-8)"
 
     cat <<EOF
 {"id":"$id","timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","session_id":"$LOA_SESSION_ID","type":"$type","summary":"$summary","tool":"test","private":false,"details":"","tags":[],"references":[]}

--- a/.claude/scripts/update-loa.sh
+++ b/.claude/scripts/update-loa.sh
@@ -19,6 +19,10 @@
 set -euo pipefail
 
 # === Colors ===
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -401,7 +405,7 @@ import_upstream_learnings() {
       --arg content "$content_text" \
       --argjson confidence 0.8 \
       --arg source "upstream-import" \
-      --arg hash "$(printf '%s' "$content_text" | sha256sum | cut -d' ' -f1)" \
+      --arg hash "$(printf '%s' "$content_text" | sha256_portable | cut -d' ' -f1)" \
       '{id: $id, timestamp: $ts, category: $cat, content: $content, confidence: $confidence, source: $source, content_hash: $hash}')
 
     # Import via append_jsonl if available, else direct append

--- a/.claude/scripts/update.sh
+++ b/.claude/scripts/update.sh
@@ -4,6 +4,10 @@
 set -euo pipefail
 
 # === Configuration ===
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 STAGING_DIR=".claude_staging"
 SYSTEM_DIR=".claude"
 OVERRIDES_DIR=".claude/overrides"
@@ -298,7 +302,7 @@ check_deps() {
   command -v jq >/dev/null || err "jq is required"
   command -v yq >/dev/null || err "yq is required"
   command -v git >/dev/null || err "git is required"
-  command -v sha256sum >/dev/null || err "sha256sum is required"
+  command -v sha256_portable >/dev/null || err "sha256_portable is required"
 }
 
 get_version() {
@@ -419,7 +423,7 @@ generate_checksums() {
 
   local first=true
   while IFS= read -r -d '' file; do
-    local hash=$(sha256sum "$file" | cut -d' ' -f1)
+    local hash=$(sha256_portable "$file" | cut -d' ' -f1)
     local relpath="${file#./}"
     [[ "$first" == "true" ]] && first=false || checksums+=','
     checksums+='"'"$relpath"'": "'"$hash"'"'
@@ -448,7 +452,7 @@ check_integrity() {
     [[ -z "$expected" ]] && continue
 
     if [[ -f "$file" ]]; then
-      local actual=$(sha256sum "$file" | cut -d' ' -f1)
+      local actual=$(sha256_portable "$file" | cut -d' ' -f1)
       if [[ "$expected" != "$actual" ]]; then
         drift_detected=true
         drifted_files+=("$file")

--- a/.claude/scripts/update.sh
+++ b/.claude/scripts/update.sh
@@ -302,7 +302,8 @@ check_deps() {
   command -v jq >/dev/null || err "jq is required"
   command -v yq >/dev/null || err "yq is required"
   command -v git >/dev/null || err "git is required"
-  command -v sha256_portable >/dev/null || err "sha256_portable is required"
+  # sprint-bug-172: sha256_portable backend availability tracked in _COMPAT_SHA256_CMD.
+  [[ -n "${_COMPAT_SHA256_CMD:-}" ]] || err "GNU coreutils or BSD shasum (sha-256 tool) is required"
 }
 
 get_version() {

--- a/.claude/scripts/upgrade-banner.sh
+++ b/.claude/scripts/upgrade-banner.sh
@@ -5,6 +5,10 @@
 # Usage: upgrade-banner.sh <old_version> <new_version> [--json]
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 
@@ -68,7 +72,7 @@ QUOTES=(
 # Get a deterministic but rotating quote based on user + week
 get_quote() {
     local seed="${USER:-unknown}$(date +%Y-%W)"
-    local hash=$(echo -n "$seed" | sha256sum | cut -c1-8)
+    local hash=$(echo -n "$seed" | sha256_portable | cut -c1-8)
     local index=$((16#$hash % ${#QUOTES[@]}))
     echo "${QUOTES[$index]}"
 }

--- a/.claude/scripts/validate-constraints.sh
+++ b/.claude/scripts/validate-constraints.sh
@@ -44,7 +44,7 @@ compute_section_hash() {
   printf '%s' "$1" \
     | tr -d '\r' \
     | sed 's/[[:space:]]*$//' \
-    | sha256sum \
+    | sha256_portable \
     | cut -c1-16
 }
 

--- a/.claude/scripts/workspace-cleanup.sh
+++ b/.claude/scripts/workspace-cleanup.sh
@@ -10,6 +10,10 @@
 
 set -euo pipefail
 
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Require bash 4.0+ (associative arrays)
 # shellcheck source=bash-version-guard.sh
@@ -700,7 +704,7 @@ stage1_copy_to_staging() {
             while IFS= read -r -d '' file; do
                 local relfile="${file#$src/}"
                 local checksum
-                checksum=$(sha256sum "$file" | cut -d' ' -f1)
+                checksum=$(sha256_portable "$file" | cut -d' ' -f1)
                 checksums["$path/$relfile"]="$checksum"
             done < <(find "$src" -type f -print0)
         else
@@ -711,7 +715,7 @@ stage1_copy_to_staging() {
             }
             # Compute checksum
             local checksum
-            checksum=$(sha256sum "$src" | cut -d' ' -f1)
+            checksum=$(sha256_portable "$src" | cut -d' ' -f1)
             checksums["$path"]="$checksum"
         fi
     done
@@ -742,7 +746,7 @@ stage2_verify_checksums() {
         fi
 
         local actual_sum
-        actual_sum=$(sha256sum "$full_path" | cut -d' ' -f1)
+        actual_sum=$(sha256_portable "$full_path" | cut -d' ' -f1)
 
         if [[ "$expected_sum" != "$actual_sum" ]]; then
             error "Checksum mismatch for: $file_path"

--- a/.github/workflows/check-no-raw-sha256sum.yml
+++ b/.github/workflows/check-no-raw-sha256sum.yml
@@ -1,0 +1,86 @@
+name: check-no-raw-sha256sum
+
+# sprint-bug-172 / bug-911 — CI gate ensuring no raw `sha256sum` invocations
+# slip back into the framework. All bash SHA-256 hashing in Loa MUST route
+# through `sha256_portable` in `.claude/scripts/compat-lib.sh` so macOS / BSD
+# hosts (where sha256sum is genuinely absent) fall back to `shasum -a 256`.
+#
+# Pre-existing class: KF-006 structural pattern. Same approach as cycle-099
+# sprint-1E.c.3.c's `check-no-raw-curl.sh` — strict tripwire, not exhaustive
+# defense.
+
+on:
+  pull_request:
+    paths:
+      - '.claude/scripts/**/*.sh'
+      - '.claude/scripts/**/*.bash'
+      - '.claude/scripts/**/*.legacy'
+      - '.claude/scripts/**/*.bats'
+      - 'tools/check-no-raw-sha256sum.sh'
+      - '.github/workflows/check-no-raw-sha256sum.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/scripts/**/*.sh'
+      - '.claude/scripts/**/*.bash'
+      - '.claude/scripts/**/*.legacy'
+      - 'tools/check-no-raw-sha256sum.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  sha256-tripwire:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for raw sha256sum invocations outside sha256_portable
+        run: |
+          set -euo pipefail
+          # The scanner enforces the literal-token contract. Exempt files
+          # (the helper itself, audit-envelope.sh defense-in-depth comments,
+          # and the scanner itself) are listed in EXEMPT_FILES in the script.
+          # Suppression marker `# check-no-raw-sha256sum: ok` is available for
+          # rare edge cases (reviewable per occurrence).
+          if ! bash tools/check-no-raw-sha256sum.sh; then
+              echo "::error::raw sha256sum detected; route through sha256_portable from compat-lib.sh"
+              echo "::error::see tools/check-no-raw-sha256sum.sh --help and KF-006 'Structural pattern' subsection"
+              exit 1
+          fi
+
+      - name: Positive control — scanner rejects a deliberately-bad sentinel
+        run: |
+          set -euo pipefail
+          # Verify the scanner ACTUALLY catches a violation (defends against
+          # the scanner accidentally exiting 0 from a syntax error).
+          SENTINEL_DIR="$(mktemp -d)"
+          cat > "$SENTINEL_DIR/sentinel.sh" <<'EOF'
+          #!/usr/bin/env bash
+          echo "test" | sha256sum | awk '{print $1}'
+          EOF
+          if bash tools/check-no-raw-sha256sum.sh --root "$SENTINEL_DIR" --quiet; then
+              echo "::error::scanner failed to reject sentinel — scanner regression"
+              exit 1
+          fi
+          echo "OK: scanner correctly rejected sentinel"
+
+      - name: Negative control — scanner accepts a sha256_portable usage
+        run: |
+          set -euo pipefail
+          # Verify the scanner does NOT over-match on sha256_portable
+          # (defends against a regex regression that catches sha256_portable
+          # because of the shared sha256 prefix).
+          NEG_DIR="$(mktemp -d)"
+          cat > "$NEG_DIR/uses-portable.sh" <<'EOF'
+          #!/usr/bin/env bash
+          # shellcheck disable=SC1091
+          source .claude/scripts/compat-lib.sh
+          echo "test" | sha256_portable | awk '{print $1}'
+          EOF
+          if ! bash tools/check-no-raw-sha256sum.sh --root "$NEG_DIR" --quiet; then
+              echo "::error::scanner false-positive on sha256_portable usage"
+              exit 1
+          fi
+          echo "OK: scanner correctly accepted sha256_portable usage"

--- a/.github/workflows/check-no-raw-sha256sum.yml
+++ b/.github/workflows/check-no-raw-sha256sum.yml
@@ -11,19 +11,20 @@ name: check-no-raw-sha256sum
 
 on:
   pull_request:
+    # DISS-002 closure: broad `.claude/scripts/**` filter so that
+    # extensionless shell scripts (`.claude/scripts/some-tool` with a bash
+    # shebang) trigger the workflow. The scanner's internal file-type filter
+    # (extension OR bash/sh shebang) is then the load-bearing decision about
+    # what to inspect. Narrow extension-only filters previously created a
+    # bypass class: extensionless shell scripts would land without scanning.
     paths:
-      - '.claude/scripts/**/*.sh'
-      - '.claude/scripts/**/*.bash'
-      - '.claude/scripts/**/*.legacy'
-      - '.claude/scripts/**/*.bats'
+      - '.claude/scripts/**'
       - 'tools/check-no-raw-sha256sum.sh'
       - '.github/workflows/check-no-raw-sha256sum.yml'
   push:
     branches: [main]
     paths:
-      - '.claude/scripts/**/*.sh'
-      - '.claude/scripts/**/*.bash'
-      - '.claude/scripts/**/*.legacy'
+      - '.claude/scripts/**'
       - 'tools/check-no-raw-sha256sum.sh'
 
 permissions:

--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -65,6 +65,7 @@ actually tried, not just what someone *said* was tried.
 | [KF-008](#kf-008-bridgebuilder-google-api-socketerror-on-large-request-bodies) | RESOLVED-architectural-complete — cycle-103 Sprint 1 unification (review-adapter path) + cycle-104 Sprint 3 T3.4 substrate-replay closure 2026-05-12 (4/4 trials clean at 297/302/317/539KB via cheval httpx). | bridgebuilder Google provider | 4 reproductions + 1 final non-reproduction |
 | [KF-010](#kf-010-cheval-delegate-google-adapter-300s-process-timeout-on-concurrent-bb-runs) | RESOLVED 2026-05-16 (sprint-bug-165, issue #921) | bridgebuilder google + anthropic voices / `deriveTimeoutMs` predicate scope | 6 (single batch, 2026-05-16) |
 | [KF-011](#kf-011-adversarial-reviewsh-malformed-response-on-review-type-prompts-post-kf-002-closure) | **RESOLVED 2026-05-17** (sub-mode (b): parser raw_decode extracts prose-prefixed JSON — PR #933 `d9ec8cb5`; sub-mode (c): route-around via 4-voice fallback chain — PR #934 `ccd510b0`; structural sub-mode (c) Gemini streaming-recovery tracked at issue #935). | adversarial-review.sh review-type — JSON contract layer + Gemini streaming-recovery gap | 2 (initial obs sprint-166 review + repro on parser-fix branch) |
+| [KF-012](#kf-012-sha256sum-not-portable-to-bsd-macos-silent-empty-hash-cascade-into-validation-failures) | **RESOLVED-STRUCTURAL 2026-05-20** (sprint-bug-172 / #911: `sha256_portable` helper in compat-lib.sh + 38 production call sites migrated + CI scanner `tools/check-no-raw-sha256sum.sh` + `tests/unit/compat-lib-sha256.bats` + masked-PATH integration test). Structural analog of cycle-099 sprint-1E.c.3.c curl wrapper migration. | macOS / BSD users of `/butterfreezone-gen` + 37 other framework scripts | 1 (single observation, sprint-bug-172 closure) |
 
 ---
 
@@ -837,6 +838,53 @@ KF-011 is now RESOLVED for sub-mode (b) — the "prose preamble + JSON envelope"
 5. **Sub-mode (c) Gemini empty-content**: route-around SHIPPED 2026-05-17 (PR #934 / `ccd510b0`) via 4th-line `claude-headless` voice in `flatline_protocol.{code_review,security_audit}.fallback_chain`. Operator surface functional. Structural fix TRACKED at issue #935 — needs streaming-recovery debug-trail diagnostic against `loa_cheval/providers/google_streaming.py` to identify which of three sub-sub-modes applies (adapter not wired, recovery silenced, thresholds mis-tuned).
 
 6. **Convergent design observation**: bridgebuilder-review uses HTML-comment markers as its envelope contract, which is structurally robust to prose preamble by design. If a future KF-011-class sub-mode emerges in adversarial-review.sh that the `raw_decode` extraction doesn't cover, consider migrating adversarial-review.sh to the marker contract. BB's `multi-model-pipeline.ts:442-444` is the reference implementation.
+
+---
+
+## KF-012: `sha256sum` not portable to BSD/macOS — silent empty-hash cascade into validation failures
+
+**Status**: RESOLVED-STRUCTURAL 2026-05-20 (sprint-bug-172 / [#911](https://github.com/0xHoneyJar/loa/issues/911)) via `sha256_portable` helper in `compat-lib.sh`, 38 production call-site migrations, CI scanner `tools/check-no-raw-sha256sum.sh`, masked-PATH integration test.
+
+**Feature**: SHA-256 hashing across 38 framework scripts — bootstrap (`mount-loa.sh`, `preflight.sh`, `update-loa.sh`), audit chain (`audit-envelope.sh`, `validate-constraints.sh`, `flatline-manifest.sh`, `flatline-snapshot.sh`, `ground-truth-gen.sh`), butterfreezone gen+validate, spiral / learning / memory / proposal / construct utilities.
+
+**Symptom**: macOS users (Darwin 25.3.0 + Loa v1.157.0+) running `/butterfreezone-gen` see `sha256sum: command not found` interleaved with normal output — 10 occurrences per gen run. Script exits 0 but with checksums silently missing. Downstream `/butterfreezone-validate` reports `FAIL: Missing provenance tags: 10/12 sections tagged` — not because provenance was genuinely missing, but because the hashing step silently failed. Identical pattern across all 38 production call sites.
+
+**First observed**: 2026-05-20 (issue #911 filed against framework v1.157.0; observation by external macOS operator).
+
+**Recurrence count**: 1 (single observation across multi-PR sweep).
+
+**Root cause**: GNU `sha256sum` ships in coreutils on Linux; macOS ships `shasum` (Perl-based, BSD lineage) without sha256sum. 38 framework scripts called raw `sha256sum`; macOS PATH-lookup failed silently because most callers piped through `awk '{print $1}'` or `cut -d' ' -f1` which mask the empty stdin → empty hash.
+
+**Resolution path** (sprint-bug-172, 5 commits expected):
+
+1. **Failing test** (G-5 gate): `tests/unit/compat-lib-sha256.bats` with 6 cases (GNU-only / BSD-only / both / neither / byte-equality / file-argv form).
+2. **Helper** in `.claude/scripts/compat-lib.sh`: `sha256_portable` dispatches via cached `_COMPAT_SHA256_CMD` detection at source time. Fails loud (exit 127, stderr diagnostic) when neither tool available — no silent empty hash. `_COMPAT_LIB_VERSION` bumped to `1.2.0`.
+3. **Sweep**: 38 production call sites migrated. Each script sources `compat-lib.sh` (idempotent thanks to `_COMPAT_LIB_LOADED` guard), then calls `sha256_portable` with the same argv shape as the original `sha256sum`. Output format byte-identical (`<hex>  <name>` with two spaces) so downstream `awk '{print $1}'` / `cut -d' ' -f1` parsing is unchanged.
+4. **audit-envelope.sh special case**: `_audit_sha256` delegates to `sha256_portable` for the GNU/BSD branch but PRESERVES the python3 last-resort fallback for hash-chain integrity defense-in-depth.
+5. **Integration test**: `tests/integration/butterfreezone-gen-sha256-portability.bats` simulates macOS by overriding the `command` builtin to fake `sha256sum` absence; asserts byte-equality of `sha256_portable` output against canonical GNU sha256sum.
+6. **CI scanner**: `tools/check-no-raw-sha256sum.sh` (mirrors cycle-099 sprint-1E.c.3.c `check-no-raw-curl.sh`). Detects raw `sha256sum` outside the EXEMPT_FILES set, with positive control + negative control in `.github/workflows/check-no-raw-sha256sum.yml`.
+
+**Structural analog**: cycle-099 sprint-1E.c.3.c (curl wrapper migration). Same pattern: per-site portability gap → helper + sweep + CI scanner + integration test.
+
+### Attempts
+
+| Date | What we tried | Outcome | Evidence |
+|------|---------------|---------|----------|
+| 2026-05-20 | Discovered class via #911 (macOS operator report — Darwin 25.3.0, v1.157.0, butterfreezone repro). Triage revealed scope is 38 production scripts + 5 test sites, not the 11 the issue claimed. | TRIAGE — bug-20260520-i911-60baf5, sprint-bug-172, beads `bd-52sc` | grimoires/loa/a2a/bug-20260520-i911-60baf5/triage.md |
+| 2026-05-20 | Helper + 38-site sweep + CI scanner + integration test + 6-case unit test | RESOLVED-STRUCTURAL — single-pass migration, scanner prevents regression on subsequent PRs | sprint-bug-172 PR (this entry); `.claude/scripts/compat-lib.sh`, `tools/check-no-raw-sha256sum.sh`, `tests/unit/compat-lib-sha256.bats`, `tests/integration/butterfreezone-gen-sha256-portability.bats` |
+
+### Reading guide
+
+If you see `sha256sum: command not found` in any `.claude/scripts/` script output:
+1. Verify the script sources `compat-lib.sh`. If not, that's a regression — the CI scanner should have caught the PR that introduced it.
+2. If the script DOES source compat-lib.sh but still calls `sha256sum`, that's a different bug — the helper exists; the call site was missed by the sweep. File a follow-up under KF-012 attempts.
+3. The scanner `tools/check-no-raw-sha256sum.sh` runs on every PR via `.github/workflows/check-no-raw-sha256sum.yml`. Suppression marker `# check-no-raw-sha256sum: ok` is available for narrow exceptions (each occurrence reviewable in PR diff).
+4. Operator running on a host where NEITHER `sha256sum` NOR `shasum` is available: install GNU coreutils (`brew install coreutils` on macOS) OR Perl 5.10+ (which provides `/usr/bin/shasum` by default on macOS).
+
+### Cross-references
+
+- Structural precedent: cycle-099 sprint-1E.c.3.c (`tools/check-no-raw-curl.sh`) — same shape, applied to `curl`/`wget`.
+- Related framework-portability concerns: `compat-lib.sh` already handles `sed_inplace`, `get_canonical_path`, `version_sort`, `make_temp`, `get_file_mtime`, `find_sorted_by_time` — this entry adds `sha256_portable` to that list (helper version 1.1.0 → 1.2.0).
 
 ---
 

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1400,7 +1400,7 @@
     },
     {
       "id": "cycle-bug-20260520-i888-8a4363",
-      "label": "Bug Fix \u2014 cycle-110 auth_type + dispatch_group reject v2/v3 schema validation",
+      "label": "Bug Fix — cycle-110 auth_type + dispatch_group reject v2/v3 schema validation",
       "type": "bugfix",
       "status": "completed",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/888",
@@ -1413,9 +1413,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260520-i888-8a4363/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260520-i888-8a4363/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260520-i911-60baf5",
+      "label": "Bug Fix — butterfreezone-gen + 37 scripts: sha256sum not portable to macOS",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/911",
+      "created_at": "2026-05-20T09:15:47Z",
+      "sprints": [
+        "sprint-bug-172"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260520-i911-60baf5/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260520-i911-60baf5/sprint.md"
     }
   ],
-  "global_sprint_counter": 171,
+  "global_sprint_counter": 172,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/integration/butterfreezone-gen-sha256-portability.bats
+++ b/tests/integration/butterfreezone-gen-sha256-portability.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/integration/butterfreezone-gen-sha256-portability.bats
+#
+# sprint-bug-172 / bug-911 — end-to-end portability proof for sha256_portable
+# on a simulated macOS host where sha256sum is genuinely absent.
+#
+# Strategy: override the `command` builtin via bash function to make
+# `command -v sha256sum` return failure. This mirrors macOS's real behavior
+# (sha256sum genuinely not findable) without requiring a hermetic PATH
+# sandbox that breaks when compat-lib calls `uname`/etc. The override
+# bypasses PATH lookup entirely, simulating "this binary does not exist."
+#
+# Pre-fix (sprint-bug-172 not landed): raw `sha256sum` calls error
+# "command not found", cascade into empty hashes, then validation reports
+# 10/12 provenance tagged. Post-fix: sha256_portable falls back to
+# shasum -a 256, all hashes computed correctly, validation 12/12.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    export PROJECT_ROOT
+
+    COMPAT_LIB="$PROJECT_ROOT/.claude/scripts/compat-lib.sh"
+    [[ -f "$COMPAT_LIB" ]] || skip "compat-lib.sh not present"
+
+    # Require shasum on test host so the bsd-fallback branch can be exercised.
+    command -v shasum >/dev/null 2>&1 || skip "shasum not available on test host"
+
+    EXPECTED_HASH="$(printf 'sprint-bug-172-integration\n' | sha256sum | awk '{print $1}')"
+    export EXPECTED_HASH
+}
+
+@test "P1 simulated-macOS: sha256_portable detects bsd backend when sha256sum is absent" {
+    run bash -c '
+        # Override command builtin to fake sha256sum absence (macOS-like).
+        command() {
+            if [[ "$1" == "-v" && "$2" == "sha256sum" ]]; then
+                return 1
+            fi
+            builtin command "$@"
+        }
+        source "'"$COMPAT_LIB"'"
+        echo "$_COMPAT_SHA256_CMD"
+    '
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "bsd" ]]
+}
+
+@test "P2 simulated-macOS: sha256_portable produces byte-identical hash via shasum fallback" {
+    run bash -c '
+        command() {
+            if [[ "$1" == "-v" && "$2" == "sha256sum" ]]; then
+                return 1
+            fi
+            builtin command "$@"
+        }
+        source "'"$COMPAT_LIB"'"
+        printf "sprint-bug-172-integration\n" | sha256_portable | awk "{print \$1}"
+    '
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "$EXPECTED_HASH" ]]
+}
+
+@test "P3 simulated-no-tools: sha256_portable fails loud (no silent empty hash)" {
+    run bash -c '
+        command() {
+            if [[ "$1" == "-v" && ( "$2" == "sha256sum" || "$2" == "shasum" ) ]]; then
+                return 1
+            fi
+            builtin command "$@"
+        }
+        source "'"$COMPAT_LIB"'"
+        echo "DETECTION=$_COMPAT_SHA256_CMD"
+        printf "data\n" | sha256_portable
+    '
+    [[ "$output" =~ "DETECTION=" ]]
+    # _COMPAT_SHA256_CMD is empty in this scenario
+    [[ "$output" =~ "DETECTION="$'\n' ]] || [[ "$output" =~ "DETECTION=" ]]
+    # Must exit non-zero (fail loud) — no silent empty-hash emission
+    [[ "$status" -ne 0 ]]
+    # Must mention the diagnostic
+    [[ "$output" =~ "sha256" ]]
+}
+
+@test "P4 unmasked PATH: sha256_portable uses gnu (preference order verified)" {
+    # No override — host PATH has both tools or just GNU. Should prefer gnu.
+    run bash -c "source '$COMPAT_LIB'; echo \$_COMPAT_SHA256_CMD"
+    [[ "$status" -eq 0 ]]
+    # On Linux CI: should detect gnu. macOS: would detect bsd.
+    [[ "$output" == "gnu" || "$output" == "bsd" ]]
+}
+
+@test "P5 audit-envelope.sh _audit_sha256 wrapper preserves python3 fallback semantics" {
+    # audit-envelope.sh defines _audit_sha256 which delegates to sha256_portable
+    # but ALSO has a python3 fallback for the "neither GNU nor BSD available"
+    # case. This test pins the wrapper's defense-in-depth contract.
+    local audit_envelope="$PROJECT_ROOT/.claude/scripts/audit-envelope.sh"
+    [[ -f "$audit_envelope" ]] || skip "audit-envelope.sh not present"
+    # python3 fallback presence
+    grep -q "python3 -c" "$audit_envelope"
+    # sha256_portable delegation in place
+    grep -q "sha256_portable" "$audit_envelope"
+    # compat-lib sourced
+    grep -q "compat-lib.sh" "$audit_envelope"
+}
+
+@test "P6 framework parse: every migrated script parses without syntax errors" {
+    local fail_count=0
+    local failed_files=()
+    # Sample of representative migrated scripts (full sweep is in CI bats)
+    for script in mount-loa.sh preflight.sh butterfreezone-gen.sh ground-truth-gen.sh audit-envelope.sh adversarial-review.sh flatline-manifest.sh check-loa.sh; do
+        local full="$PROJECT_ROOT/.claude/scripts/$script"
+        [[ -f "$full" ]] || continue
+        if ! bash -n "$full" 2>/dev/null; then
+            failed_files+=("$script")
+            fail_count=$((fail_count + 1))
+        fi
+    done
+    [[ "$fail_count" -eq 0 ]] || { echo "Parse failures: ${failed_files[*]}"; false; }
+}

--- a/tests/integration/butterfreezone-gen-sha256-portability.bats
+++ b/tests/integration/butterfreezone-gen-sha256-portability.bats
@@ -28,7 +28,14 @@ setup() {
     # Require shasum on test host so the bsd-fallback branch can be exercised.
     command -v shasum >/dev/null 2>&1 || skip "shasum not available on test host"
 
-    EXPECTED_HASH="$(printf 'sprint-bug-172-integration\n' | sha256sum | awk '{print $1}')"
+    # DISS-003 closure: hard-coded expected digest for the fixed test input
+    # `sprint-bug-172-integration\n`. The previous implementation computed
+    # EXPECTED_HASH via raw `sha256sum`, which on an actual macOS host (where
+    # this test is most needed) would fail in setup before reaching the
+    # fallback-path assertions. Hard-coding the digest makes the test itself
+    # portable to the platform it's testing for. Verified via:
+    #   printf 'sprint-bug-172-integration\n' | sha256sum
+    EXPECTED_HASH="2c975fccab45c25947b44b0acfb81c2aaaeff32012a82574f089beab3d60fb81"
     export EXPECTED_HASH
 }
 

--- a/tests/unit/compat-lib-sha256.bats
+++ b/tests/unit/compat-lib-sha256.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/unit/compat-lib-sha256.bats
+#
+# sprint-bug-172 / bug-911 — sha256_portable helper in compat-lib.sh.
+#
+# macOS ships BSD shasum, not GNU sha256sum. Loa framework scripts that called
+# raw sha256sum silently failed on macOS, producing empty hashes and cascading
+# into validation FAILs (e.g., `/butterfreezone-gen` → `/butterfreezone-validate`
+# returns 10/12 provenance tagged because hashing silently dies on macOS).
+#
+# This suite proves the sha256_portable helper:
+#   - Case A (GNU-only PATH): uses sha256sum directly, succeeds
+#   - Case B (BSD-only PATH): falls back to shasum -a 256, succeeds with byte-
+#                              identical hash to GNU's output
+#   - Case C (both present):  prefers sha256sum (deterministic, simpler dispatch)
+#   - Case D (neither):       fails loud (exit non-zero, stderr diagnostic)
+#   - Case E (byte-equality): GNU and BSD backends produce identical hex hashes
+#
+# Hermetic: each case rebuilds a clean shim PATH under $BATS_TMPDIR/bin/ so
+# no system-state mutation leaks between cases.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    export PROJECT_ROOT
+
+    COMPAT_LIB="$PROJECT_ROOT/.claude/scripts/compat-lib.sh"
+    [[ -f "$COMPAT_LIB" ]] || skip "compat-lib.sh not present"
+
+    # Capture the canonical GNU output (assumes the test host has GNU sha256sum;
+    # CI runs on Linux). Byte-equality assertions in Cases B + E pin against this.
+    EXPECTED_HASH="$(printf 'sprint-bug-172\n' | sha256sum | awk '{print $1}')"
+    export EXPECTED_HASH
+
+    # Build a clean shim directory; each case will populate it differently.
+    SHIM_DIR="$(mktemp -d)"
+    export SHIM_DIR
+
+    # The real sha256sum + shasum binary paths (used to construct shims that
+    # forward to the real implementation under a different name).
+    REAL_SHA256SUM="$(command -v sha256sum 2>/dev/null || echo '')"
+    REAL_SHASUM="$(command -v shasum 2>/dev/null || echo '')"
+    export REAL_SHA256SUM REAL_SHASUM
+}
+
+teardown() {
+    rm -rf "$SHIM_DIR"
+}
+
+# Helper: install a shim that forwards to a real binary
+_install_shim() {
+    local name="$1"
+    local target="$2"
+    cat > "$SHIM_DIR/$name" <<EOF
+#!/usr/bin/env bash
+exec "$target" "\$@"
+EOF
+    chmod 0755 "$SHIM_DIR/$name"
+}
+
+# Helper: sandbox PATH to only the shim dir + bash builtins (no system bin)
+_sandboxed_path() {
+    # Need bash core utilities (printf, command, etc.) — keep /usr/bin in path
+    # for those, but the shims for sha256sum/shasum should be the ONLY
+    # implementations findable.
+    echo "$SHIM_DIR:/usr/bin:/bin"
+}
+
+@test "A1 GNU-only PATH: sha256_portable uses sha256sum directly" {
+    [[ -n "$REAL_SHA256SUM" ]] || skip "sha256sum not available on test host"
+    _install_shim sha256sum "$REAL_SHA256SUM"
+    # No shasum in SHIM_DIR — BSD shim absent
+    PATH="$(_sandboxed_path)" run bash -c "source '$COMPAT_LIB'; printf 'sprint-bug-172\n' | sha256_portable | awk '{print \$1}'"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "$EXPECTED_HASH" ]]
+}
+
+@test "A2 BSD-only PATH: sha256_portable falls back to shasum -a 256" {
+    [[ -n "$REAL_SHASUM" ]] || skip "shasum not available on test host"
+    _install_shim shasum "$REAL_SHASUM"
+    # No sha256sum in SHIM_DIR — GNU shim absent
+    PATH="$(_sandboxed_path)" run bash -c "source '$COMPAT_LIB'; printf 'sprint-bug-172\n' | sha256_portable | awk '{print \$1}'"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "$EXPECTED_HASH" ]]
+}
+
+@test "A3 Both present: sha256_portable prefers sha256sum (GNU)" {
+    [[ -n "$REAL_SHA256SUM" ]] || skip "sha256sum not available on test host"
+    [[ -n "$REAL_SHASUM" ]] || skip "shasum not available on test host"
+    _install_shim sha256sum "$REAL_SHA256SUM"
+    _install_shim shasum "$REAL_SHASUM"
+    # Probe: source compat-lib with both shims visible and assert _COMPAT_SHA256_CMD
+    PATH="$(_sandboxed_path)" run bash -c "source '$COMPAT_LIB'; echo \$_COMPAT_SHA256_CMD"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "gnu" ]]
+}
+
+@test "A4 Neither present: sha256_portable fails loud with non-zero exit" {
+    # Nothing installed in SHIM_DIR — both backends absent
+    PATH="$SHIM_DIR" run bash -c "source '$COMPAT_LIB'; printf 'sprint-bug-172\n' | sha256_portable"
+    [[ "$status" -ne 0 ]]
+    # Stderr must mention the diagnostic (forwarded to bats output via run)
+    [[ "$output" =~ "sha256" ]] || [[ "$output" =~ "not found" ]] || [[ "$output" =~ "ERROR" ]]
+}
+
+@test "A5 Byte-equality: GNU sha256sum and BSD shasum -a 256 produce identical hash" {
+    [[ -n "$REAL_SHA256SUM" ]] || skip "sha256sum not available on test host"
+    [[ -n "$REAL_SHASUM" ]] || skip "shasum not available on test host"
+    local gnu_hash bsd_hash
+    gnu_hash="$(printf 'sprint-bug-172\n' | "$REAL_SHA256SUM" | awk '{print $1}')"
+    bsd_hash="$(printf 'sprint-bug-172\n' | "$REAL_SHASUM" -a 256 | awk '{print $1}')"
+    [[ "$gnu_hash" == "$bsd_hash" ]]
+    [[ "$gnu_hash" == "$EXPECTED_HASH" ]]
+}
+
+@test "A6 File-argv form: sha256_portable file.txt matches sha256sum file.txt" {
+    [[ -n "$REAL_SHA256SUM" ]] || skip "sha256sum not available on test host"
+    _install_shim sha256sum "$REAL_SHA256SUM"
+    local f="$SHIM_DIR/test-input.txt"
+    printf 'sprint-bug-172\n' > "$f"
+    PATH="$(_sandboxed_path)" run bash -c "source '$COMPAT_LIB'; sha256_portable '$f' | awk '{print \$1}'"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "$EXPECTED_HASH" ]]
+}

--- a/tools/check-no-raw-sha256sum.sh
+++ b/tools/check-no-raw-sha256sum.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tools/check-no-raw-sha256sum.sh
+#
+# sprint-bug-172 / bug-911 — strict scan: NO raw `sha256sum` invocations in
+# bash scripts outside the canonical exemption set. All hashing in Loa bash
+# code MUST funnel through `sha256_portable` (the helper in
+# `.claude/scripts/compat-lib.sh`) so macOS / BSD hosts where sha256sum is
+# genuinely absent fall back cleanly to `shasum -a 256`.
+#
+# Pre-existing context (KF-006 structural pattern, cycle-099 sprint-1E.c.3.c
+# precedent): every PR adding a `sha256sum` invocation without bumping a
+# schema/helper has caused multi-cycle ambient CI reds. This scanner catches
+# the regression at PR time.
+#
+# Detection logic (in order):
+#   1. File-type filter: scan `.sh` / `.bash` extensions PLUS extension-less
+#      files with a bash/sh shebang. Skip binaries, docs, JSON, etc.
+#   2. Skip line-leading comments (`# ...`).
+#   3. Skip `command -v sha256sum` / `which sha256sum` (existence checks).
+#   4. Skip lines with `# check-no-raw-sha256sum: ok` suppression marker.
+#   5. Skip exempt files (compat-lib.sh defines sha256_portable;
+#      audit-envelope.sh references sha256sum in comments documenting the
+#      legacy / defense-in-depth python3 fallback).
+#   6. Match `(^|[^[:alnum:]_])sha256sum([[:space:]]|$|"|\047|\|)` —
+#      word-boundary on both sides so `sha256_portable` and other identifiers
+#      containing the substring don't match.
+#
+# **Tripwire scope (NOT exhaustive defense)**: same caveats as
+# tools/check-no-raw-curl.sh. Variable-expanded calls, eval, or printf-
+# assembled invocations are out of scope. The helper itself + portability
+# tests + integration test are the load-bearing portability boundary; this
+# scanner is one tripwire layer.
+#
+# Usage:
+#   tools/check-no-raw-sha256sum.sh                  # scan .claude/scripts/
+#   tools/check-no-raw-sha256sum.sh --root <dir>     # scan custom root
+#   tools/check-no-raw-sha256sum.sh --quiet          # exit-code only
+#
+# Exit codes:
+#   0  no violations
+#   1  violations found (paths printed to stderr)
+#   2  argument / I/O error
+#
+# Tested by tests/integration/check-no-raw-sha256sum.bats.
+# =============================================================================
+
+set -euo pipefail
+
+# Files explicitly allowed to mention `sha256sum` directly. Path-match is
+# exact (rooted at PROJECT_ROOT); env-overridable list would be a footgun.
+EXEMPT_FILES=(
+    # The helper itself uses raw `sha256sum` in its GNU dispatch branch.
+    ".claude/scripts/compat-lib.sh"
+    # audit-envelope.sh references sha256sum in comments documenting the
+    # defense-in-depth python3 last-resort fallback. The executable line uses
+    # sha256_portable via compat-lib delegation.
+    ".claude/scripts/audit-envelope.sh"
+    # The scanner itself (this file) references sha256sum in its regex.
+    "tools/check-no-raw-sha256sum.sh"
+)
+
+QUIET=0
+ROOT=".claude/scripts"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --quiet|-q) QUIET=1; shift ;;
+        --root) ROOT="$2"; shift 2 ;;
+        --help|-h)
+            sed -n '/^# Usage:/,/^# Tested/p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            printf 'check-no-raw-sha256sum.sh: unknown arg %q\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+[[ -d "$ROOT" ]] || {
+    printf 'check-no-raw-sha256sum.sh: scan root %q not a directory\n' "$ROOT" >&2
+    exit 2
+}
+
+_is_exempt() {
+    local path="$1" ex
+    for ex in "${EXEMPT_FILES[@]}"; do
+        [[ "$path" == "$ex" ]] && return 0
+    done
+    return 1
+}
+
+# Bash/sh script detection — same approach as check-no-raw-curl.sh.
+_is_script() {
+    local path="$1"
+    case "$path" in
+        *.sh|*.bash|*.legacy|*.bats) return 0 ;;
+    esac
+    local first_line
+    first_line=$(head -c 256 "$path" 2>/dev/null | head -1 || true)
+    [[ "$first_line" == "#!"*"bash"* ]] && return 0
+    [[ "$first_line" == "#!"*"sh" ]] && return 0
+    [[ "$first_line" == "#!"*"sh "* ]] && return 0
+    return 1
+}
+
+AWK_SCAN=$(cat <<'AWK'
+# Step 1: skip line-leading comments.
+/^[[:space:]]*#/ { next }
+
+# Step 2: skip `command -v sha256sum` and `which sha256sum` existence checks.
+/command[[:space:]]+-v[[:space:]]+sha256sum/ { next }
+/which[[:space:]]+sha256sum/ { next }
+
+# Step 3: skip lines with the suppression marker. Requires `#` leader so
+# string-literal mentions don't silence real invocations.
+/#[^\n]*check-no-raw-sha256sum:[[:space:]]*ok/ { next }
+
+# Step 4: match raw sha256sum (word-boundary both sides).
+# LHS: start-of-line or non-alphanumeric/non-underscore.
+# RHS: whitespace, end-of-line, pipe, quote, etc. — so `sha256_portable` and
+# `sha256sum_something` don't match.
+/(^|[^[:alnum:]_])sha256sum([[:space:]]|$|"|\047|\|)/ {
+    print FILENAME ":" NR ":" $0
+}
+AWK
+)
+
+violations=""
+while IFS= read -r -d '' f; do
+    rel="${f#./}"
+    if _is_exempt "$rel"; then
+        continue
+    fi
+    if ! _is_script "$f"; then
+        continue
+    fi
+    file_hits=$(awk "$AWK_SCAN" "$f" 2>/dev/null || true)
+    if [[ -n "$file_hits" ]]; then
+        violations+="$file_hits"$'\n'
+    fi
+done < <(find "$ROOT" -type f -print0 | sort -z)
+
+if [[ -n "$violations" ]]; then
+    if [[ $QUIET -eq 0 ]]; then
+        printf 'sprint-bug-172 / bug-911: raw sha256sum detected outside sha256_portable\n' >&2
+        printf 'All bash SHA-256 hashing MUST funnel through .claude/scripts/compat-lib.sh::sha256_portable\n' >&2
+        printf 'so macOS / BSD hosts where sha256sum is absent fall back cleanly to shasum -a 256.\n' >&2
+        printf '\nExempt files:\n' >&2
+        for ex in "${EXEMPT_FILES[@]}"; do
+            printf '  - %s\n' "$ex" >&2
+        done
+        printf '\nSuppression marker (use sparingly with reviewer rationale):\n' >&2
+        printf '  # check-no-raw-sha256sum: ok\n' >&2
+        printf '\nViolations:\n' >&2
+        printf '%s' "$violations" | sed '/^$/d' >&2
+    fi
+    exit 1
+fi
+
+[[ $QUIET -eq 0 ]] && printf 'OK — no raw sha256sum callers outside exempt set\n'
+exit 0

--- a/tools/check-no-raw-sha256sum.sh
+++ b/tools/check-no-raw-sha256sum.sh
@@ -109,13 +109,21 @@ AWK_SCAN=$(cat <<'AWK'
 # Step 1: skip line-leading comments.
 /^[[:space:]]*#/ { next }
 
-# Step 2: skip `command -v sha256sum` and `which sha256sum` existence checks.
-/command[[:space:]]+-v[[:space:]]+sha256sum/ { next }
-/which[[:space:]]+sha256sum/ { next }
-
-# Step 3: skip lines with the suppression marker. Requires `#` leader so
+# Step 2: skip lines with the suppression marker. Requires `#` leader so
 # string-literal mentions don't silence real invocations.
 /#[^\n]*check-no-raw-sha256sum:[[:space:]]*ok/ { next }
+
+# Step 3 (DISS-001 closure): there is NO existence-check skip. The
+# post-sprint-bug-172 invariant is that NO production code references
+# raw `sha256sum` — neither as an invocation nor as a `command -v`
+# existence check. Existence checks should use `_COMPAT_SHA256_CMD`
+# instead. If a future PR adds `command -v sha256sum`, the scanner
+# correctly flags it. (Original draft of this scanner had a
+# `command -v sha256sum` line-skip — the cross-model adversarial review
+# flagged it as a smuggling vector: `command -v sha256sum && sha256sum
+# "$file"` would have been accepted because the whole line was skipped
+# before the invocation match ran. Removed entirely; matches the strict
+# tripwire semantics this scanner is meant to provide.)
 
 # Step 4: match raw sha256sum (word-boundary both sides).
 # LHS: start-of-line or non-alphanumeric/non-underscore.


### PR DESCRIPTION
## Bug Fix: sha256_portable migration (38 production scripts)

**Closes**: #911 (per-symbol; structural pattern documented as KF-012)
**Bug ID**: `20260520-i911-60baf5`
**Sprint**: `sprint-bug-172`
**Source**: `/bug` (triage of #911)

### Confidence Signals
- **Reproduction**: strong (single-command repro + #911 issue body confirms)
- **Test type**: integration + unit (bats unit + masked-PATH integration + CI scanner)
- **Risk level**: low (helper + bash callers + tests + CI workflow — no application code)
- **Files changed**: 48 (45 from initial commit + 3 from adversarial-review-closure follow-ups)
- **Lines changed**: ~870 / -111
- **Commits**: 3 (`88663546` impl → `676b8076` self-review fix → `0ac4c528` adversarial closure)

### Root Cause

GNU coreutils ships `sha256sum`; macOS ships only `shasum` (Perl-based BSD lineage). 38 framework scripts called raw `sha256sum`; macOS PATH-lookup failed silently because most callers piped through `awk '{print $1}'` or `cut -d' ' -f1` which mask the empty stdin → empty hash. Cascades into validation FAILs (`/butterfreezone-gen` → `/butterfreezone-validate` 10/12 instead of 12/12 provenance tagged).

**Structural analog**: cycle-099 sprint-1E.c.3.c (curl wrapper migration). Same shape: per-site portability gap → helper + sweep + CI scanner + integration test.

### Changes

| Component | Detail |
|-----------|--------|
| `compat-lib.sh` | +`sha256_portable` helper, `_COMPAT_SHA256_CMD` detect-once flag, `_COMPAT_LIB_VERSION 1.1.0 → 1.2.0` |
| 38 production callers | Migrated to `sha256_portable`; 33 added `source compat-lib.sh`; 5 already sourced |
| `audit-envelope.sh` | `_audit_sha256` wrapper delegates to `sha256_portable` BUT preserves python3 last-resort fallback (defense-in-depth for hash-chain integrity) |
| `tools/check-no-raw-sha256sum.sh` | NEW CI scanner (147 lines); rejects raw sha256sum + smuggled `command -v sha256sum && sha256sum file` (DISS-001) |
| `.github/workflows/check-no-raw-sha256sum.yml` | NEW workflow with positive control (sentinel must be rejected) + negative control (sha256_portable must be accepted); broad `.claude/scripts/**` path filter covers extensionless scripts (DISS-002) |
| `tests/unit/compat-lib-sha256.bats` | NEW 6-case unit test (GNU-only / BSD-only / both / neither / byte-equality / file-argv) |
| `tests/integration/butterfreezone-gen-sha256-portability.bats` | NEW 6-case integration test via `command`-builtin override; hard-coded EXPECTED_HASH for actual-macOS portability (DISS-003) |
| `grimoires/loa/known-failures.md` | KF-012 entry + index row |
| `grimoires/loa/ledger.json` | Register sprint-bug-172 |

### Quality Gates (Iron Fist)

| Gate | Outcome |
|------|---------|
| /implement | 6 tasks complete, AC Verification per cycle-057 |
| Self-adversarial review | **CAUGHT 8 SEMANTIC REGRESSIONS** from bulk-sed migration (closed in commit `676b8076`) |
| Adversarial cross-model review | gpt-5.5-pro via cheval → codex-headless; 3 findings (2 BLOCKING + 1 ADVISORY); **ALL ADDRESSED** in commit `0ac4c528` |
| /audit-sprint | APPROVED - LETS FUCKING GO (7/7 cypherpunk probes clean) |

#### Cross-Model Adversarial Findings (Iron-Fist Evidence)

The cross-model voice caught real defects the implementer's own review missed:

- **DISS-001 (BLOCKING)**: Scanner's `command -v sha256sum` line-skip allowed `command -v sha256sum && sha256sum "$file"` smuggling — entire line skipped before invocation match ran. **Fixed**: removed existence-check skip entirely.
- **DISS-002 (BLOCKING)**: Workflow path filter listed extensions but the scanner supports extensionless scripts via shebang. A PR adding `.claude/scripts/some-tool` with bash shebang would have bypassed the gate. **Fixed**: broadened filter to `.claude/scripts/**`.
- **DISS-003 (ADVISORY)**: Integration test setup computed EXPECTED_HASH via raw sha256sum — on actual macOS, setup would fail before fallback-path assertions. **Fixed**: hard-coded the deterministic digest.

### Artifacts

- Triage: `grimoires/loa/a2a/bug-20260520-i911-60baf5/triage.md` (state-zone, local)
- Sprint plan: `grimoires/loa/a2a/bug-20260520-i911-60baf5/sprint.md`
- Implementation report: `grimoires/loa/a2a/sprint-bug-172/reviewer.md`
- Reviewer feedback: `grimoires/loa/a2a/sprint-bug-172/engineer-feedback.md`
- Auditor verdict: `grimoires/loa/a2a/sprint-bug-172/auditor-sprint-feedback.md`
- Adversarial review JSON: `grimoires/loa/a2a/sprint-bug-172/adversarial-review.json`
- COMPLETED marker: `grimoires/loa/a2a/sprint-bug-172/COMPLETED`

### Authorization

System Zone edits to `.claude/scripts/` (compat-lib.sh + 37 callers) authorized via canonical `/bug → /implement` cycle per `.claude/rules/zone-system.md`.

### Status: READY FOR HUMAN REVIEW

This PR was created by `/run sprint-bug-172` autonomous mode with iron-fisted quality gates. Bias-correction protocol (per upstream issue #941 delta #1) applied at both review and audit phases — and proven its value: 2 BLOCKING findings the implementer missed were surfaced and fixed pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)