### PR TITLE
fix(#894): headless CLI env-scrub covers all auth-mode selectors

### DIFF
--- a/.claude/adapters/loa_cheval/providers/base.py
+++ b/.claude/adapters/loa_cheval/providers/base.py
@@ -469,12 +469,35 @@ def http_post_stream(
 # parent process the CLI falls back to API mode — defeating the headless
 # adapter's purpose. Operators who explicitly want API-mode routing through
 # the CLI opt in via LOA_HEADLESS_KEEP_API_KEY=1.
+#
+# Two sub-classes are scrubbed:
+#   1. Credential vars — the secret itself (ANTHROPIC_API_KEY, OPENAI_API_KEY,
+#      GOOGLE_API_KEY, GEMINI_API_KEY, GOOGLE_APPLICATION_CREDENTIALS).
+#   2. Auth-mode-selector vars — flags that flip the CLI's auth strategy
+#      off the persisted OAuth subscription path even when no credential
+#      is present. For gemini, verified against gemini-cli's
+#      `packages/core/src/core/contentGenerator.ts::getAuthTypeFromEnv()`:
+#        - GOOGLE_GENAI_USE_GCA=true             → AuthType.LOGIN_WITH_GOOGLE
+#        - GOOGLE_GENAI_USE_VERTEXAI=true        → AuthType.USE_VERTEX_AI
+#        - GOOGLE_GEMINI_BASE_URL=<url>          → AuthType.GATEWAY
+#        - GEMINI_CLI_USE_COMPUTE_ADC=true       → AuthType.COMPUTE_ADC
+#      (`CLOUD_SHELL=true` also routes to COMPUTE_ADC but is set by Google
+#      Cloud Shell as a legitimate environment signal; scrubbing it would
+#      surprise operators running cheval from Cloud Shell, so it stays.)
+#      The codex + claude CLIs have no analogous env-var selectors as of
+#      2026-05-20 (sprint-bug-173 audit); their auth-mode is selected by
+#      CLI flags (claude `--bare`) or by file presence (`~/.codex/auth.json`),
+#      not env vars. See KF-013 for the recurring-class taxonomy.
 _HEADLESS_STRIPPED_AUTH_VARS: tuple = (
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
     "GOOGLE_API_KEY",
     "GEMINI_API_KEY",
     "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_GENAI_USE_VERTEXAI",
+    "GOOGLE_GENAI_USE_GCA",
+    "GOOGLE_GEMINI_BASE_URL",
+    "GEMINI_CLI_USE_COMPUTE_ADC",
 )
 
 
@@ -482,8 +505,12 @@ def build_headless_subprocess_env(parent_env=None) -> Dict[str, str]:
     """Return an env dict suitable for headless adapter subprocess.run(env=...).
 
     Default: copy parent env (or os.environ if parent_env is None) and remove
-    auth-class vars per `_HEADLESS_STRIPPED_AUTH_VARS`. Operator opt-out via
-    `LOA_HEADLESS_KEEP_API_KEY=1` preserves the auth vars verbatim.
+    every entry in `_HEADLESS_STRIPPED_AUTH_VARS` — both the credential
+    sub-class (e.g., GOOGLE_API_KEY) and the auth-mode-selector sub-class
+    (e.g., GOOGLE_GENAI_USE_VERTEXAI). Operator opt-out via
+    `LOA_HEADLESS_KEEP_API_KEY=1` preserves ALL entries verbatim
+    (credentials AND mode-selectors — the opt-in is a full env-bypass,
+    not credential-only).
 
     The kwarg is ALWAYS supposed to be passed explicitly by callers — even
     when no key needs stripping. The headless adapter's contract is

--- a/.claude/adapters/tests/test_gemini_headless_adapter.py
+++ b/.claude/adapters/tests/test_gemini_headless_adapter.py
@@ -530,6 +530,92 @@ class TestSubprocessEnvFilter:
         assert env.get("GOOGLE_API_KEY") == "test-google"
         assert env.get("GEMINI_API_KEY") == "test-gemini"
 
+    # sprint-bug-173 / #894: auth-mode-selector env vars (GOOGLE_GENAI_USE_*)
+    # push the gemini CLI off the ~/.gemini/settings.json OAuth path onto
+    # rate-limited Vertex / GCA API auth. They must be scrubbed by default,
+    # and preserved under the LOA_HEADLESS_KEEP_API_KEY=1 opt-out (parity
+    # with GOOGLE_API_KEY / GEMINI_API_KEY semantics).
+    def test_genai_mode_selectors_scrubbed_by_default(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "true")
+        monkeypatch.setenv("GOOGLE_GENAI_USE_GCA", "true")
+        monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        kwargs = mock_run.call_args.kwargs
+        assert "env" in kwargs, "subprocess.run must pass explicit env="
+        assert "GOOGLE_GENAI_USE_VERTEXAI" not in kwargs["env"]
+        assert "GOOGLE_GENAI_USE_GCA" not in kwargs["env"]
+
+    def test_genai_mode_selectors_preserved_under_keep_api_key_opt_in(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "true")
+        monkeypatch.setenv("GOOGLE_GENAI_USE_GCA", "true")
+        monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("GOOGLE_GENAI_USE_VERTEXAI") == "true"
+        assert env.get("GOOGLE_GENAI_USE_GCA") == "true"
+
+    # sprint-bug-173 cross-model adversarial review (DISS-001) caught two
+    # additional auth-mode selectors from gemini-cli's getAuthTypeFromEnv()
+    # that dig-search.ts did NOT scrub:
+    #   - GOOGLE_GEMINI_BASE_URL → AuthType.GATEWAY
+    #   - GEMINI_CLI_USE_COMPUTE_ADC → AuthType.COMPUTE_ADC
+    # Verified directly against gemini-cli main branch
+    # (packages/core/src/core/contentGenerator.ts). The same defense-in-depth
+    # pattern (default-scrub + KEEP_API_KEY=1 preserves) applies.
+    def test_gemini_base_url_scrubbed_by_default(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_GEMINI_BASE_URL", "https://gateway.example.com")
+        monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        assert "GOOGLE_GEMINI_BASE_URL" not in mock_run.call_args.kwargs["env"]
+
+    def test_compute_adc_selector_scrubbed_by_default(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_CLI_USE_COMPUTE_ADC", "true")
+        monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        assert "GEMINI_CLI_USE_COMPUTE_ADC" not in mock_run.call_args.kwargs["env"]
+
+    def test_all_mode_selectors_preserved_under_keep_api_key_opt_in(self, monkeypatch):
+        # Confirms the docstring contract: KEEP_API_KEY=1 is a full env-bypass,
+        # not a credential-only opt-out. ALL entries in
+        # _HEADLESS_STRIPPED_AUTH_VARS are preserved verbatim.
+        monkeypatch.setenv("GOOGLE_GEMINI_BASE_URL", "https://gateway.example.com")
+        monkeypatch.setenv("GEMINI_CLI_USE_COMPUTE_ADC", "true")
+        monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("GOOGLE_GEMINI_BASE_URL") == "https://gateway.example.com"
+        assert env.get("GEMINI_CLI_USE_COMPUTE_ADC") == "true"
+
+    def test_cloud_shell_preserved_legitimate_environment_signal(self, monkeypatch):
+        # CLOUD_SHELL=true is set by Google Cloud Shell to mark the runtime.
+        # gemini-cli's getAuthTypeFromEnv() reads it as a COMPUTE_ADC selector,
+        # but operators legitimately running cheval from Cloud Shell expect
+        # COMPUTE_ADC to be the natural auth path. Scrubbing CLOUD_SHELL would
+        # surprise that operator class. Documented decision; this test pins it.
+        monkeypatch.setenv("CLOUD_SHELL", "true")
+        monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
+            adapter.complete(_make_request())
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("CLOUD_SHELL") == "true"
+
 
 # ---------------------------------------------------------------------------
 # Live test (gated)

--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -66,6 +66,7 @@ actually tried, not just what someone *said* was tried.
 | [KF-010](#kf-010-cheval-delegate-google-adapter-300s-process-timeout-on-concurrent-bb-runs) | RESOLVED 2026-05-16 (sprint-bug-165, issue #921) | bridgebuilder google + anthropic voices / `deriveTimeoutMs` predicate scope | 6 (single batch, 2026-05-16) |
 | [KF-011](#kf-011-adversarial-reviewsh-malformed-response-on-review-type-prompts-post-kf-002-closure) | **RESOLVED 2026-05-17** (sub-mode (b): parser raw_decode extracts prose-prefixed JSON — PR #933 `d9ec8cb5`; sub-mode (c): route-around via 4-voice fallback chain — PR #934 `ccd510b0`; structural sub-mode (c) Gemini streaming-recovery tracked at issue #935). | adversarial-review.sh review-type — JSON contract layer + Gemini streaming-recovery gap | 2 (initial obs sprint-166 review + repro on parser-fix branch) |
 | [KF-012](#kf-012-sha256sum-not-portable-to-bsd-macos-silent-empty-hash-cascade-into-validation-failures) | **RESOLVED-STRUCTURAL 2026-05-20** (sprint-bug-172 / #911: `sha256_portable` helper in compat-lib.sh + 38 production call sites migrated + CI scanner `tools/check-no-raw-sha256sum.sh` + `tests/unit/compat-lib-sha256.bats` + masked-PATH integration test). Structural analog of cycle-099 sprint-1E.c.3.c curl wrapper migration. | macOS / BSD users of `/butterfreezone-gen` + 37 other framework scripts | 1 (single observation, sprint-bug-172 closure) |
+| [KF-013](#kf-013-headless-cli-env-mode-selector-vars-defeat-subscription-oauth) | **RESOLVED 2026-05-20** (sprint-bug-173 / #894: `_HEADLESS_STRIPPED_AUTH_VARS` tuple extended with `GOOGLE_GENAI_USE_VERTEXAI` + `GOOGLE_GENAI_USE_GCA`; canonical scrub list mirrors `construct-k-hole/scripts/dig-search.ts`). | cheval headless CLI adapters (gemini / codex / claude) | 1 (single observation, sprint-bug-173 closure) |
 
 ---
 
@@ -885,6 +886,60 @@ If you see `sha256sum: command not found` in any `.claude/scripts/` script outpu
 
 - Structural precedent: cycle-099 sprint-1E.c.3.c (`tools/check-no-raw-curl.sh`) — same shape, applied to `curl`/`wget`.
 - Related framework-portability concerns: `compat-lib.sh` already handles `sed_inplace`, `get_canonical_path`, `version_sort`, `make_temp`, `get_file_mtime`, `find_sorted_by_time` — this entry adds `sha256_portable` to that list (helper version 1.1.0 → 1.2.0).
+
+---
+
+## KF-013: headless CLI env-mode-selector vars defeat subscription OAuth
+
+**Status**: RESOLVED 2026-05-20 (sprint-bug-173 / PR pending merge — `_HEADLESS_STRIPPED_AUTH_VARS` extended)
+**Feature**: cheval headless CLI adapters (`gemini-headless`, `codex-headless`, `claude-headless`) — env hygiene for spawned subprocess
+**Symptom**: A `kind: cli` headless adapter invocation returns `RATE_LIMITED: Rate limited by google` (or analogous 429) even though the operator's CLI works fine when invoked directly with its OAuth subscription path (`~/.gemini/settings.json`, `~/.codex/auth.json`, `~/.claude/`). Root cause: the parent shell exports an *auth-mode-selector* env var (not a credential — just a flag) that flips the CLI off OAuth onto API/Vertex/GCA mode, where it then hits API rate limits.
+**First observed**: 2026-05-20 (sprint-bug-173, issue #894). The defect class was visible since cycle-109 #879/#880 introduced `_HEADLESS_STRIPPED_AUTH_VARS` — the original tuple only scrubbed *credentials*, not *mode-selectors*. The gap was made visible by the `construct-k-hole/scripts/dig-search.ts` external pattern, which scrubs both classes.
+**Recurrence count**: 1
+**Current workaround**: `_HEADLESS_STRIPPED_AUTH_VARS` (in `.claude/adapters/loa_cheval/providers/base.py:472-489`) now scrubs both sub-classes: credentials AND auth-mode-selectors. `LOA_HEADLESS_KEEP_API_KEY=1` preserves both (operator opt-in to API mode).
+**Upstream issue**: [#894](https://github.com/0xHoneyJar/loa/issues/894); fix in sprint-bug-173 PR (pending).
+**Related visions / lore**: KF-002 (large-input class — different layer, same headless substrate); `feedback_bias_correction_protocol_validated.md` (cross-model adversarial review caught analogous defect-class gap in sprint-bug-172).
+
+### Attempts
+
+| Date | What we tried | Outcome | Evidence |
+|------|---------------|---------|----------|
+| 2026-05-20 | Initial fix: extended `_HEADLESS_STRIPPED_AUTH_VARS` tuple with `GOOGLE_GENAI_USE_VERTEXAI` + `GOOGLE_GENAI_USE_GCA`, mirroring `construct-k-hole/scripts/dig-search.ts`. Added paired unit tests. Failing-first proven (default-scrub FAIL pre-fix, PASS post-fix). | PARTIAL — covered 2 of 4 selectors | sprint-bug-173 PR commit-1; bd-rt9u; 101 headless tests pass. |
+| 2026-05-20 | Phase 2.5 cross-model adversarial review (`adversarial-review.sh --type review --sprint-id sprint-bug-173`, gpt-5.5-pro, 102.7s, 60.7K input / 5.8K output tokens) surfaced ADVISORY DISS-001: dig-search.ts scrub list is incomplete; gemini-cli's `getAuthTypeFromEnv()` checks additional auth-mode selectors. | CAUGHT-GAP | `grimoires/loa/a2a/sprint-bug-173/adversarial-review.json`; bias-correction protocol per `feedback_bias_correction_protocol_validated.md`. |
+| 2026-05-20 | Verified DISS-001 directly against gemini-cli main branch source (`packages/core/src/core/contentGenerator.ts::getAuthTypeFromEnv()`). Confirmed two more env-mode selectors: `GOOGLE_GEMINI_BASE_URL` (→ AuthType.GATEWAY) and `GEMINI_CLI_USE_COMPUTE_ADC` (→ AuthType.COMPUTE_ADC). Extended tuple in same sprint commit. Added paired scrub-by-default tests for both, plus `test_all_mode_selectors_preserved_under_keep_api_key_opt_in` confirming the docstring contract, plus `test_cloud_shell_preserved_legitimate_environment_signal` pinning the explicit decision to NOT scrub `CLOUD_SHELL=true` (legit Cloud Shell environment signal). | RESOLVED — verified against canonical source | sprint-bug-173 PR commit-2; 105/105 headless tests pass; zero regressions. |
+| 2026-05-20 | Symmetric audit of `codex_headless_adapter.py` + `claude_headless_adapter.py` for analogous OpenAI / Anthropic env-mode-selector vars. | NONE FOUND — no equivalents | `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` are endpoint-redirects (not mode-switches); `OPENAI_API_TYPE` is legacy-Azure-SDK (not consumed by codex CLI); claude's `--bare` is a CLI flag (already forbidden in adapter docstring per `claude_headless_adapter.py:26`), not an env var. Existing `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` scrubs remain sufficient. |
+
+### Reading guide
+
+When you observe `RATE_LIMITED` or `403`/`401` from a `kind: cli` headless
+adapter despite the operator's direct-CLI invocation working with subscription
+OAuth: check whether a NEW auth-mode-selector env var was introduced by a CLI
+update (gemini / codex / claude). The canonical scrub list is
+`_HEADLESS_STRIPPED_AUTH_VARS` in `.claude/adapters/loa_cheval/providers/base.py`.
+
+**Canonical source-of-truth for the gemini selector class** is gemini-cli's
+`packages/core/src/core/contentGenerator.ts::getAuthTypeFromEnv()` — the
+switch ladder of env-var checks IS the auth-mode-selector list. The original
+sprint-bug-173 fix mirrored `construct-k-hole/scripts/dig-search.ts` and got
+2 of 4 selectors right; the cross-model adversarial review caught the other
+two (`GOOGLE_GEMINI_BASE_URL`, `GEMINI_CLI_USE_COMPUTE_ADC`). When auditing
+a new CLI version, read the CLI's own source rather than relying on third-party
+scrub lists. Dig-search.ts is prior art, not specification.
+
+The opt-in preserves-test under `LOA_HEADLESS_KEEP_API_KEY=1` is regression-guard
+(the env returns the parent verbatim, so the assertion holds pre- AND post-fix).
+The failing-first proof comes from the default-scrub test alone.
+
+The codex + claude CLIs were audited (2026-05-20) for analogous env-mode-selectors
+and none exist as of the audit date. Future agents observing the same symptom
+class on the codex / claude path should first check CLI changelogs for newly-added
+env-mode-selector vars rather than re-running the same audit.
+
+**Meta-lesson for future provider-CLI additions**: this entry is the empirical
+evidence-base for the operator's `feedback_bias_correction_protocol_validated.md`
+— the Phase 2.5 cross-model adversarial review (`adversarial-review.sh`) caught
+a same-class gap that single-author audit missed. When landing a new headless
+adapter, do not skip the cross-model review under "the fix is trivial" pressure.
 
 ---
 

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -21,26 +21,26 @@
         {
           "local_id": 2,
           "global_id": 53,
-          "label": "Bridgebuilder Findings — Excellence Hardening",
+          "label": "Bridgebuilder Findings \u2014 Excellence Hardening",
           "status": "completed"
         },
         {
           "local_id": 3,
           "global_id": 54,
-          "label": "CI Hardening — Bridge Iteration 2",
+          "label": "CI Hardening \u2014 Bridge Iteration 2",
           "status": "completed"
         },
         {
           "local_id": 4,
           "global_id": 55,
-          "label": "CI Integrity — Bridge Iteration 3",
+          "label": "CI Integrity \u2014 Bridge Iteration 3",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-037",
-      "label": "Bridgebuilder Deep Review — Architectural Fixes",
+      "label": "Bridgebuilder Deep Review \u2014 Architectural Fixes",
       "status": "archived",
       "created": "2026-02-24T08:40:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -58,7 +58,7 @@
     },
     {
       "id": "cycle-038",
-      "label": "Organizational Memory Sovereignty — Three-Zone State Architecture",
+      "label": "Organizational Memory Sovereignty \u2014 Three-Zone State Architecture",
       "status": "archived",
       "created": "2026-02-24T21:00:00Z",
       "archived": "2026-02-25T12:00:00Z",
@@ -106,7 +106,7 @@
     },
     {
       "id": "cycle-039",
-      "label": "Two-Pass Bridge Review — Decouple Convergence from Enrichment",
+      "label": "Two-Pass Bridge Review \u2014 Decouple Convergence from Enrichment",
       "status": "archived",
       "created": "2026-02-25T12:30:00Z",
       "archived": "2026-02-26T00:00:00Z",
@@ -123,19 +123,19 @@
         {
           "local_id": 2,
           "global_id": 64,
-          "label": "Excellence Hardening — Bridge Iteration 2",
+          "label": "Excellence Hardening \u2014 Bridge Iteration 2",
           "status": "completed"
         },
         {
           "local_id": 3,
           "global_id": 65,
-          "label": "Final Polish — Bridge Iteration 3",
+          "label": "Final Polish \u2014 Bridge Iteration 3",
           "status": "completed"
         },
         {
           "local_id": 4,
           "global_id": 66,
-          "label": "Metacognition — Confidence-Weighted Enrichment",
+          "label": "Metacognition \u2014 Confidence-Weighted Enrichment",
           "status": "completed"
         },
         {
@@ -147,32 +147,32 @@
         {
           "local_id": 6,
           "global_id": 68,
-          "label": "Ecosystem Context Integration — Pass 0 Prototype",
+          "label": "Ecosystem Context Integration \u2014 Pass 0 Prototype",
           "status": "completed"
         },
         {
           "local_id": 7,
           "global_id": 69,
-          "label": "Enrichment Pipeline Ergonomics — Schema-First Architecture",
+          "label": "Enrichment Pipeline Ergonomics \u2014 Schema-First Architecture",
           "status": "completed"
         },
         {
           "local_id": 8,
           "global_id": 70,
-          "label": "Pass 1 Convergence Cache — Cost Intelligence",
+          "label": "Pass 1 Convergence Cache \u2014 Cost Intelligence",
           "status": "completed"
         },
         {
           "local_id": 9,
           "global_id": 71,
-          "label": "Dynamic Ecosystem Context — From Static Hints to Living Memory",
+          "label": "Dynamic Ecosystem Context \u2014 From Static Hints to Living Memory",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-040",
-      "label": "Multi-Model Adversarial Review Upgrade — GPT-5.3-Codex + Gemini Tertiary",
+      "label": "Multi-Model Adversarial Review Upgrade \u2014 GPT-5.3-Codex + Gemini Tertiary",
       "status": "archived",
       "created": "2026-02-26T00:00:00Z",
       "archived": "2026-02-26T14:00:00Z",
@@ -189,14 +189,14 @@
         {
           "local_id": 2,
           "global_id": 73,
-          "label": "Bug Fix — Scoring Engine 3-Model Tertiary Cross-Scoring",
+          "label": "Bug Fix \u2014 Scoring Engine 3-Model Tertiary Cross-Scoring",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-041",
-      "label": "Vision-Aware Planning — Creative Agency for AI Peers",
+      "label": "Vision-Aware Planning \u2014 Creative Agency for AI Peers",
       "status": "archived",
       "created": "2026-02-26T14:00:00Z",
       "archived": "2026-02-26T18:00:00Z",
@@ -207,7 +207,7 @@
         {
           "local_id": 1,
           "global_id": 74,
-          "label": "Foundation — Schema, Library, Query, Shadow Mode",
+          "label": "Foundation \u2014 Schema, Library, Query, Shadow Mode",
           "status": "completed"
         },
         {
@@ -226,7 +226,7 @@
     },
     {
       "id": "cycle-042",
-      "label": "Vision Activation — From Infrastructure to Living Memory",
+      "label": "Vision Activation \u2014 From Infrastructure to Living Memory",
       "status": "archived",
       "created": "2026-02-26T18:00:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -253,7 +253,7 @@
         {
           "local_id": 4,
           "global_id": 80,
-          "label": "Excellence Hardening — Bridgebuilder Findings",
+          "label": "Excellence Hardening \u2014 Bridgebuilder Findings",
           "status": "completed"
         }
       ],
@@ -292,7 +292,7 @@
     },
     {
       "id": "cycle-044",
-      "label": "Bridgebuilder Design Review — Pre-Implementation Architectural Intelligence",
+      "label": "Bridgebuilder Design Review \u2014 Pre-Implementation Architectural Intelligence",
       "status": "archived",
       "created": "2026-02-28T00:00:00Z",
       "archived": "2026-02-28T07:00:00Z",
@@ -322,7 +322,7 @@
     },
     {
       "id": "cycle-045",
-      "label": "Review Pipeline Hardening — Gemini Activation, Orchestrator Wiring, Red Team Post-Implementation",
+      "label": "Review Pipeline Hardening \u2014 Gemini Activation, Orchestrator Wiring, Red Team Post-Implementation",
       "status": "archived",
       "created": "2026-02-28T03:00:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -352,7 +352,7 @@
     },
     {
       "id": "cycle-046",
-      "label": "Bridgebuilder Constellation — From Pipeline to Deliberation",
+      "label": "Bridgebuilder Constellation \u2014 From Pipeline to Deliberation",
       "status": "archived",
       "created": "2026-02-28T04:30:00Z",
       "archived": "2026-02-28T06:30:00Z",
@@ -369,7 +369,7 @@
         {
           "local_id": 2,
           "global_id": 91,
-          "label": "Deliberative Council — Prior Findings Integration",
+          "label": "Deliberative Council \u2014 Prior Findings Integration",
           "status": "completed"
         },
         {
@@ -388,7 +388,7 @@
     },
     {
       "id": "cycle-047",
-      "label": "Compassionate Excellence — Bridgebuilder Deep Review Integration",
+      "label": "Compassionate Excellence \u2014 Bridgebuilder Deep Review Integration",
       "status": "archived",
       "created": "2026-02-28T06:30:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -424,7 +424,7 @@
     },
     {
       "id": "cycle-048",
-      "label": "Community Feedback — Review Pipeline Hardening",
+      "label": "Community Feedback \u2014 Review Pipeline Hardening",
       "status": "active",
       "created": "2026-02-28T08:50:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -433,7 +433,7 @@
         {
           "local_id": 1,
           "global_id": 98,
-          "label": "Foundation — Curl Guard, Error Surfacing, YAML Regex",
+          "label": "Foundation \u2014 Curl Guard, Error Surfacing, YAML Regex",
           "status": "planned"
         },
         {
@@ -458,7 +458,7 @@
     },
     {
       "id": "cycle-bug-20260418-i553-cb632b",
-      "label": "Bug Fix — agent: Plan blocks Write in /architect and /sprint-plan",
+      "label": "Bug Fix \u2014 agent: Plan blocks Write in /architect and /sprint-plan",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/553",
@@ -479,7 +479,7 @@
     },
     {
       "id": "cycle-bug-20260418-i549-1aaa93",
-      "label": "Bug Fix — Shell Tests 20+ pre-existing failures on main (5 clusters)",
+      "label": "Bug Fix \u2014 Shell Tests 20+ pre-existing failures on main (5 clusters)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/549",
@@ -498,7 +498,7 @@
     },
     {
       "id": "cycle-bug-20260418-i555-5560f6",
-      "label": "Bug Fix — Silent data loss via git stash -k / git stash pop",
+      "label": "Bug Fix \u2014 Silent data loss via git stash -k / git stash pop",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/555",
@@ -518,7 +518,7 @@
     },
     {
       "id": "cycle-bug-20260418-i545-e2c781",
-      "label": "Bug Fix — Spiral REVIEW gate fix-loop + quality_gate recovery (#545 + #546)",
+      "label": "Bug Fix \u2014 Spiral REVIEW gate fix-loop + quality_gate recovery (#545 + #546)",
       "type": "bugfix",
       "status": "active",
       "source_issues": [
@@ -542,7 +542,7 @@
     },
     {
       "id": "cycle-bug-20260418-i548-a2460c",
-      "label": "Bug Fix — vision-011 + cycle-082 deferred gates bundle (#548)",
+      "label": "Bug Fix \u2014 vision-011 + cycle-082 deferred gates bundle (#548)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/548",
@@ -558,7 +558,7 @@
     },
     {
       "id": "cycle-bug-20260418-i563-39dbdf",
-      "label": "Bug Fix — tripwire-handler rollback precheck misses untracked-only changes",
+      "label": "Bug Fix \u2014 tripwire-handler rollback precheck misses untracked-only changes",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/563",
@@ -571,7 +571,7 @@
     },
     {
       "id": "cycle-bug-20260418-i568-740715",
-      "label": "Bug Fix — spiral.task not exported to dispatch subprocess",
+      "label": "Bug Fix \u2014 spiral.task not exported to dispatch subprocess",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/568",
@@ -584,7 +584,7 @@
     },
     {
       "id": "cycle-bug-20260418-i570-83c0b5",
-      "label": "Bug Fix — spiral-harness hardcoded 300s planning timeouts",
+      "label": "Bug Fix \u2014 spiral-harness hardcoded 300s planning timeouts",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/570",
@@ -597,7 +597,7 @@
     },
     {
       "id": "cycle-bug-20260418-i573-cb3351",
-      "label": "Bug Fix — Flatline model allowlist hygiene & graceful degradation (#573+#574)",
+      "label": "Bug Fix \u2014 Flatline model allowlist hygiene & graceful degradation (#573+#574)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/573",
@@ -637,13 +637,13 @@
         {
           "local_id": "3A",
           "global_id": 116,
-          "label": "Health-Probe Core — KEYSTONE part 1 (T2.2)",
+          "label": "Health-Probe Core \u2014 KEYSTONE part 1 (T2.2)",
           "status": "merged"
         },
         {
           "local_id": "3B",
           "global_id": 117,
-          "label": "Health-Probe Resilience+CI+Integration+Runbook — KEYSTONE part 2 (T2.2)",
+          "label": "Health-Probe Resilience+CI+Integration+Runbook \u2014 KEYSTONE part 2 (T2.2)",
           "status": "merged"
         },
         {
@@ -685,7 +685,7 @@
     },
     {
       "id": "cycle-bug-20260428-i637-20ddd6",
-      "label": "Bug Fix — bridgebuilder-dist-smoke CI lane fails because workflow does not run npm ci (#637)",
+      "label": "Bug Fix \u2014 bridgebuilder-dist-smoke CI lane fails because workflow does not run npm ci (#637)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/637",
@@ -698,7 +698,7 @@
     },
     {
       "id": "cycle-095-model-currency",
-      "label": "Model Currency — gpt-5.5 + Haiku 4.5 + Gemini 3 + cost guardrails",
+      "label": "Model Currency \u2014 gpt-5.5 + Haiku 4.5 + Gemini 3 + cost guardrails",
       "status": "archived",
       "created": "2026-04-29T20:30:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -760,7 +760,7 @@
     },
     {
       "id": "cycle-bug-20260502-i669-55150d",
-      "label": "Bug Fix — post-merge automation: orchestrator scripts ship without an invoking workflow template",
+      "label": "Bug Fix \u2014 post-merge automation: orchestrator scripts ship without an invoking workflow template",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/669",
@@ -781,7 +781,7 @@
     },
     {
       "id": "cycle-098-agent-network",
-      "label": "Agent-Network Operation Primitives (L1-L7) — operator-absent network operation",
+      "label": "Agent-Network Operation Primitives (L1-L7) \u2014 operator-absent network operation",
       "status": "archived",
       "created": "2026-05-03T03:02:37.318627Z",
       "prd": "grimoires/loa/prd.md",
@@ -857,13 +857,13 @@
         }
       ],
       "shipped_at": "2026-05-04",
-      "ship_note": "COMPLETE — L1-L7 all SHIPPED on main. Sprint timeline: Sprint 1 (#693, L1+cross-cutting), 1.5 (#697 hardening), 2 (#705, L2 cost-budget), 3 (#712, L3 scheduled-cycle), H1+H2 (#716, #717 signed-mode + observer), /bug #711 (#718 gpt-review hook), 4 (#764, L4 graduated-trust), 5 (#767, L5 cross-repo-status), 6 (#771, L6 structured-handoff), 7 (#775, L7 soul-identity-doc) + follow-up #778 (L6 inheritance: strict test-mode gate + hook wiring). Cycle-098 cumulative tests on main: 760+. See archive at grimoires/loa/archive/2026-05-08-cycle-098-agent-network-l1-l7-complete/.",
+      "ship_note": "COMPLETE \u2014 L1-L7 all SHIPPED on main. Sprint timeline: Sprint 1 (#693, L1+cross-cutting), 1.5 (#697 hardening), 2 (#705, L2 cost-budget), 3 (#712, L3 scheduled-cycle), H1+H2 (#716, #717 signed-mode + observer), /bug #711 (#718 gpt-review hook), 4 (#764, L4 graduated-trust), 5 (#767, L5 cross-repo-status), 6 (#771, L6 structured-handoff), 7 (#775, L7 soul-identity-doc) + follow-up #778 (L6 inheritance: strict test-mode gate + hook wiring). Cycle-098 cumulative tests on main: 760+. See archive at grimoires/loa/archive/2026-05-08-cycle-098-agent-network-l1-l7-complete/.",
       "archived": "2026-05-07T19:11:07Z",
       "archive_path": "grimoires/loa/archive/2026-05-08-cycle-098-agent-network-l1-l7-complete"
     },
     {
       "id": "cycle-bug-20260503-i674-84adf8",
-      "label": "Bug Fix — post-merge + post-PR pipeline reliability bundle (#674, #634, #633, #676)",
+      "label": "Bug Fix \u2014 post-merge + post-PR pipeline reliability bundle (#674, #634, #633, #676)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/674",
@@ -882,7 +882,7 @@
     },
     {
       "id": "cycle-bug-20260504-i636-cb9b6d",
-      "label": "Bug Fix — T2+T3 hardening bundle (#636+#681+#687+#691+#692)",
+      "label": "Bug Fix \u2014 T2+T3 hardening bundle (#636+#681+#687+#691+#692)",
       "type": "bugfix",
       "status": "active",
       "source_issues": [
@@ -966,7 +966,7 @@
     },
     {
       "id": "cycle-bug-20260507-i774-e898cd",
-      "label": "Bug Fix — Flatline orchestrator drops 3-of-6 model calls on 38KB docs",
+      "label": "Bug Fix \u2014 Flatline orchestrator drops 3-of-6 model calls on 38KB docs",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/774",
@@ -979,7 +979,7 @@
     },
     {
       "id": "cycle-bug-20260508-i789-e3f89e",
-      "label": "Bug Fix — Coupled model-stability rollback restoration (#787 + #789)",
+      "label": "Bug Fix \u2014 Coupled model-stability rollback restoration (#787 + #789)",
       "type": "bugfix",
       "status": "active",
       "source_issues": [
@@ -1053,14 +1053,14 @@
           "tasks": 6
         }
       ],
-      "thesis": "Silent degradation is the bug. Every model failure must be (typed → operator-visible → graceful-fallback-with-WARN). Rollback is a workaround with a deadline.",
+      "thesis": "Silent degradation is the bug. Every model failure must be (typed \u2192 operator-visible \u2192 graceful-fallback-with-WARN). Rollback is a workaround with a deadline.",
       "vision_source": "grimoires/loa/visions/entries/vision-019.md",
       "archived": "2026-05-11T09:12:26Z",
       "archive_path": "grimoires/loa/cycles/cycle-102-model-stability/"
     },
     {
       "id": "cycle-103-provider-unification",
-      "label": "Provider Boundary Unification — collapse 3 HTTP boundaries to cheval substrate",
+      "label": "Provider Boundary Unification \u2014 collapse 3 HTTP boundaries to cheval substrate",
       "status": "archived",
       "created": "2026-05-11T09:12:26Z",
       "prd": "grimoires/loa/cycles/cycle-103-provider-unification/prd.md",
@@ -1102,7 +1102,7 @@
     },
     {
       "id": "cycle-104-multi-model-stabilization",
-      "label": "Multi-Model Stabilization — Within-Company Fallback + Headless Opt-In + BB Internal Dispatcher Unification",
+      "label": "Multi-Model Stabilization \u2014 Within-Company Fallback + Headless Opt-In + BB Internal Dispatcher Unification",
       "status": "active",
       "created": "2026-05-12T00:59:16Z",
       "prd": "grimoires/loa/cycles/cycle-104-multi-model-stabilization/prd.md",
@@ -1171,7 +1171,7 @@
     },
     {
       "id": "cycle-106-zone-hygiene",
-      "label": "Framework Template Hygiene — zone boundaries",
+      "label": "Framework Template Hygiene \u2014 zone boundaries",
       "status": "in-progress",
       "created": "2026-05-12T08:10:58Z",
       "prd": "grimoires/loa/cycles/cycle-106-zone-hygiene/prd.md",
@@ -1227,7 +1227,7 @@
     },
     {
       "id": "cycle-108-advisor-strategy",
-      "label": "Advisor-Strategy Benchmark — Role→Tier Routing for Sustainable Cycles",
+      "label": "Advisor-Strategy Benchmark \u2014 Role\u2192Tier Routing for Sustainable Cycles",
       "status": "completed",
       "created": "2026-05-13T00:00:00Z",
       "prd": "grimoires/loa/cycles/cycle-108-advisor-strategy/prd.md",
@@ -1237,7 +1237,7 @@
     },
     {
       "id": "cycle-109-substrate-hardening",
-      "label": "Multi-Model Substrate Hardening — Capability-Aware Dispatch + Verdict-Quality Envelope + Legacy Sunset",
+      "label": "Multi-Model Substrate Hardening \u2014 Capability-Aware Dispatch + Verdict-Quality Envelope + Legacy Sunset",
       "status": "in-progress",
       "created": "2026-05-13T00:00:00Z",
       "prd": "grimoires/loa/cycles/cycle-109-substrate-hardening/prd.md",
@@ -1303,7 +1303,7 @@
     },
     {
       "id": "cycle-bug-20260517-i900-4f7e7a",
-      "label": "Bug Fix — substrate-health hides primary model failures after fallback success",
+      "label": "Bug Fix \u2014 substrate-health hides primary model failures after fallback success",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/900",
@@ -1316,7 +1316,7 @@
     },
     {
       "id": "cycle-112-empirical-model-economy",
-      "label": "Empirical Model Economy (Phase A) — roll-up + workload tier map seed",
+      "label": "Empirical Model Economy (Phase A) \u2014 roll-up + workload tier map seed",
       "type": "feature",
       "status": "in-progress",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/925",
@@ -1348,7 +1348,7 @@
         }
       ],
       "prd": "grimoires/loa/cycles/cycle-112-empirical-model-economy/prd.md",
-      "phase": "A of 3 (Activate → Codify → Optimize)",
+      "phase": "A of 3 (Activate \u2192 Codify \u2192 Optimize)",
       "sdd": "grimoires/loa/cycles/cycle-112-empirical-model-economy/sdd.md",
       "sprint_plan": "grimoires/loa/cycles/cycle-112-empirical-model-economy/sprint.md"
     },
@@ -1400,7 +1400,7 @@
     },
     {
       "id": "cycle-bug-20260520-i888-8a4363",
-      "label": "Bug Fix — cycle-110 auth_type + dispatch_group reject v2/v3 schema validation",
+      "label": "Bug Fix \u2014 cycle-110 auth_type + dispatch_group reject v2/v3 schema validation",
       "type": "bugfix",
       "status": "completed",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/888",
@@ -1416,7 +1416,7 @@
     },
     {
       "id": "cycle-bug-20260520-i911-60baf5",
-      "label": "Bug Fix — butterfreezone-gen + 37 scripts: sha256sum not portable to macOS",
+      "label": "Bug Fix \u2014 butterfreezone-gen + 37 scripts: sha256sum not portable to macOS",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/911",
@@ -1428,7 +1428,7 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260520-i911-60baf5/sprint.md"
     }
   ],
-  "global_sprint_counter": 172,
+  "global_sprint_counter": 173,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -1491,7 +1491,7 @@
     },
     {
       "id": "cycle-bug-20260502-i668-3b9765",
-      "label": "Bug Fix — Post-merge classifier silently classifies cycle PRs as other (#668)",
+      "label": "Bug Fix \u2014 Post-merge classifier silently classifies cycle PRs as other (#668)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/668",
@@ -1504,7 +1504,7 @@
     },
     {
       "id": "cycle-bug-20260502-i665-3962d9",
-      "label": "Bug Fix — post-pr Bridgebuilder MEDIUMs auto-triage to log_only without operator visibility (#665)",
+      "label": "Bug Fix \u2014 post-pr Bridgebuilder MEDIUMs auto-triage to log_only without operator visibility (#665)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/665",
@@ -1517,7 +1517,7 @@
     },
     {
       "id": "cycle-bug-20260502-i664-653da7",
-      "label": "Bug Fix — post-pr-state.sh update-phase rejects bridgebuilder_review (#664)",
+      "label": "Bug Fix \u2014 post-pr-state.sh update-phase rejects bridgebuilder_review (#664)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/664",
@@ -1530,7 +1530,7 @@
     },
     {
       "id": "cycle-bug-20260502-i663-ec337e",
-      "label": "Bug Fix — post-pr-orchestrator passes invalid --phase pr to flatline-orchestrator (#663)",
+      "label": "Bug Fix \u2014 post-pr-orchestrator passes invalid --phase pr to flatline-orchestrator (#663)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/663",
@@ -1543,7 +1543,7 @@
     },
     {
       "id": "cycle-bug-20260502-i661-cd5f4f",
-      "label": "Bug Fix — Defensive diagnostic for beads_rust 0.2.1 migration error (#661)",
+      "label": "Bug Fix \u2014 Defensive diagnostic for beads_rust 0.2.1 migration error (#661)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/661",
@@ -1556,7 +1556,7 @@
     },
     {
       "id": "cycle-bug-20260502-i660-dd4514",
-      "label": "Bug Fix — mount-submodule.sh BSD realpath portability + silent reconcile exit (#660)",
+      "label": "Bug Fix \u2014 mount-submodule.sh BSD realpath portability + silent reconcile exit (#660)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/660",
@@ -1569,7 +1569,7 @@
     },
     {
       "id": "cycle-bug-20260503-i675-ceb96f",
-      "label": "Bug Fix — model-adapter large-payload hardening (cheval/httpx HTTP/2 disconnect on 137KB+ payloads, Anthropic 60s timeout, #675)",
+      "label": "Bug Fix \u2014 model-adapter large-payload hardening (cheval/httpx HTTP/2 disconnect on 137KB+ payloads, Anthropic 60s timeout, #675)",
       "type": "bugfix",
       "status": "completed",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/675",
@@ -1585,7 +1585,7 @@
     },
     {
       "id": "cycle-bug-20260503-i697-475b02",
-      "label": "Bug Fix — post-merge automation: gt_regen arg mismatch + CHANGELOG cross-scope leak (#697)",
+      "label": "Bug Fix \u2014 post-merge automation: gt_regen arg mismatch + CHANGELOG cross-scope leak (#697)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/697",
@@ -1598,7 +1598,7 @@
     },
     {
       "id": "cycle-bug-20260516-i921-e386d6",
-      "label": "Bug Fix — KF-010 root cause: deriveTimeoutMs reasoning-class predicate is OpenAI-only (#921)",
+      "label": "Bug Fix \u2014 KF-010 root cause: deriveTimeoutMs reasoning-class predicate is OpenAI-only (#921)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/921",
@@ -1608,12 +1608,25 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260516-i921-e386d6/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260516-i921-e386d6/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260520-i894-cdaf96",
+      "label": "Bug Fix \u2014 cheval headless CLI env-scrub misses GENAI auth-mode selectors (#894)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/894",
+      "created_at": "2026-05-20T00:00:00Z",
+      "sprints": [
+        "sprint-bug-173"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260520-i894-cdaf96/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260520-i894-cdaf96/sprint.md"
     }
   ],
   "bugfixes": [
     {
       "id": "cycle-bug-20260428-i640-1cc190",
-      "label": "Bug Fix — /mount writes stale framework_version: 0.6.0 (THIRD recurrence #640)",
+      "label": "Bug Fix \u2014 /mount writes stale framework_version: 0.6.0 (THIRD recurrence #640)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/640",
@@ -1625,5 +1638,5 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260428-i640-1cc190/sprint.md"
     }
   ],
-  "next_sprint_number": 171
+  "next_sprint_number": 174
 }


### PR DESCRIPTION
## Summary

- Extends `_HEADLESS_STRIPPED_AUTH_VARS` (cheval headless adapters) from 5 → 9 entries to cover all four `gemini-cli` auth-mode-selector env vars, not just credentials. Fixes the `kind: cli` gemini-headless invocations returning `RATE_LIMITED` despite operator's direct-CLI invocation working with `~/.gemini/settings.json` subscription OAuth.
- Source-verified against `gemini-cli` `packages/core/src/core/contentGenerator.ts::getAuthTypeFromEnv()` ladder: GCA + VERTEXAI + GEMINI_BASE_URL + GEMINI_CLI_USE_COMPUTE_ADC are all auth-mode selectors. `CLOUD_SHELL` is also a selector but is set as a legitimate environment signal on Google Cloud Shell — explicit non-scrub decision pinned by behavioral test.
- Phase 2.5 cross-model adversarial review (`gpt-5.5-pro`, ADVISORY DISS-001) caught a same-class gap missed by single-author implementation. Bias-correction protocol per `feedback_bias_correction_protocol_validated.md` empirically vindicated for the second consecutive sprint.

## Test plan

- [x] `pytest .claude/adapters/tests/test_gemini_headless_adapter.py tests/test_codex_headless_adapter.py tests/test_claude_headless_adapter.py` → 105 passed, 3 skipped
- [x] Failing-first proven (default-scrub FAIL pre-fix, PASS post-fix) for `GOOGLE_GENAI_USE_VERTEXAI`
- [x] Full adapter suite — zero regressions (3 pre-existing failures in `test_flatline_routing.py` verified red on clean `main` via stash round-trip, unrelated)
- [x] Symmetric audit for codex + claude (no env-mode-selectors found; existing API_KEY scrubs sufficient)
- [x] KF-013 entry appended to `grimoires/loa/known-failures.md` with full schema + Reading guide promoting `gemini-cli` source as canonical-over-`dig-search.ts`
- [ ] Operator-driven pre-merge cross-model adversarial review against this open PR (`/run-bridge` or BB pipeline)
- [ ] Manual smoke: invoke `gemini-headless` via cheval with `GOOGLE_GENAI_USE_VERTEXAI=true` set in parent shell, confirm OAuth path is used

## Iteration trail

| Iter | Trigger | Selectors covered | Tests |
|------|---------|-------------------|-------|
| 1 | dig-search.ts pattern-port | GCA + VERTEXAI (2/4) | +2 |
| 2 | Phase 2.5 adversarial review (DISS-001) + source verification | + GEMINI_BASE_URL + GEMINI_CLI_USE_COMPUTE_ADC (4/4) | +4 |

## Files changed

| File | Δ |
|------|---|
| `.claude/adapters/loa_cheval/providers/base.py` | tuple +4 entries + sub-class taxonomy comment + docstring rewrite |
| `.claude/adapters/tests/test_gemini_headless_adapter.py` | +6 paired tests (scrub-by-default, opt-in-preserves, CLOUD_SHELL pin) |
| `grimoires/loa/known-failures.md` | KF-013 entry + index row + Reading guide |
| `grimoires/loa/ledger.json` | sprint counter 172 → 173 (`/bug` triage bump) |

## Process artifacts

Gitignored under `grimoires/loa/a2a/` (per `.gitignore` line 'grimoires/loa/a2a/*'):
- `bug-20260520-i894-cdaf96/triage.md` + `sprint.md`
- `sprint-bug-173/reviewer.md` (AC Verification + Feedback Addressed sections)
- `sprint-bug-173/engineer-feedback.md` (senior-lead review, APPROVED iter-2)
- `sprint-bug-173/adversarial-review.json` (gpt-5.5-pro dissenter envelope)

Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)