### PR TITLE
feat(#948): capture post-flight tokens_input/tokens_output in MODELINV envelope (D-7)

### DIFF
--- a/.claude/adapters/cheval.py
+++ b/.claude/adapters/cheval.py
@@ -1309,6 +1309,14 @@ def cmd_invoke(args: argparse.Namespace) -> int:
         # None means the gate did not evaluate (bypass path, e.g.
         # LOA_CHEVAL_DISABLE_INPUT_GATE=1 or pre-resolution failure).
         "capability_evaluation": None,
+        # Cycle-112 Phase A.1 D-7 (#948) — post-flight token counts.
+        # Set from _result.usage on successful chain entry; remain None
+        # on chain-exhausted / cancelled paths. Together with the pre-
+        # flight estimated_input_tokens these support honest cost-per-
+        # clean-output in /loa status --economy (replaces the Phase A
+        # estimate-only proxy).
+        "tokens_input": None,
+        "tokens_output": None,
     }
     _verbose = bool(os.environ.get("LOA_HEADLESS_VERBOSE"))
 
@@ -1587,6 +1595,12 @@ def cmd_invoke(args: argparse.Namespace) -> int:
                         calling_primitive=(getattr(args, "skill", None) or agent_name),
                         invocation_latency_ms=_modelinv_state["invocation_latency_ms"],
                         cost_micro_usd=_modelinv_state["cost_micro_usd"],
+                        # Cycle-112 D-7 (#948): post-flight token counts
+                        # captured from CompletionResult.usage above.
+                        # None preserved when chain exhausted before any
+                        # entry returned a usage envelope.
+                        tokens_input=_modelinv_state.get("tokens_input"),
+                        tokens_output=_modelinv_state.get("tokens_output"),
                         streaming=_modelinv_state["streaming"],
                         final_model_id=_modelinv_state["final_model_id"],
                         transport=_modelinv_state["transport"],
@@ -2107,6 +2121,21 @@ def cmd_invoke(args: argparse.Namespace) -> int:
             _cost = getattr(_result, "cost_micro_usd", None)
             if _cost is not None:
                 _modelinv_state["cost_micro_usd"] = _cost
+            # Cycle-112 Phase A.1 D-7 (#948) — capture post-flight token
+            # counts from CompletionResult.usage. Defensive getattr chain:
+            # _result.usage is typed as `Usage` in types.py but some headless
+            # / mock paths may produce a result without a usage field, or
+            # with zero-valued usage. Treat 0 as valid (some providers
+            # report 0 output_tokens on empty responses), only None as "no
+            # signal." The schema permits integer >= 0.
+            _usage = getattr(_result, "usage", None)
+            if _usage is not None:
+                _in = getattr(_usage, "input_tokens", None)
+                _out = getattr(_usage, "output_tokens", None)
+                if isinstance(_in, int) and _in >= 0:
+                    _modelinv_state["tokens_input"] = _in
+                if isinstance(_out, int) and _out >= 0:
+                    _modelinv_state["tokens_output"] = _out
             _result_meta = getattr(_result, "metadata", None) or {}
             _modelinv_state["streaming"] = _result_meta.get("streaming")
             # cycle-113 sprint-170 T3.3 (FR-C-1, I-3): propagate the
@@ -2290,6 +2319,10 @@ def cmd_invoke(args: argparse.Namespace) -> int:
                     calling_primitive=(getattr(args, "skill", None) or agent_name),
                     invocation_latency_ms=_modelinv_state["invocation_latency_ms"],
                     cost_micro_usd=_modelinv_state["cost_micro_usd"],
+                    # Cycle-112 D-7 (#948): post-flight token counts.
+                    # Same source-of-truth as chunked-path emit above.
+                    tokens_input=_modelinv_state.get("tokens_input"),
+                    tokens_output=_modelinv_state.get("tokens_output"),
                     streaming=_modelinv_state["streaming"],
                     final_model_id=_modelinv_state["final_model_id"],
                     transport=_modelinv_state["transport"],

--- a/.claude/adapters/loa_cheval/audit/modelinv.py
+++ b/.claude/adapters/loa_cheval/audit/modelinv.py
@@ -453,6 +453,19 @@ def emit_model_invoke_complete(
     auto_selection_inputs: Optional[Dict[str, Any]] = None,
     auto_evaluation_timestamp: Optional[float] = None,
     semaphore_exhausted: Optional[bool] = None,
+    # Cycle-112 Phase A.1 D-7 (#948) — post-flight token counts captured
+    # from CompletionResult.usage. Per-provider extraction (already done in
+    # provider adapters; this is the metadata pass-through layer):
+    #   - Anthropic:  usage.input_tokens     / usage.output_tokens
+    #   - OpenAI:     usage.prompt_tokens    / usage.completion_tokens
+    #   - Gemini:     usageMetadata.promptTokenCount / candidatesTokenCount
+    # Together with the existing pricing_snapshot field these enable
+    # honest cost-per-clean-output in /loa status --economy (replacing
+    # the Phase A pre-flight capability_evaluation.estimated_input_tokens
+    # proxy). Optional/additive — legacy callers omitting them produce
+    # shape-identical envelopes (no `tokens_*` keys in payload).
+    tokens_input: Optional[int] = None,
+    tokens_output: Optional[int] = None,
 ) -> None:
     """Emit a model.invoke.complete envelope to the MODELINV audit chain.
 
@@ -518,6 +531,14 @@ def emit_model_invoke_complete(
         payload["invocation_latency_ms"] = invocation_latency_ms
     if cost_micro_usd is not None:
         payload["cost_micro_usd"] = cost_micro_usd
+    # Cycle-112 Phase A.1 D-7 (#948) — post-flight token attribution.
+    # Caller is responsible for validation (provider responses occasionally
+    # contain nulls / negatives on partial-stream failures); we accept the
+    # value verbatim and let the JSON-schema gate catch out-of-range.
+    if tokens_input is not None:
+        payload["tokens_input"] = tokens_input
+    if tokens_output is not None:
+        payload["tokens_output"] = tokens_output
     # cycle-104 Sprint 2 T2.6 (FR-S2.3 / SDD §3.4): chain-walk evidence.
     # final_model_id, transport, config_observed are additive — the schema's
     # additionalProperties:false constraint means we only attach them when

--- a/.claude/data/trajectory-schemas/model-events/model-invoke-complete.payload.schema.json
+++ b/.claude/data/trajectory-schemas/model-events/model-invoke-complete.payload.schema.json
@@ -86,6 +86,16 @@
       "type": "integer",
       "minimum": 0
     },
+    "tokens_input": {
+      "description": "Post-flight input token count reported by the provider (Anthropic usage.input_tokens, OpenAI usage.prompt_tokens, Gemini usageMetadata.promptTokenCount). Cycle-112 Phase A.1 D-7 (#948). Populated from CompletionResult.usage on successful invocations; absent on chain-exhausted / cancelled paths and on legacy emits.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "tokens_output": {
+      "description": "Post-flight output token count reported by the provider (Anthropic usage.output_tokens, OpenAI usage.completion_tokens, Gemini usageMetadata.candidatesTokenCount). Cycle-112 Phase A.1 D-7 (#948). Together with tokens_input replaces the pre-flight capability_evaluation.estimated_input_tokens used as a cost-estimate proxy in Phase A.",
+      "type": "integer",
+      "minimum": 0
+    },
     "kill_switch_active": {
       "description": "True iff LOA_FORCE_LEGACY_MODELS=1 at invocation time (SDD section 11 / gemini IMP-004 HIGH). Audits operator-driven legacy-mode use.",
       "type": "boolean"

--- a/tests/unit/cheval-tokens-postflight.bats
+++ b/tests/unit/cheval-tokens-postflight.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Cycle-112 D-7 (#948) — post-flight tokens_input / tokens_output attribution
+# =============================================================================
+# Pins the contract that cheval.cmd_invoke captures provider-reported token
+# counts from `CompletionResult.usage` and threads them into the MODELINV
+# envelope as `payload.tokens_input` + `payload.tokens_output`.
+#
+# Pre-D-7 reality: writer signature lacked these fields entirely; cost
+# computation in `/loa status --economy` fell back to
+# `pricing_snapshot.input_per_mtok × capability_evaluation.estimated_input_tokens`
+# (pre-flight estimate, present in 50% of envelopes). D-7 closes that gap
+# with the actual provider-reported usage so cost rolls up honestly.
+#
+# Test strategy: invoke cheval with --mock-fixture-dir against a fixture
+# that returns a canned CompletionResult with known usage values, redirect
+# MODELINV log to a temp path via LOA_MODELINV_LOG_PATH, and assert the
+# resulting envelope's payload carries the expected token counts.
+# =============================================================================
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    CHEVAL="$REPO_ROOT/.claude/adapters/cheval.py"
+    TMP_DIR="$(mktemp -d)"
+    export PROJECT_ROOT="$REPO_ROOT"
+    export LOA_MODELINV_LOG_PATH="$TMP_DIR/model-invoke.jsonl"
+    export LOA_ADVISOR_STRATEGY_DISABLE=1
+
+    # Mock fixture with known token values. cheval's mock-fixture path
+    # loads response.json and synthesizes a CompletionResult — usage
+    # values flow through to _result.usage.{input,output}_tokens.
+    FIXTURE_DIR="$TMP_DIR/fixture"
+    mkdir -p "$FIXTURE_DIR"
+    cat > "$FIXTURE_DIR/response.json" <<'EOF'
+{
+  "content": "## D-7 post-flight token capture test",
+  "usage": {"input_tokens": 12345, "output_tokens": 678}
+}
+EOF
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+_pick_agent() {
+    if python3 "$CHEVAL" --print-effective-config 2>/dev/null \
+        | grep -qE 'flatline-reviewer'; then
+        echo "flatline-reviewer"
+    else
+        echo "reviewing-code"
+    fi
+}
+
+@test "D-7: payload.tokens_input is populated from CompletionResult.usage" {
+    if ! command -v python3 >/dev/null 2>&1; then
+        skip "python3 not on PATH"
+    fi
+    [[ -f "$CHEVAL" ]] || skip "cheval.py not found"
+
+    local agent
+    agent="$(_pick_agent)"
+
+    run python3 "$CHEVAL" \
+        --agent "$agent" \
+        --prompt "test input" \
+        --mock-fixture-dir "$FIXTURE_DIR" \
+        --output-format json
+
+    [ -f "$LOA_MODELINV_LOG_PATH" ]
+    # Exact match — fixture said input_tokens: 12345, envelope must mirror.
+    grep -qE '"tokens_input":[[:space:]]*12345' "$LOA_MODELINV_LOG_PATH"
+}
+
+@test "D-7: payload.tokens_output is populated from CompletionResult.usage" {
+    if ! command -v python3 >/dev/null 2>&1; then
+        skip "python3 not on PATH"
+    fi
+    [[ -f "$CHEVAL" ]] || skip "cheval.py not found"
+
+    local agent
+    agent="$(_pick_agent)"
+
+    run python3 "$CHEVAL" \
+        --agent "$agent" \
+        --prompt "test input" \
+        --mock-fixture-dir "$FIXTURE_DIR" \
+        --output-format json
+
+    [ -f "$LOA_MODELINV_LOG_PATH" ]
+    grep -qE '"tokens_output":[[:space:]]*678' "$LOA_MODELINV_LOG_PATH"
+}
+
+@test "D-7: both token fields appear in same envelope (atomic capture)" {
+    # Negative-confound guard: ensures we aren't accidentally writing one
+    # value and the other separately (e.g., from a different invocation's
+    # state). The mock fixture path writes ONE envelope; both fields must
+    # be in that single envelope.
+    if ! command -v python3 >/dev/null 2>&1; then
+        skip "python3 not on PATH"
+    fi
+    [[ -f "$CHEVAL" ]] || skip "cheval.py not found"
+
+    local agent
+    agent="$(_pick_agent)"
+
+    run python3 "$CHEVAL" \
+        --agent "$agent" \
+        --prompt "test input" \
+        --mock-fixture-dir "$FIXTURE_DIR" \
+        --output-format json
+
+    [ -f "$LOA_MODELINV_LOG_PATH" ]
+
+    # Exactly one envelope on this log; it should contain BOTH fields.
+    local n
+    n=$(wc -l < "$LOA_MODELINV_LOG_PATH")
+    [ "$n" -eq 1 ]
+    grep -qE '"tokens_input":[[:space:]]*12345' "$LOA_MODELINV_LOG_PATH"
+    grep -qE '"tokens_output":[[:space:]]*678' "$LOA_MODELINV_LOG_PATH"
+}
+
+@test "D-7: zero output_tokens is recorded (not omitted)" {
+    # Some providers report 0 output_tokens on empty content. Treating
+    # 0 as "no signal" would silently drop the data point. The cheval
+    # capture logic uses `isinstance(x, int) and x >= 0`, so 0 is kept.
+    # This regression guard pins that behavior.
+    if ! command -v python3 >/dev/null 2>&1; then
+        skip "python3 not on PATH"
+    fi
+    [[ -f "$CHEVAL" ]] || skip "cheval.py not found"
+
+    cat > "$FIXTURE_DIR/response.json" <<'EOF'
+{
+  "content": "",
+  "usage": {"input_tokens": 100, "output_tokens": 0}
+}
+EOF
+
+    local agent
+    agent="$(_pick_agent)"
+
+    run python3 "$CHEVAL" \
+        --agent "$agent" \
+        --prompt "test input" \
+        --mock-fixture-dir "$FIXTURE_DIR" \
+        --output-format json
+
+    [ -f "$LOA_MODELINV_LOG_PATH" ]
+    grep -qE '"tokens_input":[[:space:]]*100' "$LOA_MODELINV_LOG_PATH"
+    grep -qE '"tokens_output":[[:space:]]*0' "$LOA_MODELINV_LOG_PATH"
+}


### PR DESCRIPTION
## Summary

- Closes the cycle-112 Phase A.1 **D-7** follow-up — partner of D-6 (#931, shipped v1.170.0 in PR #949). Every MODELINV envelope now carries `payload.tokens_input` + `payload.tokens_output` captured post-flight from `CompletionResult.usage`.
- Together D-6 + D-7 flip every row in `/loa status --economy` from coverage-caveat-heavy to fully-attributed cost reality:
  - D-6 (already shipped): **WHICH** skill made the call (`calling_primitive`)
  - D-7 (this PR): **HOW MANY** tokens it actually consumed
- Phase B (skills consuming `workload_tier_map`) is now fully unblocked — the rollup can compute real per-skill cost-per-clean-output from observed provider usage instead of pre-flight estimate proxy.
- Phase 2.5 cross-model adversarial review (`gpt-5.5-pro`): **0 findings, status=clean, APPROVED**, `confidence_floor=high`, `chain_health=ok`.

## Per-provider data source (zero adapter changes required)

Provider adapters already normalize provider-specific usage shapes into the canonical `Usage` dataclass at `types.py`:

| Provider | Source field |
|---|---|
| Anthropic | `usage.input_tokens` + `usage.output_tokens` |
| OpenAI | `usage.prompt_tokens` + `usage.completion_tokens` |
| Gemini | `usageMetadata.promptTokenCount` + `usageMetadata.candidatesTokenCount` |

D-7 is the metadata pass-through layer: cheval.cmd_invoke reads `_result.usage` on the SUCCESS path and threads it into the MODELINV envelope.

## Test plan

- [x] `bats tests/unit/cheval-tokens-postflight.bats` → 4/4 pass (failing-first proven via stash: 4/4 fail pre-fix)
- [x] `bats tests/unit/cheval-calling-primitive-attribution.bats` → 3/3 pass (D-6 regression guard)
- [x] `bats tests/unit/model-adapter-skill-forwarding.bats` → 3/3 pass (D-6 bash-side regression guard)
- [x] `pytest .claude/adapters/tests/` → 1664/1664 pass + 3 skipped, zero regressions
- [x] End-to-end smoke: real MODELINV envelope confirmed to carry `calling_primitive: "/audit-sprint"`, `tokens_input: 1000`, `tokens_output: 500`, `pricing_input_per_mtok: 5000000` — rollup can now compute real cost
- [x] Phase 2.5 adversarial review: 0 findings, clean
- [ ] Post-merge: confirm `/loa status --economy` shows cost-per-clean-output computed from `tokens_*` × `pricing_snapshot` as MODELINV log accumulates

## Files changed

| File | Δ |
|------|---|
| `.claude/data/trajectory-schemas/model-events/model-invoke-complete.payload.schema.json` | +10 lines (2 new optional integer properties) |
| `.claude/adapters/loa_cheval/audit/modelinv.py` | +25 lines (kwargs + payload attachment + provenance comment) |
| `.claude/adapters/cheval.py` | +28 lines (state init + capture from `_result.usage` + pass-through at both emit sites) |
| `tests/unit/cheval-tokens-postflight.bats` | +153 lines (4 tests including zero-output-tokens regression guard) |

## What Phase A.1 unblocks

Before D-6 + D-7:
> `/loa status --economy` shows 9 rows, all `(unattributed) × <model>`. Useful for MODEL-level economy but cannot answer "is /review-sprint cheaper on advisor or executor?" — the question Phase B needs.

After D-6 + D-7 (new envelopes only — log is append-only):
- Per-`(skill × model)` attribution: ✅
- Real provider-reported cost: ✅
- Rolled-up per-skill cost-per-clean-output: ✅
- Phase B (skills consume `workload_tier_map`) can be filed as planning-grade issue and a new cycle begins

## References

- Roadmap meta-tracker: #947
- Sister D-6: #931 (shipped v1.170.0 in PR #949)
- Origin cycle: #925 (Phase A, shipped 2026-05-17 / PR #928)
- Cycle-112 SDD §0.3 (empirical attribution finding that motivated Phase A.1)
- Adversarial review envelope: `grimoires/loa/a2a/sprint-d7-tokens/adversarial-review.json`

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)