### PR TITLE
chore(ci): clear pre-existing-red CI checks (Fixture Sync, Shell Tests, macos bash)

### DIFF
--- a/.claude/scripts/adversarial-review.sh
+++ b/.claude/scripts/adversarial-review.sh
@@ -36,12 +36,19 @@
 set -euo pipefail
 
 
-# sprint-bug-172 / bug-911: sha256_portable from compat-lib
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/compat-lib.sh"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG_FILE="${CONFIG_FILE:-$PROJECT_ROOT/.loa.config.yaml}"
+
+# sprint-bug-172 / bug-911: sha256_portable from compat-lib.
+# Defensive source pattern (`|| true`) mirrors the lib-content.sh import
+# below: under eval-based test sourcing, BASH_SOURCE[0] resolves to a bats
+# temp file, so the absolute SCRIPT_DIR-rooted path is the safe form, and
+# the soft-failure allows tests to pre-source compat-lib.sh in setup().
+# See: Bridgebuilder Review Finding #1 (PR #235), KF-011 debug regression.
+_COMPAT_LIB_PATH="$SCRIPT_DIR/compat-lib.sh"
+# shellcheck source=compat-lib.sh
+source "$_COMPAT_LIB_PATH" 2>/dev/null || true
 
 # Source shared content processing functions (file_priority, prepare_content, estimate_tokens)
 # These were extracted from gpt-review-api.sh into lib-content.sh to avoid the

--- a/.github/workflows/model-registry-drift.yml
+++ b/.github/workflows/model-registry-drift.yml
@@ -158,6 +158,19 @@ jobs:
         working-directory: .claude/skills/bridgebuilder-review
         run: npm ci
 
+      - name: Install GNU bash on macOS (toolchain requires bash 5.0+)
+        if: matrix.os == 'macos-latest'
+        # macOS runners ship bash 3.2 by default (Apple stopped updating
+        # due to GPL3 licensing). tools/check-codegen-toolchain.sh requires
+        # bash >= 5.0 and was failing the macos-latest matrix variant on
+        # every PR since the gate landed (admin-merged through #945, #946,
+        # #949, #950 before this fix). brew bash installs to /opt/homebrew/
+        # bin/bash, which `command -v bash` then prefers over /bin/bash.
+        run: |
+          brew install bash
+          # Verify the new bash is on PATH (homebrew prepends /opt/homebrew/bin)
+          bash --version | head -1
+
       - name: Verify pinned codegen toolchain
         # Closes BB iter-1 F7: the paths filter triggers this workflow when
         # tools/check-codegen-toolchain.sh changes, but until this step was

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,19 @@ grimoires/loa/BEAUVOIR.md
 grimoires/loa/SOUL.md
 grimoires/loa/decisions.yaml
 
+# /ride --enriched analysis artifacts (regenerable from current codebase state).
+# Were untracked across multiple sessions causing git-status noise; pinning
+# them as ignored keeps the working tree clean while preserving local copies
+# for reference when /ride runs.
+grimoires/loa/consistency-report.md
+grimoires/loa/drift-report.md
+grimoires/loa/gaps.md
+grimoires/loa/governance-report.md
+grimoires/loa/trajectory-audit.md
+
+# /schedule skill runtime locks
+.claude/scheduled_tasks.lock
+
 # User config (copy from .loa.config.yaml.example)
 .loa.config.yaml
 # But DO track config files inside eval fixtures (needed for CI)

--- a/evals/fixtures/loa-skill-dir/.claude/scripts/mount-loa.sh
+++ b/evals/fixtures/loa-skill-dir/.claude/scripts/mount-loa.sh
@@ -1042,7 +1042,7 @@ generate_checksums() {
 
   local first=true
   while IFS= read -r -d '' file; do
-    local hash=$(sha256sum "$file" | cut -d' ' -f1)
+    local hash=$(sha256_portable "$file" | cut -d' ' -f1)
     local relpath="${file#./}"
     if [[ "$first" == "true" ]]; then
       first=false
@@ -1905,7 +1905,7 @@ Then re-run:
       local expected_hash actual_hash
       expected_hash=$(jq -r --arg f "$relpath" '.files[$f] // ""' "$CHECKSUMS_FILE" 2>/dev/null)
       if [[ -n "$expected_hash" && "$expected_hash" != "null" ]]; then
-        actual_hash=$(sha256sum "$file" | cut -d' ' -f1)
+        actual_hash=$(sha256_portable "$file" | cut -d' ' -f1)
         if [[ "$expected_hash" == "$actual_hash" ]]; then
           framework_files+=("$relpath")
         else

--- a/tests/unit/adversarial-review-kf-011-debug.bats
+++ b/tests/unit/adversarial-review-kf-011-debug.bats
@@ -27,6 +27,10 @@ setup() {
 
     local saved_root="$PROJECT_ROOT"
     source "$PROJECT_ROOT/.claude/scripts/lib-content.sh"
+    # sprint-bug-172 follow-up: pre-source compat-lib.sh so sha256_portable
+    # is available when adversarial-review.sh is eval'd below (the script's
+    # own source line falls through defensively under eval).
+    source "$PROJECT_ROOT/.claude/scripts/compat-lib.sh"
     eval "$(sed 's/^main "\$@"/# main disabled for testing/' "$ADVERSARIAL_REVIEW")"
 
     PROJECT_ROOT="$SANDBOX_ROOT"

--- a/tests/unit/adversarial-review.bats
+++ b/tests/unit/adversarial-review.bats
@@ -22,6 +22,10 @@ setup() {
     # eval'd script can't find it (BASH_SOURCE[0] resolves to bats tmp dir).
     # The double-source guard in lib-content.sh prevents duplicate loading.
     source "$PROJECT_ROOT/.claude/scripts/lib-content.sh"
+    # sprint-bug-172 follow-up: same eval-time BASH_SOURCE problem applies
+    # to compat-lib.sh (sha256_portable). Pre-source before eval; the
+    # script's own source line falls through defensively under eval.
+    source "$PROJECT_ROOT/.claude/scripts/compat-lib.sh"
 
     # Source the script functions (but don't run main)
     eval "$(sed 's/^main "\$@"/# main disabled for testing/' "$ADVERSARIAL_REVIEW")"


### PR DESCRIPTION
## Summary

Three CI checks have been red on main and admin-merged over for the last 4 PRs straight (#945 → #946 → #949 → #950). Each was small in isolation but together they form an accumulating CI-noise smell — at some point a real failure will hide behind the always-red pattern. This PR fixes all three so the next PR ships with a clean green CI surface for the first time since cycle-113 closed.

## What's broken and why

| Check | Root cause | Fix |
|---|---|---|
| **Fixture Sync Check** | `evals/fixtures/.../mount-loa.sh` got out of sync when sprint-bug-172 / PR #945 (sha256_portable migration) updated the source file but didn't run `sync-fixtures.sh` | Resync the fixture |
| **Shell Tests** | sprint-bug-172 added `source compat-lib.sh` at adversarial-review.sh:40 using the brittle `BASH_SOURCE[0]` pattern — fails under bats eval-based test sourcing where BASH_SOURCE resolves to a bats temp file. 40+ tests fail with `compat-lib.sh: No such file or directory` | Move source AFTER SCRIPT_DIR computation; defensive `\|\| true` (same pattern lib-content.sh already uses at L55); test setup pre-sources compat-lib.sh (same pattern test already uses for lib-content.sh) |
| **TS codegen (macos-latest)** | macOS runners ship bash 3.2 (Apple stopped updating due to GPL3 licensing); `tools/check-codegen-toolchain.sh` requires bash >= 5.0 | Add `brew install bash` step gated by `if: matrix.os == 'macos-latest'` before the toolchain verify step |

## Working-tree noise reduction

The 9-file untracked-noise problem in `git status` has been present across 4+ sessions. Gitignored (regenerable / runtime):
- `grimoires/loa/{consistency,drift,gaps,governance}-report.md` + `trajectory-audit.md` (`/ride --enriched` artifacts)
- `.claude/scheduled_tasks.lock` (runtime lock from `/schedule`)

Deleted (working-tree only): `c -l)|g` (1-line grep fragment captured by a malformed shell pipeline — accidental shell-output redirect).

**Left in status (operator-bound, NOT touched this PR)**:
- `SOUL.md` (root) — pending operator adoption decision per file header
- `.github/workflows/bedrock-contract-smoke.yml` — pending operator AWS budget authorization (~$15/mo cron cap)

## Test plan

- [x] `bats tests/unit/adversarial-review*.bats` → **106/106 pass** (was 40+ failing across 2 files pre-fix)
- [x] `evals/fixtures/sync-fixtures.sh --check` → "All fixtures current"
- [x] No regressions on the 1664-test pytest suite (no Python files touched)
- [ ] **This PR's CI will demonstrate all three previously-red checks green simultaneously** — the empirical end-to-end test

## Files changed

| File | Δ |
|---|---|
| `.claude/scripts/adversarial-review.sh` | +9 / -3 (reorder + defensive source pattern) |
| `evals/fixtures/loa-skill-dir/.claude/scripts/mount-loa.sh` | sync to source (2 sha256sum → sha256_portable lines) |
| `tests/unit/adversarial-review.bats` | +4 (pre-source compat-lib.sh in setup) |
| `tests/unit/adversarial-review-kf-011-debug.bats` | +4 (same) |
| `.github/workflows/model-registry-drift.yml` | +13 (macos bash install step) |
| `.gitignore` | +13 (regenerable reports + runtime lock) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)