### PR TITLE
fix(#878): guard mktemp in flatline-orchestrator (chmod-on-empty-arg)

### DIFF
--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -574,7 +574,14 @@ aggregate_and_write_final_consensus() {
         vq=$(jq -c '.verdict_quality // empty' "$f" 2>/dev/null || true)
         if [[ -n "$vq" && "$vq" != "null" ]]; then
             local tmp
-            tmp=$(mktemp "${TEMP_DIR:-/tmp}/vq-input.XXXXXX.json")
+            # #878: guard mktemp failure (template collision, disk full, no
+            # mktemp on PATH). Without the check, downstream chmod/printf on
+            # an empty $tmp produces confusing "No such file or directory"
+            # errors that mask the real mktemp failure.
+            if ! tmp=$(mktemp "${TEMP_DIR:-/tmp}/vq-input.XXXXXX.json"); then
+                log "WARNING: mktemp failed for vq-input ($(date)) — skipping verdict-quality envelope for $f"
+                continue
+            fi
             printf '%s' "$vq" > "$tmp"
             vq_files+=("$tmp")
             cleanup_files+=("$tmp")
@@ -2279,7 +2286,16 @@ main() {
 
             # Build arbiter prompt
             local arbiter_prompt_file
-            arbiter_prompt_file=$(mktemp)
+            # #878: guard mktemp failure. Without this, the subsequent
+            # `chmod 600 "$arbiter_prompt_file"` with an empty arg produces
+            # `chmod: : No such file or directory` and the prompt-write at
+            # L2298 silently writes to the current working directory or
+            # fails with cwd permission errors. Fail fast with a clear
+            # message instead of cascading to downstream confusion.
+            if ! arbiter_prompt_file=$(mktemp); then
+                log "ERROR: mktemp failed for arbiter prompt — skipping arbiter step for $phase"
+                continue
+            fi
             chmod 600 "$arbiter_prompt_file"
 
             local doc_excerpt=""

--- a/tests/unit/flatline-orchestrator-mktemp-guard.bats
+++ b/tests/unit/flatline-orchestrator-mktemp-guard.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Issue #878 — flatline-orchestrator: chmod-on-empty-arg when mktemp fails
+# =============================================================================
+# Pins the contract that flatline-orchestrator.sh guards every `mktemp`
+# assignment against failure (template collision, disk full, mktemp not on
+# PATH) before downstream chmod/write operations. Without the guard, a
+# failed mktemp produces an empty variable, and `chmod 600 ""` errors with
+# "No such file or directory" that masks the real mktemp failure.
+#
+# Strategy: grep-level static check. The script's mktemp call sites at
+# the verdict-quality (~L577) + arbiter-prompt (~L2282) sections are the
+# documented historical hot spots. New unguarded mktemp sites should also
+# be flagged at review time.
+# =============================================================================
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    ORCHESTRATOR="$REPO_ROOT/.claude/scripts/flatline-orchestrator.sh"
+    [[ -f "$ORCHESTRATOR" ]] || skip "flatline-orchestrator.sh not found"
+}
+
+@test "#878: arbiter_prompt_file mktemp is guarded against failure" {
+    # The exact guard pattern: `if ! arbiter_prompt_file=$(mktemp); then`
+    # followed (within the next ~5 lines) by a `continue` or `return`.
+    # If a future PR reverts the guard to bare `arbiter_prompt_file=$(mktemp)`,
+    # this test fails.
+    grep -A1 "arbiter_prompt_file=" "$ORCHESTRATOR" \
+        | grep -qE "if ! arbiter_prompt_file=\\\$\\(mktemp\\)" \
+        || {
+            echo "REGRESSION: arbiter_prompt_file mktemp is no longer guarded." >&2
+            echo "See issue #878. Expected pattern:" >&2
+            echo "    if ! arbiter_prompt_file=\$(mktemp); then" >&2
+            return 1
+        }
+}
+
+@test "#878: vq-input mktemp is guarded against failure" {
+    # The verdict-quality temp file site at ~L577. Same shape.
+    grep -B1 -A1 'mktemp.*vq-input' "$ORCHESTRATOR" \
+        | grep -qE "if ! tmp=\\\$\\(mktemp" \
+        || {
+            echo "REGRESSION: vq-input mktemp is no longer guarded." >&2
+            echo "See issue #878. Expected pattern:" >&2
+            echo "    if ! tmp=\$(mktemp \"\${TEMP_DIR:-/tmp}/vq-input.XXXXXX.json\"); then" >&2
+            return 1
+        }
+}
+
+@test "#878: chmod-after-mktemp pattern is guarded" {
+    # Narrower invariant than "all chmod must be guarded": specifically
+    # the chmod-after-mktemp pattern. A `chmod NNN "$var"` line preceded
+    # within 3 lines by `$var=$(mktemp...)` MUST have the mktemp itself
+    # guarded by an `if !` or trailing `|| ...` clause; otherwise an
+    # empty $var reaches chmod and produces the documented #878 error.
+    #
+    # Template-assigned vars (e.g., `var="$DIR/file.jsonl"`) don't need
+    # this guard because string assignment can't fail to an empty value.
+    while IFS=: read -r line _content; do
+        local var_name
+        var_name=$(sed -n "${line}p" "$ORCHESTRATOR" \
+            | grep -oE 'chmod [0-9]+ "\$[A-Za-z_][A-Za-z0-9_]*"' \
+            | grep -oE '\$[A-Za-z_][A-Za-z0-9_]*' \
+            | tr -d '$' | head -1)
+        [[ -z "$var_name" ]] && continue
+
+        local start=$(( line > 3 ? line - 3 : 1 ))
+        local end=$(( line - 1 ))
+        local preceding_lines
+        preceding_lines=$(sed -n "${start},${end}p" "$ORCHESTRATOR")
+
+        # Is this chmod preceded by a mktemp assignment to the same var?
+        if echo "$preceding_lines" | grep -qE "${var_name}=\\\$\\(.*mktemp"; then
+            # mktemp assignment found — check it's guarded
+            if echo "$preceding_lines" | grep -qE "(if ! ${var_name}=|${var_name}=\\\$\\(mktemp.*\\) \\|\\| )"; then
+                continue  # guarded ✓
+            fi
+            echo "REGRESSION at line $line: chmod on $var_name follows unguarded mktemp" >&2
+            echo "Add: if ! ${var_name}=\$(mktemp); then log ERROR; continue; fi" >&2
+            return 1
+        fi
+    done < <(grep -n 'chmod [0-9]* "\$' "$ORCHESTRATOR")
+}


### PR DESCRIPTION
## Summary

Closes external-reporter issue #878 from @zkSoju (8 days open). flatline-orchestrator.sh was running `chmod 600 "$arbiter_prompt_file"` after a bare `arbiter_prompt_file=$(mktemp)`. When mktemp failed (template collision under concurrent runs, disk full, unclean prior run), the variable was empty and chmod errored with `chmod: : No such file or directory` — masking the real mktemp failure.

## Fix

Two unguarded mktemp sites in flatline-orchestrator.sh:
- `arbiter_prompt_file=$(mktemp)` at ~L2282
- `tmp=$(mktemp "${TEMP_DIR:-/tmp}/vq-input.XXXXXX.json")` at ~L577

Both now use the canonical guard pattern with distinct error messages per site so an operator triaging the next occurrence can identify which mktemp failed.

## Test

`tests/unit/flatline-orchestrator-mktemp-guard.bats` — 3 structural tests pinning the contract:
1. arbiter_prompt_file mktemp is guarded
2. vq-input mktemp is guarded
3. **chmod-after-mktemp class invariant** — any future unguarded mktemp+chmod cluster anywhere in the script fails this test, including correctly NOT flagging template-assigned vars (`log_file="$DIR/file.jsonl"`)

## Scope note

A repo-wide grep finds ~20 other unguarded `var=$(mktemp)` sites across other scripts. Same defect class but no observed failures reported. Out of scope for this issue-driven PR; could be a follow-up class sweep if the pattern resurfaces in another report.

Closes #878
