### PR TITLE
fix(#927): mount-submodule symlink validation resolves relative target correctly

### DIFF
--- a/.claude/scripts/mount-submodule.sh
+++ b/.claude/scripts/mount-submodule.sh
@@ -369,27 +369,61 @@ get_repo_root() {
 # Returns: 0 if safe, 1 if escapes bounds
 validate_symlink_target() {
   local target="$1"
+  # #927: accept optional `source` (the symlink file path) as 2nd arg
+  # so we can resolve RELATIVE targets correctly. Pre-fix, this function
+  # resolved targets from the CWD, which is wrong for symlinks like
+  # `.claude/scripts -> ../.loa/.claude/scripts` (target is relative to
+  # `.claude/`, not to CWD). Result was a "Cannot resolve symlink target"
+  # warning fired for every valid relative target — ~100+ warnings per
+  # install on the mount-submodule path.
+  local source="${2:-}"
   local repo_root
   repo_root=$(get_repo_root)
 
-  # Resolve the target to an absolute path
+  # Determine the base directory against which a relative target should
+  # be resolved:
+  #   - Absolute target → no base needed
+  #   - Source provided → dirname of source (the symlink's parent dir)
+  #   - Source omitted  → CWD (legacy behavior — preserves call sites
+  #     that haven't been migrated)
+  local resolve_base=""
+  if [[ "$target" != /* ]]; then
+    if [[ -n "$source" ]]; then
+      resolve_base=$(cd "$(dirname "$source")" 2>/dev/null && pwd)
+    fi
+    if [[ -z "$resolve_base" ]]; then
+      resolve_base="$(pwd)"
+    fi
+  fi
+
+  # Build the candidate absolute path
+  local candidate
+  if [[ "$target" = /* ]]; then
+    candidate="$target"
+  else
+    candidate="$resolve_base/$target"
+  fi
+
+  # Resolve the candidate to a canonical absolute path
   local resolved_target
-  if [[ -e "$target" ]]; then
-    resolved_target=$(cd "$(dirname "$target")" && pwd)/$(basename "$target")
+  if [[ -e "$candidate" ]]; then
+    resolved_target=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd)/$(basename "$candidate")
   else
     # For not-yet-existing paths, resolve the parent
     local parent_dir
-    parent_dir=$(dirname "$target")
+    parent_dir=$(dirname "$candidate")
     if [[ -d "$parent_dir" ]]; then
-      resolved_target=$(cd "$parent_dir" && pwd)/$(basename "$target")
+      resolved_target=$(cd "$parent_dir" 2>/dev/null && pwd)/$(basename "$candidate")
     else
-      # Cannot resolve, allow but warn
-      warn "Cannot resolve symlink target: $target"
+      # Genuinely unresolvable — neither candidate nor its parent exists.
+      # Allow but warn (preserves existing fail-soft behavior for the
+      # actually-pathological case).
+      warn "Cannot resolve symlink target: $target (source=${source:-<unset>})"
       return 0
     fi
   fi
 
-  # Normalize paths (remove trailing slashes, resolve ..)
+  # Normalize paths (resolve .. components)
   repo_root=$(realpath "$repo_root" 2>/dev/null || echo "$repo_root")
   resolved_target=$(realpath "$resolved_target" 2>/dev/null || echo "$resolved_target")
 
@@ -410,8 +444,9 @@ safe_symlink() {
   local source="$1"
   local target="$2"
 
-  # Validate target is within repository
-  if ! validate_symlink_target "$target"; then
+  # #927: pass source so validate_symlink_target can resolve relative
+  # targets correctly (against dirname source, not CWD).
+  if ! validate_symlink_target "$target" "$source"; then
     return 1
   fi
 

--- a/tests/unit/mount-submodule-symlink-validation.bats
+++ b/tests/unit/mount-submodule-symlink-validation.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Issue #927 — mount-submodule validate_symlink_target resolves from CWD
+# instead of from symlink's parent directory
+# =============================================================================
+# Pre-fix, validate_symlink_target("../.loa/.claude/scripts") resolved the
+# target relative to the script's CWD (the repo root), where ../.loa/...
+# does not exist. Result: a "Cannot resolve symlink target" warning fired
+# for every legitimate symlink the mount path creates (~100+ warnings).
+#
+# Post-fix, the validator accepts an optional 2nd arg (source = symlink
+# file path) and resolves relative targets against dirname(source).
+#
+# Test strategy: structural diff check — the validator function's
+# signature MUST accept a 2nd arg and the resolve_base logic MUST use
+# dirname(source) when source is provided. This is a regression guard.
+# A full integration test would require running mount-submodule.sh
+# end-to-end against a fixture submodule, which is heavy and tested
+# in cycle-099 fixture tests separately.
+# =============================================================================
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    MOUNT="$REPO_ROOT/.claude/scripts/mount-submodule.sh"
+    [[ -f "$MOUNT" ]] || skip "mount-submodule.sh not found"
+}
+
+@test "#927: validate_symlink_target accepts 2nd arg (source)" {
+    # Pre-fix: `local target="$1"` followed immediately by `local repo_root`
+    # Post-fix: `local target="$1"` followed (within ~5 lines) by
+    #          `local source="${2:-}"` (or equivalent 2nd arg capture).
+    # 15-line window covers the function preamble (comments + arg binds).
+    grep -A15 'validate_symlink_target() {' "$MOUNT" \
+        | grep -qE 'source="\$\{?2' \
+        || {
+            echo "REGRESSION: validate_symlink_target signature dropped 2nd arg" >&2
+            echo "Pre-fix bug per #927: resolves from CWD, warns on every relative target" >&2
+            return 1
+        }
+}
+
+@test "#927: safe_symlink passes \$source to validate_symlink_target" {
+    # The caller must pass both args, not just target.
+    grep -E 'validate_symlink_target "\$target"' "$MOUNT" \
+        | grep -qE '"\$target" "\$source"' \
+        || {
+            echo "REGRESSION: safe_symlink no longer passes source to validate_symlink_target" >&2
+            return 1
+        }
+}
+
+@test "#927: resolve_base uses dirname(source) for relative targets" {
+    # The core logic of the fix: when source is provided AND target is
+    # relative, resolve_base must equal `dirname "$source"`. Static check.
+    grep -qE 'resolve_base=.*dirname.*source' "$MOUNT" \
+        || {
+            echo "REGRESSION: relative-target resolve_base no longer derives from source" >&2
+            return 1
+        }
+}
+
+@test "#927: behavioral — relative target with source arg resolves cleanly" {
+    # End-to-end: extract just validate_symlink_target into a standalone
+    # harness, exercise it with the failing case from the issue body.
+    # We bypass the lib-source maze in mount-submodule.sh by writing a
+    # minimal harness that supplies the helpers the function depends on.
+    local tmp_harness
+    tmp_harness=$(mktemp)
+
+    # Minimal stubs for the helpers validate_symlink_target uses.
+    cat > "$tmp_harness" <<'HARNESS'
+warn() { echo "WARN: $*" >&2; }
+err()  { echo "ERR:  $*" >&2; }
+get_repo_root() { echo "$REPO_ROOT_OVERRIDE"; }
+HARNESS
+
+    # Extract the validate_symlink_target function body from the script.
+    awk '/^validate_symlink_target\(\) \{/,/^\}/' "$MOUNT" >> "$tmp_harness"
+
+    # Build a stub repo layout: $TMP/.loa/.claude/scripts exists,
+    # symlink at $TMP/.claude/scripts -> ../.loa/.claude/scripts should
+    # validate cleanly.
+    local tmp_repo
+    tmp_repo=$(mktemp -d)
+    mkdir -p "$tmp_repo/.loa/.claude/scripts"
+    mkdir -p "$tmp_repo/.claude"
+
+    # Append the invocation to the harness
+    cat >> "$tmp_harness" <<HARNESS_INVOKE
+
+cd "$tmp_repo" || exit 99
+REPO_ROOT_OVERRIDE="$tmp_repo"
+validate_symlink_target "../.loa/.claude/scripts" ".claude/scripts"
+echo "EXIT=\$?"
+HARNESS_INVOKE
+
+    run bash "$tmp_harness"
+    rm -rf "$tmp_repo" "$tmp_harness"
+
+    # Success: validator returns 0 AND no "Cannot resolve" warning fires.
+    [[ "$output" == *"EXIT=0"* ]]
+    ! [[ "$output" == *"Cannot resolve symlink target"* ]]
+}
+
+@test "#927: escape attempt via deep .. still rejected" {
+    # Defense-in-depth: a malicious target like ../../../etc/passwd should
+    # still be rejected even with the new source-aware resolution.
+    local tmp_harness
+    tmp_harness=$(mktemp)
+
+    cat > "$tmp_harness" <<'HARNESS'
+warn() { echo "WARN: $*" >&2; }
+err()  { echo "ERR:  $*" >&2; }
+get_repo_root() { echo "$REPO_ROOT_OVERRIDE"; }
+HARNESS
+    awk '/^validate_symlink_target\(\) \{/,/^\}/' "$MOUNT" >> "$tmp_harness"
+
+    local tmp_repo
+    tmp_repo=$(mktemp -d)
+    mkdir -p "$tmp_repo/.claude"
+
+    cat >> "$tmp_harness" <<HARNESS_INVOKE
+cd "$tmp_repo" || exit 99
+REPO_ROOT_OVERRIDE="$tmp_repo"
+validate_symlink_target "../../../../../../etc/passwd" ".claude/scripts"
+echo "EXIT=\$?"
+HARNESS_INVOKE
+
+    run bash "$tmp_harness"
+    rm -rf "$tmp_repo" "$tmp_harness"
+
+    # Reject (exit 1) AND emit "escapes repository bounds" error.
+    [[ "$output" == *"EXIT=1"* ]]
+    [[ "$output" == *"escapes repository bounds"* ]]
+}


### PR DESCRIPTION
## Summary

Closes external-reporter issue #927 from @zkSoju. `mount-submodule.sh` was emitting `WARNING: Cannot resolve symlink target: ../.loa/.claude/scripts` for **every** symlink it created (~100+ warnings per install) because `validate_symlink_target` resolved relative targets from the CWD instead of from the symlink's parent directory.

## Root cause

For a symlink at `.claude/scripts` pointing to `../.loa/.claude/scripts`, the target is valid relative to `.claude/` (the symlink's parent) but invalid relative to `pwd` (the repo root). The validator's `[[ -e "$target" ]]` check ran from CWD, so every legitimate relative target fell into the "warn but allow" branch.

## Fix

`validate_symlink_target` now accepts an optional 2nd arg `source` (the symlink file path). When target is relative AND source is provided, the validator resolves against `dirname(source)` — same way the kernel resolves symlinks at follow time.

| target form | source provided | resolve_base | result |
|---|---|---|---|
| absolute | any | (none) | as-is |
| relative | yes | dirname(source) | **correct** ✓ |
| relative | no | CWD (legacy) | warn-but-allow (preserved) |

`safe_symlink` updated to pass `$source`. The repo-bounds security check is unchanged — defeats `../../../etc/passwd` style escapes — and Test #927-4 pins this.

## Test

`tests/unit/mount-submodule-symlink-validation.bats` — 5 tests:
1. Signature accepts 2nd arg (regression guard)
2. `safe_symlink` passes source (caller integration)
3. `resolve_base` derives from source (logic regression guard)
4. **Behavioral**: relative target `.claude/scripts -> ../.loa/.claude/scripts` validates cleanly in stub repo layout (the exact case from the issue body)
5. **Behavioral**: `../../../../../../etc/passwd` still rejected as escapes-bounds

All 5 pass. Test 4 uses a minimal extracted-function harness to bypass mount-submodule.sh's lib-source chain (avoiding the same eval-time BASH_SOURCE problem PR #951 just fixed in adversarial-review.sh).

Closes #927
