### PR TITLE
fix(#865): pipe install downloads complete lib/ dependency set

### DIFF
--- a/.claude/scripts/mount-loa.sh
+++ b/.claude/scripts/mount-loa.sh
@@ -75,8 +75,16 @@ if [[ -z "${BASH_SOURCE[0]:-}" ]] && [[ -z "${_LOA_MOUNT_REEXEC:-}" ]]; then
     exit 1
   fi
 
-  # Download auxiliary scripts (non-fatal if missing in older versions)
-  for _f in bootstrap.sh bash-version-guard.sh lib/symlink-manifest.sh; do
+  # Download auxiliary scripts (non-fatal if missing in older versions).
+  # #865: mount-loa.sh + mount-submodule.sh source lib/scaffold-post-merge-workflow.sh
+  # and lib/portable-realpath.sh respectively. Without these in the pipe-mode
+  # download set, the curl|bash install path errors with "No such file or
+  # directory" on the first mount. The clone-then-run path is unaffected
+  # because those files exist on disk from the clone.
+  for _f in bootstrap.sh bash-version-guard.sh \
+            lib/symlink-manifest.sh \
+            lib/scaffold-post-merge-workflow.sh \
+            lib/portable-realpath.sh; do
     curl --proto =https --proto-redir =https --max-redirs 10 \
          -fsSL -o "$_loa_tmpdir/$_f" -- "$_loa_base/$_f" 2>/dev/null || true
   done

--- a/evals/fixtures/loa-skill-dir/.claude/scripts/mount-loa.sh
+++ b/evals/fixtures/loa-skill-dir/.claude/scripts/mount-loa.sh
@@ -75,8 +75,16 @@ if [[ -z "${BASH_SOURCE[0]:-}" ]] && [[ -z "${_LOA_MOUNT_REEXEC:-}" ]]; then
     exit 1
   fi
 
-  # Download auxiliary scripts (non-fatal if missing in older versions)
-  for _f in bootstrap.sh bash-version-guard.sh lib/symlink-manifest.sh; do
+  # Download auxiliary scripts (non-fatal if missing in older versions).
+  # #865: mount-loa.sh + mount-submodule.sh source lib/scaffold-post-merge-workflow.sh
+  # and lib/portable-realpath.sh respectively. Without these in the pipe-mode
+  # download set, the curl|bash install path errors with "No such file or
+  # directory" on the first mount. The clone-then-run path is unaffected
+  # because those files exist on disk from the clone.
+  for _f in bootstrap.sh bash-version-guard.sh \
+            lib/symlink-manifest.sh \
+            lib/scaffold-post-merge-workflow.sh \
+            lib/portable-realpath.sh; do
     curl --proto =https --proto-redir =https --max-redirs 10 \
          -fsSL -o "$_loa_tmpdir/$_f" -- "$_loa_base/$_f" 2>/dev/null || true
   done

--- a/tests/unit/mount-loa-pipe-download-complete.bats
+++ b/tests/unit/mount-loa-pipe-download-complete.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Issue #865 — pipe install (curl | bash) fails: missing lib/ downloads
+# =============================================================================
+# Pre-fix, mount-loa.sh's pipe-detection block downloaded a fixed set of
+# auxiliary scripts but didn't include lib/scaffold-post-merge-workflow.sh
+# or lib/portable-realpath.sh — both sourced by the scripts that run
+# after re-exec. The curl|bash install path errored with "No such file
+# or directory"; the clone-then-run path worked because those files
+# existed on disk.
+#
+# Structural test: scan mount-loa.sh + mount-submodule.sh for lib/* sources,
+# then verify each one appears in the pipe-detection download list. New
+# lib/ deps added in the future will fail this test until added to the
+# download set.
+# =============================================================================
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    MOUNT_LOA="$REPO_ROOT/.claude/scripts/mount-loa.sh"
+    MOUNT_SUBMODULE="$REPO_ROOT/.claude/scripts/mount-submodule.sh"
+    [[ -f "$MOUNT_LOA" ]] || skip "mount-loa.sh not found"
+    [[ -f "$MOUNT_SUBMODULE" ]] || skip "mount-submodule.sh not found"
+}
+
+# Extract sourced lib/*.sh basenames from a script. Handles both
+# `source "${SCRIPT_DIR}/lib/foo.sh"` and `. lib/foo.sh` patterns.
+_sourced_libs() {
+    local file="$1"
+    grep -hoE 'lib/[A-Za-z0-9_.-]+\.sh' "$file" 2>/dev/null \
+        | sort -u
+}
+
+@test "#865: pipe-detection download list includes scaffold-post-merge-workflow.sh" {
+    grep -qE 'lib/scaffold-post-merge-workflow\.sh' "$MOUNT_LOA" \
+        || {
+            echo "REGRESSION: lib/scaffold-post-merge-workflow.sh not in pipe-detection block" >&2
+            return 1
+        }
+}
+
+@test "#865: pipe-detection download list includes portable-realpath.sh" {
+    grep -qE 'lib/portable-realpath\.sh' "$MOUNT_LOA" \
+        || {
+            echo "REGRESSION: lib/portable-realpath.sh not in pipe-detection block" >&2
+            return 1
+        }
+}
+
+@test "#865: every lib/ file sourced by mount-loa.sh or mount-submodule.sh is in the download list" {
+    # The auxiliary download block in mount-loa.sh (~L79-83). Extract
+    # everything inside it.
+    local pipe_block
+    pipe_block=$(awk '/Download auxiliary scripts/,/^  done/' "$MOUNT_LOA")
+
+    local missing=()
+    local lib
+    for lib in $(_sourced_libs "$MOUNT_LOA") $(_sourced_libs "$MOUNT_SUBMODULE"); do
+        # symlink-manifest.sh appears in both; dedupe by skipping duplicates
+        if ! echo "$pipe_block" | grep -qF "$lib"; then
+            missing+=("$lib")
+        fi
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "REGRESSION: the following lib/ files are sourced but NOT in pipe-download list:" >&2
+        printf '  %s\n' "${missing[@]}" >&2
+        echo "Add them to the 'for _f in ...' loop in mount-loa.sh ~L79 so the" >&2
+        echo "curl|bash install path can fetch them. See #865 for the failure shape." >&2
+        return 1
+    fi
+}


### PR DESCRIPTION
## Summary

**HIGH IMPACT: blocks first-time users on the documented one-liner install path.** Closes external-reporter issue #865 from @gumibera (9 days open).

The pipe-detection block in `mount-loa.sh` (~L79) downloaded a fixed set of `lib/*.sh` files but didn't include two that are sourced after re-exec:

- `lib/scaffold-post-merge-workflow.sh` (sourced by mount-loa.sh:929)
- `lib/portable-realpath.sh` (sourced by mount-submodule.sh:429)

Resulting failure on `curl ... | bash`:

```
mount-loa.sh: line 929: /tmp/loa-mount.XXX/lib/scaffold-post-merge-workflow.sh: No such file or directory
[loa] ERROR (E013): Unexpected failure (exit code 1)
```

The clone-then-run path is unaffected (those files exist on disk from the clone).

## Fix

Add both lib files to the auxiliary download loop. Reporter identified the exact line + suggested fix; applying verbatim with an inline comment documenting the failure class.

## Structural regression guard

`tests/unit/mount-loa-pipe-download-complete.bats` — 3 tests:
1. `lib/scaffold-post-merge-workflow.sh` is in the download list
2. `lib/portable-realpath.sh` is in the download list
3. **Class invariant**: every `lib/*.sh` file sourced by mount-loa.sh OR mount-submodule.sh must appear in the pipe-download block. New lib/ deps added in the future will fail this test until added to the download set — closes the class of bug that produced #865 so the same shape can't recur.

All 3 pass.

Closes #865
