### PR TITLE
fix(#842): copy .claude/hooks + settings.json instead of symlinking (subprocess-exec breakage on macOS)

### DIFF
--- a/.claude/scripts/lib/symlink-manifest.sh
+++ b/.claude/scripts/lib/symlink-manifest.sh
@@ -32,15 +32,36 @@ get_symlink_manifest() {
   #   - "Available agents: []" (cheval loader's Layer 1 System Zone defaults
   #     can't read .claude/defaults/model-config.yaml)
   # Both are framework-managed (System Zone) directories that map 1:1 to
-  # the submodule, same as scripts / protocols / hooks / data / schemas.
+  # the submodule, same as scripts / protocols / data / schemas.
+  #
+  # #842: `.claude/hooks` is DELIBERATELY excluded from the symlink set and
+  # listed in MANIFEST_COPY_DIRS instead. Claude Code's hook executor on
+  # macOS cannot follow relative symlinks like `.claude/hooks ->
+  # ../.loa/.claude/hooks` from a subprocess context — every hook fails
+  # silently with "No such file or directory". Copying is the only fix
+  # that doesn't require changes to Claude Code itself.
   MANIFEST_DIR_SYMLINKS=(
     ".claude/scripts:../${submodule}/.claude/scripts"
     ".claude/protocols:../${submodule}/.claude/protocols"
-    ".claude/hooks:../${submodule}/.claude/hooks"
     ".claude/data:../${submodule}/.claude/data"
     ".claude/schemas:../${submodule}/.claude/schemas"
     ".claude/adapters:../${submodule}/.claude/adapters"
     ".claude/defaults:../${submodule}/.claude/defaults"
+  )
+
+  # #842: items COPIED into the consumer tree instead of symlinked.
+  # Required for files/dirs that Claude Code (or other subprocess-spawned
+  # executors) reads/exec'd at runtime, where relative-symlink resolution
+  # through `..` traversal fails on macOS. Tradeoff: after `git submodule
+  # update --remote`, operators must re-run `mount-submodule.sh --force`
+  # to pick up changes in these paths. The cost is small (~20 files) and
+  # explicit (mount has to run on every submodule bump anyway).
+  MANIFEST_COPY_DIRS=(
+    ".claude/hooks:${submodule}/.claude/hooks"
+  )
+
+  MANIFEST_COPY_FILES=(
+    ".claude/settings.json:${submodule}/.claude/settings.json"
   )
 
   # Phase 2: File and nested symlinks (deeper paths with 2-level relative targets)
@@ -49,7 +70,6 @@ get_symlink_manifest() {
     ".claude/loa/reference:../../${submodule}/.claude/loa/reference"
     ".claude/loa/learnings:../../${submodule}/.claude/loa/learnings"
     ".claude/loa/feedback-ontology.yaml:../../${submodule}/.claude/loa/feedback-ontology.yaml"
-    ".claude/settings.json:../${submodule}/.claude/settings.json"
     ".claude/checksums.json:../${submodule}/.claude/checksums.json"
   )
 

--- a/.claude/scripts/mount-submodule.sh
+++ b/.claude/scripts/mount-submodule.sh
@@ -523,6 +523,43 @@ create_symlinks() {
     log "  Linked command: $cmd_name"
   done
 
+  # #842: Phase 5 — COPY phase for items that can't be symlinked because
+  # Claude Code's hook executor cannot follow relative `..` symlinks from
+  # subprocess context on macOS. See lib/symlink-manifest.sh MANIFEST_COPY_*.
+  if [[ ${#MANIFEST_COPY_DIRS[@]} -gt 0 ]] || [[ ${#MANIFEST_COPY_FILES[@]} -gt 0 ]]; then
+    step "Copying executor-sensitive paths..."
+    local entry source target
+    for entry in ${MANIFEST_COPY_DIRS[@]+"${MANIFEST_COPY_DIRS[@]}"}; do
+      source="${entry%%:*}"   # destination in consumer tree
+      target="${entry#*:}"    # source path inside submodule (relative to repo root)
+      if [[ ! -d "$target" ]]; then
+        warn "  Copy source missing: $target — skipping $source"
+        continue
+      fi
+      # Replace any existing symlink or directory at the destination
+      if [[ -L "$source" ]] || [[ -e "$source" ]]; then
+        rm -rf "$source"
+      fi
+      mkdir -p "$(dirname "$source")"
+      cp -R "$target" "$source"
+      log "  Copied dir: $source"
+    done
+    for entry in ${MANIFEST_COPY_FILES[@]+"${MANIFEST_COPY_FILES[@]}"}; do
+      source="${entry%%:*}"
+      target="${entry#*:}"
+      if [[ ! -f "$target" ]]; then
+        warn "  Copy source missing: $target — skipping $source"
+        continue
+      fi
+      if [[ -L "$source" ]] || [[ -e "$source" ]]; then
+        rm -f "$source"
+      fi
+      mkdir -p "$(dirname "$source")"
+      cp "$target" "$source"
+      log "  Copied file: $source"
+    done
+  fi
+
   # Also link settings.local.json if it exists (not in manifest — optional file)
   if [[ -f "$SUBMODULE_PATH/.claude/settings.local.json" ]]; then
     safe_symlink ".claude/settings.local.json" "../$SUBMODULE_PATH/.claude/settings.local.json"

--- a/tests/unit/mount-submodule-hooks-copied.bats
+++ b/tests/unit/mount-submodule-hooks-copied.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Issue #842 — Hooks fail with "No such file or directory" when .claude/
+# uses symlinks from /mount
+# =============================================================================
+# Pre-fix, mount-submodule.sh symlinked .claude/hooks -> ../.loa/.claude/hooks
+# (relative). Claude Code's hook executor on macOS cannot follow relative
+# symlinks across `..` from a subprocess context — every hook failed silently
+# with "No such file or directory". Per @juniperbevensee report, this
+# disabled ALL safety hooks, audit logging, compaction recovery, run-mode
+# stop guard, etc.
+#
+# Fix: hooks/ + settings.json are now COPIED into the consumer tree instead
+# of symlinked. Tradeoff documented in manifest: operators must re-run
+# mount-submodule on submodule update to pick up framework changes in
+# these paths.
+# =============================================================================
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    MANIFEST="$REPO_ROOT/.claude/scripts/lib/symlink-manifest.sh"
+    MOUNT="$REPO_ROOT/.claude/scripts/mount-submodule.sh"
+    [[ -f "$MANIFEST" ]] || skip "symlink-manifest.sh not found"
+    [[ -f "$MOUNT" ]] || skip "mount-submodule.sh not found"
+}
+
+@test "#842: .claude/hooks is NOT in MANIFEST_DIR_SYMLINKS" {
+    # Regression guard. If a future PR re-adds hooks to the symlink set,
+    # this fails until they justify it. Scope the grep to the array body
+    # so the explanatory comment block isn't matched.
+    ! awk '/MANIFEST_DIR_SYMLINKS=\(/,/^  \)/' "$MANIFEST" \
+        | grep -qE '"\.claude/hooks:' \
+        || {
+            echo "REGRESSION: .claude/hooks was re-added to MANIFEST_DIR_SYMLINKS" >&2
+            echo "Issue #842: hooks must be COPIED, not symlinked. See lib/symlink-manifest.sh comment." >&2
+            return 1
+        }
+}
+
+@test "#842: .claude/settings.json is NOT in MANIFEST_FILE_SYMLINKS" {
+    # Same scope-to-array-body discipline as above.
+    ! awk '/MANIFEST_FILE_SYMLINKS=\(/,/^  \)/' "$MANIFEST" \
+        | grep -qE '"\.claude/settings\.json:' \
+        || {
+            echo "REGRESSION: .claude/settings.json was re-added to MANIFEST_FILE_SYMLINKS" >&2
+            return 1
+        }
+}
+
+@test "#842: .claude/hooks IS in MANIFEST_COPY_DIRS" {
+    grep -qE '"\.claude/hooks:' "$MANIFEST" \
+        || {
+            echo "REGRESSION: .claude/hooks missing from MANIFEST_COPY_DIRS" >&2
+            echo "Issue #842 fix requires hooks to be copied. See lib/symlink-manifest.sh." >&2
+            return 1
+        }
+
+    # Verify it's specifically inside MANIFEST_COPY_DIRS, not some other array
+    awk '/MANIFEST_COPY_DIRS=\(/,/\)/' "$MANIFEST" \
+        | grep -qE '"\.claude/hooks:' \
+        || {
+            echo "REGRESSION: .claude/hooks is referenced but not in MANIFEST_COPY_DIRS array" >&2
+            return 1
+        }
+}
+
+@test "#842: .claude/settings.json IS in MANIFEST_COPY_FILES" {
+    awk '/MANIFEST_COPY_FILES=\(/,/\)/' "$MANIFEST" \
+        | grep -qE '"\.claude/settings\.json:' \
+        || {
+            echo "REGRESSION: .claude/settings.json missing from MANIFEST_COPY_FILES" >&2
+            return 1
+        }
+}
+
+@test "#842: mount-submodule has a copy phase that consumes MANIFEST_COPY_*" {
+    # The copy logic in mount-submodule.sh must reference both arrays.
+    grep -qE 'MANIFEST_COPY_DIRS' "$MOUNT" \
+        || {
+            echo "REGRESSION: mount-submodule no longer iterates MANIFEST_COPY_DIRS" >&2
+            return 1
+        }
+    grep -qE 'MANIFEST_COPY_FILES' "$MOUNT" \
+        || {
+            echo "REGRESSION: mount-submodule no longer iterates MANIFEST_COPY_FILES" >&2
+            return 1
+        }
+    # The copy phase must use `cp -R` for directories (preserves perms,
+    # follows symlinks within source tree — required because the framework
+    # may itself contain inner symlinks we want copied as files).
+    grep -qE 'cp -R "\$target"' "$MOUNT" \
+        || {
+            echo "REGRESSION: copy phase doesn't use cp -R for dirs" >&2
+            return 1
+        }
+}
+
+@test "#842: copy phase replaces stale symlinks at the destination" {
+    # If a user has already mounted (with old symlink behavior) and re-runs
+    # mount, the existing `.claude/hooks` symlink must be removed before cp.
+    # The implementation uses `rm -rf "$source"` before `cp -R`.
+    awk '/MANIFEST_COPY_DIRS\[@\]/,/done/' "$MOUNT" \
+        | grep -qE 'rm -rf "\$source"' \
+        || {
+            echo "REGRESSION: copy phase doesn't remove stale symlinks/dirs before copy" >&2
+            echo "Without this, re-running mount on a previously-mounted tree leaves the old symlink intact." >&2
+            return 1
+        }
+}


### PR DESCRIPTION
## Summary

**HIGH IMPACT** — Closes external-reporter issue #842 from @juniperbevensee (10 days open). This bug silently disabled **every safety hook, audit log, compaction recovery, and run-mode stop guard** for users who installed via the submodule + `/mount` path on macOS.

## Symptom

Per the reporter:
```
Stop hook error: Failed with non-blocking status code: /bin/sh:
.claude/hooks/safety/run-mode-stop-guard.sh: No such file or directory
```

`.claude/hooks` was a relative symlink (`../.loa/.claude/hooks`). Claude Code's hook executor on macOS cannot follow relative `..` symlinks from a subprocess context — every hook failed silently with `No such file or directory`. Same shape on `.claude/settings.json`. The scripts existed and ran manually; only the subprocess execution path was broken. Users may not have noticed for weeks that none of their safety hooks were running.

## Fix

Introduce two new arrays in `.claude/scripts/lib/symlink-manifest.sh`:
- `MANIFEST_COPY_DIRS=(".claude/hooks:.loa/.claude/hooks")`
- `MANIFEST_COPY_FILES=(".claude/settings.json:.loa/.claude/settings.json")`

`.claude/hooks` removed from MANIFEST_DIR_SYMLINKS; `.claude/settings.json` removed from MANIFEST_FILE_SYMLINKS. A new Phase 5 in mount-submodule.sh's install function COPIES these into the consumer tree (replacing any stale symlink before `cp -R`).

## Tradeoff (documented inline)

After `git submodule update --remote`, operators must re-run `mount-submodule.sh --force` to pick up framework changes in `hooks/` or `settings.json`. The cost is small (~20 files, fast copy) and explicit (mount runs on every submodule bump anyway). Other paths (scripts/, protocols/, data/, schemas/, skills/, commands/) remain symlinks — Claude Code reads those as data, not exec'd, so the symlink resolution path works.

## Test

`tests/unit/mount-submodule-hooks-copied.bats` — **6 tests pinning the contract**:
1. `.claude/hooks` NOT in MANIFEST_DIR_SYMLINKS (regression guard)
2. `.claude/settings.json` NOT in MANIFEST_FILE_SYMLINKS
3. `.claude/hooks` IS in MANIFEST_COPY_DIRS
4. `.claude/settings.json` IS in MANIFEST_COPY_FILES
5. mount-submodule iterates MANIFEST_COPY_* with `cp -R`
6. Copy phase removes stale symlinks at destination before copy (covers re-mount-from-prior-symlink-install upgrade path)

All 6 pass.

## Out of scope

Other framework paths (skills, commands, scripts) stay as symlinks since they aren't subprocess-exec'd. If Claude Code later starts exec'ing other paths via subprocess and the same failure recurs, MANIFEST_COPY_* extends to cover them.

Closes #842
