### PR TITLE
chore(karpathy): inline 4 principles into CLAUDE.loa.md (apply on every turn)

### DIFF
--- a/.claude/loa/CLAUDE.loa.md
+++ b/.claude/loa/CLAUDE.loa.md
@@ -85,8 +85,56 @@ Grimoire and state file locations configurable via `.loa.config.yaml`. Overrides
 
 - **Memory**: Maintain `grimoires/loa/NOTES.md`
 - **Feedback**: Check audit feedback FIRST, then engineer feedback
-- **Karpathy**: Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven
 - **Git Safety**: 4-layer upstream detection with soft block
+
+## Karpathy Principles (applies on EVERY turn, not just /implement)
+
+Adapted from [Andrej Karpathy's LLM coding observations](https://x.com/karpathy/status/2015883857489522876).
+The four principles apply to every code-touching turn in Loa — not just the
+two skills that embed `<karpathy_principles>` (`implementing-tasks`,
+`reviewing-code`). Detailed protocol: `.claude/protocols/karpathy-principles.md`.
+
+### 1. Think Before Coding
+
+Surface assumptions explicitly. When multiple interpretations exist, present
+them rather than choosing silently. When requirements are unclear, ask before
+implementing. Use `AskUserQuestion` for clarifications rather than inferring
+beyond what was stated.
+
+### 2. Simplicity First
+
+Write minimum code that solves the request — nothing speculative.
+- No features beyond what was asked
+- No abstractions for single-use code
+- No "flexibility" or "configurability" that wasn't requested
+- No error handling for impossible scenarios
+- If 200 lines could be 50, rewrite simpler
+
+The test: would a senior engineer call this overcomplicated?
+
+### 3. Surgical Changes
+
+Touch only what the request requires. When editing existing code:
+- Match existing style, even if you'd do it differently
+- Don't "improve" adjacent code, comments, or formatting
+- Don't refactor things that aren't broken
+- Only remove imports/variables that YOUR changes made unused
+- Leave pre-existing dead code alone (mention separately if noticed)
+
+Every changed line should trace directly to the user's request. No
+"while I'm here" changes — note them in the PR description instead.
+
+### 4. Goal-Driven Execution
+
+Transform tasks into verifiable goals before starting:
+- "Add validation" → "write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "write a test that reproduces it, then make it pass"
+- "Refactor X" → "ensure tests pass before and after"
+
+For multi-step tasks, state the plan + per-step verification before
+implementing. Vague success criteria ("make it robust", "improve quality")
+get replaced with concrete checks ("returns 401 on invalid creds", "test
+file X passes").
 
 ## Process Compliance
 


### PR DESCRIPTION
## Summary

Karpathy principles audit (2026-05-22 session) found they were first-class in Loa's **docs DNA** (full 335-line protocol doc, key-protocols-table mention, v1.8.0 version pin) but **second-class in operational mechanics** — only **2 of 40 skills** embedded `<karpathy_principles>` blocks (`implementing-tasks`, `reviewing-code`).

The Key Protocols table at `CLAUDE.loa.md:84-89` listed "Karpathy: Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven" — dense shorthand that required drilling into the protocol doc to act on. Meanwhile, the upstream [multica-ai/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills) loads the 4 principles into a top-level CLAUDE.md directly — applying to every agent turn with less infrastructure than Loa's elaborate version.

This PR mirrors the upstream pattern: the 4 principles now sit inline in `CLAUDE.loa.md`, loaded at session start by every agent. They apply universally — not just to the 2 skills that embed the XML block.

## Diff scope (Karpathy "Surgical Changes" check ✓)

| File | Δ |
|---|---|
| `.claude/loa/CLAUDE.loa.md` | +49 / -1 (replaced 1-line Karpathy entry in Key Protocols with a new inline `## Karpathy Principles` section before Process Compliance) |

Nothing else touched. The 335-line protocol doc remains as-is for the deeper material (anti-patterns, integration sketches, reviewer checklist template). The inline CLAUDE.loa.md content is the load-bearing behavioral spec.

## What's NOT in this PR

- **The 38 skills that don't embed `<karpathy_principles>`** — the inline CLAUDE.loa.md addition closes the gap for them (they all inherit the rules now). A separate sweep to add explicit XML blocks remains possible but isn't load-bearing.
- **`.loa.config.yaml::karpathy_principles` config layer** — the protocol doc sketched it but never landed. Companion planning-grade issue for the enforcement-hook work (Surgical-Changes diff-size warnings, etc.) is being filed alongside this PR.

Closes the documentation-DNA half of the audit. The enforcement-mechanics half is the companion issue.
