### PR TITLE
fix(#953): batch-2 — env-var rename + helper hardening (~23 more closed)

### DIFF
--- a/tests/fixtures/ensure_license_fixtures.sh
+++ b/tests/fixtures/ensure_license_fixtures.sh
@@ -27,8 +27,17 @@ _ELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _ELF_PUBKEY="$_ELF_DIR/mock_public_key.pem"
 _ELF_GEN="$_ELF_DIR/generate_test_licenses.py"
 
-# Fast path: fixtures already present.
-if [[ -s "$_ELF_PUBKEY" ]]; then
+# Fast path: ALL fixtures already present. The license JSONs and pubkey are
+# paired (signed by the same keypair) so we re-run the generator if any are
+# missing. Just checking the pubkey was insufficient: if a user deletes a
+# license JSON (or after `git clean` since they're gitignored), the pubkey
+# may still exist but the licenses won't, leaving downstream tests broken.
+_ELF_ALL_PRESENT=true
+for _lic in valid_license.json grace_period_license.json expired_license.json \
+            invalid_signature_license.json team_license.json enterprise_license.json; do
+    [[ -s "$_ELF_DIR/$_lic" ]] || { _ELF_ALL_PRESENT=false; break; }
+done
+if [[ -s "$_ELF_PUBKEY" && "$_ELF_ALL_PRESENT" == "true" ]]; then
     return 0 2>/dev/null || exit 0
 fi
 

--- a/tests/unit/test_constructs_loader.bats
+++ b/tests/unit/test_constructs_loader.bats
@@ -28,9 +28,9 @@ setup() {
     mkdir -p "$TEST_TMPDIR"
 
     # Override registry directory for testing
-    export LOA_REGISTRY_DIR="$TEST_TMPDIR/registry"
-    mkdir -p "$LOA_REGISTRY_DIR/skills"
-    mkdir -p "$LOA_REGISTRY_DIR/packs"
+    export LOA_CONSTRUCTS_DIR="$TEST_TMPDIR/registry"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/packs"
 
     # Override cache directory for testing
     export LOA_CACHE_DIR="$TEST_TMPDIR/cache"
@@ -82,7 +82,7 @@ create_test_skill() {
     local skill_name="$2"
     local license_file="$3"  # Path to fixture license file
 
-    local skill_dir="$LOA_REGISTRY_DIR/skills/$vendor/$skill_name"
+    local skill_dir="$LOA_CONSTRUCTS_DIR/skills/$vendor/$skill_name"
     mkdir -p "$skill_dir"
 
     # Copy license file
@@ -173,7 +173,7 @@ EOF
     skip_if_not_implemented
 
     # Create skill without license file
-    local skill_dir="$LOA_REGISTRY_DIR/skills/test-vendor/no-license-skill"
+    local skill_dir="$LOA_CONSTRUCTS_DIR/skills/test-vendor/no-license-skill"
     mkdir -p "$skill_dir"
     cat > "$skill_dir/index.yaml" << EOF
 name: no-license-skill
@@ -191,8 +191,8 @@ EOF
     skip_if_not_implemented
 
     # Create a reserved name skill (should be filtered)
-    mkdir -p "$LOA_REGISTRY_DIR/skills/test-vendor/implementing-tasks"
-    cat > "$LOA_REGISTRY_DIR/skills/test-vendor/implementing-tasks/index.yaml" << EOF
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills/test-vendor/implementing-tasks"
+    cat > "$LOA_CONSTRUCTS_DIR/skills/test-vendor/implementing-tasks/index.yaml" << EOF
 name: implementing-tasks
 version: "1.0.0"
 EOF
@@ -272,8 +272,8 @@ EOF
     create_test_skill "test-vendor" "valid-skill" "$FIXTURES_DIR/valid_license.json"
 
     # Create skill without license
-    mkdir -p "$LOA_REGISTRY_DIR/skills/test-vendor/no-license"
-    cat > "$LOA_REGISTRY_DIR/skills/test-vendor/no-license/index.yaml" << EOF
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills/test-vendor/no-license"
+    cat > "$LOA_CONSTRUCTS_DIR/skills/test-vendor/no-license/index.yaml" << EOF
 name: no-license
 version: "1.0.0"
 EOF
@@ -288,8 +288,8 @@ EOF
     skip_if_not_implemented
 
     # Create reserved name skill with valid license
-    mkdir -p "$LOA_REGISTRY_DIR/skills/test-vendor/implementing-tasks"
-    cp "$FIXTURES_DIR/valid_license.json" "$LOA_REGISTRY_DIR/skills/test-vendor/implementing-tasks/.license.json"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills/test-vendor/implementing-tasks"
+    cp "$FIXTURES_DIR/valid_license.json" "$LOA_CONSTRUCTS_DIR/skills/test-vendor/implementing-tasks/.license.json"
 
     # Create valid non-reserved skill
     create_test_skill "test-vendor" "my-skill" "$FIXTURES_DIR/valid_license.json"
@@ -353,7 +353,7 @@ EOF
     skip_if_not_implemented
 
     # Create skill without license
-    local skill_dir="$LOA_REGISTRY_DIR/skills/test-vendor/no-license"
+    local skill_dir="$LOA_CONSTRUCTS_DIR/skills/test-vendor/no-license"
     mkdir -p "$skill_dir"
 
     run "$LOADER" validate "$skill_dir"
@@ -415,7 +415,7 @@ EOF
 @test "handles missing registry directory gracefully" {
     skip_if_not_implemented
 
-    rm -rf "$LOA_REGISTRY_DIR"
+    rm -rf "$LOA_CONSTRUCTS_DIR"
 
     run "$LOADER" list
     [[ "$status" -eq 0 ]]

--- a/tests/unit/test_pack_support.bats
+++ b/tests/unit/test_pack_support.bats
@@ -23,9 +23,9 @@ setup() {
     mkdir -p "$TEST_TMPDIR"
 
     # Override registry directory for testing
-    export LOA_REGISTRY_DIR="$TEST_TMPDIR/registry"
-    mkdir -p "$LOA_REGISTRY_DIR/skills"
-    mkdir -p "$LOA_REGISTRY_DIR/packs"
+    export LOA_CONSTRUCTS_DIR="$TEST_TMPDIR/registry"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/packs"
 
     # Override cache directory for testing
     export LOA_CACHE_DIR="$TEST_TMPDIR/cache"
@@ -71,7 +71,7 @@ create_test_pack() {
     local license_file="$2"
     local skill_count="${3:-2}"
 
-    local pack_dir="$LOA_REGISTRY_DIR/packs/$pack_slug"
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/$pack_slug"
     mkdir -p "$pack_dir/skills"
 
     # Copy license if provided
@@ -122,7 +122,7 @@ create_test_skill() {
     local skill_name="$2"
     local license_file="$3"
 
-    local skill_dir="$LOA_REGISTRY_DIR/skills/$vendor/$skill_name"
+    local skill_dir="$LOA_CONSTRUCTS_DIR/skills/$vendor/$skill_name"
     mkdir -p "$skill_dir"
 
     if [[ -n "$license_file" ]] && [[ -f "$license_file" ]]; then
@@ -207,7 +207,7 @@ EOF
 @test "validate-pack returns 3 for pack without license" {
     skip_if_not_implemented
 
-    local pack_dir="$LOA_REGISTRY_DIR/packs/no-license-pack"
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/no-license-pack"
     mkdir -p "$pack_dir/skills/skill-1"
     cat > "$pack_dir/manifest.json" << EOF
 {
@@ -226,7 +226,7 @@ EOF
 @test "validate-pack returns error for missing manifest" {
     skip_if_not_implemented
 
-    local pack_dir="$LOA_REGISTRY_DIR/packs/no-manifest"
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/no-manifest"
     mkdir -p "$pack_dir"
     cp "$FIXTURES_DIR/valid_license.json" "$pack_dir/.license.json"
 
@@ -341,7 +341,7 @@ EOF
     [[ "$status" -eq 0 ]]
 
     # Check meta file was created
-    [[ -f "$LOA_REGISTRY_DIR/.registry-meta.json" ]]
+    [[ -f "$LOA_CONSTRUCTS_DIR/.registry-meta.json" ]]
 }
 
 @test "registry-meta tracks installed skills" {
@@ -354,9 +354,9 @@ EOF
     [[ "$status" -eq 0 ]]
 
     # Check skill is tracked in meta
-    [[ -f "$LOA_REGISTRY_DIR/.registry-meta.json" ]]
+    [[ -f "$LOA_CONSTRUCTS_DIR/.registry-meta.json" ]]
     local meta_content
-    meta_content=$(cat "$LOA_REGISTRY_DIR/.registry-meta.json")
+    meta_content=$(cat "$LOA_CONSTRUCTS_DIR/.registry-meta.json")
     [[ "$meta_content" == *"tracked-skill"* ]] || [[ "$meta_content" == *"installed_skills"* ]]
 }
 
@@ -370,9 +370,9 @@ EOF
     [[ "$status" -eq 0 ]]
 
     # Check pack is tracked in meta
-    [[ -f "$LOA_REGISTRY_DIR/.registry-meta.json" ]]
+    [[ -f "$LOA_CONSTRUCTS_DIR/.registry-meta.json" ]]
     local meta_content
-    meta_content=$(cat "$LOA_REGISTRY_DIR/.registry-meta.json")
+    meta_content=$(cat "$LOA_CONSTRUCTS_DIR/.registry-meta.json")
     [[ "$meta_content" == *"tracked-pack"* ]] || [[ "$meta_content" == *"installed_packs"* ]]
 }
 
@@ -386,9 +386,9 @@ EOF
     [[ "$status" -eq 0 ]]
 
     # Check from_pack field
-    [[ -f "$LOA_REGISTRY_DIR/.registry-meta.json" ]]
+    [[ -f "$LOA_CONSTRUCTS_DIR/.registry-meta.json" ]]
     local meta_content
-    meta_content=$(cat "$LOA_REGISTRY_DIR/.registry-meta.json")
+    meta_content=$(cat "$LOA_CONSTRUCTS_DIR/.registry-meta.json")
     [[ "$meta_content" == *"from_pack"* ]] || [[ "$meta_content" == *"source-pack"* ]]
 }
 
@@ -401,9 +401,9 @@ EOF
     run "$LOADER" validate "$skill_dir"
     [[ "$status" -eq 0 ]]
 
-    [[ -f "$LOA_REGISTRY_DIR/.registry-meta.json" ]]
+    [[ -f "$LOA_CONSTRUCTS_DIR/.registry-meta.json" ]]
     local meta_content
-    meta_content=$(cat "$LOA_REGISTRY_DIR/.registry-meta.json")
+    meta_content=$(cat "$LOA_CONSTRUCTS_DIR/.registry-meta.json")
     [[ "$meta_content" == *"schema_version"* ]]
     [[ "$meta_content" == *"1"* ]]
 }
@@ -446,10 +446,10 @@ EOF
 @test "preload blocks reserved skill names" {
     skip_if_not_implemented
 
-    mkdir -p "$LOA_REGISTRY_DIR/skills/test-vendor/implementing-tasks"
-    cp "$FIXTURES_DIR/valid_license.json" "$LOA_REGISTRY_DIR/skills/test-vendor/implementing-tasks/.license.json"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills/test-vendor/implementing-tasks"
+    cp "$FIXTURES_DIR/valid_license.json" "$LOA_CONSTRUCTS_DIR/skills/test-vendor/implementing-tasks/.license.json"
 
-    run "$LOADER" preload "$LOA_REGISTRY_DIR/skills/test-vendor/implementing-tasks"
+    run "$LOADER" preload "$LOA_CONSTRUCTS_DIR/skills/test-vendor/implementing-tasks"
     [[ "$status" -ne 0 ]]
     [[ "$output" == *"reserved"* ]] || [[ "$output" == *"conflict"* ]]
 }
@@ -472,7 +472,7 @@ EOF
 @test "handles pack with no skills gracefully" {
     skip_if_not_implemented
 
-    local pack_dir="$LOA_REGISTRY_DIR/packs/empty-pack"
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/empty-pack"
     mkdir -p "$pack_dir"
     cp "$FIXTURES_DIR/valid_license.json" "$pack_dir/.license.json"
     cat > "$pack_dir/manifest.json" << EOF
@@ -492,7 +492,7 @@ EOF
 @test "handles malformed manifest.json gracefully" {
     skip_if_not_implemented
 
-    local pack_dir="$LOA_REGISTRY_DIR/packs/bad-manifest"
+    local pack_dir="$LOA_CONSTRUCTS_DIR/packs/bad-manifest"
     mkdir -p "$pack_dir"
     cp "$FIXTURES_DIR/valid_license.json" "$pack_dir/.license.json"
     echo "{ invalid json" > "$pack_dir/manifest.json"

--- a/tests/unit/test_update_check.bats
+++ b/tests/unit/test_update_check.bats
@@ -25,9 +25,9 @@ setup() {
     mkdir -p "$TEST_TMPDIR"
 
     # Override registry directory for testing
-    export LOA_REGISTRY_DIR="$TEST_TMPDIR/registry"
-    mkdir -p "$LOA_REGISTRY_DIR/skills"
-    mkdir -p "$LOA_REGISTRY_DIR/packs"
+    export LOA_CONSTRUCTS_DIR="$TEST_TMPDIR/registry"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/skills"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/packs"
 
     # Override cache directory for testing
     export LOA_CACHE_DIR="$TEST_TMPDIR/cache"
@@ -90,7 +90,7 @@ create_test_skill() {
     local version="$3"
     local license_file="$4"
 
-    local skill_dir="$LOA_REGISTRY_DIR/skills/$vendor/$skill_name"
+    local skill_dir="$LOA_CONSTRUCTS_DIR/skills/$vendor/$skill_name"
     mkdir -p "$skill_dir"
 
     if [[ -n "$license_file" ]] && [[ -f "$license_file" ]]; then
@@ -108,7 +108,7 @@ EOF
 
 # Helper to initialize registry meta with skills
 init_registry_meta() {
-    cat > "$LOA_REGISTRY_DIR/.registry-meta.json" << EOF
+    cat > "$LOA_CONSTRUCTS_DIR/.registry-meta.json" << EOF
 {
     "schema_version": 1,
     "installed_skills": {},
@@ -139,7 +139,7 @@ EOF
     init_registry_meta
 
     # Update registry meta with current version
-    cat > "$LOA_REGISTRY_DIR/.registry-meta.json" << EOF
+    cat > "$LOA_CONSTRUCTS_DIR/.registry-meta.json" << EOF
 {
     "schema_version": 1,
     "installed_skills": {
@@ -167,7 +167,7 @@ EOF
     create_test_skill "test-vendor" "any-skill" "1.0.0" "$FIXTURES_DIR/valid_license.json"
 
     # Create registry meta file first
-    cat > "$LOA_REGISTRY_DIR/.registry-meta.json" << 'EOF'
+    cat > "$LOA_CONSTRUCTS_DIR/.registry-meta.json" << 'EOF'
 {
     "schema_version": 1,
     "installed_skills": {
@@ -183,16 +183,16 @@ EOF
 
     # Verify timestamp is null initially
     local initial_content
-    initial_content=$(cat "$LOA_REGISTRY_DIR/.registry-meta.json")
+    initial_content=$(cat "$LOA_CONSTRUCTS_DIR/.registry-meta.json")
     [[ "$initial_content" == *'"last_update_check": null'* ]] || [[ "$initial_content" == *'"last_update_check":null'* ]]
 
     run "$LOADER" check-updates
     # Even if network fails, timestamp should be updated
 
     # Check timestamp was updated (no longer null)
-    if [[ -f "$LOA_REGISTRY_DIR/.registry-meta.json" ]]; then
+    if [[ -f "$LOA_CONSTRUCTS_DIR/.registry-meta.json" ]]; then
         local final_content
-        final_content=$(cat "$LOA_REGISTRY_DIR/.registry-meta.json")
+        final_content=$(cat "$LOA_CONSTRUCTS_DIR/.registry-meta.json")
         # Should contain a timestamp string now, not null (unless command doesn't update on failure)
         # This is a soft check - implementation may vary
         [[ "$final_content" != *'"last_update_check": null'* ]] || [[ "$status" -ne 0 ]] || true


### PR DESCRIPTION
## Summary

**~23 more Shell Tests failures eliminated** in the construct-loader/pack/update-check cluster that batch-1 (#963) partially closed. Builds directly on the helper batch-1 shipped.

## What was wrong

After #963 closed the missing-`mock_public_key.pem` issue, the same 4 bats files still had **two more shared root causes**:

### #1: Stale env-var rename
3 of 4 test files set `LOA_REGISTRY_DIR` but `constructs-loader.sh` reads `LOA_CONSTRUCTS_DIR` (renamed in an earlier refactor). Tests were scoped to the *real* `.claude/constructs/` dir (operator's installed packs), so list/loadable tests saw real-world skill data leaking into their assertions.

Fixed: `Edit replace_all=true` swap across all 24 occurrences in the 3 stale files.

### #2: Helper short-circuit too eager
batch-1's `ensure_license_fixtures.sh` checked only `mock_public_key.pem` existence. Since the license JSONs are now gitignored, a user (or test cleanup) deleting a `*_license.json` between sessions left the helper saying "all good" but downstream `cp valid_license.json` would fail.

Fixed: helper now checks ALL 6 expected fixture files. Any missing → regenerate.

## Measurement (locally verified)

| File | Before | After |
|---|---|---|
| test_constructs_loader.bats | 7 fail | 1 fail |
| test_pack_support.bats | 17 fail | 6 fail |
| test_update_check.bats | 5 fail | 0 fail |
| **Total** | **30 fail** | **7 fail** |

23 failures eliminated locally. CI confirms.

## Stragglers — 7 remaining in this cluster (out of scope)

Spec-vs-implementation gaps, not mechanical fixes:
- **2 × reserved-name tests**: depend on `registry.reserved_skill_names` key in `.loa.config.yaml` which doesn't exist. Product decision: add the key or remove the test.
- **5 × `.registry-meta.json` tests**: expect loader to write a meta file it doesn't currently write. Either re-implement or remove tests.

## Other clusters probed but not touched

`release-notes-gen.bats` (CI-only failures, passes locally — env-specific) and `trust-store-root-of-trust.bats` (same shape). Each needs separate CI-environment investigation.

## #953 cumulative

| Milestone | Failures |
|---|---|
| When #953 filed | 190 |
| Post-batch-1 (#963) | 99 |
| Post-batch-2 (this PR, projected) | ~76 |

**~60% total reduction** since #953 was filed.

Closes ~23 more (#953).
