### PR TITLE
fix(#953): batch-3 — gpt-review-hook + subagent-reports (~9 more closed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,7 +292,10 @@ app/ecosystem.config.js
 grimoires/loa/cycles/
 grimoires/loa/NOTES.md
 grimoires/loa/handoffs/
-grimoires/loa/a2a/
+# #953 batch-3: `grimoires/loa/a2a/` (with trailing slash) was duplicated here
+# but conflicts with the line ~183 `grimoires/loa/a2a/*` pattern that supports
+# `!` exceptions. Removed the duplicate; line ~183 already handles a2a/ correctly
+# and the `!.../subagent-reports/.gitkeep` exception there now works.
 grimoires/loa/visions/
 grimoires/loa/memory/
 grimoires/loa/legacy/

--- a/grimoires/loa/a2a/subagent-reports/.gitkeep
+++ b/grimoires/loa/a2a/subagent-reports/.gitkeep
@@ -1,0 +1,5 @@
+# Subagent reports landing zone.
+# Subagent invocations (architecture-validator, security-scanner,
+# test-adequacy-reviewer, goal-validation) write reports here.
+# This .gitkeep is tracked so a fresh checkout has the directory
+# the loaders expect (tests/unit/subagent-reports.bats:235).

--- a/tests/unit/gpt-review-hook.bats
+++ b/tests/unit/gpt-review-hook.bats
@@ -50,7 +50,7 @@ setup() {
     cp "$FIXTURES_DIR/configs/enabled.yaml" "$TEST_DIR/.loa.config.yaml"
     cd "$TEST_DIR"
 
-    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
     echo "$output" | jq empty
 }
@@ -59,7 +59,7 @@ setup() {
     cp "$FIXTURES_DIR/configs/enabled.yaml" "$TEST_DIR/.loa.config.yaml"
     cd "$TEST_DIR"
 
-    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
     echo "$output" | jq -e '.hookSpecificOutput' > /dev/null
 }
@@ -68,7 +68,7 @@ setup() {
     cp "$FIXTURES_DIR/configs/enabled.yaml" "$TEST_DIR/.loa.config.yaml"
     cd "$TEST_DIR"
 
-    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
     echo "$output" | jq -e '.hookSpecificOutput.additionalContext' > /dev/null
 }
@@ -77,7 +77,7 @@ setup() {
     cp "$FIXTURES_DIR/configs/enabled.yaml" "$TEST_DIR/.loa.config.yaml"
     cd "$TEST_DIR"
 
-    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
     local context
     context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
@@ -88,7 +88,7 @@ setup() {
     cp "$FIXTURES_DIR/configs/enabled.yaml" "$TEST_DIR/.loa.config.yaml"
     cd "$TEST_DIR"
 
-    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
     local context
     context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
@@ -110,7 +110,7 @@ setup() {
     cp "$FIXTURES_DIR/configs/enabled.yaml" "$TEST_DIR/.loa.config.yaml"
     cd "$TEST_DIR"
 
-    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
     local context
     context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
@@ -123,7 +123,7 @@ setup() {
     cp "$FIXTURES_DIR/configs/enabled.yaml" "$TEST_DIR/.loa.config.yaml"
     cd "$TEST_DIR"
 
-    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
     local context
     context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
@@ -138,7 +138,7 @@ setup() {
     cp "$FIXTURES_DIR/configs/disabled.yaml" "$TEST_DIR/.loa.config.yaml"
     cd "$TEST_DIR"
 
-    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
     [[ -z "$output" ]]
 }
@@ -146,7 +146,7 @@ setup() {
 @test "no output when config file missing" {
     cd "$TEST_DIR"
 
-    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
     [[ -z "$output" ]]
 }
@@ -167,7 +167,7 @@ setup() {
     cp "$FIXTURES_DIR/configs/enabled.yaml" "$TEST_DIR/.loa.config.yaml"
     cd "$TEST_DIR"
 
-    run timeout 5 bash -c 'echo "{\"tool_input\":{\"file_path\":\"test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
+    run timeout 5 bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/test.ts\"}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
 }
 
@@ -177,6 +177,9 @@ setup() {
 
     run bash -c 'echo "{\"tool_input\":{}}" | .claude/scripts/gpt-review-hook.sh'
     [[ "$status" -eq 0 ]]
-    # Should still output (with "a file" as fallback)
-    echo "$output" | jq -e '.hookSpecificOutput' > /dev/null
+    # Per #711 resolution: conservative default — when classification is
+    # ambiguous (empty file_path, malformed input), SKIP rather than fire.
+    # The hook should exit 0 with NO output, not fall back to "a file".
+    # Old behavior (output with fallback string) was the #711 bug.
+    [[ -z "$output" ]]
 }


### PR DESCRIPTION
## Summary

**~9 more Shell Tests failures eliminated** in the gpt-review-hook + subagent-reports clusters. Two independent root causes.

## Fix #1: gpt-review-hook stale test fixtures (7 failures)

10 tests used `file_path: "test.ts"` but the hook was updated in #711 (zksoju feedback) to add a PATH ALLOWLIST filtering anything outside `grimoires/loa/(prd|sdd|sprint).md`, `src/`, `lib/`, `app/`. `test.ts` (no dir prefix) is filtered, so the hook silently exits 0 — every assertion on `.hookSpecificOutput` failed.

**Fix**: bulk-rename to `src/test.ts` (in-allowlist) + update the "empty file_path" test to match the hook's documented #711 design (skip-on-ambiguous, not fallback-to-"a file").

**Result**: 7 failures → 0. All 16 gpt-review-hook tests pass.

## Fix #2: subagent-reports placeholder dir missing (2 failures)

Tests assert `grimoires/loa/a2a/subagent-reports/` exists with a `.gitkeep`. The .gitignore had **a duplicate `grimoires/loa/a2a/` rule** (with trailing slash, matching the dir itself) AFTER the proper `grimoires/loa/a2a/*` (content-only with `!` exception support). Per git's documented behavior, `!` exceptions can't re-include files inside a parent dir excluded as a whole.

**Fix**: removed the redundant dir-form rule; re-added the `!.../subagent-reports/.gitkeep` exception; created the `.gitkeep` with explanatory content.

**Result**: 2 failures → 0.

## CI-env-specific clusters probed (pass locally)

Several clusters pass cleanly on local dev — failures are CI-runner-specific:
- `scheduled-cycle-lib-3A/B.bats` (FR-L3-* + cycle_invoke — 11 CI failures)
- `test_bb_zero_direct_fetch.bats` (T3.3 — 6 CI failures)
- `release-notes-gen.bats` (5 CI failures)
- `trust-store-root-of-trust.bats` (4 CI failures)

These need separate CI-runner investigation; out of scope for batch-3.

## #953 cumulative

| Milestone | Failures | PR |
|---|---|---|
| When filed | 190 | — |
| Post-batch-1 | 99 | #963 / v1.172.2 |
| Post-batch-2 | 79 | #964 / v1.172.3 |
| Post-batch-3 (projected) | ~70 | this PR |

**~63% total reduction in 3 PRs.**

Closes ~9 more (#953).
