### PR TITLE
fix(#971): post-merge classifier — case-insensitive Cycle-NNN matching

### DIFF
--- a/.claude/scripts/classify-pr-type.sh
+++ b/.claude/scripts/classify-pr-type.sh
@@ -48,7 +48,12 @@ classify_pr_type() {
         return 0
     fi
 
-    if echo "$title" | grep -qE '\bcycle-[0-9]+\b'; then
+    # cycle-114 #971: case-INSENSITIVE so a capitalized token like "Cycle-114:"
+    # classifies as cycle (PR #970 merge subject was misrouted to "other" by the
+    # prior case-sensitive match, skipping the post-merge Full Pipeline). The
+    # \b word-boundary + [0-9]+ anchors are preserved, so "Precycle-082" and
+    # "Cycle-abc" still classify as "other".
+    if echo "$title" | grep -qiE '\bcycle-[0-9]+\b'; then
         echo "cycle"
         return 0
     fi

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1479,7 +1479,7 @@
       ]
     }
   ],
-  "global_sprint_counter": 176,
+  "global_sprint_counter": 177,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -1672,6 +1672,19 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260520-i894-cdaf96/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260520-i894-cdaf96/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260601-i971-727e7f",
+      "label": "Bug Fix — classify-pr-type.sh rule #2 case-sensitive (Cycle-NNN misroute, #971)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/971",
+      "created_at": "2026-06-01T06:11:21Z",
+      "sprints": [
+        "sprint-bug-177"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260601-i971-727e7f/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260601-i971-727e7f/sprint.md"
     }
   ],
   "bugfixes": [

--- a/tests/unit/post-merge-classifier.bats
+++ b/tests/unit/post-merge-classifier.bats
@@ -67,6 +67,24 @@ setup() {
 }
 
 # =========================================================================
+# PCT-T-CASE: capitalized cycle-NNN token (#971 regression — PR #970 misroute)
+# The merge subject "Cycle-114: ..." (capital C) was classified 'other' because
+# rule #2 used case-sensitive grep, so the post-merge Full Pipeline was skipped.
+# =========================================================================
+
+@test "Cycle-114: capitalized leading token → cycle (#971 / PR #970)" {
+    run "$CLASSIFIER" --title "Cycle-114: Harness Modernization for Opus 4.8 (#970)"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+@test "mid-title uppercase CYCLE-099 → cycle (#971 triangulation)" {
+    run "$CLASSIFIER" --title "Some CYCLE-099 work in progress"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cycle" ]
+}
+
+# =========================================================================
 # PCT-T11..PCT-T13: anti-false-positive (the bug's mirror image)
 # =========================================================================
 


### PR DESCRIPTION
## fix(#971): post-merge classifier — case-insensitive `Cycle-NNN` matching

**Closes #971.** Bug micro-sprint `sprint-bug-177` (bead `bd-fvjp`).

### Problem
The cycle-114 merge subject `Cycle-114: Harness Modernization for Opus 4.8 (#970)` was classified `pr_type=other` by `classify-pr-type.sh`, so `post-merge.yml` ran **Simple Release (tag-only)** and **skipped Full Pipeline (Cycle)** — no CHANGELOG/GT/RTFM/GitHub-release were auto-produced (had to be completed manually).

### Root cause
Rule #2 matched `\bcycle-[0-9]+\b` anywhere in the title but used **case-sensitive** `grep -qE`, so capital `Cycle-114` slipped through (lowercase `cycle-114` would have matched).

### Fix (surgical, test-first)
- `.claude/scripts/classify-pr-type.sh`: rule #2 `grep -qE` → `grep -qiE`. The `\b` word-boundary + `[0-9]+` anchors are preserved, so negatives stay `other` (`precycle-082`, `cycle-abc`).
- `tests/unit/post-merge-classifier.bats`: +2 regression tests (capital `Cycle-114:`, mid-title `CYCLE-099`). Confirmed failing pre-fix.

### Verification
- `bats tests/unit/post-merge-classifier.bats` → **27/27** (was 25).
- `Cycle-114: …` → `cycle` ✓ · `precycle-082`/`cycle-abc`/`feat(auth):` → `other` ✓ (negatives preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
