### PR TITLE
fix(cheval): process-group-kill headless CLI on timeout (no orphan grandchildren; chain advances) — closes #982

### DIFF
--- a/.claude/adapters/loa_cheval/providers/base.py
+++ b/.claude/adapters/loa_cheval/providers/base.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import select
+import signal
 import socket
+import subprocess
 import sys
+import threading
 import time
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
@@ -529,6 +534,162 @@ def build_headless_subprocess_env(parent_env=None) -> Dict[str, str]:
     for var in _HEADLESS_STRIPPED_AUTH_VARS:
         base.pop(var, None)
     return base
+
+
+# Memory backstop for a runaway CLI flooding a stream. subprocess.run buffered
+# unbounded; we keep that effective behavior for real review payloads while
+# capping pathological floods. We always DRAIN beyond the cap (so the child's
+# pipe never fills and deadlocks) but only RETAIN up to this many bytes.
+_HEADLESS_CAPTURE_MAX_BYTES = 64 * 1024 * 1024  # 64 MiB per stream
+
+
+def run_subprocess_pgkill(
+    cmd: List[str],
+    *,
+    input: Optional[str] = None,  # noqa: A002 — mirrors subprocess.run kwarg name
+    timeout: float,
+    env: Dict[str, str],
+    max_bytes: int = _HEADLESS_CAPTURE_MAX_BYTES,
+) -> "subprocess.CompletedProcess":
+    """Drop-in for `subprocess.run` that bounds an agentic CLI by PROCESS GROUP.
+
+    KF-014 (recurrence-3, STRUCTURAL): the headless completion adapters used
+    `subprocess.run(timeout=...)`, whose timeout cleanup `process.kill()`s only
+    the IMMEDIATE child (the `node` CLI) — never the process group. An agentic
+    CLI (`codex exec` / `gemini -p` / `claude -p`) spawns helper grandchildren;
+    on timeout those are orphaned (proven: a SIGKILL of the parent leaves the
+    grandchildren running). The orphans keep consuming the rate-limited
+    subscription, so a transient provider throttle compounds into a multi-minute
+    "hang" that reads as unbounded and never falls through cleanly.
+
+    This helper applies the cycle-110 `doctor.py` pattern to the COMPLETION path:
+      - `start_new_session=True` → the child is its own process-group leader.
+      - streaming `select` read with a per-stream byte cap (never
+        `communicate()`, which buffers unbounded).
+      - on the wall-clock deadline → `os.killpg(SIGKILL)` tears down the WHOLE
+        tree, then re-raise `subprocess.TimeoutExpired` so the existing
+        `except subprocess.TimeoutExpired` branch converts the hang into a
+        `ProviderUnavailableError` and the cheval fallback chain advances.
+
+    Contract parity with `subprocess.run(..., capture_output=True, text=True,
+    check=False)`: returns a `CompletedProcess` with `.returncode`, `.stdout`
+    (str), `.stderr` (str); raises `subprocess.TimeoutExpired` on deadline and
+    `FileNotFoundError` when `cmd[0]` is not on PATH.
+    """
+    proc = subprocess.Popen(  # noqa: S603 — cmd is adapter-built argv, not shell
+        cmd,
+        stdin=subprocess.PIPE if input is not None else subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,  # process-group isolation for killpg
+        env=env,
+    )
+
+    # `writer`/buffers are declared before the try so the finally can reap the
+    # already-spawned child even if SETUP below (encode / thread-start / fileno)
+    # raises — that window would otherwise orphan the process group (the exact
+    # KF-014 failure mode, reintroduced on the error path).
+    writer: Optional[threading.Thread] = None
+    out_buf = bytearray()
+    err_buf = bytearray()
+    timed_out = False
+
+    try:
+        # Pump stdin on a thread so a large prompt never deadlocks against the
+        # child filling stdout (the classic write-all-then-read deadlock).
+        if input is not None and proc.stdin is not None:
+            payload = input.encode("utf-8")
+
+            def _pump_stdin() -> None:
+                try:
+                    proc.stdin.write(payload)
+                    proc.stdin.close()
+                except (BrokenPipeError, ValueError, OSError):
+                    # ValueError: the finally may close stdin while this daemon
+                    # writer is still blocked mid-write — swallow (no leak/hang).
+                    pass
+
+            writer = threading.Thread(target=_pump_stdin, daemon=True)
+            writer.start()
+
+        out_fd = proc.stdout.fileno() if proc.stdout else -1
+        err_fd = proc.stderr.fileno() if proc.stderr else -1
+        open_fds = [fd for fd in (out_fd, err_fd) if fd >= 0]
+        deadline = time.monotonic() + timeout
+
+        while open_fds:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            readable, _, _ = select.select(open_fds, [], [], remaining)
+            if not readable:
+                timed_out = True
+                break
+            for fd in readable:
+                try:
+                    chunk = os.read(fd, 65536)
+                except OSError:
+                    chunk = b""
+                if not chunk:
+                    open_fds.remove(fd)
+                    continue
+                buf = out_buf if fd == out_fd else err_buf
+                if len(buf) < max_bytes:
+                    buf.extend(chunk[: max_bytes - len(buf)])
+                # else: drained but discarded — pipe stays unblocked.
+
+        if not timed_out:
+            # Pipes hit EOF. The child is normally already exiting; bound the
+            # reap so a child that closed its pipes but lingers can't hang us.
+            try:
+                proc.wait(timeout=max(0.5, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                timed_out = True
+
+        if timed_out:
+            _killpg(proc)
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                pass
+            raise subprocess.TimeoutExpired(
+                cmd,
+                timeout,
+                output=bytes(out_buf).decode("utf-8", "replace"),
+                stderr=bytes(err_buf).decode("utf-8", "replace"),
+            )
+
+        return subprocess.CompletedProcess(
+            cmd,
+            proc.returncode if proc.returncode is not None else -1,
+            stdout=bytes(out_buf).decode("utf-8", "replace"),
+            stderr=bytes(err_buf).decode("utf-8", "replace"),
+        )
+    finally:
+        # Never leak the tree on any exit path (incl. unexpected exceptions).
+        if proc.poll() is None:
+            _killpg(proc)
+        if writer is not None:
+            writer.join(timeout=1.0)
+        for stream in (proc.stdout, proc.stderr, proc.stdin):
+            try:
+                if stream is not None:
+                    stream.close()
+            except (OSError, ValueError):
+                pass
+
+
+def _killpg(proc: "subprocess.Popen") -> None:
+    """Best-effort SIGKILL of the child's whole process group (ProcessLookupError-safe)."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        # Already exited, or group gone between poll and kill — idempotent.
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
 
 
 def estimate_tokens(messages: List[Dict[str, Any]]) -> int:

--- a/.claude/adapters/loa_cheval/providers/claude_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/claude_headless_adapter.py
@@ -57,6 +57,7 @@ from loa_cheval.providers.base import (
     ProviderAdapter,
     build_headless_subprocess_env,
     enforce_context_window,
+    run_subprocess_pgkill,
 )
 from loa_cheval.types import (
     CompletionRequest,
@@ -147,15 +148,15 @@ class ClaudeHeadlessAdapter(ProviderAdapter):
         try:
             with _acquire_slot("claude-headless", n_slots=n_slots):
                 try:
-                    proc = subprocess.run(
+                    proc = run_subprocess_pgkill(
                         cmd,
-                        capture_output=True,
-                        text=True,
                         timeout=timeout_s,
-                        check=False,
-                        # claude -p reads prompt from argv (we passed it via the cmd
-                        # array). Stdin stays closed to avoid hangs.
-                        stdin=subprocess.DEVNULL,
+                        # claude -p reads the prompt from argv; stdin stays closed
+                        # (input=None → DEVNULL in the helper).
+                        # KF-014: process-group-killing bound (base.py) so a
+                        # throttled/hung `claude -p` is SIGKILL'd by group and
+                        # converted to TimeoutExpired → fallback chain advances,
+                        # instead of leaking orphan grandchildren and "hanging".
                         # cycle-109 follow-up (#879 / #880): strip ANTHROPIC_API_KEY
                         # so claude -p uses OAuth subscription, not API mode.
                         env=build_headless_subprocess_env(),

--- a/.claude/adapters/loa_cheval/providers/codex_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/codex_headless_adapter.py
@@ -54,6 +54,7 @@ from loa_cheval.providers.base import (
     ProviderAdapter,
     build_headless_subprocess_env,
     enforce_context_window,
+    run_subprocess_pgkill,
 )
 from loa_cheval.types import (
     CompletionRequest,
@@ -141,13 +142,14 @@ class CodexHeadlessAdapter(ProviderAdapter):
         try:
             with _acquire_slot("codex-headless", n_slots=n_slots):
                 try:
-                    proc = subprocess.run(
+                    proc = run_subprocess_pgkill(
                         cmd,
                         input=prompt,
-                        capture_output=True,
-                        text=True,
                         timeout=timeout_s,
-                        check=False,
+                        # KF-014: process-group-killing bound (base.py) so a
+                        # throttled/hung `codex exec` is SIGKILL'd by group and
+                        # converted to TimeoutExpired → fallback chain advances,
+                        # instead of leaking orphan grandchildren and "hanging".
                         # cycle-109 follow-up (#879 / #880 symmetric): strip
                         # OPENAI_API_KEY so codex exec uses OAuth, not API mode.
                         env=build_headless_subprocess_env(),

--- a/.claude/adapters/loa_cheval/providers/gemini_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/gemini_headless_adapter.py
@@ -48,6 +48,7 @@ from loa_cheval.providers.base import (
     ProviderAdapter,
     build_headless_subprocess_env,
     enforce_context_window,
+    run_subprocess_pgkill,
 )
 from loa_cheval.types import (
     CompletionRequest,
@@ -137,17 +138,15 @@ class GeminiHeadlessAdapter(ProviderAdapter):
         try:
             with _acquire_slot("gemini-headless", n_slots=n_slots):
                 try:
-                    proc = subprocess.run(
+                    proc = run_subprocess_pgkill(
                         cmd,
-                        capture_output=True,
-                        text=True,
                         timeout=timeout_s,
-                        check=False,
-                        # gemini-cli's `-p` flag triggers headless mode and consumes the
-                        # prompt argument directly. Stdin is appended only when both -p
-                        # and stdin are piped — we use -p exclusively so stdin stays
-                        # closed (avoids hangs in some shell environments).
-                        stdin=subprocess.DEVNULL,
+                        # gemini-cli's `-p` flag carries the prompt directly; stdin
+                        # stays closed (input=None → DEVNULL in the helper).
+                        # KF-014: process-group-killing bound (base.py) so a
+                        # throttled/hung `gemini -p` is SIGKILL'd by group and
+                        # converted to TimeoutExpired → fallback chain advances,
+                        # instead of leaking orphan grandchildren and "hanging".
                         # cycle-109 follow-up (#879 / #880 symmetric): strip
                         # GOOGLE_API_KEY + GEMINI_API_KEY so gemini -p uses GCA
                         # OAuth, not API mode.

--- a/.claude/adapters/tests/test_claude_headless_adapter.py
+++ b/.claude/adapters/tests/test_claude_headless_adapter.py
@@ -314,7 +314,7 @@ class TestPromptFlattening:
 class TestJsonParsing:
     def test_parses_result_and_usage(self):
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             result = adapter.complete(_make_request())
         assert result.content == "pong"
@@ -328,7 +328,7 @@ class TestJsonParsing:
 
     def test_cache_tokens_propagate_to_metadata(self):
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             result = adapter.complete(_make_request())
         assert result.metadata.get("cache_creation_input_tokens") == 14179
@@ -339,7 +339,7 @@ class TestJsonParsing:
     def test_missing_usage_yields_estimated_source(self):
         no_usage = json.dumps({"type": "result", "is_error": False, "result": "ok", "session_id": "x"})
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(no_usage)
             result = adapter.complete(_make_request())
         assert result.content == "ok"
@@ -357,7 +357,7 @@ class TestJsonParsing:
             }
         )
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(with_denials)
             result = adapter.complete(_make_request())
         assert result.metadata.get("permission_denials")
@@ -376,7 +376,7 @@ class TestJsonParsing:
             }
         )
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(with_actual)
             # Request opus, but server actually used sonnet — adapter should report sonnet.
             result = adapter.complete(_make_request(model="claude-opus-4-7"))
@@ -392,7 +392,7 @@ class TestErrorClassification:
     def test_not_logged_in_raises_config_error(self):
         adapter = ClaudeHeadlessAdapter(_make_config())
         # Claude Code returns exit 0 even on auth failure but is_error=true in JSON.
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(NOT_LOGGED_IN_JSON)
             with pytest.raises(ConfigError) as exc_info:
                 adapter.complete(_make_request())
@@ -400,21 +400,21 @@ class TestErrorClassification:
 
     def test_overloaded_raises_rate_limit(self):
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(OVERLOADED_JSON)
             with pytest.raises(RateLimitError):
                 adapter.complete(_make_request())
 
     def test_stderr_429_raises_rate_limit(self):
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(1, stderr="HTTP 429 Too Many Requests")
             with pytest.raises(RateLimitError):
                 adapter.complete(_make_request())
 
     def test_generic_failure_raises_provider_unavailable(self):
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(2, stderr="some unexpected error")
             with pytest.raises(ProviderUnavailableError) as exc_info:
                 adapter.complete(_make_request())
@@ -422,7 +422,7 @@ class TestErrorClassification:
 
     def test_timeout_raises_provider_unavailable(self):
         adapter = ClaudeHeadlessAdapter(_make_config(read_timeout=5.0))
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=5)
             with pytest.raises(ProviderUnavailableError) as exc_info:
                 adapter.complete(_make_request())
@@ -430,7 +430,7 @@ class TestErrorClassification:
 
     def test_claude_not_on_path_raises_config_error(self):
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.side_effect = FileNotFoundError("claude: command not found")
             with pytest.raises(ConfigError) as exc_info:
                 adapter.complete(_make_request())
@@ -438,7 +438,7 @@ class TestErrorClassification:
 
     def test_unparseable_stdout_raises_provider_unavailable(self):
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc("garbage not json")
             with pytest.raises(ProviderUnavailableError) as exc_info:
                 adapter.complete(_make_request())
@@ -496,7 +496,7 @@ class TestValidateAndHealth:
 class TestEndToEnd:
     def test_complete_round_trip(self):
         adapter = ClaudeHeadlessAdapter(_make_config(extra={"effort": "high"}))
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             result = adapter.complete(
                 _make_request(
@@ -553,7 +553,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-depleted-key")
         monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         kwargs = mock_run.call_args.kwargs
@@ -572,7 +572,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("PATH", "/test/bin:/usr/bin")
         monkeypatch.setenv("HOME", "/test/home")
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})
@@ -584,7 +584,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})
@@ -598,7 +598,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
         adapter = ClaudeHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.claude_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         # env kwarg MUST be present (not None) even when no key needs stripping.

--- a/.claude/adapters/tests/test_codex_headless_adapter.py
+++ b/.claude/adapters/tests/test_codex_headless_adapter.py
@@ -340,21 +340,21 @@ class TestJsonlParsing:
 class TestErrorClassification:
     def test_rate_limit_in_stderr_raises_rate_limit_error(self):
         adapter = CodexHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(1, "Error: rate limit exceeded — retry in 60s")
             with pytest.raises(RateLimitError):
                 adapter.complete(_make_request())
 
     def test_429_in_stderr_raises_rate_limit_error(self):
         adapter = CodexHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(1, "HTTP 429 Too Many Requests")
             with pytest.raises(RateLimitError):
                 adapter.complete(_make_request())
 
     def test_auth_failure_raises_config_error(self):
         adapter = CodexHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(1, "Error: not authenticated. Run codex login.")
             with pytest.raises(ConfigError) as exc_info:
                 adapter.complete(_make_request())
@@ -362,7 +362,7 @@ class TestErrorClassification:
 
     def test_generic_failure_raises_provider_unavailable(self):
         adapter = CodexHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(2, "some unexpected error")
             with pytest.raises(ProviderUnavailableError) as exc_info:
                 adapter.complete(_make_request())
@@ -370,7 +370,7 @@ class TestErrorClassification:
 
     def test_timeout_raises_provider_unavailable(self):
         adapter = CodexHeadlessAdapter(_make_config(read_timeout=5.0))
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired(cmd=["codex"], timeout=5)
             with pytest.raises(ProviderUnavailableError) as exc_info:
                 adapter.complete(_make_request())
@@ -378,7 +378,7 @@ class TestErrorClassification:
 
     def test_codex_not_on_path_raises_config_error(self):
         adapter = CodexHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.side_effect = FileNotFoundError("codex: command not found")
             with pytest.raises(ConfigError) as exc_info:
                 adapter.complete(_make_request())
@@ -437,7 +437,7 @@ class TestValidateAndHealth:
 class TestEndToEnd:
     def test_complete_round_trip(self):
         adapter = CodexHeadlessAdapter(_make_config(extra={"reasoning_effort": "high"}))
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_JSONL_OUTPUT)
             result = adapter.complete(
                 _make_request(
@@ -478,7 +478,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-test-depleted")
         monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
         adapter = CodexHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_JSONL_OUTPUT)
             adapter.complete(_make_request())
         kwargs = mock_run.call_args.kwargs
@@ -490,7 +490,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("PATH", "/test/bin:/usr/bin")
         monkeypatch.setenv("HOME", "/test/home")
         adapter = CodexHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_JSONL_OUTPUT)
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})
@@ -501,7 +501,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-test")
         monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
         adapter = CodexHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.codex_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_JSONL_OUTPUT)
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})

--- a/.claude/adapters/tests/test_gemini_headless_adapter.py
+++ b/.claude/adapters/tests/test_gemini_headless_adapter.py
@@ -259,7 +259,7 @@ class TestPromptFlattening:
 class TestJsonParsing:
     def test_parses_response_and_stats(self):
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             result = adapter.complete(_make_request())
         assert result.content == "pong"
@@ -289,7 +289,7 @@ class TestJsonParsing:
             }
         )
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(stats_under_alt)
             result = adapter.complete(_make_request())
         assert result.usage.input_tokens == 100
@@ -298,7 +298,7 @@ class TestJsonParsing:
     def test_missing_stats_yields_estimated_source(self):
         no_stats = json.dumps({"session_id": "x", "response": "ok"})
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(no_stats)
             result = adapter.complete(_make_request())
         assert result.content == "ok"
@@ -315,7 +315,7 @@ class TestJsonParsing:
             }
         )
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(with_warnings)
             result = adapter.complete(_make_request())
         assert result.metadata.get("warnings") == ["some non-fatal warning", "another"]
@@ -335,7 +335,7 @@ class TestJsonParsing:
             }
         )
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(with_cached)
             result = adapter.complete(_make_request())
         assert result.metadata.get("cached_tokens") == 80
@@ -351,7 +351,7 @@ class TestErrorClassification:
         adapter = GeminiHeadlessAdapter(_make_config())
         # gemini may exit non-zero AND emit JSON error — verify we surface the
         # structured diagnostic.
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(41, stdout=AUTH_ERROR_JSON)
             with pytest.raises(ConfigError) as exc_info:
                 adapter.complete(_make_request())
@@ -359,21 +359,21 @@ class TestErrorClassification:
 
     def test_quota_error_raises_rate_limit(self):
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(8, stdout=QUOTA_ERROR_JSON)
             with pytest.raises(RateLimitError):
                 adapter.complete(_make_request())
 
     def test_stderr_429_raises_rate_limit(self):
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(1, stderr="HTTP 429 Too Many Requests")
             with pytest.raises(RateLimitError):
                 adapter.complete(_make_request())
 
     def test_generic_failure_raises_provider_unavailable(self):
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(2, stderr="some unexpected internal error")
             with pytest.raises(ProviderUnavailableError) as exc_info:
                 adapter.complete(_make_request())
@@ -381,7 +381,7 @@ class TestErrorClassification:
 
     def test_timeout_raises_provider_unavailable(self):
         adapter = GeminiHeadlessAdapter(_make_config(read_timeout=5.0))
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired(cmd=["gemini"], timeout=5)
             with pytest.raises(ProviderUnavailableError) as exc_info:
                 adapter.complete(_make_request())
@@ -389,7 +389,7 @@ class TestErrorClassification:
 
     def test_gemini_not_on_path_raises_config_error(self):
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.side_effect = FileNotFoundError("gemini: command not found")
             with pytest.raises(ConfigError) as exc_info:
                 adapter.complete(_make_request())
@@ -397,7 +397,7 @@ class TestErrorClassification:
 
     def test_unparseable_stdout_raises_provider_unavailable(self):
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc("this is not json at all")
             with pytest.raises(ProviderUnavailableError) as exc_info:
                 adapter.complete(_make_request())
@@ -455,7 +455,7 @@ class TestValidateAndHealth:
 class TestEndToEnd:
     def test_complete_round_trip(self):
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             result = adapter.complete(
                 _make_request(
@@ -498,7 +498,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
         monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         kwargs = mock_run.call_args.kwargs
@@ -511,7 +511,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("PATH", "/test/bin:/usr/bin")
         monkeypatch.setenv("HOME", "/test/home")
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})
@@ -523,7 +523,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("GEMINI_API_KEY", "test-gemini")
         monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})
@@ -540,7 +540,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("GOOGLE_GENAI_USE_GCA", "true")
         monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         kwargs = mock_run.call_args.kwargs
@@ -553,7 +553,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("GOOGLE_GENAI_USE_GCA", "true")
         monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})
@@ -572,7 +572,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("GOOGLE_GEMINI_BASE_URL", "https://gateway.example.com")
         monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         assert "GOOGLE_GEMINI_BASE_URL" not in mock_run.call_args.kwargs["env"]
@@ -581,7 +581,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("GEMINI_CLI_USE_COMPUTE_ADC", "true")
         monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         assert "GEMINI_CLI_USE_COMPUTE_ADC" not in mock_run.call_args.kwargs["env"]
@@ -594,7 +594,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("GEMINI_CLI_USE_COMPUTE_ADC", "true")
         monkeypatch.setenv("LOA_HEADLESS_KEEP_API_KEY", "1")
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})
@@ -610,7 +610,7 @@ class TestSubprocessEnvFilter:
         monkeypatch.setenv("CLOUD_SHELL", "true")
         monkeypatch.delenv("LOA_HEADLESS_KEEP_API_KEY", raising=False)
         adapter = GeminiHeadlessAdapter(_make_config())
-        with patch("loa_cheval.providers.gemini_headless_adapter.subprocess.run") as mock_run:
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _ok_proc(SAMPLE_OK_JSON)
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})

--- a/.claude/adapters/tests/test_run_subprocess_pgkill.py
+++ b/.claude/adapters/tests/test_run_subprocess_pgkill.py
@@ -1,0 +1,116 @@
+"""Tests for run_subprocess_pgkill — the process-group-killing subprocess wrapper.
+
+This is the fix for the headless-completion hang (KF-014): the headless adapters
+previously used `subprocess.run(timeout=...)`, whose timeout cleanup SIGKILLs only
+the immediate child — orphaning the agentic CLI's grandchildren and presenting as
+an unbounded hang with no fallthrough. `run_subprocess_pgkill` runs the child in a
+new session (process group), reads with a bounded `select` loop, and on timeout
+SIGKILLs the WHOLE group, re-raising `subprocess.TimeoutExpired` so callers convert
+it to `ProviderUnavailableError` and the fallback chain advances.
+
+These use real `sh`/`sleep` subprocesses (no mocks) so they prove the actual
+process-group semantics. POSIX-only.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from loa_cheval.providers.base import (  # noqa: E402
+    build_headless_subprocess_env,
+    run_subprocess_pgkill,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix", reason="process-group semantics are POSIX-only"
+)
+
+
+def test_happy_path_parity_with_subprocess_run():
+    """returncode / stdout / stderr match subprocess.run(capture_output, text)."""
+    r = run_subprocess_pgkill(
+        ["sh", "-c", "echo hello; echo oops >&2; exit 3"],
+        timeout=5,
+        env=dict(os.environ),
+    )
+    assert isinstance(r, subprocess.CompletedProcess)
+    assert r.returncode == 3
+    assert r.stdout == "hello\n"
+    assert r.stderr == "oops\n"
+
+
+def test_stdin_input_is_pumped():
+    """`input=` is written to the child's stdin (codex passes input=prompt)."""
+    r = run_subprocess_pgkill(["cat"], input="PONG-via-stdin", timeout=5, env=dict(os.environ))
+    assert r.returncode == 0
+    assert r.stdout == "PONG-via-stdin"
+
+
+def test_timeout_raises_and_kills_whole_process_group(tmp_path):
+    """On timeout: raise TimeoutExpired AND kill the orphan grandchild (the fix).
+
+    subprocess.run would SIGKILL only the immediate child, leaving the
+    backgrounded grandchild alive. run_subprocess_pgkill killpg's the group.
+    """
+    pidfile = tmp_path / "grandchild.pid"
+    # immediate child backgrounds a grandchild that records its pid then sleeps,
+    # and the immediate child also sleeps -> nothing exits before the timeout.
+    fake_cli = [
+        "sh",
+        "-c",
+        f'sh -c "echo \\$\\$ > {pidfile}; exec sleep 120" & sleep 120',
+    ]
+    start = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_subprocess_pgkill(fake_cli, timeout=2, env=dict(os.environ))
+    elapsed = time.monotonic() - start
+    assert elapsed < 8, f"timeout not honored: {elapsed:.1f}s"
+
+    # The grandchild must be dead (process-group killed), not orphaned.
+    time.sleep(0.5)
+    assert pidfile.exists(), "grandchild never recorded its pid"
+    gc_pid = int(pidfile.read_text().strip())
+    with pytest.raises(ProcessLookupError):
+        os.kill(gc_pid, 0)  # raises ProcessLookupError iff the process is gone
+
+
+def test_setup_failure_does_not_orphan_the_child(tmp_path):
+    """An exception in the setup window (encode of a lone surrogate) still reaps
+    the already-spawned child via the finally->killpg path (no orphan)."""
+    pidfile = tmp_path / "child.pid"
+    fake_cli = ["sh", "-c", f"echo $$ > {pidfile}; exec sleep 60"]
+    with pytest.raises(UnicodeEncodeError):
+        run_subprocess_pgkill(fake_cli, input="bad\ud800surrogate", timeout=10, env=dict(os.environ))
+    time.sleep(0.4)
+    if pidfile.exists():
+        child_pid = int(pidfile.read_text().strip())
+        with pytest.raises(ProcessLookupError):
+            os.kill(child_pid, 0)
+
+
+def test_env_is_passed_through_and_stripped():
+    """The explicit env reaches the child; auth vars are stripped by the helper."""
+    parent = dict(os.environ)
+    parent["OPENAI_API_KEY"] = "sk-should-be-stripped"
+    r = run_subprocess_pgkill(
+        ["sh", "-c", "echo ${OPENAI_API_KEY:-STRIPPED}"],
+        timeout=5,
+        env=build_headless_subprocess_env(parent),
+    )
+    assert r.stdout.strip() == "STRIPPED"
+
+
+def test_missing_binary_raises_filenotfound():
+    """Same contract as subprocess.run: a missing binary raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        run_subprocess_pgkill(
+            ["/nonexistent/loa-pgkill-binary-xyz"], timeout=5, env=dict(os.environ)
+        )


### PR DESCRIPTION
## Summary

The three headless **completion** adapters (`codex` / `gemini` / `claude`) bound the agentic CLI with `subprocess.run(cmd, timeout=timeout_s)`. On timeout, `subprocess.run` SIGKILLs only the **immediate** child (no `start_new_session` / no `os.killpg`), so the CLI's helper **grandchildren are orphaned** and keep running (and keep consuming the rate-limited subscription). Combined with the ~610s framework-default per-provider timeout × the fallback chain, a single stalled/throttled headless CLI presents as an **unbounded multi-minute "hang" with no fallthrough** — the cheval fallback chain never advances because the call neither returns nor errors in a timely, tree-killing way.

`cycle-110` already ships the correct pattern in `doctor.py` (`Popen(start_new_session=True)` + streaming `select` read + `os.killpg(SIGKILL)` on `TimeoutExpired`) — but only on the health-probe path, **never the completion path** that runs reviews/audits/dissent. This PR closes that gap.

## Related Issues

Closes #982

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`providers/base.py`** — add `run_subprocess_pgkill(cmd, *, input=None, timeout, env, max_bytes=64MiB)`: a **drop-in** for `subprocess.run(capture_output=True, text=True, check=False)` that runs the child in its own process group, reads stdout/stderr with a byte-capped `select` loop (never `communicate()`), pumps `input` on a writer thread (no large-prompt deadlock), and on the wall-clock deadline `killpg(SIGKILL)`s the **whole tree** before re-raising `subprocess.TimeoutExpired`. Returns a `CompletedProcess` and raises `TimeoutExpired` + `FileNotFoundError` **identically** to `subprocess.run`. The setup window (encode / thread-start / fileno) is inside the `try`, so an exception there still reaps the just-spawned child via `finally → killpg` (no orphan).
- **`{codex,gemini,claude}_headless_adapter.py`** — route the completion call through `run_subprocess_pgkill`. Because the contract is identical, each adapter's existing `except subprocess.TimeoutExpired: raise ProviderUnavailableError` branch is unchanged and the fallback chain advances on a hang. `health_check`'s `--version` probe is unaffected (left on `subprocess.run` — it has no agentic grandchildren).
- **tests** — completion-path mocks re-targeted from `subprocess.run` → `run_subprocess_pgkill` (the `MagicMock(spec=CompletedProcess)` return values and `TimeoutExpired`/`FileNotFoundError` side-effects are contract-identical, so only the patch target changes). New `test_run_subprocess_pgkill.py` proves the fix with real subprocesses.

## Backward compatibility

Non-breaking. `run_subprocess_pgkill` is a behavioral superset of the previous `subprocess.run` call on the success path (same `returncode`/`stdout`/`stderr`); it only changes the **timeout** path from "kill immediate child, leak the tree" to "kill the whole group, raise `TimeoutExpired`". No public API, config, or wire change.

## Testing

- [x] Added/updated tests
- [x] All existing tests pass

```
# suites this PR touches — all green
pytest tests/test_codex_headless_adapter.py tests/test_gemini_headless_adapter.py \
       tests/test_claude_headless_adapter.py tests/test_run_subprocess_pgkill.py tests/test_doctor.py
# 141 passed, 3 skipped   (105 existing adapter tests unchanged-green + 6 new helper tests)
```

New `test_run_subprocess_pgkill.py` (real subprocesses, no mocks) covers: happy-path `returncode`/`stdout`/`stderr` parity, stdin pumping, **timeout → `TimeoutExpired` + grandchild process-group-killed (no orphan)**, setup-failure cleanup, env-strip, and `FileNotFoundError` parity.

End-to-end (downstream score-api, the originating repo): before this fix `adversarial-review.sh --type review` hung 17–36 min and had to be `pkill`'d by name; after, a hung/throttled CLI converts to `ProviderUnavailableError` at the timeout (chain advances) with the grandchild reaped, and the gate returns `status:clean` / `degraded:false` / verdict `APPROVED` in ~6s.

> Reviewer note: in my local checkout `test_streaming_transport.py` (httpx/h2 transport) and 4 `test_flatline_routing.py` shim tests fail **identically on pristine `main`** (a local httpx/h2 + shell-env gap) — i.e. pre-existing and unrelated to this change, verified by stashing the diff and re-running. They should be green in CI.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code (+ a 3-lens adversarial review: 0 BLOCKING/HIGH/MEDIUM)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
