### PR TITLE
fix(#942): next-bug-sprint-id.sh consults ledger cycle-claimed sprint ids (sprint-bug-180)

### DIFF
--- a/.claude/scripts/next-bug-sprint-id.sh
+++ b/.claude/scripts/next-bug-sprint-id.sh
@@ -15,6 +15,10 @@
 #      `grimoires/loa/a2a/bug-*/sprint.md`
 #   3. origin/main's ledger.json's `global_sprint_counter` (best-effort —
 #      no fetch; uses whatever's in the local refspec)
+#   4. max cycle-claimed global sprint id in `cycles[].sprints` +
+#      `bugfix_cycles[].sprints` of BOTH ledgers (issue #942 — the counter
+#      can lag behind ids already claimed by a planned cycle; observed live
+#      as counter=177 while cycle-114 claimed 177/178/179)
 # …and emits `sprint-bug-{max+1}` on stdout.
 #
 # Diagnostic-only output goes to stderr; stdout is exactly one line:
@@ -42,11 +46,28 @@ _log() { echo "[next-bug-sprint-id] $*" >&2; }
 
 command -v jq >/dev/null 2>&1 || { _log "ERROR: jq required"; exit 1; }
 
+# Max cycle-claimed global sprint id in a ledger (cycles[] + bugfix_cycles[]).
+# Handles both sprint entry shapes: objects with `global_id` and bare
+# "sprint-N" / "sprint-bug-N" strings. Malformed shapes degrade to 0.
+_CLAIMS_JQ='[
+  (.cycles[]?.sprints[]?, .bugfix_cycles[]?.sprints[]?)
+  | if type == "object" then .global_id
+    elif type == "string" then (capture("^sprint-(?:bug-)?(?<n>[0-9]+)$").n | tonumber)?
+    else empty end
+] | map(numbers) | max // 0'
+
 # 1. Local ledger's global_sprint_counter
 local_counter=0
 if [[ -f "$LEDGER" ]]; then
     local_counter=$(jq -r '.global_sprint_counter // 0' "$LEDGER" 2>/dev/null || echo 0)
     [[ "$local_counter" =~ ^[0-9]+$ ]] || local_counter=0
+fi
+
+# 1b. Max cycle-claimed global sprint id in the local ledger (issue #942)
+local_claims=0
+if [[ -f "$LEDGER" ]]; then
+    local_claims=$(jq -r "$_CLAIMS_JQ" "$LEDGER" 2>/dev/null || echo 0)
+    [[ "$local_claims" =~ ^[0-9]+$ ]] || local_claims=0
 fi
 
 # 2. Max sprint-bug-N on disk under grimoires/loa/a2a/bug-*/sprint.md
@@ -63,19 +84,24 @@ for f in "$PROJECT_ROOT"/grimoires/loa/a2a/bug-*/sprint.md; do
 done
 shopt -u nullglob
 
-# 3. origin/main's global_sprint_counter (best-effort, no fetch)
+# 3. origin/main's global_sprint_counter + cycle claims (best-effort, no fetch)
 origin_counter=0
+origin_claims=0
 if git -C "$PROJECT_ROOT" rev-parse "${REMOTE}/${BRANCH}" >/dev/null 2>&1; then
     if origin_blob=$(git -C "$PROJECT_ROOT" show "${REMOTE}/${BRANCH}:grimoires/loa/ledger.json" 2>/dev/null); then
         origin_counter=$(echo "$origin_blob" | jq -r '.global_sprint_counter // 0' 2>/dev/null || echo 0)
         [[ "$origin_counter" =~ ^[0-9]+$ ]] || origin_counter=0
+        origin_claims=$(echo "$origin_blob" | jq -r "$_CLAIMS_JQ" 2>/dev/null || echo 0)
+        [[ "$origin_claims" =~ ^[0-9]+$ ]] || origin_claims=0
     fi
 fi
 
-# Pick the max of all three, then increment
+# Pick the max of all sources, then increment
 next="$local_counter"
+[[ "$local_claims" -gt "$next" ]] && next="$local_claims"
 [[ "$disk_max" -gt "$next" ]] && next="$disk_max"
 [[ "$origin_counter" -gt "$next" ]] && next="$origin_counter"
+[[ "$origin_claims" -gt "$next" ]] && next="$origin_claims"
 next=$((next + 1))
 
 echo "sprint-bug-$next"

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1483,7 +1483,7 @@
       ]
     }
   ],
-  "global_sprint_counter": 177,
+  "global_sprint_counter": 180,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -1689,6 +1689,19 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260601-i971-727e7f/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260601-i971-727e7f/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260610-i942-0f917b",
+      "label": "Bug Fix — next-bug-sprint-id.sh emits colliding sprint ids (ignores ledger cycles[].sprints, #942)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/942",
+      "created_at": "2026-06-10T08:46:53Z",
+      "sprints": [
+        "sprint-bug-180"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260610-i942-0f917b/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260610-i942-0f917b/sprint.md"
     }
   ],
   "bugfixes": [
@@ -1706,5 +1719,5 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260428-i640-1cc190/sprint.md"
     }
   ],
-  "next_sprint_number": 180
+  "next_sprint_number": 181
 }

--- a/tests/unit/next-bug-sprint-id.bats
+++ b/tests/unit/next-bug-sprint-id.bats
@@ -154,3 +154,114 @@ EOF
     [[ "$(echo "$output" | wc -l)" == "1" ]]
     [[ "$output" =~ ^sprint-bug-[0-9]+$ ]]
 }
+
+# =============================================================================
+# Issue #942 — cycle-claimed global sprint ids in ledger cycles[].sprints /
+# bugfix_cycles[].sprints must be consulted. Observed live 2026-06-10:
+# global_sprint_counter=177 while cycle-114 claimed ids 177/178/179, so the
+# helper emitted sprint-bug-178 — colliding with cycle-114's sprint-178.
+# =============================================================================
+
+@test "issue#942: cycle-claimed object-shape ids beat a stale counter (live 177-vs-179 shape)" {
+    cat > "$PROJECT_ROOT/grimoires/loa/ledger.json" <<'EOF'
+{
+  "global_sprint_counter": 177,
+  "cycles": [
+    {
+      "cycle_id": "cycle-114-harness-modernization",
+      "sprints": [
+        {"id": "sprint-177", "global_id": 177},
+        {"id": "sprint-178", "global_id": 178},
+        {"id": "sprint-179", "global_id": 179}
+      ]
+    }
+  ],
+  "bugfix_cycles": []
+}
+EOF
+    cd "$PROJECT_ROOT" && git init --quiet
+    run bash "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sprint-bug-180" ]]
+}
+
+@test "issue#942: string-shape sprint claims in cycles[].sprints are consulted" {
+    cat > "$PROJECT_ROOT/grimoires/loa/ledger.json" <<'EOF'
+{
+  "global_sprint_counter": 50,
+  "cycles": [
+    {"cycle_id": "cycle-x", "sprints": ["sprint-184", "sprint-bug-185"]}
+  ],
+  "bugfix_cycles": []
+}
+EOF
+    cd "$PROJECT_ROOT" && git init --quiet
+    run bash "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sprint-bug-186" ]]
+}
+
+@test "issue#942: bugfix_cycles[].sprints claims are consulted too" {
+    cat > "$PROJECT_ROOT/grimoires/loa/ledger.json" <<'EOF'
+{
+  "global_sprint_counter": 50,
+  "cycles": [],
+  "bugfix_cycles": [
+    {"cycle_id": "cycle-bug-x", "sprints": [{"id": "sprint-bug-240", "global_id": 240}]}
+  ]
+}
+EOF
+    cd "$PROJECT_ROOT" && git init --quiet
+    run bash "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sprint-bug-241" ]]
+}
+
+@test "issue#942: malformed cycles/bugfix_cycles keys degrade gracefully to other sources" {
+    cat > "$PROJECT_ROOT/grimoires/loa/ledger.json" <<'EOF'
+{
+  "global_sprint_counter": 50,
+  "cycles": "not-an-array",
+  "bugfix_cycles": [
+    {"cycle_id": "ok", "sprints": [42, "weird-entry", {"id": "no-global-id"}]},
+    {"cycle_id": "no-sprints-key"}
+  ]
+}
+EOF
+    cd "$PROJECT_ROOT" && git init --quiet
+    run bash "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sprint-bug-51" ]]
+}
+
+@test "issue#942: origin/main ledger's cycle claims are consulted (not just its counter)" {
+    cd "$PROJECT_ROOT" && git init --quiet
+    git config user.email "test@example.com"
+    git config user.name "Test"
+
+    local upstream="$BATS_TEST_TMPDIR/upstream-claims"
+    mkdir -p "$upstream/grimoires/loa"
+    cat > "$upstream/grimoires/loa/ledger.json" <<'EOF'
+{
+  "global_sprint_counter": 300,
+  "cycles": [
+    {"cycle_id": "cycle-y", "sprints": [{"id": "sprint-310", "global_id": 310}]}
+  ],
+  "bugfix_cycles": []
+}
+EOF
+    (
+        cd "$upstream" && git init --quiet
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m init
+        git checkout -b main 2>/dev/null || true
+    )
+    cd "$PROJECT_ROOT"
+    git remote add origin "$upstream" 2>/dev/null || true
+    git fetch --quiet origin main 2>/dev/null || skip "could not set up upstream fetch"
+
+    _write_ledger 50
+    run bash "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sprint-bug-311" ]]
+}


### PR DESCRIPTION
## What

`next-bug-sprint-id.sh` consulted three id sources (local counter, `bug-*/sprint.md` disk scan, origin counter) but never the ledger's cycle-claimed sprint ids. **Live failure**: with `global_sprint_counter=177` and cycle-114 claiming global ids 177/178/179, the helper emitted `sprint-bug-178` — a guaranteed collision on the next `/bug` invocation.

## Fix

Fourth max source: a shared `_CLAIMS_JQ` filter over `cycles[].sprints` + `bugfix_cycles[].sprints` in **both** ledgers (local + the origin blob the script already fetches), handling both entry shapes (object `{global_id}` and string `"sprint-(bug-)?N"`). All new jq outputs pass the existing `^[0-9]+$` validation gate before any arithmetic — a malformed/malicious ledger degrades that source to 0 and the max over remaining sources still holds the never-reuse invariant (fail direction is id gaps, never collisions).

## Tests (test-first)

5 new bats cases in `tests/unit/next-bug-sprint-id.bats`: the pinned live 177-vs-179 shape, string shape, `bugfix_cycles` array, malformed-keys degradation guard, origin-claims. Pre-fix: `not ok 9,10,11,13`. Post-fix: **13/13 ok** (test 6's env-dependent skip pre-existing).

Ledger: counter resynced 177→180 by the `/bug` triage that minted sprint-bug-180.

## Process

Full gate cycle per Loa process: `/bug` (triage, eligibility 4/4) → `/implement sprint-bug-180` → `/review-sprint` (**approved**; cross-model gpt-5.5-pro: 0 findings, verdict_quality APPROVED, KF-004 suspicion-lens checked) → `/audit-sprint` (**APPROVED**; cross-model audit: 0 findings; arithmetic-injection gate verified; COMPLETED marker written).

Wave context: first item of the pre-OSS-release hardening wave (`grimoires/loa/proposals/oss-release-wave-triage-2026-06-10.md`, bundle H) — sequenced first because every subsequent `/bug` micro-sprint depends on safe id minting.

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)