### PR TITLE
fix(#992): drop TruffleHog base/head pin that zeroed main secret-scan coverage (sprint-bug-187)

### DIFF
--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -31,6 +31,7 @@ on:
       - 'tests/run-unit-tests.sh'
       - 'grimoires/loa/runbooks/curl-mock-harness.md'  # BB iter-1 FIND-005
       - '.github/workflows/bats-tests.yml'
+      - '.github/workflows/secret-scanning.yml' # bug-992: contract test pins this workflow's shape
   pull_request:
     branches: [main]
     paths:
@@ -44,6 +45,7 @@ on:
       - 'tests/run-unit-tests.sh'
       - 'grimoires/loa/runbooks/curl-mock-harness.md'  # BB iter-1 FIND-005
       - '.github/workflows/bats-tests.yml'
+      - '.github/workflows/secret-scanning.yml' # bug-992: contract test pins this workflow's shape
 
 permissions:
   contents: read

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -33,8 +33,6 @@ jobs:
         uses: trufflesecurity/trufflehog@7f4e37db2d928c18ddd7ddf0604f8f7d1f5793ec # v3.93.0
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
           extra_args: --only-verified
 
       - name: Run GitLeaks

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1481,9 +1481,22 @@
           "created": "2026-06-01T04:11:15Z"
         }
       ]
+    },
+    {
+      "id": "cycle-bug-20260610-i992-8fc4da",
+      "label": "Bug Fix — secret-scanning.yml TruffleHog base==HEAD on push/schedule — zero scan coverage on main",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/992",
+      "created_at": "2026-06-10T09:21:02Z",
+      "sprints": [
+        "sprint-bug-187"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260610-i992-8fc4da/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260610-i992-8fc4da/sprint.md"
     }
   ],
-  "global_sprint_counter": 180,
+  "global_sprint_counter": 187,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -1719,5 +1732,5 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260428-i640-1cc190/sprint.md"
     }
   ],
-  "next_sprint_number": 181
+  "next_sprint_number": 188
 }

--- a/tests/unit/bug-992-secret-scanning-base-head.bats
+++ b/tests/unit/bug-992-secret-scanning-base-head.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# =============================================================================
+# bug-992-secret-scanning-base-head.bats — contract test for issue #992
+# =============================================================================
+# secret-scanning.yml passed `base: <default_branch>` / `head: HEAD` to the
+# TruffleHog action. On push-to-main and schedule events both resolve to the
+# same commit and the action exits 1 with "BASE and HEAD commits are the
+# same. TruffleHog won't scan anything." — every main push and the weekly
+# history scan was red AND performed zero actual scanning. The action handles
+# push/PR/schedule natively when base/head are omitted.
+#
+# Shape assertions follow the bug-887 workflow-contract precedent: yq against
+# the workflow file; no GH event context needed.
+# =============================================================================
+
+WORKFLOW=".github/workflows/secret-scanning.yml"
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+    WF="$REPO_ROOT/$WORKFLOW"
+    [[ -f "$WF" ]] || skip "workflow file not found"
+    command -v yq >/dev/null || skip "yq required"
+}
+
+@test "bug-992: TruffleHog step exists, SHA-pinned (mutable refs like @main rejected)" {
+    run yq eval '.jobs.scan-secrets.steps[] | select(.id == "trufflehog") | .uses' "$WF"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ ^trufflesecurity/trufflehog@[0-9a-f]{40}$ ]]
+}
+
+@test "bug-992: TruffleHog step has NO with.base (base==HEAD kills push/schedule scans)" {
+    run yq eval '.jobs.scan-secrets.steps[] | select(.id == "trufflehog") | .with | has("base")' "$WF"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "false" ]]
+}
+
+@test "bug-992: TruffleHog step has NO with.head (base==HEAD kills push/schedule scans)" {
+    run yq eval '.jobs.scan-secrets.steps[] | select(.id == "trufflehog") | .with | has("head")' "$WF"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "false" ]]
+}
+
+@test "bug-992: regression guard — with.path and extra_args preserved" {
+    run yq eval '.jobs.scan-secrets.steps[] | select(.id == "trufflehog") | .with.path' "$WF"
+    [[ "$output" == "./" ]]
+    run yq eval '.jobs.scan-secrets.steps[] | select(.id == "trufflehog") | .with.extra_args' "$WF"
+    [[ "$output" == "--only-verified" ]]
+}
+
+@test "bug-992: regression guard — checkout fetch-depth 0 preserved (full-history scan)" {
+    run yq eval '.jobs.scan-secrets.steps[] | select(.uses | test("actions/checkout")) | .with.fetch-depth' "$WF"
+    [[ "$output" == "0" ]]
+}
+
+@test "bug-992: regression guard — push/pull_request/schedule triggers preserved" {
+    # note: yq needs the bracket form for the "on" key and parenthesized has() chains
+    run yq eval '(.["on"] | has("push")) and (.["on"] | has("pull_request")) and (.["on"] | has("schedule"))' "$WF"
+    [[ "$output" == "true" ]]
+    run yq eval '.["on"].schedule[0].cron' "$WF"
+    [[ "$output" == "0 2 * * 1" ]]
+}


### PR DESCRIPTION
## What

`secret-scanning.yml` passed `base: ${{ github.event.repository.default_branch }}` / `head: HEAD` to TruffleHog. On push-to-main and schedule events both resolve to the same commit → the action exits 1 with "BASE and HEAD commits are the same. TruffleHog won't scan anything." Every main push and the weekly history scan has been red since at least 2026-05-22 — **and actual scan coverage on main was silently zero**. PR runs were unaffected (PR head ≠ main).

Fix: remove the two inputs (the action handles push/PR/schedule natively). Strictly shrinks the `${{ }}` expression surface; SHA pin untouched.

## Audit-loop hardening (KF-004 sidecar save)

The cross-model audit's headline was "0 findings" but `rejected_count: 2` — two real MEDIUM findings recovered from the rejected-payloads sidecar and fixed in iteration 2:

1. **bats-tests.yml path filters didn't include `secret-scanning.yml`** — the new contract test would never run on workflow-only changes. Added to both push and pull_request paths.
2. **The pinned-action assertion accepted mutable refs** (`@main` passed the glob). Now asserts `^trufflesecurity/trufflehog@[0-9a-f]{40}$`.

## Tests

`tests/unit/bug-992-secret-scanning-base-head.bats` — 6 contract cases (yq workflow-shape, bug-887 precedent): base/head-absence assertions failed pre-fix; 6/6 green post-fix; regression guards pin SHA-pin, path/extra_args, fetch-depth 0, and all three triggers.

## ⚠️ Expectation for the next scheduled run

The weekly scan will scan history that was **never actually scanned before**. A red run with real findings post-merge would be the system working, not a regression from this PR.

## Process

`/bug` → `/implement` → `/review-sprint` (approved; cross-model 0 findings, genuine zero) → `/audit-sprint` iter-1 (**CHANGES_REQUIRED** via sidecar-recovered findings) → `/implement` iter-2 → `/audit-sprint` iter-2 (**APPROVED**, COMPLETED). Wave: bundle A of `grimoires/loa/proposals/oss-release-wave-triage-2026-06-10.md`.

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)