### PR TITLE
fix(#886): bats-tests.yml installs pinned Python deps before tests/unit (sprint-bug-188)

### DIFF
--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -88,7 +88,11 @@ jobs:
           # consumers previously leaned on ubuntu's system python3-yaml (PR #996
           # empirical run: omitting it broke 182 tests). Pin matches
           # cycle099-sprint-2d-c-ts-tests.yml.
-          pip install 'rfc8785==0.1.4' 'jsonschema==4.26.0' 'ruamel.yaml==0.18.17' 'cryptography==46.0.7' 'pyyaml==6.0.2'
+          # idna: endpoint-validator's Unicode hostname canonicalization
+          # (lib/endpoint-validator.sh:39 requires idna>=3.6) — system python has
+          # it, the clean env does not (PR #996 run 2: broke the guarded_curl
+          # chain behind call_api / 401-handler suites).
+          pip install 'rfc8785==0.1.4' 'jsonschema==4.26.0' 'ruamel.yaml==0.18.17' 'cryptography==46.0.7' 'pyyaml==6.0.2' 'idna==3.10'
 
       # NOTE: yq install step is below (line ~85) and is pre-existing on main.
       # cycle-102 Sprint 1C T1C.1 made yq a hard requirement for the curl-mock

--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -84,7 +84,11 @@ jobs:
           # Pins match cycle099-sprint-1e-tests.yml (ruamel.yaml, jsonschema),
           # the jcs-conformance suite (rfc8785), and ubuntu-latest's
           # cryptography floor. Keep pin sites in sync when rotating.
-          pip install 'rfc8785==0.1.4' 'jsonschema==4.26.0' 'ruamel.yaml==0.18.17' 'cryptography==46.0.7'
+          # pyyaml: setup-python creates a CLEAN env — the suite's 16+ `import yaml`
+          # consumers previously leaned on ubuntu's system python3-yaml (PR #996
+          # empirical run: omitting it broke 182 tests). Pin matches
+          # cycle099-sprint-2d-c-ts-tests.yml.
+          pip install 'rfc8785==0.1.4' 'jsonschema==4.26.0' 'ruamel.yaml==0.18.17' 'cryptography==46.0.7' 'pyyaml==6.0.2'
 
       # NOTE: yq install step is below (line ~85) and is pre-existing on main.
       # cycle-102 Sprint 1C T1C.1 made yq a hard requirement for the curl-mock

--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -69,6 +69,23 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci@example.com"
 
+      # PINNING: SHA matches the actions/setup-python v5.3.0 pin used by
+      # cycle099-sprint-1e-tests.yml and jcs-conformance.yml. Rotate together.
+      # bug-886: tests/unit/ exercises lib/jcs.sh (rfc8785), trust-store
+      # signing (rfc8785 + cryptography), and yaml/schema suites
+      # (ruamel.yaml + jsonschema) — without these installs ~22 bats fail.
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.13'
+
+      - name: Install Python deps for bats suites
+        run: |
+          python -m pip install --upgrade pip
+          # Pins match cycle099-sprint-1e-tests.yml (ruamel.yaml, jsonschema),
+          # the jcs-conformance suite (rfc8785), and ubuntu-latest's
+          # cryptography floor. Keep pin sites in sync when rotating.
+          pip install 'rfc8785==0.1.4' 'jsonschema==4.26.0' 'ruamel.yaml==0.18.17' 'cryptography==46.0.7'
+
       # NOTE: yq install step is below (line ~85) and is pre-existing on main.
       # cycle-102 Sprint 1C T1C.1 made yq a hard requirement for the curl-mock
       # harness shim (per BB iter-1 F1/FIND-001: tool absence must be a hard

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1494,9 +1494,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260610-i992-8fc4da/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260610-i992-8fc4da/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260610-i886-b5cddf",
+      "label": "Bug Fix — bats-tests.yml runs tests/unit/ without installing Python dependencies",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/886",
+      "created_at": "2026-06-10T10:00:12Z",
+      "sprints": [
+        "sprint-bug-188"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260610-i886-b5cddf/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260610-i886-b5cddf/sprint.md"
     }
   ],
-  "global_sprint_counter": 187,
+  "global_sprint_counter": 188,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/bug-886-bats-tests-python-deps.bats
+++ b/tests/unit/bug-886-bats-tests-python-deps.bats
@@ -41,6 +41,9 @@ setup() {
     # pyyaml: fresh setup-python env loses ubuntu's system python3-yaml;
     # 16+ suites `import yaml` (PR #996 run 27268920412: 182 failures without it)
     [[ "$output" == *"pyyaml==6.0.2"* ]]
+    # idna: endpoint-validator hard dep (lib/endpoint-validator.sh:39); absent
+    # from clean env -> guarded_curl chain fails (PR #996 run 27269518686)
+    [[ "$output" == *"idna==3.10"* ]]
 }
 
 @test "bug-886: pip-install step runs BEFORE the unit-test step" {

--- a/tests/unit/bug-886-bats-tests-python-deps.bats
+++ b/tests/unit/bug-886-bats-tests-python-deps.bats
@@ -38,6 +38,9 @@ setup() {
     [[ "$output" == *"jsonschema==4.26.0"* ]]
     [[ "$output" == *"ruamel.yaml==0.18.17"* ]]
     [[ "$output" == *"cryptography==46.0.7"* ]]
+    # pyyaml: fresh setup-python env loses ubuntu's system python3-yaml;
+    # 16+ suites `import yaml` (PR #996 run 27268920412: 182 failures without it)
+    [[ "$output" == *"pyyaml==6.0.2"* ]]
 }
 
 @test "bug-886: pip-install step runs BEFORE the unit-test step" {

--- a/tests/unit/bug-886-bats-tests-python-deps.bats
+++ b/tests/unit/bug-886-bats-tests-python-deps.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# =============================================================================
+# bug-886-bats-tests-python-deps.bats — contract test for issue #886
+# =============================================================================
+# bats-tests.yml ran tests/unit/ with no Python-deps install step: ~22 of the
+# 68 main-red bats failures were dependency-shaped — 16 "jcs: 'rfc8785' Python
+# package not installed" (lib/jcs.sh:48-49), 4 ModuleNotFoundError: rfc8785
+# (trust-store-root signing), plus ruamel.yaml/jsonschema casualties.
+# Canonical pattern mirrored: cycle099-sprint-1e-tests.yml (setup-python
+# v5.3.0 SHA pin) + jcs-conformance.yml (rfc8785 precedent).
+# Shape assertions per the bug-992 precedent (yq v4: bracket form for "on",
+# parenthesized has() chains).
+# =============================================================================
+
+WORKFLOW=".github/workflows/bats-tests.yml"
+SETUP_PYTHON_SHA="0b93645e9fea7318ecaed2b359559ac225c90a2b"
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+    WF="$REPO_ROOT/$WORKFLOW"
+    [[ -f "$WF" ]] || skip "workflow file not found"
+    command -v yq >/dev/null || skip "yq required"
+}
+
+@test "bug-886: SHA-pinned setup-python step exists in bats job (mutable refs rejected)" {
+    run yq eval '.jobs.bats.steps[] | select(.uses | test("actions/setup-python")) | .uses' "$WF"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ ^actions/setup-python@[0-9a-f]{40}$ ]]
+    [[ "$output" == "actions/setup-python@${SETUP_PYTHON_SHA}" ]]
+    run yq eval '.jobs.bats.steps[] | select(.uses | test("actions/setup-python")) | .with.python-version' "$WF"
+    [[ "$output" == "3.13" ]]
+}
+
+@test "bug-886: pip-install step includes all four pinned packages" {
+    run yq eval '.jobs.bats.steps[] | select(.name == "Install Python deps for bats suites") | .run' "$WF"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"rfc8785==0.1.4"* ]]
+    [[ "$output" == *"jsonschema==4.26.0"* ]]
+    [[ "$output" == *"ruamel.yaml==0.18.17"* ]]
+    [[ "$output" == *"cryptography==46.0.7"* ]]
+}
+
+@test "bug-886: pip-install step runs BEFORE the unit-test step" {
+    names=$(yq eval '.jobs.bats.steps[].name // .jobs.bats.steps[].uses' "$WF" 2>/dev/null || true)
+    # robust index extraction: list step names with line numbers
+    install_idx=$(yq eval '[.jobs.bats.steps[].name] | to_entries | .[] | select(.value == "Install Python deps for bats suites") | .key' "$WF")
+    run_idx=$(yq eval '[.jobs.bats.steps[].name] | to_entries | .[] | select(.value == "Run framework unit tests") | .key' "$WF")
+    [[ -n "$install_idx" && "$install_idx" != "null" ]]
+    [[ -n "$run_idx" && "$run_idx" != "null" ]]
+    [[ "$install_idx" -lt "$run_idx" ]]
+}
+
+@test "bug-886: regression guard — bats-core and yq install steps preserved" {
+    run yq eval '[.jobs.bats.steps[].name] | contains(["Install bats-core v1.13.0"])' "$WF"
+    [[ "$output" == "true" ]]
+    run yq eval '[.jobs.bats.steps[].name // ""] | map(select(test("yq"))) | length > 0' "$WF"
+    [[ "$output" == "true" ]]
+}
+
+@test "bug-886: regression guard — path filters still cover tests/unit and the workflow" {
+    run yq eval '(.["on"].push.paths | contains(["tests/unit/**"])) and (.["on"].pull_request.paths | contains(["tests/unit/**"]))' "$WF"
+    [[ "$output" == "true" ]]
+    run yq eval '(.["on"].push.paths | contains([".github/workflows/bats-tests.yml"]))' "$WF"
+    [[ "$output" == "true" ]]
+}


### PR DESCRIPTION
## What

The Shell Tests job ran `tests/unit/` with no Python environment setup. ~22 of main's 68 red bats are dependency-shaped (`rfc8785` missing for `lib/jcs.sh` + trust-store signing; `ruamel.yaml`/`jsonschema` casualties). This inserts a SHA-pinned `setup-python` (same v5.3.0 pin as the two canonical sites) + one pinned 4-package install before the test run.

## Empirical gate

**Baseline**: 68 `not ok` on run [27267595538](https://github.com/0xHoneyJar/loa/actions/runs/27267595538). **This PR's Shell Tests run is the proof** — expect ~46 with zero `rfc8785` signatures (newly-unskipped tests may shift the count; that's recovered signal, not regression). First PR of the #953 CI-green sequence.

## Tests

`tests/unit/bug-886-bats-tests-python-deps.bats` — 5 contract cases (3 failed pre-fix): SHA-pin enforcement (mutable refs rejected), 4-package pins, install-before-test ordering, bats-core/yq + path-filter guards.

## Cross-model note

DISS-001 ADVISORY: direct pins but no `--require-hashes` (transitives free). Matches the repo-wide convention; a hashed-requirements migration across all workflows is recommended as a follow-up on #953 close-out rather than forking the convention here.

## Process

`/bug` → `/implement` → `/review-sprint` (approved with noted concerns) → `/audit-sprint` (APPROVED, COMPLETED). Wave bundle A, item 1 of `grimoires/loa/proposals/oss-release-wave-triage-2026-06-10.md`.

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)