### PR TITLE
Bundle B: kernel hash lifecycle (#989) + worktree pre-commit hook (#991) — sprint-bug-189/190

### DIFF
--- a/.claude/loa/CLAUDE.loa.md
+++ b/.claude/loa/CLAUDE.loa.md
@@ -1,4 +1,4 @@
-<!-- @loa-managed: true | version: 1.94.0 | hash: 5c812c0a8bd9b617722e55ab233f92f5c76afd006bfb36cb79afeb312cee1329PLACEHOLDER -->
+<!-- @loa-managed: true | version: 1.173.3 | hash: 3824353f16dfd31c7a7552fdbf7ae154797685ca95a203ff433aeb797ffde6d4 -->
 <!-- WARNING: This file is managed by the Loa Framework. Do not edit directly. -->
 
 # Loa Framework Instructions

--- a/.claude/loa/CLAUDE.loa.md
+++ b/.claude/loa/CLAUDE.loa.md
@@ -1,4 +1,4 @@
-<!-- @loa-managed: true | version: 1.173.3 | hash: 3824353f16dfd31c7a7552fdbf7ae154797685ca95a203ff433aeb797ffde6d4 -->
+<!-- @loa-managed: true | version: 1.173.6 | hash: 3824353f16dfd31c7a7552fdbf7ae154797685ca95a203ff433aeb797ffde6d4 -->
 <!-- WARNING: This file is managed by the Loa Framework. Do not edit directly. -->
 
 # Loa Framework Instructions

--- a/.claude/scripts/git-hooks/pre-commit-beads
+++ b/.claude/scripts/git-hooks/pre-commit-beads
@@ -52,7 +52,15 @@ fi
 br_stderr=$(mktemp)
 trap 'rm -f "$br_stderr"' EXIT
 
-if br sync --flush-only >/dev/null 2>"$br_stderr"; then
+# bug-991 / KF-014: br resolves .beads/ from CWD. In a linked worktree the
+# CWD has no .beads, so run the flush from the main checkout root (the
+# MAIN_REPO_ROOT already resolved above). Subshell keeps the hook's own CWD.
+BR_RUN_DIR="."
+if [ -n "${MAIN_REPO_ROOT:-}" ] && [ "$BEADS_DIR" = "$MAIN_REPO_ROOT/.beads" ]; then
+    BR_RUN_DIR="$MAIN_REPO_ROOT"
+fi
+
+if (cd "$BR_RUN_DIR" && br sync --flush-only) >/dev/null 2>"$br_stderr"; then
     # Success path — stage updated JSONL if applicable
     if [ -f "$BEADS_DIR/issues.jsonl" ]; then
         if [ "$(git rev-parse --git-dir)" = "$(git rev-parse --git-common-dir)" ]; then

--- a/.claude/scripts/lint-invariants.sh
+++ b/.claude/scripts/lint-invariants.sh
@@ -117,6 +117,27 @@ check_claude_md() {
   else
     report "WARN" "claude-md" "CLAUDE.loa.md missing @loa-managed header"
   fi
+
+  # bug-989: verify the header integrity hash. WARN-only by design — drift is
+  # informational (operators re-stamp via marker-utils.sh update-hash), never
+  # a lint blocker. marker-utils resolves relative to THIS script's dir so the
+  # check works regardless of caller CWD.
+  local lint_dir
+  lint_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local hash_status
+  hash_status=$(bash "$lint_dir/marker-utils.sh" verify-hash "$file" 2>/dev/null || echo "NO_HASH")
+  case "$hash_status" in
+    VALID) report "PASS" "claude-md" "CLAUDE.loa.md header integrity hash verifies (VALID)" ;;
+    *)     report "WARN" "claude-md" "CLAUDE.loa.md header integrity hash check: ${hash_status} — re-stamp via .claude/scripts/marker-utils.sh update-hash" ;;
+  esac
+
+  # bug-989 review DISS-001: verify_hash compares the hex PREFIX only, so a
+  # header glued by the pre-fix update_hash ("<correct-hex>PLACEHOLDER") still
+  # verifies VALID. Flag the residue independently so installed-base repos get
+  # the re-stamp signal too.
+  if head -1 "$file" | grep -q 'PLACEHOLDER'; then
+    report "WARN" "claude-md" "CLAUDE.loa.md header carries a PLACEHOLDER residue — re-stamp via .claude/scripts/marker-utils.sh update-hash"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/.claude/scripts/marker-utils.sh
+++ b/.claude/scripts/marker-utils.sh
@@ -356,8 +356,10 @@ update_hash() {
       return 1
     fi
   else
-    # Replace the hash value in the marker line
-    sed "s/\(${MARKER_PREFIX}.*hash: \)[a-f0-9]*/\1${new_hash}/" "$file" > "$temp_file"
+    # Replace the hash value in the marker line. The bootstrap form carries a
+    # literal "PLACEHOLDER" suffix glued to the hex (bug-989) — consume it so
+    # the first real stamp drops it instead of gluing the new hash in front.
+    sed "s/\(${MARKER_PREFIX}.*hash: \)[a-f0-9]*\(PLACEHOLDER\)\{0,1\}/\1${new_hash}/" "$file" > "$temp_file"
   fi
 
   mv "$temp_file" "$file"

--- a/.claude/scripts/update-loa-bump-version.sh
+++ b/.claude/scripts/update-loa-bump-version.sh
@@ -144,8 +144,9 @@ bump_version_json() {
 # Header format:
 #   <!-- @loa-managed: true | version: X.Y.Z | hash: <hash>PLACEHOLDER -->
 #
-# Idempotent: no-op if version already matches target. Preserves the hash
-# segment (and its PLACEHOLDER suffix) untouched.
+# Idempotent: no-op if version already matches target. On a real bump the
+# integrity hash is re-stamped via marker-utils.sh update-hash (bug-989);
+# the bootstrap PLACEHOLDER suffix is dropped on first stamp.
 # -----------------------------------------------------------------------------
 bump_claude_loa_header() {
     local target="$1"
@@ -180,6 +181,16 @@ bump_claude_loa_header() {
     } { print }' "$file" > "$tmp"
     mv "$tmp" "$file"
     _log "Bumped $file header version: $current_version → $target"
+
+    # bug-989: refresh the integrity hash after rewriting the header. The hash
+    # covers content below line 1 (marker excluded by compute_hash), so
+    # stamping post-bump is stable across future version-only bumps. Failure
+    # is non-fatal — lint-invariants surfaces a stale hash as WARN.
+    if bash "$SCRIPT_DIR/marker-utils.sh" update-hash "$file" >/dev/null 2>&1; then
+        _log "Stamped integrity hash in $file header"
+    else
+        _log "WARN: could not stamp integrity hash in $file (marker-utils update-hash failed)"
+    fi
 }
 
 # -----------------------------------------------------------------------------

--- a/.loa-version.json
+++ b/.loa-version.json
@@ -1,7 +1,7 @@
 {
-  "framework_version": "1.173.3",
+  "framework_version": "1.173.6",
   "schema_version": 2,
-  "last_sync": "2026-06-10T12:38:23Z",
+  "last_sync": "2026-06-10T13:26:47Z",
   "zones": {
     "system": ".claude",
     "state": [

--- a/.loa-version.json
+++ b/.loa-version.json
@@ -1,7 +1,7 @@
 {
-  "framework_version": "1.173.0",
+  "framework_version": "1.173.3",
   "schema_version": 2,
-  "last_sync": "2026-06-01T06:37:58Z",
+  "last_sync": "2026-06-10T12:38:23Z",
   "zones": {
     "system": ".claude",
     "state": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.173.6] — 2026-06-10 — Pre-OSS-release hardening wave (patch rollup 1.173.1–1.173.6)
+
+Tag-only patch releases consolidated. Full triage + wave plan: `grimoires/loa/proposals/oss-release-wave-triage-2026-06-10.md`.
+
+### Fixed
+- **CLAUDE.loa.md always-loaded budget cut 56%** (8,923 → 3,927 tokens/turn): L1–L7 agent-network constraint tables, multi-model detail, and safety-hooks detail moved byte-verbatim to on-demand reference files behind a MUST-read routing table; all `@constraint-generated` blocks byte-identical (#988, PR #990 → v1.173.3).
+- **`next-bug-sprint-id.sh` sprint-id collisions**: cycle-claimed global ids in `ledger.json` `cycles[].sprints`/`bugfix_cycles[].sprints` (both shapes, both local + origin ledgers) now consulted; live 177-vs-179 collision shape pinned by bats (#942, PR #993 → v1.173.4).
+- **Secret scanning silently zero on main**: removed the TruffleHog `base`/`head` pin that made every push-to-main and weekly scheduled scan exit with "BASE and HEAD commits are the same" — first green (and first actual) main scan since 2026-05-22; contract test pins the workflow shape + SHA-pinned action (#992, PR #994 → v1.173.5).
+- **Shell Tests dependency failures (68 → 50)**: `bats-tests.yml` now installs pinned Python deps (`rfc8785`, `jsonschema`, `ruamel.yaml`, `cryptography`, `pyyaml`, `idna`) under a SHA-pinned setup-python before `tests/unit/`; two additional missing pins discovered by the PR's own empirical CI gate (#886, PR #996 → v1.173.6).
+- Tracker hygiene: 9 stale/resolved issues closed with evidence; KF-014 filed (#991) and `secret-scanning` misconfig filed (#992).
+
 ## [1.173.0] — 2026-06-01 — Harness Modernization: Opus 4.8
 
 Cycle-114 (`/oracle` audit-driven). 9 framework improvements + 1 ADR, all additive/opt-in and test-first (55 new bats + 14 pytest). PR #970.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Power user interface: 48 slash commands (truenames).
 Architecture: Three-zone model (System: .claude/, State: grimoires/ + .beads/, App: src/).
 Configuration: .loa.config.yaml (user-owned, never modified by framework).
 Health check: /loa doctor
-Version: 1.173.0
+Version: 1.173.3
 -->
 
-[![Version](https://img.shields.io/badge/version-1.173.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.173.3-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE.md)
 [![Release](https://img.shields.io/badge/release-v1.173.0%20Opus%204.8-purple.svg)](CHANGELOG.md#11730---2026-06-01)
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Power user interface: 48 slash commands (truenames).
 Architecture: Three-zone model (System: .claude/, State: grimoires/ + .beads/, App: src/).
 Configuration: .loa.config.yaml (user-owned, never modified by framework).
 Health check: /loa doctor
-Version: 1.173.3
+Version: 1.173.6
 -->
 
-[![Version](https://img.shields.io/badge/version-1.173.3-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.173.6-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE.md)
 [![Release](https://img.shields.io/badge/release-v1.173.0%20Opus%204.8-purple.svg)](CHANGELOG.md#11730---2026-06-01)
 

--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -67,7 +67,7 @@ actually tried, not just what someone *said* was tried.
 | [KF-011](#kf-011-adversarial-reviewsh-malformed-response-on-review-type-prompts-post-kf-002-closure) | **RESOLVED 2026-05-17** (sub-mode (b): parser raw_decode extracts prose-prefixed JSON — PR #933 `d9ec8cb5`; sub-mode (c): route-around via 4-voice fallback chain — PR #934 `ccd510b0`; structural sub-mode (c) Gemini streaming-recovery tracked at issue #935). | adversarial-review.sh review-type — JSON contract layer + Gemini streaming-recovery gap | 2 (initial obs sprint-166 review + repro on parser-fix branch) |
 | [KF-012](#kf-012-sha256sum-not-portable-to-bsd-macos-silent-empty-hash-cascade-into-validation-failures) | **RESOLVED-STRUCTURAL 2026-05-20** (sprint-bug-172 / #911: `sha256_portable` helper in compat-lib.sh + 38 production call sites migrated + CI scanner `tools/check-no-raw-sha256sum.sh` + `tests/unit/compat-lib-sha256.bats` + masked-PATH integration test). Structural analog of cycle-099 sprint-1E.c.3.c curl wrapper migration. | macOS / BSD users of `/butterfreezone-gen` + 37 other framework scripts | 1 (single observation, sprint-bug-172 closure) |
 | [KF-013](#kf-013-headless-cli-env-mode-selector-vars-defeat-subscription-oauth) | **RESOLVED 2026-05-20** (sprint-bug-173 / #894: `_HEADLESS_STRIPPED_AUTH_VARS` tuple extended with `GOOGLE_GENAI_USE_VERTEXAI` + `GOOGLE_GENAI_USE_GCA`; canonical scrub list mirrors `construct-k-hole/scripts/dig-search.ts`). | cheval headless CLI adapters (gemini / codex / claude) | 1 (single observation, sprint-bug-173 closure) |
-| [KF-014](#kf-014-pre-commit-beads-hook-fails-in-linked-git-worktrees) | OPEN (upstream [#991](https://github.com/0xHoneyJar/loa/issues/991)) | pre-commit beads flush in linked worktrees | 1 |
+| [KF-014](#kf-014-pre-commit-beads-hook-fails-in-linked-git-worktrees) | **RESOLVED 2026-06-10** (sprint-bug-190 / #991: hook flushes from MAIN_REPO_ROOT subshell in worktrees; PCB-T7/T8/T9 pin it; live worktree-commit verification) | pre-commit beads flush in linked worktrees | 1 |
 
 ---
 
@@ -968,7 +968,9 @@ re-discovery cost on every cycle.
 
 ## KF-014: pre-commit beads hook fails in linked git worktrees
 
-**Status**: OPEN
+**Status**: RESOLVED 2026-06-10 (sprint-bug-190 / #991 — `.claude/scripts/git-hooks/pre-commit-beads` now runs the flush as `(cd "$MAIN_REPO_ROOT" && br sync --flush-only)` when the resolved beads dir is the main checkout's; bats PCB-T7 (worktree CWD assertion via recording stub), PCB-T8 (main-checkout regression guard), PCB-T9 (worktree failure-path stderr passthrough); live verification: empty-commit in a fresh linked worktree succeeded without --no-verify)
+
+**Original Status**: OPEN
 **Feature**: `.git/hooks/pre-commit` beads flush (`br sync --flush-only`)
 **Symptom**: `git commit` in any `git worktree add` linked worktree fails with `Error: Beads not initialized: run 'br init' first` — the hook resolves the main checkout's `.beads/` via `--git-common-dir` but then invokes plain `br sync`, which resolves `.beads/` from CWD (the worktree, which has none). The worktree-detection branch is dead code for the actual invocation.
 **First observed**: 2026-06-10 (CLAUDE.loa.md token-refactor branch build, PR #990)

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1507,9 +1507,35 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260610-i886-b5cddf/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260610-i886-b5cddf/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260610-i989-e8ab1c",
+      "label": "Bug Fix — Kernel integrity stamp is a hollow PLACEHOLDER — @loa-managed hash verifies nothing",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/989",
+      "created_at": "2026-06-10T12:32:23Z",
+      "sprints": [
+        "sprint-bug-189"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260610-i989-e8ab1c/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260610-i989-e8ab1c/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260610-i991-9c97f1",
+      "label": "Bug Fix — pre-commit beads hook fails in linked git worktrees: br sync runs from worktree CWD",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/991",
+      "created_at": "2026-06-10T12:46:49Z",
+      "sprints": [
+        "sprint-bug-190"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260610-i991-9c97f1/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260610-i991-9c97f1/sprint.md"
     }
   ],
-  "global_sprint_counter": 188,
+  "global_sprint_counter": 190,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/bug-989-kernel-hash-stamp.bats
+++ b/tests/unit/bug-989-kernel-hash-stamp.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# =============================================================================
+# bug-989-kernel-hash-stamp.bats — issue #989: @loa-managed hash is a hollow
+# PLACEHOLDER that nothing stamps or verifies.
+# =============================================================================
+# Pre-fix defects pinned here:
+#   1. marker-utils.sh update_hash sed class [a-f0-9]* cannot consume the
+#      literal PLACEHOLDER suffix -> new hash gets glued to "PLACEHOLDER".
+#   2. update-loa-bump-version.sh bump_claude_loa_header rewrites version only
+#      and documents preserving the placeholder hash.
+#   3. lint-invariants.sh check_claude_md checks header PRESENCE only.
+# =============================================================================
+
+setup() {
+    export PROJECT_ROOT="$BATS_TEST_DIRNAME/../.."
+    export MARKER_UTILS="$PROJECT_ROOT/.claude/scripts/marker-utils.sh"
+    export BUMP_SCRIPT="$PROJECT_ROOT/.claude/scripts/update-loa-bump-version.sh"
+    export LINT_SCRIPT="$PROJECT_ROOT/.claude/scripts/lint-invariants.sh"
+    export TEST_DIR="$BATS_TEST_TMPDIR/hash-stamp"
+    mkdir -p "$TEST_DIR/.claude/loa"
+
+    export VERSION_FILE="$TEST_DIR/.loa-version.json"
+    export CLAUDE_LOA_FILE="$TEST_DIR/.claude/loa/CLAUDE.loa.md"
+
+    cat > "$VERSION_FILE" <<'EOF'
+{
+  "framework_version": "1.0.0",
+  "schema_version": 2,
+  "zones": {"system": ".claude", "state": ["grimoires"], "app": ["src"]},
+  "migrations_applied": [],
+  "integrity": {"enforcement": "warn"},
+  "dependencies": {}
+}
+EOF
+
+    cat > "$CLAUDE_LOA_FILE" <<'EOF'
+<!-- @loa-managed: true | version: 1.0.0 | hash: abc123PLACEHOLDER -->
+<!-- WARNING: This file is managed by the Loa Framework. Do not edit directly. -->
+
+# Loa Framework Instructions
+
+Content...
+EOF
+}
+
+teardown() {
+    # bats handles BATS_TEST_TMPDIR cleanup; nothing to do
+    :
+}
+
+@test "bug-989: update-hash drops the PLACEHOLDER suffix and stamps a bare 64-hex hash" {
+    run bash "$MARKER_UTILS" update-hash "$CLAUDE_LOA_FILE"
+    [ "$status" -eq 0 ]
+    local line1
+    line1=$(head -1 "$CLAUDE_LOA_FILE")
+    [[ "$line1" != *"PLACEHOLDER"* ]]
+    [[ "$line1" =~ hash:\ [a-f0-9]{64} ]]
+}
+
+@test "bug-989: update-hash -> verify-hash roundtrip is VALID; content edit flips to MISMATCH" {
+    bash "$MARKER_UTILS" update-hash "$CLAUDE_LOA_FILE"
+    run bash "$MARKER_UTILS" verify-hash "$CLAUDE_LOA_FILE"
+    [[ "$output" == "VALID" ]]
+    echo "drift" >> "$CLAUDE_LOA_FILE"
+    run bash "$MARKER_UTILS" verify-hash "$CLAUDE_LOA_FILE"
+    [[ "$output" == "MISMATCH" ]]
+}
+
+@test "bug-989: bump_claude_loa_header stamps a real hash on version bump" {
+    run "$BUMP_SCRIPT" --target "2.0.0"
+    [ "$status" -eq 0 ]
+    local line1
+    line1=$(head -1 "$CLAUDE_LOA_FILE")
+    [[ "$line1" == *"version: 2.0.0"* ]]
+    [[ "$line1" != *"PLACEHOLDER"* ]]
+    run bash "$MARKER_UTILS" verify-hash "$CLAUDE_LOA_FILE"
+    [[ "$output" == "VALID" ]]
+}
+
+@test "bug-989: idempotency guard — no-op bump leaves file byte-identical" {
+    "$BUMP_SCRIPT" --target "2.0.0"
+    local before
+    before=$(md5sum "$CLAUDE_LOA_FILE" | awk '{print $1}')
+    run "$BUMP_SCRIPT" --target "2.0.0"
+    [ "$status" -eq 0 ]
+    [ "$(md5sum "$CLAUDE_LOA_FILE" | awk '{print $1}')" = "$before" ]
+}
+
+@test "bug-989: lint check_claude_md WARNs (never ERRORs) on stale/placeholder hash" {
+    cd "$TEST_DIR"
+    run bash "$LINT_SCRIPT"
+    local claude_lines
+    claude_lines=$(echo "$output" | grep -i 'claude-md')
+    [[ "$claude_lines" == *"WARN"* ]]
+    [[ "$claude_lines" == *"hash"* ]]
+}
+
+@test "bug-989: lint check_claude_md PASSes hash check after update-hash" {
+    bash "$MARKER_UTILS" update-hash "$CLAUDE_LOA_FILE"
+    cd "$TEST_DIR"
+    run bash "$LINT_SCRIPT"
+    local hash_lines
+    hash_lines=$(echo "$output" | grep -i 'claude-md' | grep -i 'hash')
+    [[ "$hash_lines" == *"PASS"* ]]
+}
+
+@test "bug-989: lint WARNs on glued correct-hex+PLACEHOLDER residue even though verify says VALID (DISS-001)" {
+    # Reproduce the OLD update_hash glue state: stamp a real hash, then glue
+    # the literal PLACEHOLDER back onto it. verify-hash still reports VALID
+    # (hex-prefix comparison), so the residue check must WARN independently.
+    bash "$MARKER_UTILS" update-hash "$CLAUDE_LOA_FILE"
+    sed -i '1s/\(hash: [a-f0-9]*\)/\1PLACEHOLDER/' "$CLAUDE_LOA_FILE"
+    run bash "$MARKER_UTILS" verify-hash "$CLAUDE_LOA_FILE"
+    [[ "$output" == "VALID" ]]
+    cd "$TEST_DIR"
+    run bash "$LINT_SCRIPT"
+    local residue_lines
+    residue_lines=$(echo "$output" | grep -i 'claude-md' | grep -i 'PLACEHOLDER residue')
+    [[ "$residue_lines" == *"WARN"* ]]
+}
+
+@test "bug-989: live kernel header carries a real verified hash (no PLACEHOLDER, version != 1.94.0)" {
+    local line1
+    line1=$(head -1 "$PROJECT_ROOT/.claude/loa/CLAUDE.loa.md")
+    [[ "$line1" != *"PLACEHOLDER"* ]]
+    [[ "$line1" != *"version: 1.94.0"* ]]
+    run bash "$MARKER_UTILS" verify-hash "$PROJECT_ROOT/.claude/loa/CLAUDE.loa.md"
+    [[ "$output" == "VALID" ]]
+}

--- a/tests/unit/pre-commit-beads.bats
+++ b/tests/unit/pre-commit-beads.bats
@@ -147,3 +147,53 @@ _stub_br_missing() {
     # Must NOT include the migration-specific diagnostic (signature didn't match)
     [[ "$output" != *"upstream beads_rust 0.2.1"* ]]
 }
+
+# =============================================================================
+# bug-991 / KF-014: linked-worktree support. The hook resolved the main
+# checkout's .beads via --git-common-dir but invoked plain `br sync` from the
+# worktree CWD, where br finds no .beads and dies with "Beads not initialized".
+# =============================================================================
+
+# Helper: br stub that mimics real br's CWD resolution — succeeds only when
+# CWD contains .beads, and records its physical CWD for assertions.
+_stub_br_cwd_sensitive() {
+    cat >"$STUB_BIN/br" <<'STUB'
+#!/usr/bin/env bash
+pwd -P >> "${BR_CWD_LOG:?}"
+if [ -d .beads ]; then
+    exit 0
+fi
+echo "Error: Beads not initialized: run 'br init' first" >&2
+exit 1
+STUB
+    chmod +x "$STUB_BIN/br"
+}
+
+@test "PCB-T7 (bug-991): hook runs flush from MAIN repo root inside a linked worktree" {
+    _stub_br_cwd_sensitive
+    export BR_CWD_LOG="$TMPDIR_TEST/br-cwd.log"
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    git worktree add -q "$TMPDIR_TEST/wt" -b wt-branch
+    cd "$TMPDIR_TEST/wt"
+    run sh "$HOOK"
+    [ "$status" -eq 0 ]
+    grep -qx "$(cd "$TEST_REPO" && pwd -P)" "$BR_CWD_LOG"
+}
+
+@test "PCB-T8 (bug-991): main-checkout invocation still flushes from the repo root (regression guard)" {
+    _stub_br_cwd_sensitive
+    export BR_CWD_LOG="$TMPDIR_TEST/br-cwd-main.log"
+    run sh "$HOOK"
+    [ "$status" -eq 0 ]
+    grep -qx "$(cd "$TEST_REPO" && pwd -P)" "$BR_CWD_LOG"
+}
+
+@test "PCB-T9 (bug-991): worktree failure path still surfaces verbatim stderr" {
+    _stub_br_other_failure
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    git worktree add -q "$TMPDIR_TEST/wt9" -b wt-branch-9
+    cd "$TMPDIR_TEST/wt9"
+    run sh "$HOOK"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"connection to remote refused"* ]]
+}

--- a/tests/unit/update-loa-bump.bats
+++ b/tests/unit/update-loa-bump.bats
@@ -90,15 +90,19 @@ teardown() {
 }
 
 # =========================================================================
-# UB-T5: CLAUDE.loa.md header preserves hash + PLACEHOLDER segments
+# UB-T5: CLAUDE.loa.md header hash is RE-STAMPED on bump (bug-989)
 # =========================================================================
+# Contract change: pre-#989 the bump preserved the bootstrap
+# "abc123PLACEHOLDER" hash untouched; the header stamp was hollow. The bump
+# now re-stamps a real verifiable hash and drops the PLACEHOLDER suffix.
 
-@test "bump preserves hash + PLACEHOLDER in CLAUDE.loa.md header" {
+@test "bump re-stamps a real hash and drops PLACEHOLDER in CLAUDE.loa.md header (bug-989)" {
     run "$BUMP_SCRIPT" --target "2.5.0"
     [ "$status" -eq 0 ]
     local header
     header=$(head -n 1 "$CLAUDE_LOA_FILE")
-    [[ "$header" == *"hash: abc123PLACEHOLDER"* ]]
+    [[ "$header" != *"PLACEHOLDER"* ]]
+    [[ "$header" =~ hash:\ [a-f0-9]{64} ]]
     [[ "$header" == *"@loa-managed: true"* ]]
 }
 


### PR DESCRIPTION
## What (release wave bundle B — kernel & hook integrity)

**Commit 1 — #989 (sprint-bug-189):** the kernel's line-1 `@loa-managed` stamp was hollow (`version: 1.94.0 | hash: ...PLACEHOLDER` at framework 1.173.x, verified by nothing). The existing marker-utils machinery is now wired end-to-end: `update_hash` consumes the PLACEHOLDER suffix (it used to glue the new hash in front of it), `bump_claude_loa_header` re-stamps the hash on every real version bump, and `lint-invariants` verifies the hash in WARN-only mode **plus** flags PLACEHOLDER residue independently — the review's cross-model dissenter caught that a glued `<correct-hex>PLACEHOLDER` header (exactly what the old glue bug left in installed-base repos) verifies VALID via the hex-prefix comparison. The live kernel is restamped to `1.173.3` + a real verified hash, also fixing the `.loa-version.json` 1.173.0 drift through the canonical tool.

**Commit 2 — #991 / KF-014 (sprint-bug-190):** the pre-commit beads hook resolved the main checkout's `.beads/` for linked worktrees and then never used it — `br sync --flush-only` ran from the worktree CWD and died with "Beads not initialized" on every worktree commit (the framework's own stash-safety guidance recommends worktrees). The flush now runs in a POSIX-sh subshell from `MAIN_REPO_ROOT`, with all #661 diagnostics preserved and pre-fix degradation if resolution fails. Live-verified: an empty commit in a fresh linked worktree succeeds without `--no-verify`. KF-014 flipped to RESOLVED.

## Tests

- `bug-989-kernel-hash-stamp.bats` (8, incl. glued-state DISS-001 repro + live-kernel pin), `update-loa-bump.bats` 23/23 with UB-T5 re-pinned from the old hollow contract — 31 total
- `pre-commit-beads.bats` PCB-T7/T8/T9 (CWD-recording stub) — 8/9, PCB-T3 pre-existing (#953 residual)

## Gates

Both sprints: `/bug` → `/implement` → `/review-sprint` → `/audit-sprint` (APPROVED, COMPLETED). #989 took one review iteration (cross-model DISS-001 → residue check). Cross-model audits clean, no rejected-sidecar entries.

Closes #989
Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)