### PR TITLE
Bundle D: gate honesty — red-team degraded-run contract (#984/#985) + status:clean semantics (#809) — sprint-bug-194/195

### DIFF
--- a/.claude/schemas/adversarial-finding.schema.json
+++ b/.claude/schemas/adversarial-finding.schema.json
@@ -4,19 +4,32 @@
   "title": "Adversarial Finding",
   "description": "Documentation contract for adversarial cross-model dissent findings. Runtime validation uses jq-based validate_finding() in adversarial-review.sh, NOT this schema file directly.",
   "type": "object",
-  "required": ["findings", "metadata"],
+  "required": [
+    "findings",
+    "metadata"
+  ],
   "properties": {
     "findings": {
       "type": "array",
-      "items": { "$ref": "#/$defs/finding" }
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
     },
-    "metadata": { "$ref": "#/$defs/metadata" }
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    }
   },
   "additionalProperties": false,
   "$defs": {
     "finding": {
       "type": "object",
-      "required": ["id", "severity", "category", "description", "failure_mode"],
+      "required": [
+        "id",
+        "severity",
+        "category",
+        "description",
+        "failure_mode"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -27,18 +40,47 @@
           "type": "string",
           "description": "Review: BLOCKING|ADVISORY. Audit: CRITICAL|HIGH|MEDIUM|LOW",
           "oneOf": [
-            { "enum": ["BLOCKING", "ADVISORY"], "title": "Review severities" },
-            { "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"], "title": "Audit severities" }
+            {
+              "enum": [
+                "BLOCKING",
+                "ADVISORY"
+              ],
+              "title": "Review severities"
+            },
+            {
+              "enum": [
+                "CRITICAL",
+                "HIGH",
+                "MEDIUM",
+                "LOW"
+              ],
+              "title": "Audit severities"
+            }
           ]
         },
         "category": {
           "type": "string",
           "enum": [
-            "injection", "authz", "data-loss", "null-safety", "concurrency",
-            "type-error", "resource-leak", "error-handling", "spec-violation",
-            "performance", "secrets", "xss", "ssrf", "deserialization",
-            "crypto", "info-disclosure", "rate-limiting", "input-validation",
-            "config", "other"
+            "injection",
+            "authz",
+            "data-loss",
+            "null-safety",
+            "concurrency",
+            "type-error",
+            "resource-leak",
+            "error-handling",
+            "spec-violation",
+            "performance",
+            "secrets",
+            "xss",
+            "ssrf",
+            "deserialization",
+            "crypto",
+            "info-disclosure",
+            "rate-limiting",
+            "input-validation",
+            "config",
+            "other"
           ],
           "description": "Constrained category from prompt template enum"
         },
@@ -58,22 +100,40 @@
         },
         "anchor_type": {
           "type": "string",
-          "enum": ["function", "hunk", "line", "file"],
+          "enum": [
+            "function",
+            "hunk",
+            "line",
+            "file"
+          ],
           "description": "Type of anchor reference"
         },
         "anchor_stability": {
           "type": "string",
-          "enum": ["symbol", "hunk_header", "line_number"],
+          "enum": [
+            "symbol",
+            "hunk_header",
+            "line_number"
+          ],
           "description": "Set by process_findings: stability classification of the anchor"
         },
         "anchor_status": {
           "type": "string",
-          "enum": ["valid", "cross_file", "out_of_scope", "needs_triage", "unresolved"],
+          "enum": [
+            "valid",
+            "cross_file",
+            "out_of_scope",
+            "needs_triage",
+            "unresolved"
+          ],
           "description": "Set by process_findings: validation result of anchor against diff"
         },
         "scope": {
           "type": "string",
-          "enum": ["diff", "cross_file"],
+          "enum": [
+            "diff",
+            "cross_file"
+          ],
           "description": "Whether finding is within diff or references cross-file impact"
         },
         "trigger_anchor": {
@@ -98,11 +158,17 @@
     },
     "metadata": {
       "type": "object",
-      "required": ["type", "status"],
+      "required": [
+        "type",
+        "status"
+      ],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["review", "audit"],
+          "enum": [
+            "review",
+            "audit"
+          ],
           "description": "Dissent type: code review or security audit"
         },
         "model": {
@@ -140,7 +206,12 @@
         },
         "status": {
           "type": "string",
-          "enum": ["api_failure", "malformed_response", "clean", "reviewed"],
+          "enum": [
+            "api_failure",
+            "malformed_response",
+            "clean",
+            "reviewed"
+          ],
           "description": "Response state machine outcome"
         },
         "context_escalated": {
@@ -154,6 +225,10 @@
         "error": {
           "type": "string",
           "description": "Error message when status is api_failure"
+        },
+        "status_note": {
+          "type": "string",
+          "description": "bug-809: qualifier on status=clean \u2014 zero findings means nothing met the BLOCKING/ADVISORY bar, not an affirmative approval"
         }
       },
       "additionalProperties": false

--- a/.claude/scripts/adversarial-review.sh
+++ b/.claude/scripts/adversarial-review.sh
@@ -617,7 +617,9 @@ invoke_dissenter() {
   # as no-op.
   local -a skill_args=()
   if [[ -n "$type" ]]; then
-    skill_args=(--skill "adversarial-review:$type")
+    # bug-868 residue: also pass --phase so model-adapter logs the real
+    # phase instead of its cosmetic "prd" default on review/audit calls.
+    skill_args=(--skill "adversarial-review:$type" --phase "$type")
   fi
 
   if [[ -n "$vq_sidecar" ]]; then
@@ -807,11 +809,17 @@ while i < len(text):
   local finding_count
   finding_count=$(echo "$parsed" | jq '.findings | length' 2>/dev/null || echo "0")
   if [[ "$finding_count" == "0" ]]; then
+    # bug-809: keep status "clean" for backward compat, but qualify it —
+    # zero findings means nothing met the BLOCKING/ADVISORY bar, NOT an
+    # affirmative approval of the reviewed surface. verdict_quality covers
+    # the degraded axis; status_note covers the high-bar-lens axis.
     jq -n \
       --arg type "$type" --arg model "$model" --arg sid "$sprint_id" \
       --arg ts "$timestamp" \
       '{findings: [], metadata: {type: $type, model: $model, sprint_id: $sid,
-        timestamp: $ts, status: "clean", degraded: false}}'
+        timestamp: $ts, status: "clean",
+        status_note: "no findings met the BLOCKING/ADVISORY bar — not an approval of unreviewed surface",
+        degraded: false}}'
     return 0
   fi
 

--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -1895,7 +1895,7 @@ main() {
     doc_bytes=$(wc -c < "$doc" 2>/dev/null || echo 0)
     doc_kb=$(( (doc_bytes + 512) / 1024 ))   # round to nearest KB
     if [[ "$doc_bytes" -gt 30720 ]]; then
-        echo "WARNING: Document size ${doc_kb} KB; long prompts may trip the cheval connection-loss path on Anthropic + OpenAI. See issue #774 if Phase 1 reports failure_class=PROVIDER_DISCONNECT. The --per-call-max-tokens flag does NOT address this failure mode." >&2
+        echo "WARNING: Document size ${doc_kb} KB. Large documents are handled by the streaming transport default + chunked dispatch (KF-002 RESOLVED-STRUCTURAL); if Phase 1 still reports provider failures at this size, check the verdict_quality envelope and .run/model-invoke.jsonl rather than retrying. The --per-call-max-tokens flag does NOT change input handling." >&2
     fi
 
     # Validate orchestrator mode

--- a/.claude/scripts/pipeline-self-review.sh
+++ b/.claude/scripts/pipeline-self-review.sh
@@ -310,6 +310,7 @@ main() {
 
     # Run Red Team code-vs-design against each governing SDD
     local total_findings=0
+    local degraded_count=0
     local sdd_index=0
 
     while IFS= read -r sdd; do
@@ -336,11 +337,22 @@ main() {
         elif [[ $exit_code -eq 3 ]]; then
             log "  → No security sections in SDD, skipped"
         else
-            log "  → Red Team gate returned exit $exit_code"
+            # bug-984 DISS-001: the gate now exits non-zero WITH a degraded
+            # artifact on model failure / empty content. Count it so the
+            # summary can't read as a clean sweep, and surface the reason.
+            degraded_count=$((degraded_count + 1))
+            local degr_reason="unknown"
+            if [[ -f "$output_file" ]]; then
+                degr_reason=$(jq -r '.degradation_reason // "unknown"' "$output_file" 2>/dev/null || echo "unknown")
+            fi
+            log "  → DEGRADED: Red Team gate exit $exit_code (${degr_reason})"
         fi
     done <<< "$sdds"
 
     log "Pipeline self-review complete: $total_findings total divergence finding(s) across $sdd_count SDD(s)"
+    if [[ $degraded_count -gt 0 ]]; then
+        log "WARNING: $degraded_count of $sdd_count SDD review(s) DEGRADED — totals above are partial; see per-SDD artifacts"
+    fi
 
     # Write summary (includes constitutional markers, T2.1 cycle-047)
     local constitutional_count=${#constitutional_changes[@]}
@@ -355,11 +367,13 @@ main() {
         --argjson change_count "$change_count" \
         --argjson constitutional_count "$constitutional_count" \
         --argjson constitutional_files "$constitutional_json" \
+        --argjson degraded_reviews "$degraded_count" \
         '{
             type: "pipeline_self_review",
             pipeline_files_changed: $change_count,
             sdds_reviewed: $sdd_count,
             total_divergence_findings: $total_findings,
+            degraded_reviews: $degraded_reviews,
             constitutional_changes: $constitutional_count,
             constitutional_files: $constitutional_files
         }' > "$output_dir/pipeline-self-review-summary.json"

--- a/.claude/scripts/red-team-code-vs-design.sh
+++ b/.claude/scripts/red-team-code-vs-design.sh
@@ -39,6 +39,18 @@ CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
 # shellcheck source=lib/model-resolver.sh
 source "$SCRIPT_DIR/lib/model-resolver.sh"
 MODEL_ADAPTER="$SCRIPT_DIR/model-adapter.sh"
+# bug-984: test-mode-gated adapter override (canonical dual-gate: opt-in flag
+# AND bats marker, per the L7 / cycle-099 #761 pattern). Production ignores it.
+if [[ "${LOA_RTCD_TEST_MODE:-}" == "1" ]] && [[ -n "${BATS_TEST_FILENAME:-}${BATS_VERSION:-}" ]]; then
+    MODEL_ADAPTER="${LOA_RTCD_MODEL_ADAPTER:-$MODEL_ADAPTER}"
+fi
+
+# bug-984: script-scope the model-path temp files so the EXIT trap (set at
+# function depth) can both SEE them under set -u and actually clean them up.
+# Pre-fix they were function-locals: the trap died with "prompt_file: unbound
+# variable" on every run and the temp files leaked (KF-015).
+prompt_file=""
+stderr_tmp=""
 
 # Source shared libraries (cycle-047 T3.3)
 source "$SCRIPT_DIR/lib/findings-lib.sh"
@@ -334,11 +346,10 @@ main() {
         exit 0
     fi
 
-    # Build comparison prompt
-    local prompt_file stderr_tmp
+    # Build comparison prompt (vars are script-scope — see bug-984 note at top)
     prompt_file=$(mktemp)
     stderr_tmp=$(mktemp)
-    trap 'rm -f "$prompt_file" "$stderr_tmp"' EXIT
+    trap 'rm -f "${prompt_file:-}" "${stderr_tmp:-}"' EXIT
     cat > "$prompt_file" << 'PROMPT'
 You are a security design verification agent. Compare the SDD security design specifications below to the actual code changes.
 
@@ -470,6 +481,15 @@ PROMPT
         local stderr_tail
         stderr_tail=$(tail -5 "$stderr_tmp" 2>/dev/null || echo "(no stderr)")
         error "Model invocation failed (exit $exit_code): $stderr_tail"
+        # bug-984/#985 (KF-015): leave a structured degraded record (the
+        # scoring-engine contract) instead of exiting with no artifact.
+        # Note: adapter exit 12 is cheval CHAIN_EXHAUSTED — the chain WAS
+        # walked; exhaustion is typically environmental (missing auth for
+        # chain entries on submodule mounts).
+        mkdir -p "$(dirname "$output_path")"
+        jq -n --argjson code "$exit_code" --arg stderr_tail "$stderr_tail" \
+            '{findings: [], summary: {total: 0, confirmed_divergence: 0, partial_implementation: 0, fully_implemented: 0, actionable: 0}, degraded: true, degradation_reason: "model_invocation_failed", model_exit_code: $code, stderr_tail: $stderr_tail}' > "$output_path"
+        chmod 600 "$output_path"
         exit 1
     fi
 
@@ -480,11 +500,16 @@ PROMPT
     # Strip markdown code fences if present (delegated to findings-lib.sh, cycle-047 T3.3)
     findings_json=$(strip_code_fences "$findings_json")
 
-    # Validate JSON
-    if ! echo "$findings_json" | jq '.' > /dev/null 2>&1; then
-        error "Model output is not valid JSON"
-        # Write error findings
-        jq -n '{findings: [], summary: {total: 0, confirmed_divergence: 0, partial_implementation: 0, fully_implemented: 0}, error: "invalid_model_output"}' > "$output_path"
+    # Validate JSON. bug-984 (KF-015): `jq .` exits 0 on EMPTY input — empty
+    # model content used to write a 0-byte findings file and exit 0 (the
+    # silent-clean gate bypass). Require non-empty content AND an object
+    # carrying a findings array.
+    if [[ -z "${findings_json//[$' \t\n\r']/}" ]] || \
+       ! echo "$findings_json" | jq -e 'type == "object" and (.findings | type == "array")' > /dev/null 2>&1; then
+        error "Model output is empty or not a findings object"
+        mkdir -p "$(dirname "$output_path")"
+        jq -n '{findings: [], summary: {total: 0, confirmed_divergence: 0, partial_implementation: 0, fully_implemented: 0, actionable: 0}, degraded: true, degradation_reason: "empty_or_invalid_model_output"}' > "$output_path"
+        chmod 600 "$output_path"
         exit 1
     fi
 

--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -68,6 +68,7 @@ actually tried, not just what someone *said* was tried.
 | [KF-012](#kf-012-sha256sum-not-portable-to-bsd-macos-silent-empty-hash-cascade-into-validation-failures) | **RESOLVED-STRUCTURAL 2026-05-20** (sprint-bug-172 / #911: `sha256_portable` helper in compat-lib.sh + 38 production call sites migrated + CI scanner `tools/check-no-raw-sha256sum.sh` + `tests/unit/compat-lib-sha256.bats` + masked-PATH integration test). Structural analog of cycle-099 sprint-1E.c.3.c curl wrapper migration. | macOS / BSD users of `/butterfreezone-gen` + 37 other framework scripts | 1 (single observation, sprint-bug-172 closure) |
 | [KF-013](#kf-013-headless-cli-env-mode-selector-vars-defeat-subscription-oauth) | **RESOLVED 2026-05-20** (sprint-bug-173 / #894: `_HEADLESS_STRIPPED_AUTH_VARS` tuple extended with `GOOGLE_GENAI_USE_VERTEXAI` + `GOOGLE_GENAI_USE_GCA`; canonical scrub list mirrors `construct-k-hole/scripts/dig-search.ts`). | cheval headless CLI adapters (gemini / codex / claude) | 1 (single observation, sprint-bug-173 closure) |
 | [KF-014](#kf-014-pre-commit-beads-hook-fails-in-linked-git-worktrees) | **RESOLVED 2026-06-10** (sprint-bug-190 / #991: hook flushes from MAIN_REPO_ROOT subshell in worktrees; PCB-T7/T8/T9 pin it; live worktree-commit verification) | pre-commit beads flush in linked worktrees | 1 |
+| [KF-015](#kf-015-red-team-code-vs-designsh-silent-clean-gate-pass-on-degraded-runs) | **RESOLVED 2026-06-11** (sprint-bug-194 / #984+#985: trap script-scoped, empty/shape validation, degraded-record contract on model failure; RTC-T1..T7 pin all three defects) | red-team code-vs-design gate (silent-clean degraded run) | 4 (4/4 sprints, one downstream cycle) + 1 local repro |
 
 ---
 
@@ -989,3 +990,29 @@ re-discovery cost on every cycle.
 ### Reading guide
 
 If a commit fails with `Beads not initialized` inside a linked worktree: do NOT run `br init` there (it would create a second, divergent beads DB). Either commit from the main checkout or, for beads-free commits, use `--no-verify` and disclose it. Route the structural fix through #991 (hook should `cd` to the main repo root for the flush).
+
+---
+
+## KF-015: red-team-code-vs-design.sh silent-clean gate pass on degraded runs
+
+**Status**: RESOLVED 2026-06-11 (sprint-bug-194 — `.claude/scripts/red-team-code-vs-design.sh`: (1) prompt/stderr temp vars script-scoped so the EXIT trap works under `set -u`; (2) validation requires non-empty content + object-with-findings-array (bare `jq .` passed EMPTY input — the silent-clean bypass); (3) model failure (incl. exit-12 CHAIN_EXHAUSTED) writes a `{degraded:true, degradation_reason, model_exit_code, stderr_tail}` record and exits non-zero, matching the scoring-engine contract. Pinned by `tests/unit/red-team-code-vs-design.bats` RTC-T1..T7 incl. functional empty-content and exit-12 cases via the test-mode-gated adapter seam.)
+
+**Original Status**: OPEN (fix in flight: sprint-bug-194, triaged 2026-06-11 from #984 + #985)
+**Feature**: `.claude/scripts/red-team-code-vs-design.sh` — RED_TEAM_CODE gate (Deliberative Council code-vs-design layer, `red_team.code_vs_design.enabled: true`)
+**Symptom**: The gate reports success on degraded runs. Three composing defects (script untouched since 2026-05-05 / PR #723, predates cycle-104/109 degraded-run hardening): (1) EXIT trap references function-local vars under `set -u` → `line 1: prompt_file: unbound variable` on every success path (cleanup never runs, temp files leak, exit code bash-version-dependent); (2) line-484 `jq '.'` exits 0 on EMPTY input → empty model content writes a 0-byte findings file, logs blank counts (`Findings:  total,  divergences`), exits 0 — silent-clean gate pass; (3) model-invoke failure (incl. exit-12 CHAIN_EXHAUSTED, timeout) exits 1 with NO record at `--output` — failure produces no auditable artifact, unlike the SDD-phase pipeline's `{degraded: true, degradation_reason}` contract (scoring-engine.sh:736-763).
+**First observed**: 2026-06-06 (#984, Loa v1.171.6 submodule mount); 4/4 sprint failures across deadwax (hosaka-fm) cycle 1 (#985); local repro confirmed 2026-06-11 (sprint-bug-194 triage)
+**Recurrence count**: 4 (4 distinct failure modes, one per sprint, single downstream cycle) + 1 local repro
+**Current workaround**: Gate callers must NOT trust exit code alone — inspect the findings file content and treat empty/0-byte/missing as degraded → fail-open with an auditable manual-pass record (the deadwax pattern). Independent `adversarial-review.sh` cross-model dissent carries coverage while this gate is dead weight.
+**Upstream issue**: [#984](https://github.com/0xHoneyJar/loa/issues/984) + [#985](https://github.com/0xHoneyJar/loa/issues/985); fix sprint: sprint-bug-194 (`grimoires/loa/a2a/bug-20260611-i984-8b8a94/`)
+**Related visions / lore**: vision-023 Fractal Recursion ("the very gate built to detect silent degradation experienced silent degradation"); KF-002/KF-004 are the same silent-degradation class at other pipeline layers; `feedback_zero_blocker_demotion_pattern.md`
+
+### Attempts
+
+| Date | What we tried | Outcome | Evidence |
+|------|---------------|---------|----------|
+| 2026-06-06..09 | deadwax cycle 1 ran the gate 4/4 sprints (alias exit-12, trap crash + 0-byte file, empty output ×2) | DID NOT WORK — gate never exercised once; fail-opened each time with manual records | #985 failure table; grimoires/loa/a2a/sprint-{1..4}/red-team-code-findings.json in hosaka-fm/deadwax |
+| 2026-06-11 | sprint-bug-194 triage: minimal trap repro + jq-on-empty mechanics verification | ROOT CAUSES CONFIRMED — all three defects verified at source (script:338-341, :484, :463-516); fix is structural (trap scope + `jq -e` output assertion + degraded-record contract) | triage.md in `grimoires/loa/a2a/bug-20260611-i984-8b8a94/` |
+
+### Reading guide
+
+If a RED_TEAM_CODE gate logs `Findings:  total,  divergences` (blank counts), writes a 0-byte findings file, or stderr shows `prompt_file: unbound variable`: this is the documented defect cluster, NOT a model/provider problem — do not retry the invocation or bump budgets. Note the exit-12 sub-case is environmentally distinct: exit 12 IS `CHAIN_EXHAUSTED` (cheval.py EXIT_CODES) and `claude-opus-4-7` HAS a within-company fallback_chain (model-config.yaml:381) — the chain was walked and exhausted (e.g., submodule mount lacking auth for chain entries); fix the environment's auth, not the script's model routing. Until sprint-bug-194 lands: treat empty/0-byte/missing findings files as degraded and fail-open with an auditable record. After it lands: the script itself writes `{degraded: true, degradation_reason, model_exit_code}` and exits non-zero on every degraded run.

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1572,9 +1572,35 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260611-i805-732c34/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260611-i805-732c34/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260611-i984-8b8a94",
+      "label": "Bug Fix — red-team-code-vs-design.sh silently passes quality gate on degraded runs — #984 + #985",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/984",
+      "created_at": "2026-06-11T00:41:32Z",
+      "sprints": [
+        "sprint-bug-194"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260611-i984-8b8a94/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260611-i984-8b8a94/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260611-i809-0cef92",
+      "label": "Bug Fix — adversarial-review status:clean qualifier + stale #774 warning + missing --phase attribution",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/809",
+      "created_at": "2026-06-11T01:02:10Z",
+      "sprints": [
+        "sprint-bug-195"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260611-i809-0cef92/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260611-i809-0cef92/sprint.md"
     }
   ],
-  "global_sprint_counter": 193,
+  "global_sprint_counter": 195,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/integration/flatline-orchestrator-disconnect-hint.bats
+++ b/tests/integration/flatline-orchestrator-disconnect-hint.bats
@@ -20,7 +20,7 @@
 
 # Canonical warning phrase the orchestrator emits at the 30KB threshold.
 # Pinning ONE canonical string (not an OR over substrings) per BB F1.
-readonly CANONICAL_WARN="long prompts may trip the cheval connection-loss path"
+readonly CANONICAL_WARN="Large documents are handled by the streaming transport default + chunked dispatch"
 
 setup() {
     SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"

--- a/tests/unit/bug-809-status-note.bats
+++ b/tests/unit/bug-809-status-note.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# =============================================================================
+# bug-809-status-note.bats — issue #809 + #866/#868 residues:
+#   1. adversarial-review.sh STATE-3 zero-findings emission said bare
+#      `status: clean` — operators/consumers read empty findings as
+#      affirmative approval. Additive status_note qualifies it.
+#   2. flatline-orchestrator.sh document-size warning referenced CLOSED #774.
+#   3. adversarial-review.sh never passed --phase, so model-adapter logged
+#      cosmetic "Phase: prd" on review/audit calls.
+# =============================================================================
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    export PROJECT_ROOT
+    ADV="$PROJECT_ROOT/.claude/scripts/adversarial-review.sh"
+    FLAT="$PROJECT_ROOT/.claude/scripts/flatline-orchestrator.sh"
+}
+
+@test "bug-809: STATE-3 clean emission carries a status_note qualifier (shape)" {
+    # The zero-findings jq emission must include status_note alongside
+    # status: "clean" (backward-compat field retained).
+    grep -B 3 -A 8 'STATE 3: Empty findings' "$ADV" | grep -q 'status_note'
+    grep -B 3 -A 8 'STATE 3: Empty findings' "$ADV" | grep -q '"clean"'
+}
+
+@test "bug-809: status_note text disclaims approval of unreviewed surface" {
+    grep -q 'not an approval' "$ADV"
+}
+
+@test "bug-809: functional — process_findings on zero findings emits status_note" {
+    source "$PROJECT_ROOT/.claude/scripts/lib-content.sh"
+    source "$PROJECT_ROOT/.claude/scripts/compat-lib.sh"
+    eval "$(sed 's/^main "\$@"/# main disabled for testing/' "$ADV")"
+    local out
+    # raw_response is the model-adapter envelope; arg 6 (diff_files) is
+    # required under set -u.
+    out=$(process_findings '{"content": "{\"findings\": []}"}' "review" "test-model" "sprint-test" 0 "" 2>/dev/null)
+    [ "$(echo "$out" | jq -r '.metadata.status')" = "clean" ]
+    [ "$(echo "$out" | jq -r '.metadata.status_note')" != "null" ]
+    [[ "$(echo "$out" | jq -r '.metadata.status_note')" == *"not an approval"* ]]
+}
+
+@test "bug-866-residue: flatline doc-size warning no longer references closed #774" {
+    # Scoped to the operator-facing document-size warning only.
+    ! grep -E 'WARNING: Document size' -A 1 "$FLAT" | grep -q '#774'
+}
+
+@test "bug-868-residue: adversarial-review passes --phase to model-adapter (both branches)" {
+    [ "$(grep -c '\-\-phase' "$ADV")" -ge 2 ]
+}

--- a/tests/unit/red-team-code-vs-design.bats
+++ b/tests/unit/red-team-code-vs-design.bats
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+# =============================================================================
+# red-team-code-vs-design.bats — issues #984/#985 (KF-015): the code-vs-design
+# gate silently passed degraded runs. Three defects pinned:
+#   1. EXIT trap referenced function-locals under set -u (cleanup dead,
+#      unbound-variable noise on every success path).
+#   2. `jq .` exits 0 on EMPTY input — empty model content wrote a 0-byte
+#      findings file and exited 0 (the silent-clean bypass).
+#   3. Model-invoke failure (incl. exit-12 CHAIN_EXHAUSTED) exited with NO
+#      artifact — unlike scoring-engine's {degraded:true} contract.
+# Functional tests use the test-mode-gated adapter seam
+# (LOA_RTCD_TEST_MODE=1 + bats marker -> LOA_RTCD_MODEL_ADAPTER), which is
+# itself part of the fix — they fail fast pre-fix without network.
+# =============================================================================
+
+SCRIPT_REL=".claude/scripts/red-team-code-vs-design.sh"
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/$SCRIPT_REL"
+    [[ -f "$SCRIPT" ]] || skip "script not found"
+
+    FIX="$BATS_TEST_TMPDIR/rtcd"
+    mkdir -p "$FIX/stub"
+    cat > "$FIX/sdd.md" <<'EOF'
+# SDD
+
+## Security Design
+
+Authentication uses short-lived tokens. All inputs are validated at the
+boundary. Audit events are hash-chained.
+EOF
+    printf 'diff --git a/x b/x\n+++ b/x\n+token check added\n' > "$FIX/diff.txt"
+    export LOA_RTCD_TEST_MODE=1
+}
+
+_run_gate() {
+    LOA_RTCD_MODEL_ADAPTER="$1" run bash "$SCRIPT" \
+        --sdd "$FIX/sdd.md" --diff "$FIX/diff.txt" \
+        --output "$FIX/out.json" --sprint sprint-test
+}
+
+_require_seam() {
+    grep -q 'LOA_RTCD_TEST_MODE' "$SCRIPT" || {
+        echo "adapter test seam missing (pre-fix state)" >&2
+        return 1
+    }
+}
+
+# --- shape pins (red pre-fix, no execution) ---------------------------------
+
+@test "RTC-T1: EXIT trap does not reference bare function-locals under set -u" {
+    # Pre-fix: `local prompt_file stderr_tmp` + trap 'rm -f "$prompt_file" ...'
+    # -> unbound at EXIT. Fix must script-scope the vars (cleanup actually runs).
+    ! grep -qE 'local prompt_file stderr_tmp' "$SCRIPT"
+}
+
+@test "RTC-T2: validation requires an object with a findings array (not bare jq .)" {
+    grep -q 'findings | type == "array"' "$SCRIPT"
+}
+
+@test "RTC-T3: model-failure branch writes a degraded record before exiting" {
+    grep -A 12 'Model invocation failed' "$SCRIPT" | grep -q 'degradation_reason'
+}
+
+# --- functional (seam-gated; fail fast pre-fix) ------------------------------
+
+@test "RTC-T4: happy path — valid findings produce exit 0 + computed summary" {
+    _require_seam
+    cat > "$FIX/stub/adapter" <<'STUB'
+#!/usr/bin/env bash
+printf '{"content": "{\\"findings\\":[{\\"classification\\":\\"CONFIRMED_DIVERGENCE\\",\\"severity\\":800,\\"requirement\\":\\"tokens\\"}]}"}'
+STUB
+    chmod +x "$FIX/stub/adapter"
+    _run_gate "$FIX/stub/adapter"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.summary.total' "$FIX/out.json")" = "1" ]
+    [ "$(jq -r '.summary.confirmed_divergence' "$FIX/out.json")" = "1" ]
+    [[ "$output" != *"unbound variable"* ]]
+}
+
+@test "RTC-T5: EMPTY model content -> non-zero exit + degraded record (the #984 bypass)" {
+    _require_seam
+    cat > "$FIX/stub/adapter" <<'STUB'
+#!/usr/bin/env bash
+printf '{"content": ""}'
+STUB
+    chmod +x "$FIX/stub/adapter"
+    _run_gate "$FIX/stub/adapter"
+    [ "$status" -ne 0 ]
+    [ -s "$FIX/out.json" ]
+    [ "$(jq -r '.degraded' "$FIX/out.json")" = "true" ]
+    [ "$(jq -r '.findings | length' "$FIX/out.json")" = "0" ]
+}
+
+@test "RTC-T6: adapter exit-12 (CHAIN_EXHAUSTED) -> non-zero exit + degraded record with code" {
+    _require_seam
+    cat > "$FIX/stub/adapter" <<'STUB'
+#!/usr/bin/env bash
+echo "chain exhausted: all fallbacks failed" >&2
+exit 12
+STUB
+    chmod +x "$FIX/stub/adapter"
+    _run_gate "$FIX/stub/adapter"
+    [ "$status" -ne 0 ]
+    [ -s "$FIX/out.json" ]
+    [ "$(jq -r '.degraded' "$FIX/out.json")" = "true" ]
+    [ "$(jq -r '.model_exit_code' "$FIX/out.json")" = "12" ]
+    [ "$(jq -r '.degradation_reason' "$FIX/out.json")" = "model_invocation_failed" ]
+}
+
+@test "RTC-T7: success path emits no unbound-variable noise and cleans temp files" {
+    _require_seam
+    cat > "$FIX/stub/adapter" <<'STUB'
+#!/usr/bin/env bash
+printf '{"content": "{\\"findings\\":[]}"}'
+STUB
+    chmod +x "$FIX/stub/adapter"
+    _run_gate "$FIX/stub/adapter"
+    [[ "$output" != *"unbound variable"* ]]
+}
+
+# --- DISS-001 propagation (review iteration 1) -------------------------------
+# pipeline-self-review.sh must not swallow the gate's new degraded exits:
+# the loop counts them (reading degradation_reason from the artifact) and the
+# summary JSON carries degraded_reviews. Gate-level behavior is functionally
+# covered by RTC-T5/T6; these pin the parent's propagation arithmetic.
+
+@test "RTC-T8a: pipeline-self-review counts degraded gate exits and reads the reason" {
+    local psr="$REPO_ROOT/.claude/scripts/pipeline-self-review.sh"
+    [[ -f "$psr" ]] || skip "pipeline-self-review.sh not found"
+    grep -q 'degraded_count=\$((degraded_count + 1))' "$psr"
+    grep -q 'degradation_reason' "$psr"
+    grep -qE 'DEGRADED: Red Team gate exit' "$psr"
+}
+
+@test "RTC-T8b: pipeline-self-review summary JSON carries degraded_reviews + loud WARN" {
+    local psr="$REPO_ROOT/.claude/scripts/pipeline-self-review.sh"
+    [[ -f "$psr" ]] || skip "pipeline-self-review.sh not found"
+    grep -q 'degraded_reviews: \$degraded_reviews' "$psr"
+    grep -q 'WARNING: \$degraded_count of \$sdd_count' "$psr"
+}


### PR DESCRIPTION
## What (release wave bundle D — "degraded runs never silently pass a gate")

This bundle closes the framework's two remaining contradictions of its own headline claim:

**Commit 1 — #984 + #985 / KF-015 (sprint-bug-194):** the code-vs-design security gate silently passed degraded runs (a downstream cycle hit 4/4 sprint failures with the gate never exercising). Fixed: the `set -u` trap crash (vars script-scoped, cleanup actually runs), the empty-content bypass (`jq .` exits 0 on EMPTY input — validation now demands an object with a findings array), and the no-artifact model-failure path (now a structured `{degraded:true, model_exit_code, stderr_tail}` record + non-zero exit; exit-12 documented as CHAIN_EXHAUSTED with the environmental-exhaustion correction relayed). The review loop's dissenter then caught the next layer: **pipeline-self-review.sh** would have logged-and-continued — it now counts degraded reviews, WARNs loudly, and carries `degraded_reviews` in its summary JSON. Hermetic tests via a canonical dual-gated adapter seam (RTC-T1..T8b, 9/9). The audit sidecar recovered 2 dissenter HIGHs (eaten by the validator — the #814 mechanism again); both dispositioned explicitly in the audit record.

**Commit 2 — #809 + residues (sprint-bug-195):** zero-findings verdicts now say what they mean — `status: "clean"` (kept for backward compat) plus `status_note: "no findings met the BLOCKING/ADVISORY bar — not an approval of unreviewed surface"`. The schema was updated in lockstep after the dissenter caught that `additionalProperties: false` would reject the new key (and exposed pre-existing drift, logged as bd-ebh9). Also: the flatline doc-size warning no longer cites closed #774, and adversarial-review passes `--phase` so logs stop saying "Phase: prd" on review/audit calls.

## Tests

14 new bats (red-before/green-after) + 78/78 adjacent shape suites + the disconnect-hint suite re-pinned to the new canonical warning (7/7). Recursive dogfood: the sprints' own cross-model verdicts ran through the new code paths during their gates. KF-015 → RESOLVED with evidence.

Closes #984
Closes #985
Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)