### PR TITLE
Bundle G (residuals): full SemVer 2.0 bump grammar (#745) + golden-path fails-loud on path-lib init failure (#980) — sprint-bug-203/204

### DIFF
--- a/.claude/scripts/golden-path.sh
+++ b/.claude/scripts/golden-path.sh
@@ -26,8 +26,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/bootstrap.sh"
 source "${SCRIPT_DIR}/compat-lib.sh"
 
-# Resolve paths using path-lib getters
-_GP_GRIMOIRE_DIR=$(get_grimoire_dir)
+# Resolve paths using path-lib getters.
+# bug-980: errexit is disabled when this file is sourced from a suppressed
+# context (the normal skill-invocation shape), so a failing substitution
+# does NOT abort — guard explicitly and return (sourced) or exit loud.
+_GP_GRIMOIRE_DIR=$(get_grimoire_dir) || _GP_GRIMOIRE_DIR=""
+if [[ -z "${_GP_GRIMOIRE_DIR}" ]]; then
+  echo "[golden-path] ERROR: grimoire dir unresolved (path-lib init failed) — refusing phase detection against root-anchored paths" >&2
+  return 1 2>/dev/null || exit 1
+fi
 _GP_PRD_FILE="${_GP_GRIMOIRE_DIR}/prd.md"
 _GP_SDD_FILE="${_GP_GRIMOIRE_DIR}/sdd.md"
 _GP_SPRINT_FILE="${_GP_GRIMOIRE_DIR}/sprint.md"

--- a/.claude/scripts/path-lib.sh
+++ b/.claude/scripts/path-lib.sh
@@ -55,6 +55,14 @@ _init_path_lib() {
     return 0
   fi
 
+  # bug-980 (review iter-1): an empty PROJECT_ROOT root-anchors EVERY branch
+  # (config read, env inherit, defaults) at "/grimoires/loa" — guard once at
+  # the entry, not only in _use_defaults. Legacy mode resolves its own paths.
+  if [[ -z "${PROJECT_ROOT:-}" && "${LOA_USE_LEGACY_PATHS:-}" != "1" ]]; then
+    echo "[path-lib] ERROR: PROJECT_ROOT is empty — refusing to anchor state paths at / (set PROJECT_ROOT or run bootstrap.sh)" >&2
+    return 1
+  fi
+
   # Check for legacy mode (rollback during migration)
   if [[ "${LOA_USE_LEGACY_PATHS:-}" == "1" ]]; then
     _use_legacy_paths
@@ -101,8 +109,7 @@ _init_path_lib() {
 }
 
 _use_defaults() {
-  # bug-980 (latent): an empty PROJECT_ROOT silently produced root-anchored
-  # paths (/grimoires/loa) — fail loud instead.
+  # bug-980: defense-in-depth (the primary guard is at _init_path_lib entry).
   if [[ -z "${PROJECT_ROOT:-}" ]]; then
     echo "[path-lib] ERROR: PROJECT_ROOT is empty — refusing to anchor state paths at /" >&2
     return 1

--- a/.claude/scripts/path-lib.sh
+++ b/.claude/scripts/path-lib.sh
@@ -101,6 +101,12 @@ _init_path_lib() {
 }
 
 _use_defaults() {
+  # bug-980 (latent): an empty PROJECT_ROOT silently produced root-anchored
+  # paths (/grimoires/loa) — fail loud instead.
+  if [[ -z "${PROJECT_ROOT:-}" ]]; then
+    echo "[path-lib] ERROR: PROJECT_ROOT is empty — refusing to anchor state paths at /" >&2
+    return 1
+  fi
   export LOA_GRIMOIRE_DIR="${PROJECT_ROOT}/${_DEFAULT_GRIMOIRE}"
   export LOA_BEADS_DIR="${PROJECT_ROOT}/${_DEFAULT_BEADS}"
   export LOA_SOUL_SOURCE="${PROJECT_ROOT}/${_DEFAULT_SOUL_SOURCE}"
@@ -330,7 +336,13 @@ _validate_paths() {
 # =============================================================================
 
 get_grimoire_dir() {
-  _init_path_lib || return 1
+  # bug-980: init failure must be LOUD — the silent empty echo turned every
+  # caller's derived path root-anchored (/prd.md) and golden-path reported
+  # phase "discovery" regardless of project state.
+  if ! _init_path_lib; then
+    echo "[path-lib] ERROR: init failed — cannot resolve grimoire dir (check yq + .loa.config.yaml)" >&2
+    return 1
+  fi
   echo "$LOA_GRIMOIRE_DIR"
 }
 

--- a/.claude/scripts/path-lib.sh
+++ b/.claude/scripts/path-lib.sh
@@ -58,7 +58,10 @@ _init_path_lib() {
   # bug-980 (review iter-1): an empty PROJECT_ROOT root-anchors EVERY branch
   # (config read, env inherit, defaults) at "/grimoires/loa" — guard once at
   # the entry, not only in _use_defaults. Legacy mode resolves its own paths.
-  if [[ -z "${PROJECT_ROOT:-}" && "${LOA_USE_LEGACY_PATHS:-}" != "1" ]]; then
+  # Empty PROJECT_ROOT root-anchors at "/" in EVERY branch (config, env
+  # inherit, defaults, AND legacy) — no mode makes that valid, so no
+  # exemption (review iter-2).
+  if [[ -z "${PROJECT_ROOT:-}" ]]; then
     echo "[path-lib] ERROR: PROJECT_ROOT is empty — refusing to anchor state paths at / (set PROJECT_ROOT or run bootstrap.sh)" >&2
     return 1
   fi

--- a/.claude/scripts/semver-bump.sh
+++ b/.claude/scripts/semver-bump.sh
@@ -79,6 +79,13 @@ get_version_from_tag() {
   # restoring §11 precedence (v1.0.0-alpha < v1.0.0) under descending sort.
   # (Build-metadata '+' tags are equal-precedence per §10; the grep keeps
   # them eligible and version sort breaks ties deterministically.)
+  # KNOWN LIMIT (review iter-2): git version-sort is NOT a full SemVer §11
+  # comparator — it can misorder two prereleases with arbitrary hyphenated /
+  # dotted identifiers (e.g. alpha.1 vs alpha.beta). Accepted: this picker
+  # selects among the project's own monotonic release tags, and the
+  # CHANGELOG header is the authoritative current-version source
+  # (get_version_from_tag is the fallback). A full bash SemVer comparator is
+  # out of scope; release-vs-prerelease (the real-world failure) is correct.
   tag=$(git -C "$PROJECT_ROOT" -c versionsort.suffix=- \
     tag -l 'v[0-9]*.[0-9]*.[0-9]*' 'v[0-9]*.[0-9]*.[0-9]*-*' 'v[0-9]*.[0-9]*.[0-9]*+*' \
     --sort=-v:refname 2>/dev/null \

--- a/.claude/scripts/semver-bump.sh
+++ b/.claude/scripts/semver-bump.sh
@@ -72,7 +72,15 @@ get_version_from_tag() {
   # covered alpha|beta|rc.N only; pre.N/dev.N/dotted forms and +metadata
   # were silently filtered, skipping tag/CHANGELOG/release downstream.
   local semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
-  tag=$(git -C "$PROJECT_ROOT" tag -l 'v[0-9]*.[0-9]*.[0-9]*' 'v[0-9]*.[0-9]*.[0-9]*-*' 'v[0-9]*.[0-9]*.[0-9]*+*' \
+  # bug-745 (review iter-1): git's -v:refname does NOT honor SemVer
+  # prerelease precedence by default — `v1.0.0-alpha` sorts AFTER `v1.0.0`,
+  # so a prerelease could be picked ahead of its own stable release.
+  # `-c versionsort.suffix=-` tells git the '-' introduces a prerelease,
+  # restoring §11 precedence (v1.0.0-alpha < v1.0.0) under descending sort.
+  # (Build-metadata '+' tags are equal-precedence per §10; the grep keeps
+  # them eligible and version sort breaks ties deterministically.)
+  tag=$(git -C "$PROJECT_ROOT" -c versionsort.suffix=- \
+    tag -l 'v[0-9]*.[0-9]*.[0-9]*' 'v[0-9]*.[0-9]*.[0-9]*-*' 'v[0-9]*.[0-9]*.[0-9]*+*' \
     --sort=-v:refname 2>/dev/null \
     | grep -E "$semver_re" \
     | head -1)

--- a/.claude/scripts/semver-bump.sh
+++ b/.claude/scripts/semver-bump.sh
@@ -66,9 +66,15 @@ get_version_from_tag() {
   # `tag -l` accepts multiple patterns; combine release + prerelease shapes,
   # then filter by precise regex (the glob is permissive — matches strings
   # like "v1.2.3-foo" too).
-  tag=$(git -C "$PROJECT_ROOT" tag -l 'v[0-9]*.[0-9]*.[0-9]*' 'v[0-9]*.[0-9]*.[0-9]*-*' \
+  # bug-745 residual (sprint-bug-203): full SemVer 2.0 §9/§10 — the official
+  # grammar (pre-release: dot-separated alphanumeric/hyphen identifiers, no
+  # leading-zero numerics, none empty; build metadata after '+'). PR #785
+  # covered alpha|beta|rc.N only; pre.N/dev.N/dotted forms and +metadata
+  # were silently filtered, skipping tag/CHANGELOG/release downstream.
+  local semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+  tag=$(git -C "$PROJECT_ROOT" tag -l 'v[0-9]*.[0-9]*.[0-9]*' 'v[0-9]*.[0-9]*.[0-9]*-*' 'v[0-9]*.[0-9]*.[0-9]*+*' \
     --sort=-v:refname 2>/dev/null \
-    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$' \
+    | grep -E "$semver_re" \
     | head -1)
   if [[ -n "$tag" ]]; then
     echo "${tag#v}"
@@ -105,16 +111,38 @@ get_version_from_changelog() {
 # Validate version format (M-05) — accept either release or prerelease.
 bump_version() {
   local current="$1" bump="$2"
-  local prerelease_re='^([0-9]+)\.([0-9]+)\.([0-9]+)-(alpha|beta|rc)\.([0-9]+)$'
+  # bug-745: SemVer §10 — build metadata denotes a build of a version; the
+  # NEXT version never inherits it. Strip before bumping (validated below
+  # via the identifier grammar on what remains).
+  local meta_re='^([^+]+)\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)$'
+  if [[ "$current" =~ $meta_re ]]; then
+    current="${BASH_REMATCH[1]}"
+  fi
+  # Full SemVer §9 pre-release grammar (PR #785 covered alpha|beta|rc.N only)
+  local pre_id='(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)'
+  local prerelease_re="^([0-9]+)\.([0-9]+)\.([0-9]+)-(${pre_id}(\.${pre_id})*)\$"
   local release_re='^([0-9]+)\.([0-9]+)\.([0-9]+)$'
 
   if [[ "$current" =~ $prerelease_re ]]; then
     local major="${BASH_REMATCH[1]}"
     local minor="${BASH_REMATCH[2]}"
     local patch="${BASH_REMATCH[3]}"
-    local pre_kind="${BASH_REMATCH[4]}"
-    local pre_num="${BASH_REMATCH[5]}"
-    echo "${major}.${minor}.${patch}-${pre_kind}.$((pre_num + 1))"
+    local pre="${BASH_REMATCH[4]}"
+    # #785 policy preserved: any commit during a pre-release advances the
+    # pre-release counter. Trailing numeric identifier increments; a
+    # non-numeric tail gains a .1 (deterministic, precedence-increasing
+    # per §11: alpha.beta < alpha.beta.1).
+    local pre_head="${pre%.*}" pre_tail="${pre##*.}"
+    if [[ "$pre" != *.* ]]; then pre_head=""; fi
+    if [[ "$pre_tail" =~ ^(0|[1-9][0-9]*)$ ]]; then
+      if [[ -n "$pre_head" ]]; then
+        echo "${major}.${minor}.${patch}-${pre_head}.$((pre_tail + 1))"
+      else
+        echo "${major}.${minor}.${patch}-$((pre_tail + 1))"
+      fi
+    else
+      echo "${major}.${minor}.${patch}-${pre}.1"
+    fi
     return 0
   fi
 

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1702,9 +1702,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260612-i745-731985/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260612-i745-731985/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260612-i980-6cfd2b",
+      "label": "Bug Fix — Golden-path silently mis-detects workflow phase when path-lib init fails",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/980",
+      "created_at": "2026-06-12T06:42:26Z",
+      "sprints": [
+        "sprint-bug-204"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260612-i980-6cfd2b/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260612-i980-6cfd2b/sprint.md"
     }
   ],
-  "global_sprint_counter": 203,
+  "global_sprint_counter": 204,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1689,9 +1689,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260612-1fd0bf/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260612-1fd0bf/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260612-i745-731985",
+      "label": "Bug Fix — semver-bump.sh rejects SemVer 2.0 pre-release versions (regex too strict)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/745",
+      "created_at": "2026-06-12T06:31:32Z",
+      "sprints": [
+        "sprint-bug-203"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260612-i745-731985/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260612-i745-731985/sprint.md"
     }
   ],
-  "global_sprint_counter": 202,
+  "global_sprint_counter": 203,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -1927,5 +1940,5 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260428-i640-1cc190/sprint.md"
     }
   ],
-  "next_sprint_number": 192
+  "next_sprint_number": 204
 }

--- a/tests/unit/golden-path-grimoire-guard.bats
+++ b/tests/unit/golden-path-grimoire-guard.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# bug-980 / sprint-bug-204: golden-path silently mis-detected the workflow
+# phase when path-lib init failed — get_grimoire_dir echoed nothing, every
+# _GP_* path became root-anchored (/prd.md), and phase detection reported
+# "discovery" regardless of project state. Sourcing from an errexit-
+# suppressed context (the normal skill invocation shape) disabled set -e
+# for the whole file, so the empty assignment never aborted.
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "GPG-T1 bug-980: get_grimoire_dir emits a stderr diagnostic on init failure" {
+    run bash -c '
+        cd "$1"
+        source .claude/scripts/path-lib.sh
+        # Force init failure: yq required + a config that cannot parse
+        _init_path_lib() { return 1; }
+        get_grimoire_dir
+    ' _ "$PROJECT_ROOT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"path-lib"* ]] || [[ "$output" == *"grimoire"* ]]
+}
+
+@test "GPG-T2 bug-980: golden-path guard aborts loud when get_grimoire_dir fails (shipped guard block)" {
+    # golden-path.sh re-sources bootstrap (which re-sources path-lib),
+    # clobbering any externally-injected poison — so we exercise the SHIPPED
+    # guard block directly: extract it from the file and run it against a
+    # failing get_grimoire_dir, asserting it (a) emits the diagnostic and
+    # (b) returns non-zero before any _GP_PRD_FILE is derived.
+    run bash -c '
+        set +e
+        get_grimoire_dir() { return 1; }
+        # extract the guard block (the get_grimoire_dir assignment through
+        # the closing fi) verbatim from the shipped script
+        guard=$(awk "/^_GP_GRIMOIRE_DIR=\\$\(get_grimoire_dir\)/,/^fi\$/" "$1/.claude/scripts/golden-path.sh")
+        [ -n "$guard" ] || { echo "GUARD-BLOCK-NOT-FOUND"; exit 3; }
+        eval "$guard"
+        echo "REACHED-PAST-GUARD prd=${_GP_PRD_FILE:-UNSET}"
+    ' _ "$PROJECT_ROOT"
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"REACHED-PAST-GUARD"* ]]
+    [[ "$output" == *"grimoire"* ]]
+}
+
+@test "GPG-T3 bug-980: empty PROJECT_ROOT does not yield root-anchored /grimoires paths" {
+    run bash -c '
+        cd "$1"
+        source .claude/scripts/path-lib.sh
+        PROJECT_ROOT="" 
+        _use_defaults 2>/dev/null || exit 7
+        echo "LOA_GRIMOIRE_DIR=$LOA_GRIMOIRE_DIR"
+    ' _ "$PROJECT_ROOT"
+    # Either the guard aborts (exit 7) or the dir is NOT root-anchored
+    if [ "$status" -eq 0 ]; then
+        [[ "$output" != *"LOA_GRIMOIRE_DIR=/grimoires"* ]]
+    else
+        [ "$status" -eq 7 ]
+    fi
+}

--- a/tests/unit/golden-path-grimoire-guard.bats
+++ b/tests/unit/golden-path-grimoire-guard.bats
@@ -58,3 +58,18 @@ setup() {
         [ "$status" -eq 7 ]
     fi
 }
+
+@test "GPG-T4 bug-980 iter-1: empty PROJECT_ROOT fails at init entry even via the config branch" {
+    run bash -c '
+        cd "$1"
+        source .claude/scripts/path-lib.sh
+        PROJECT_ROOT=""
+        export CONFIG_FILE="$1/.loa.config.yaml"   # exists → config branch
+        _path_lib_initialized=false
+        _init_path_lib 2>&1
+        echo "rc=$?"
+        echo "GRIMOIRE=${LOA_GRIMOIRE_DIR:-UNSET}"
+    ' _ "$PROJECT_ROOT"
+    [[ "$output" == *"PROJECT_ROOT is empty"* ]]
+    [[ "$output" != *"GRIMOIRE=/grimoires"* ]]
+}

--- a/tests/unit/golden-path-grimoire-guard.bats
+++ b/tests/unit/golden-path-grimoire-guard.bats
@@ -73,3 +73,18 @@ setup() {
     [[ "$output" == *"PROJECT_ROOT is empty"* ]]
     [[ "$output" != *"GRIMOIRE=/grimoires"* ]]
 }
+
+@test "GPG-T5 bug-980 iter-2: empty PROJECT_ROOT fails even in legacy-paths mode" {
+    run bash -c '
+        cd "$1"
+        source .claude/scripts/path-lib.sh
+        PROJECT_ROOT=""
+        export LOA_USE_LEGACY_PATHS=1
+        _path_lib_initialized=false
+        _init_path_lib 2>&1
+        echo "rc=$?"
+        echo "GRIMOIRE=${LOA_GRIMOIRE_DIR:-UNSET}"
+    ' _ "$PROJECT_ROOT"
+    [[ "$output" == *"PROJECT_ROOT is empty"* ]]
+    [[ "$output" != *"GRIMOIRE=/grimoires"* ]]
+}

--- a/tests/unit/semver-bump.bats
+++ b/tests/unit/semver-bump.bats
@@ -687,3 +687,17 @@ EOF
         [ "$status" -eq 2 ]
     fi
 }
+
+@test "bug-745 iter-1: release tag wins over its own prerelease at the same M.M.P (versionsort precedence)" {
+    skip_if_deps_missing
+    make_commit "initial"
+    make_tag "1.0.0-alpha.1"
+    make_commit "c2"
+    make_tag "1.0.0"
+    make_commit "fix: post-release"
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    # must bump the RELEASE (→1.0.1), not the prerelease (→1.0.0-alpha.2)
+    [ "$(echo "$output" | jq -r '.current')" = "1.0.0" ]
+    [ "$(echo "$output" | jq -r '.next')" = "1.0.1" ]
+}

--- a/tests/unit/semver-bump.bats
+++ b/tests/unit/semver-bump.bats
@@ -533,23 +533,22 @@ EOF
     [ "$next" = "1.1.0" ]
 }
 
-@test "semver-bump: malformed prerelease tag (missing .N suffix) rejected by version regex" {
+@test "semver-bump: bare prerelease tag (no .N) is VALID SemVer and bumps by appending .1 (bug-745)" {
     skip_if_deps_missing
 
-    # The grep regex in get_version_from_tag() requires the prerelease
-    # to have an explicit numeric suffix. A bare `v1.0.0-alpha` (no .N)
-    # is matched neither by the strict regex nor by the prerelease regex,
-    # so get_version_from_tag returns 1 (no version source) — the script
-    # falls back to changelog or fails cleanly.
+    # HISTORY: pre-#745 this test pinned the rejection of `v1.0.0-alpha` —
+    # but that form is fully valid SemVer 2.0 (§9: a single alphanumeric
+    # identifier). The bug-745 residual fix widens the grammar, so the
+    # correct behavior is acceptance + a deterministic .1 append
+    # (precedence-increasing per §11: alpha < alpha.1).
     make_commit "initial"
-    git -C "$TEST_REPO" tag -a "v1.0.0-alpha" -m "malformed prerelease"
-    make_commit "feat: post-malformed"
+    git -C "$TEST_REPO" tag -a "v1.0.0-alpha" -m "bare prerelease"
+    make_commit "feat: post-bare"
 
     run "$TEST_SCRIPT" --from-tag
-    # Either exit 2 (no version source) OR fall back to changelog (which
-    # is also empty in this fixture, also exit 2). Behavior must NOT
-    # silently accept the malformed tag and produce empty/garbage next.
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.current')" = "1.0.0-alpha" ]
+    [ "$(echo "$output" | jq -r '.next')" = "1.0.0-alpha.1" ]
 }
 
 @test "semver-bump: picks latest version-sorted prerelease across alpha.N range" {
@@ -590,4 +589,101 @@ EOF
     local current
     current=$(echo "$output" | jq -r '.current')
     [ "$current" = "2.0.0-alpha.5" ]
+}
+
+# =============================================================================
+# bug-745 residual (sprint-bug-203): full SemVer 2.0 §9/§10 — arbitrary
+# pre-release identifiers + build metadata. PR #785 fixed alpha|beta|rc.N
+# only; pre.N / dev.N / dotted-alphanumeric / +metadata still rejected at
+# both layers (get_version_from_tag grep, bump_version regexes).
+# =============================================================================
+
+@test "bug-745: arbitrary numeric pre-release identifier bumps (v1.0.0-pre.1 -> pre.2)" {
+    skip_if_deps_missing
+    make_commit "initial"
+    make_tag "1.0.0-pre.1"
+    make_commit "fix: something"
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.next')" = "1.0.0-pre.2" ]
+}
+
+@test "bug-745: dev-channel pre-release bumps (v2.0.0-dev.3 -> dev.4)" {
+    skip_if_deps_missing
+    make_commit "initial"
+    make_tag "2.0.0-dev.3"
+    make_commit "feat: thing"
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.next')" = "2.0.0-dev.4" ]
+}
+
+@test "bug-745: non-numeric-trailing pre-release appends .1 (alpha.beta -> alpha.beta.1)" {
+    skip_if_deps_missing
+    make_commit "initial"
+    make_tag "1.0.0-alpha.beta"
+    make_commit "fix: x"
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.next')" = "1.0.0-alpha.beta.1" ]
+}
+
+@test "bug-745: dotted multi-identifier pre-release bumps trailing numeric (x.7.z.92 -> x.7.z.93)" {
+    skip_if_deps_missing
+    make_commit "initial"
+    make_tag "1.0.0-x.7.z.92"
+    make_commit "fix: y"
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.next')" = "1.0.0-x.7.z.93" ]
+}
+
+@test "bug-745: build metadata accepted and STRIPPED on bump (SemVer §10: next version does not inherit it)" {
+    skip_if_deps_missing
+    make_commit "initial"
+    make_tag "1.0.0-rc.1+build.5"
+    make_commit "fix: z"
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.next')" = "1.0.0-rc.2" ]
+}
+
+@test "bug-745: release version with build metadata bumps cleanly (1.2.3+exp.sha -> patch 1.2.4)" {
+    skip_if_deps_missing
+    make_commit "initial"
+    make_tag "1.2.3+exp.sha5114f85"
+    make_commit "fix: w"
+    run "$TEST_SCRIPT" --from-tag
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.next')" = "1.2.4" ]
+}
+
+@test "bug-745: invalid pre-release tag forms are NOT picked up as a version source" {
+    skip_if_deps_missing
+    make_commit "initial"
+    # NB: double-dot forms are illegal GIT refnames (cannot exist as tags);
+    # underscore is git-legal but outside SemVer's [0-9A-Za-z-] grammar.
+    make_tag "1.0.0-alpha_1"
+    make_commit "fix: q"
+    run "$TEST_SCRIPT" --from-tag
+    # The malformed tag must be filtered out: either no version source
+    # (exit 2) or a changelog-derived next — never a bump of the bad tag.
+    if [ "$status" -eq 0 ]; then
+        [ "$(echo "$output" | jq -r '.current')" != "1.0.0-alpha..1" ]
+    else
+        [ "$status" -eq 2 ]
+    fi
+}
+
+@test "bug-745: leading-zero numeric pre-release identifier rejected per SemVer grammar" {
+    skip_if_deps_missing
+    make_commit "initial"
+    make_tag "1.0.0-01"
+    make_commit "fix: r"
+    run "$TEST_SCRIPT" --from-tag
+    if [ "$status" -eq 0 ]; then
+        [ "$(echo "$output" | jq -r '.current')" != "1.0.0-01" ]
+    else
+        [ "$status" -eq 2 ]
+    fi
 }


### PR DESCRIPTION
## OSS-release wave — Bundle G residuals

Two gated micro-sprints (`/bug` → `/implement` → `/review-sprint` → `/audit-sprint`, cross-model iterations).

### sprint-bug-203 — #745: full SemVer 2.0 §9/§10 in semver-bump.sh
PR #785 fixed `alpha|beta|rc.N` only; the residual grammar (arbitrary dot-separated pre-release identifiers, bare single identifiers, build metadata) still rejected at both layers, reproducing the original silent post-merge tag/CHANGELOG/release skip. Both layers now carry the official anchored SemVer regex; §10 build metadata is stripped before bumping (the next version never inherits it); #785's type-agnostic bump policy is preserved. **Review iter-1** caught that `git -v:refname` doesn't honor §11 prerelease precedence (a prerelease could be picked ahead of its own stable release) → `versionsort.suffix=-`. **Iter-2** flagged that git version-sort still isn't a full §11 comparator for arbitrary hyphenated identifiers — accepted and documented (the picker selects among the project's own monotonic tags; the CHANGELOG header is authoritative; a bash SemVer comparator is disproportionate). Test 32 corrected: `v1.0.0-alpha` was asserted *rejected* — it's valid SemVer, now bumps to `alpha.1`. 8 failing-first + release-wins regression.

### sprint-bug-204 — #980: golden-path silent phase mis-detection
`get_grimoire_dir` echoed nothing on path-lib init failure → root-anchored `/prd.md` → phase always "discovery". Silent because golden-path is sourced from errexit-suppressed contexts. Three fail-loud guards: diagnostic in `get_grimoire_dir`, explicit non-empty guard + sourced-safe abort in golden-path before any path derives, and an empty-`PROJECT_ROOT` guard. **Review iter-1**: the root guard only covered `_use_defaults` — hoisted to `_init_path_lib` entry (covers config-read + env-inherit). **Iter-2**: the legacy-paths branch also root-anchored → exemption dropped (no mode makes empty root valid). GPG-T1..T5 pin diagnostic / shipped-guard abort / no-root-anchor / config-branch / legacy-branch.

### Gate evidence
- Cross-model: both sprints reached clean/0-findings after the iterations; audit clean/0, no sidecar. semver + golden-path-guard suites 48/48.
- Companion finding from the parallel codebase review filed as **#1016** (chunked-path MODELINV envelope field-drop) — not in this PR.

Closes #745
Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)