### PR TITLE
docs: repoint CLI-INSTALLATION.md link to loa-constructs (fixes #1019)

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -892,7 +892,7 @@ registry:
   check_updates_on_setup: true
 ```
 
-See [CLI-INSTALLATION.md](grimoires/loa/context/CLI-INSTALLATION.md) for the full setup guide.
+See [CLI-INSTALLATION.md](https://github.com/0xHoneyJar/loa-constructs/blob/main/docs/CLI-INSTALLATION.md) for the full setup guide.
 
 ## Frictionless Permissions
 


### PR DESCRIPTION
Fixes #1019.

## What

One-line repoint of the broken link at `INSTALLATION.md:895`.

```diff
-See [CLI-INSTALLATION.md](grimoires/loa/context/CLI-INSTALLATION.md) for the full setup guide.
+See [CLI-INSTALLATION.md](https://github.com/0xHoneyJar/loa-constructs/blob/main/docs/CLI-INSTALLATION.md) for the full setup guide.
```

## Why this target

- `git log --all --diff-filter=A` shows `CLI-INSTALLATION.md` never existed in this repo. The link was born broken in ee01ddce ("docs: add Loa Constructs documentation"), whose commit message says it "links to CLI-INSTALLATION.md as single source of truth".
- That source of truth exists at `0xHoneyJar/loa-constructs/docs/CLI-INSTALLATION.md` (public repo), and its content is exactly the registry CLI setup guide this section promises.
- Cross-repo URL beats committing a copy here: one source of truth, and downstream repos that vendor `INSTALLATION.md` via `/update-loa` inherit a working link instead of a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
