### PR TITLE
security(invoke-diagnostics): redact_secrets gaps — AWS session-key prefixes + base64 Bearer padding

### DIFF
--- a/.claude/scripts/lib/invoke-diagnostics.sh
+++ b/.claude/scripts/lib/invoke-diagnostics.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 #
 # Redact known secret patterns from stdin.
 # Expanded patterns: sk-*, ghp_*, gho_*, ghs_*, ghr_*, Bearer, Authorization,
-# AKIA* (AWS), eyJ* (JWT).
+# AWS key IDs (AKIA/ASIA/AROA/AGPA/AIPA/ANPA/ANVA), eyJ* (JWT).
 
 redact_secrets() {
   # Pattern coverage:
@@ -32,9 +32,11 @@ redact_secrets() {
   #   gho_*    — GitHub OAuth tokens
   #   ghs_*    — GitHub App installation tokens
   #   ghr_*    — GitHub Refresh tokens
-  #   Bearer   — OAuth/JWT Bearer tokens in headers
+  #   Bearer   — OAuth/JWT Bearer tokens in headers (incl. base64 '=' padding)
   #   Authorization — Full Authorization header values
-  #   AKIA*    — AWS IAM access key IDs
+  #   AKIA* &c — AWS key IDs: access (AKIA), session (ASIA), role (AROA),
+  #              group (AGPA), instance-profile (AIPA), managed-policy (ANPA),
+  #              policy-version (ANVA) — #1009
   #   eyJ*     — JWT/JWS tokens (base64-encoded JSON header starting with {"...)
   #
   # Pattern Maintenance: When new model providers are added to the Hounfour
@@ -45,9 +47,9 @@ redact_secrets() {
     -e 's/gho_[A-Za-z0-9]{36}/gho_***REDACTED***/g' \
     -e 's/ghs_[A-Za-z0-9]{36}/ghs_***REDACTED***/g' \
     -e 's/ghr_[A-Za-z0-9]{36}/ghr_***REDACTED***/g' \
-    -e 's/(Bearer )[A-Za-z0-9._-]+/\1***REDACTED***/g' \
+    -e 's/(Bearer )[A-Za-z0-9=._-]+/\1***REDACTED***/g' \
     -e 's/(Authorization: )[A-Za-z0-9._: -]+/\1***REDACTED***/g' \
-    -e 's/AKIA[A-Z0-9]{16}/AKIA***REDACTED***/g' \
+    -e 's/(AKIA|ASIA|AROA|AGPA|AIPA|ANPA|ANVA)[A-Z0-9]{16}/\1***REDACTED***/g' \
     -e 's/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/eyJ***REDACTED***/g'
 }
 

--- a/tests/unit/invoke-diagnostics-redaction.bats
+++ b/tests/unit/invoke-diagnostics-redaction.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# =============================================================================
+# invoke-diagnostics-redaction.bats — sprint-bug-206 (#1009)
+# =============================================================================
+# redact_secrets() in .claude/scripts/lib/invoke-diagnostics.sh had two
+# pattern gaps (recovered from the sprint-bug-198 cross-model audit rejection
+# sidecar, gpt-5.5-pro, KF-004 class):
+#
+#   1. AWS key-ID prefixes: only AKIA* was masked — the session/role classes
+#      ASIA*, AROA*, AGPA*, AIPA*, ANPA*, ANVA* passed through unredacted
+#      (session tokens are common in CI env dumps).
+#   2. The Bearer char class [A-Za-z0-9._-]+ excluded '=', so base64-padded
+#      tokens were only partially redacted — the padding and anything after a
+#      stripped match boundary leaked.
+#
+# Note: this suite covers redact_secrets() from lib/invoke-diagnostics.sh.
+# The sibling lib lib/secret-redaction.sh (_redact_secrets) has its own suite
+# in tests/unit/secret-redaction.bats.
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    LIB="$PROJECT_ROOT/.claude/scripts/lib/invoke-diagnostics.sh"
+}
+
+# Source-and-run helper. invoke-diagnostics.sh sets `set -euo pipefail`;
+# calling through a command substitution keeps that confined to the subshell.
+redact() {
+    # shellcheck disable=SC1090
+    source "$LIB"
+    printf '%s\n' "$1" | redact_secrets
+}
+
+# -----------------------------------------------------------------------------
+# AWS key-ID prefix classes (table-driven) — bug #1009 gap 1
+# AKIA was already covered; ASIA/AROA/AGPA/AIPA/ANPA/ANVA are the red rows.
+# -----------------------------------------------------------------------------
+@test "bug-1009: every AWS key-ID prefix class is redacted (table-driven)" {
+    local prefix out failed=""
+    for prefix in AKIA ASIA AROA AGPA AIPA ANPA ANVA; do
+        out="$(redact "aws_key=${prefix}IOSFODNN7EXAMPLE")"
+        if [[ "$out" == *"IOSFODNN7EXAMPLE"* ]]; then
+            failed+=" $prefix"
+            continue
+        fi
+        # Prefix is preserved in the mask (diagnostic value, no leak).
+        if [[ "$out" != *"${prefix}***REDACTED***"* ]]; then
+            failed+=" $prefix(mask-shape)"
+        fi
+    done
+    echo "leaking prefix classes:${failed:-none}"
+    [ -z "$failed" ]
+}
+
+@test "bug-1009: ASIA session key in a CI env-dump line is redacted" {
+    local out
+    out="$(redact 'AWS_ACCESS_KEY_ID=ASIAIOSFODNN7EXAMPLE AWS_REGION=us-east-1')"
+    [[ "$out" != *"ASIAIOSFODNN7EXAMPLE"* ]]
+    [[ "$out" == *"ASIA***REDACTED***"* ]]
+    # Non-secret context survives.
+    [[ "$out" == *"AWS_REGION=us-east-1"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# Bearer base64 padding — bug #1009 gap 2
+# -----------------------------------------------------------------------------
+@test "bug-1009: base64-padded Bearer token is fully redacted (no '=' remnant)" {
+    # Deliberately NOT an 'Authorization: ' header — the Authorization rule
+    # also rewrites 'Bearer ' itself (pre-existing interplay, out of scope);
+    # a neutral prefix isolates the Bearer rule under test.
+    local out
+    out="$(redact 'auth: Bearer dGVzdC10b2tlbi1ib2R5LXNlY3JldA==')"
+    [[ "$out" != *"dGVzdC10b2tlbi1ib2R5"* ]]
+    # The old pattern stopped at the first '=', leaving 'Bearer ***REDACTED***=='.
+    [[ "$out" != *"REDACTED***="* ]]
+    [[ "$out" == *"Bearer ***REDACTED***"* ]]
+}
+
+@test "bug-1009: Bearer token fragment after an internal '=' does not leak" {
+    local out
+    out="$(redact 'hdr: Bearer dG9rZW4=c2VjcmV0LXRhaWw=')"
+    # Old behavior: match stopped at '=', leaking '=c2VjcmV0LXRhaWw='.
+    [[ "$out" != *"c2VjcmV0LXRhaWw"* ]]
+    [[ "$out" == *"Bearer ***REDACTED***"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# Regression pins — behavior that was already correct must stay correct
+# -----------------------------------------------------------------------------
+@test "bug-1009 pin: AKIA access key stays redacted with prefix-preserving mask" {
+    local out
+    out="$(redact 'key=AKIAIOSFODNN7EXAMPLE')"
+    [[ "$out" != *"IOSFODNN7EXAMPLE"* ]]
+    [[ "$out" == *"AKIA***REDACTED***"* ]]
+}
+
+@test "bug-1009 pin: unpadded Bearer token stays redacted" {
+    local out
+    out="$(redact 'auth: Bearer abc.def_ghi-jkl0123456789')"
+    [[ "$out" != *"abc.def_ghi-jkl"* ]]
+    [[ "$out" == *"Bearer ***REDACTED***"* ]]
+}
+
+@test "bug-1009 pin: sk- API key stays redacted" {
+    local out
+    out="$(redact 'OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz1234')"
+    [[ "$out" != *"sk-abcdefghijklm"* ]]
+    [[ "$out" == *"sk-***REDACTED***"* ]]
+}
+
+@test "bug-1009 pin: JWT (eyJ) stays redacted" {
+    local out
+    out="$(redact 'token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.sflKxwRJSMeKKF2QT4')"
+    [[ "$out" != *"eyJhbGciOiJIUzI1NiJ9"* ]]
+    [[ "$out" == *"eyJ***REDACTED***"* ]]
+}
+
+@test "bug-1009 pin: non-secret text passes through unchanged" {
+    local out
+    out="$(redact 'hello world: exit 3 after 120s')"
+    [ "$out" = "hello world: exit 3 after 120s" ]
+}


### PR DESCRIPTION
Closes #1009 · sprint-bug-206 · recovered from the sprint-bug-198 cross-model audit rejection sidecar (gpt-5.5-pro, KF-004 class).

## What

Two pattern gaps in `redact_secrets()` (`lib/invoke-diagnostics.sh`):

| Gap | Before | After |
|---|---|---|
| AWS key IDs | only `AKIA*` masked — `ASIA/AROA/AGPA/AIPA/ANPA/ANVA` passed through | alternation over all 7 prefix classes, prefix-preserving mask |
| Bearer tokens | `[A-Za-z0-9._-]+` excluded `=` — base64 padding + post-boundary fragments leaked | `=` added to the char class; padded tokens redact fully |

## Test-first

New table-driven suite `tests/unit/invoke-diagnostics-redaction.bats` (this lib had no redaction coverage — `secret-redaction.bats` covers the sibling `_redact_secrets`):

- red-before-fix verified: 4 red (all 6 unmasked AWS prefix classes enumerated in one table row + CI env-dump ASIA case + 2 padded-Bearer cases), 5 regression pins green
- post-fix: 9/9 green
- `tests/unit/secret-redaction.bats`: 22/22 green (unchanged)

## Notes for reviewer

- Weakest link to check: the Bearer tests deliberately use a non-`Authorization:` header prefix, because the `Authorization:` rule also rewrites `Bearer ` itself (pre-existing rule interplay, out of scope here).
- Sibling lib `lib/secret-redaction.sh` has NO AWS pattern at all and the same Bearer `=` exclusion — out of scope per #1009, candidate follow-up issue.
- The macOS-only `mktemp-bsd-portability` failure (`stat -c`, GNU-only) is pre-existing on `origin/main`, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)