### PR TITLE
fix(constructs): find_local_source slug-matches candidate dirs (bd-mjd, stacked on #1021)

### DIFF
--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -399,17 +399,18 @@ unlink_pack_skills() {
 # (skipped in offline mode; failure tolerated, the existing origin/main ref is
 # used). Non-git sources (or clones without an origin/main ref) fall back to a
 # working-tree copy.
+# Materializes into a STAGING directory supplied by the caller (DISS-001 /
+# BB-002): never writes into the live pack dir, so a failed materialization
+# leaves the prior install untouched, and a successful one can atomically
+# replace it — making the result a true mirror (files deleted upstream are
+# pruned).
 # Args:
-#   $1 - Pack slug
-#   $2 - Local source path
-#   $3 - Packs directory
+#   $1 - Local source path
+#   $2 - Staging directory (must exist, empty)
 # Outputs: resolved origin/main commit to stdout (empty for working-tree copy)
 materialize_pack_from_local() {
-    local pack_slug="$1"
-    local local_source="$2"
-    local packs_dir="$3"
-
-    mkdir -p "$packs_dir/$pack_slug"
+    local local_source="$1"
+    local staging_dir="$2"
 
     if git -C "$local_source" rev-parse --git-dir >/dev/null 2>&1; then
         if [[ "${LOA_OFFLINE:-}" != "1" ]]; then
@@ -417,7 +418,7 @@ materialize_pack_from_local() {
                 echo "  WARN: git fetch failed for $local_source — using existing origin/main ref" >&2
         fi
         if git -C "$local_source" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
-            if git -C "$local_source" archive origin/main | tar -x -C "$packs_dir/$pack_slug"; then
+            if git -C "$local_source" archive origin/main | tar -x -C "$staging_dir"; then
                 git -C "$local_source" rev-parse origin/main
                 return 0
             fi
@@ -427,7 +428,7 @@ materialize_pack_from_local() {
         fi
     fi
 
-    cp -r "$local_source/." "$packs_dir/$pack_slug/"
+    cp -r "$local_source/." "$staging_dir/"
 }
 
 # Install (or re-sync) a pack from a local source clone: materialize content,
@@ -444,16 +445,40 @@ install_pack_from_local() {
 
     echo "  Installing from local source: $local_source"
 
+    # DISS-001 / BB-002: materialize into a staging dir, then atomically
+    # replace the pack dir — a true mirror (deleted-upstream files pruned),
+    # and a failed materialization leaves the prior install untouched.
+    # Deterministic name (no $$) so a crashed prior run is self-healed here;
+    # hidden so do_resync's glob never treats it as an installed pack.
+    local pack_dir="$packs_dir/$pack_slug"
+    local staging_dir="$packs_dir/.${pack_slug}.staging"
+    rm -rf "$staging_dir"
+    mkdir -p "$staging_dir"
+
     local resolved_commit
-    resolved_commit=$(materialize_pack_from_local "$pack_slug" "$local_source" "$packs_dir") || {
-        print_error "ERROR: Failed to materialize '$pack_slug' from $local_source"
+    if ! resolved_commit=$(materialize_pack_from_local "$local_source" "$staging_dir"); then
+        rm -rf "$staging_dir"
+        print_error "ERROR: Failed to materialize '$pack_slug' from $local_source (prior install untouched)"
         return $EXIT_EXTRACT_ERROR
-    }
+    fi
     if [[ -n "$resolved_commit" ]]; then
         echo "  Mirrored origin/main @ ${resolved_commit:0:12}"
     else
         echo "  Copied working tree (no git origin/main ref at source)"
     fi
+
+    if [[ -d "$pack_dir" ]]; then
+        # Preserve runtime state written by prior (registry) installs
+        if [[ -f "$pack_dir/.license.json" && ! -f "$staging_dir/.license.json" ]]; then
+            cp "$pack_dir/.license.json" "$staging_dir/.license.json"
+        fi
+        # Drop symlinks into the old tree (including commands/skills removed
+        # upstream) before replacing it; relinked from the clean tree below
+        unlink_pack_commands "$pack_slug" >/dev/null 2>&1 || true
+        unlink_pack_skills "$pack_slug" >/dev/null 2>&1 || true
+        rm -rf "$pack_dir"
+    fi
+    mv "$staging_dir" "$pack_dir"
 
     # Update metadata
     local meta_file
@@ -462,12 +487,17 @@ install_pack_from_local() {
     now_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     init_registry_meta
     local meta_tmp="${meta_file}.tmp.$$"
-    jq --arg slug "$pack_slug" --arg ts "$now_ts" --arg src "$local_source" --arg commit "$resolved_commit" \
+    if ! jq --arg slug "$pack_slug" --arg ts "$now_ts" --arg src "$local_source" --arg commit "$resolved_commit" \
         '.installed_packs[$slug].installed_at = $ts
          | .installed_packs[$slug].source = "local"
          | .installed_packs[$slug].local_source = $src
          | (if $commit != "" then .installed_packs[$slug].commit = $commit else . end)' \
-        "$meta_file" > "$meta_tmp" && mv "$meta_tmp" "$meta_file"
+        "$meta_file" > "$meta_tmp"; then
+        rm -f "$meta_tmp"
+        print_error "ERROR: Failed to update registry meta for '$pack_slug'"
+        return $EXIT_ERROR
+    fi
+    mv "$meta_tmp" "$meta_file"
 
     # Symlink commands
     echo "  Linking commands..."
@@ -527,10 +557,12 @@ do_resync() {
     done
 
     echo ""
-    print_success "Resync complete: $synced synced, $skipped skipped (no local source), $failed failed"
+    # BB-003: banner must agree with the exit code — no green on partial failure
     if [[ $failed -gt 0 ]]; then
+        print_error "Resync partial: $synced synced, $skipped skipped (no local source), $failed failed"
         return $EXIT_ERROR
     fi
+    print_success "Resync complete: $synced synced, $skipped skipped (no local source), $failed failed"
     return $EXIT_SUCCESS
 }
 

--- a/.claude/scripts/constructs-install.sh
+++ b/.claude/scripts/constructs-install.sh
@@ -10,6 +10,7 @@
 #   constructs-install.sh uninstall pack <slug>    # Remove a pack
 #   constructs-install.sh uninstall skill <slug>   # Remove a skill
 #   constructs-install.sh link-commands <slug>     # Re-link pack commands
+#   constructs-install.sh resync <slug|--all>      # Re-sync from local source clones
 #
 # Exit Codes:
 #   0 = success
@@ -392,7 +393,150 @@ unlink_pack_skills() {
 # Pack Installation
 # =============================================================================
 
-# Download and install a pack from the registry
+# Materialize pack content from a local source clone (sprint-bug-205,
+# loa-constructs#253). Git sources mirror origin/main — NOT the working tree,
+# since clones routinely park on WIP branches — with a best-effort fetch first
+# (skipped in offline mode; failure tolerated, the existing origin/main ref is
+# used). Non-git sources (or clones without an origin/main ref) fall back to a
+# working-tree copy.
+# Args:
+#   $1 - Pack slug
+#   $2 - Local source path
+#   $3 - Packs directory
+# Outputs: resolved origin/main commit to stdout (empty for working-tree copy)
+materialize_pack_from_local() {
+    local pack_slug="$1"
+    local local_source="$2"
+    local packs_dir="$3"
+
+    mkdir -p "$packs_dir/$pack_slug"
+
+    if git -C "$local_source" rev-parse --git-dir >/dev/null 2>&1; then
+        if [[ "${LOA_OFFLINE:-}" != "1" ]]; then
+            git -C "$local_source" fetch origin --quiet 2>/dev/null || \
+                echo "  WARN: git fetch failed for $local_source — using existing origin/main ref" >&2
+        fi
+        if git -C "$local_source" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+            if git -C "$local_source" archive origin/main | tar -x -C "$packs_dir/$pack_slug"; then
+                git -C "$local_source" rev-parse origin/main
+                return 0
+            fi
+            echo "  WARN: git archive origin/main failed for $local_source — copying working tree" >&2
+        else
+            echo "  WARN: no origin/main ref in $local_source — copying working tree" >&2
+        fi
+    fi
+
+    cp -r "$local_source/." "$packs_dir/$pack_slug/"
+}
+
+# Install (or re-sync) a pack from a local source clone: materialize content,
+# record meta (source=local, resolved commit when git), link commands + skills.
+# Shared by do_install_pack (local-first path) and do_resync.
+# Args:
+#   $1 - Pack slug
+#   $2 - Local source path
+#   $3 - Packs directory
+install_pack_from_local() {
+    local pack_slug="$1"
+    local local_source="$2"
+    local packs_dir="$3"
+
+    echo "  Installing from local source: $local_source"
+
+    local resolved_commit
+    resolved_commit=$(materialize_pack_from_local "$pack_slug" "$local_source" "$packs_dir") || {
+        print_error "ERROR: Failed to materialize '$pack_slug' from $local_source"
+        return $EXIT_EXTRACT_ERROR
+    }
+    if [[ -n "$resolved_commit" ]]; then
+        echo "  Mirrored origin/main @ ${resolved_commit:0:12}"
+    else
+        echo "  Copied working tree (no git origin/main ref at source)"
+    fi
+
+    # Update metadata
+    local meta_file
+    meta_file=$(get_registry_meta_path)
+    local now_ts
+    now_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    init_registry_meta
+    local meta_tmp="${meta_file}.tmp.$$"
+    jq --arg slug "$pack_slug" --arg ts "$now_ts" --arg src "$local_source" --arg commit "$resolved_commit" \
+        '.installed_packs[$slug].installed_at = $ts
+         | .installed_packs[$slug].source = "local"
+         | .installed_packs[$slug].local_source = $src
+         | (if $commit != "" then .installed_packs[$slug].commit = $commit else . end)' \
+        "$meta_file" > "$meta_tmp" && mv "$meta_tmp" "$meta_file"
+
+    # Symlink commands
+    echo "  Linking commands..."
+    local commands_linked
+    commands_linked=$(symlink_pack_commands "$pack_slug")
+    echo "  Created $commands_linked command symlinks"
+
+    # Symlink skills
+    echo "  Linking skills..."
+    local skills_linked
+    skills_linked=$(symlink_pack_skills "$pack_slug")
+    echo "  Created $skills_linked skill symlinks"
+
+    echo ""
+    print_success "Pack '$pack_slug' installed from local source"
+    return $EXIT_SUCCESS
+}
+
+# Force re-sync of installed packs from their local source clones
+# (sprint-bug-205, loa-constructs#253). Never contacts the registry: packs
+# without a local source are skipped with a report line.
+# Args:
+#   $1 - Pack slug, or --all/all for every installed pack
+do_resync() {
+    local target="$1"
+    local packs_dir
+    packs_dir=$(get_packs_dir)
+
+    local slugs=()
+    if [[ "$target" == "--all" || "$target" == "all" ]]; then
+        local d
+        for d in "$packs_dir"/*/; do
+            [[ -d "$d" ]] && slugs+=("$(basename "$d")")
+        done
+        if [[ ${#slugs[@]} -eq 0 ]]; then
+            echo "No packs installed under $packs_dir — nothing to resync"
+            return $EXIT_SUCCESS
+        fi
+    else
+        slugs=("$target")
+    fi
+
+    local synced=0 skipped=0 failed=0
+    local slug
+    local local_source
+    for slug in "${slugs[@]}"; do
+        if local_source=$(find_local_source "$slug"); then
+            if install_pack_from_local "$slug" "$local_source" "$packs_dir"; then
+                synced=$((synced + 1))
+            else
+                failed=$((failed + 1))
+            fi
+        else
+            echo "  SKIP: $slug — no local source found"
+            skipped=$((skipped + 1))
+        fi
+    done
+
+    echo ""
+    print_success "Resync complete: $synced synced, $skipped skipped (no local source), $failed failed"
+    if [[ $failed -gt 0 ]]; then
+        return $EXIT_ERROR
+    fi
+    return $EXIT_SUCCESS
+}
+
+# Install a pack: local source clone first (the GitHub SoT), registry as the
+# last resort (sprint-bug-205, loa-constructs#253 — the prior meta-gated
+# ordering left installed packs stale against a dead registry).
 # Args:
 #   $1 - Pack slug
 do_install_pack() {
@@ -402,6 +546,33 @@ do_install_pack() {
     local packs_dir
 
     print_status "$icon_valid" "Installing pack: $pack_slug"
+
+    # Create directories
+    packs_dir=$(get_packs_dir)
+    mkdir -p "$packs_dir"
+
+    # Ensure constructs directory is gitignored
+    ensure_constructs_gitignored
+
+    # Local source clone first — the clone IS the source of truth. A present
+    # canonical clone always beats the registry (sprint-bug-205,
+    # loa-constructs#253: the prior freshness gate defaulted to a dead
+    # registry whenever .constructs-meta.json was absent). Materialization is
+    # idempotent (origin/main mirror), so no freshness proof is needed.
+    local local_source
+    if local_source=$(find_local_source "$pack_slug"); then
+        if [[ -d "$packs_dir/$pack_slug" ]]; then
+            echo "  Local source found at: $local_source (re-syncing installed pack)"
+        else
+            echo "  Local source found at: $local_source (not yet installed)"
+        fi
+        install_pack_from_local "$pack_slug" "$local_source" "$packs_dir"
+        return $?
+    fi
+
+    # Registry is the LAST RESORT — only reached when no local source exists.
+    echo "  No local source found for '$pack_slug' (searched constructs.local_source_paths and default clone locations)"
+    echo "  Falling back to registry (last resort)"
 
     # Check offline mode
     if [[ "${LOA_OFFLINE:-}" == "1" ]]; then
@@ -423,82 +594,6 @@ do_install_pack() {
 
     # Get registry URL
     registry_url=$(get_registry_url)
-
-    # Create directories
-    packs_dir=$(get_packs_dir)
-    mkdir -p "$packs_dir"
-
-    # Ensure constructs directory is gitignored
-    ensure_constructs_gitignored
-
-    # Check for local source clone (prefer over stale registry download) — Issue #449
-    local local_source
-    if local_source=$(find_local_source "$pack_slug"); then
-        local meta_file
-        meta_file=$(get_registry_meta_path)
-        local should_use_local=false
-
-        if [[ ! -d "$packs_dir/$pack_slug" ]]; then
-            # Not installed yet — use local if available
-            should_use_local=true
-            echo "  Local source found at: $local_source (not yet installed)"
-        elif [[ -f "$meta_file" ]]; then
-            # Already installed — check if local is newer
-            local installed_at
-            installed_at=$(jq -r --arg s "$pack_slug" '.installed_packs[$s].installed_at // empty' "$meta_file" 2>/dev/null) || installed_at=""
-            if [[ -n "$installed_at" ]]; then
-                # Check if ANY file in local source is newer than install time
-                # (not just construct.yaml — the P0 bug was in dig-search.ts)
-                local installed_epoch
-                if type _date_to_epoch &>/dev/null; then
-                    installed_epoch=$(_date_to_epoch "$installed_at" 2>/dev/null) || installed_epoch=0
-                else
-                    installed_epoch=$(date -d "$installed_at" +%s 2>/dev/null) || installed_epoch=0
-                fi
-
-                if [[ $installed_epoch -gt 0 ]]; then
-                    # Find any file newer than install time
-                    local newer_file
-                    newer_file=$(find "$local_source" -type f -newer "$packs_dir/$pack_slug" -print -quit 2>/dev/null) || newer_file=""
-                    if [[ -n "$newer_file" ]]; then
-                        should_use_local=true
-                        echo "  Local source at $local_source has changes since last install"
-                    fi
-                fi
-            fi
-        fi
-
-        if [[ "$should_use_local" == "true" ]]; then
-            echo "  Installing from local source: $local_source"
-            # Copy from local source instead of downloading
-            mkdir -p "$packs_dir/$pack_slug"
-            cp -r "$local_source/." "$packs_dir/$pack_slug/"
-            # Update metadata
-            local now_ts
-            now_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-            init_registry_meta
-            local meta_tmp="${meta_file}.tmp.$$"
-            jq --arg slug "$pack_slug" --arg ts "$now_ts" --arg src "$local_source" \
-                '.installed_packs[$slug].installed_at = $ts | .installed_packs[$slug].source = "local" | .installed_packs[$slug].local_source = $src' \
-                "$meta_file" > "$meta_tmp" && mv "$meta_tmp" "$meta_file"
-
-            # Symlink commands
-            echo "  Linking commands..."
-            local commands_linked
-            commands_linked=$(symlink_pack_commands "$pack_slug")
-            echo "  Created $commands_linked command symlinks"
-
-            # Symlink skills
-            echo "  Linking skills..."
-            local skills_linked
-            skills_linked=$(symlink_pack_skills "$pack_slug")
-            echo "  Created $skills_linked skill symlinks"
-
-            echo ""
-            print_success "Pack '$pack_slug' installed from local source"
-            return $EXIT_SUCCESS
-        fi
-    fi
 
     echo "  Downloading from $registry_url/packs/$pack_slug/download..."
 
@@ -1262,6 +1357,9 @@ Commands:
     uninstall pack <slug>    Uninstall a pack
     uninstall skill <slug>   Uninstall a skill
     link-commands <slug>     Re-link pack commands (use "all" for all packs)
+    resync <slug|--all>      Force re-sync from local source clones (alias: update)
+                             Never contacts the registry; packs without a
+                             local source are skipped with a report line
 
 Exit Codes:
     0 = success
@@ -1331,6 +1429,10 @@ main() {
         link-commands)
             [[ -n "${2:-}" ]] || { print_error "ERROR: Missing pack slug (or 'all')"; exit $EXIT_ERROR; }
             do_link_commands "$2"
+            ;;
+        resync|--resync|update|--update)
+            [[ -n "${2:-}" ]] || { print_error "ERROR: Missing pack slug (or --all)"; show_usage; exit $EXIT_ERROR; }
+            do_resync "$2"
             ;;
         -h|--help|help)
             show_usage

--- a/.claude/scripts/constructs-lib.sh
+++ b/.claude/scripts/constructs-lib.sh
@@ -588,12 +588,47 @@ find_local_source() {
 
     for path in "${search_paths[@]}"; do
         if [[ -d "$path" && ( -f "$path/construct.yaml" || -f "$path/manifest.json" ) ]]; then
-            echo "$path"
-            return 0
+            # bd-mjd: a candidate dir must MATCH the requested slug — without
+            # this, every configured local_source_paths entry satisfied every
+            # slug, and the first existing dir won (post-#1021 that mirrors
+            # the WRONG pack's content over an installed pack). Default paths
+            # embed the slug, so they pass the basename check unchanged.
+            if _local_source_matches_slug "$path" "$slug"; then
+                echo "$path"
+                return 0
+            fi
         fi
     done
 
     return 1
+}
+
+# Does a candidate local-source dir belong to the requested slug? (bd-mjd)
+# Accepts: basename `construct-<slug>` or `<slug>` (case-insensitive), OR a
+# declared name/slug in the dir's construct.yaml (.name) / manifest.json
+# (.slug, falling back to .name) equal to the slug case-insensitively.
+# Args: $1 = candidate dir, $2 = requested slug
+_local_source_matches_slug() {
+    local path="$1"
+    local slug="$2"
+
+    local slug_lc base_lc
+    slug_lc=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
+    base_lc=$(basename "$path" | tr '[:upper:]' '[:lower:]')
+    if [[ "$base_lc" == "construct-$slug_lc" || "$base_lc" == "$slug_lc" ]]; then
+        return 0
+    fi
+
+    local declared=""
+    if [[ -f "$path/construct.yaml" ]]; then
+        declared=$(yq eval '.name // ""' "$path/construct.yaml" 2>/dev/null) || declared=""
+    fi
+    if [[ -z "$declared" && -f "$path/manifest.json" ]]; then
+        declared=$(jq -r '.slug // .name // ""' "$path/manifest.json" 2>/dev/null) || declared=""
+    fi
+    declared=$(printf '%s' "$declared" | tr '[:upper:]' '[:lower:]')
+
+    [[ -n "$declared" && "$declared" == "$slug_lc" ]]
 }
 
 # Update registry meta file

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1715,9 +1715,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260612-i980-6cfd2b/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260612-i980-6cfd2b/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260612-75116b",
+      "label": "Bug Fix — Constructs install falls through to dead registry instead of local GitHub SoT",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa-constructs/issues/253",
+      "created_at": "2026-06-12T20:08:56Z",
+      "sprints": [
+        "sprint-bug-205"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260612-75116b/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260612-75116b/sprint.md"
     }
   ],
-  "global_sprint_counter": 204,
+  "global_sprint_counter": 205,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1728,9 +1728,23 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260612-75116b/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260612-75116b/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260612-ca7070",
+      "label": "Bug Fix — find_local_source is slug-blind for configured paths",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": null,
+      "beads": "bd-mjd",
+      "created_at": "2026-06-12T21:17:01Z",
+      "sprints": [
+        "sprint-bug-207"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260612-ca7070/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260612-ca7070/sprint.md"
     }
   ],
-  "global_sprint_counter": 205,
+  "global_sprint_counter": 207,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/test_constructs_install.bats
+++ b/tests/unit/test_constructs_install.bats
@@ -633,3 +633,130 @@ EOF
     run check_pack_staleness "missing-pack" 7
     [ "$status" -eq 1 ]
 }
+
+# =============================================================================
+# Local SoT preference & resync (sprint-bug-205, loa-constructs#253)
+# =============================================================================
+
+# Helper: create a git local source clone for a slug under the current $HOME.
+# main branch (pushed to a file-based origin) carries payload.txt=main-content;
+# the clone is then parked on a WIP branch with divergent payload.txt, so tests
+# can distinguish origin/main content from working-tree content.
+create_git_local_source() {
+    local slug="$1"
+    local src="$HOME/Documents/GitHub/construct-$slug"
+    local bare="$TEST_TMPDIR/origins/$slug.git"
+
+    mkdir -p "$HOME/Documents/GitHub" "$TEST_TMPDIR/origins"
+    git init -q "$src"
+    git -C "$src" checkout -q -b main 2>/dev/null || true
+    git -C "$src" config user.email "test@test.invalid"
+    git -C "$src" config user.name "test"
+    echo "name: $slug" > "$src/construct.yaml"
+    echo "main-content" > "$src/payload.txt"
+    git -C "$src" add -A
+    git -C "$src" commit -qm "main content"
+    git init -q --bare "$bare"
+    git -C "$src" remote add origin "$bare"
+    git -C "$src" push -q origin main
+    git -C "$src" fetch -q origin
+    git -C "$src" checkout -q -b wip
+    echo "wip-content" > "$src/payload.txt"
+    git -C "$src" add -A
+    git -C "$src" commit -qm "wip divergence"
+    echo "$src"
+}
+
+@test "installed pack with local source and absent meta installs from local SoT (not registry)" {
+    skip_if_not_implemented
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    export HOME="$TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+    export LOA_CONSTRUCTS_API_KEY="test-key"
+    export LOA_REGISTRY_URL="https://127.0.0.1:1"
+
+    create_git_local_source "metaless" >/dev/null
+
+    # Pack already installed (stale copy: payload.txt missing), meta file ABSENT
+    mkdir -p "$LOA_CONSTRUCTS_DIR/packs/metaless"
+    echo 'name: metaless' > "$LOA_CONSTRUCTS_DIR/packs/metaless/construct.yaml"
+    [ ! -f ".claude/constructs/.constructs-meta.json" ]
+
+    source "$INSTALL_SCRIPT"
+    run do_install_pack "metaless"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Downloading from"* ]]
+    [[ "$output" == *"local source"* ]]
+    [ -f "$LOA_CONSTRUCTS_DIR/packs/metaless/payload.txt" ]
+}
+
+@test "local source parked on WIP branch installs origin/main content, not working tree" {
+    skip_if_not_implemented
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    export HOME="$TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+    export LOA_CONSTRUCTS_API_KEY="test-key"
+    export LOA_REGISTRY_URL="https://127.0.0.1:1"
+
+    create_git_local_source "wipper" >/dev/null
+
+    source "$INSTALL_SCRIPT"
+    run do_install_pack "wipper"
+
+    [ "$status" -eq 0 ]
+    [ -f "$LOA_CONSTRUCTS_DIR/packs/wipper/payload.txt" ]
+    [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/wipper/payload.txt")" = "main-content" ]
+}
+
+@test "resync --all re-syncs packs with local sources and skips packs without" {
+    skip_if_not_implemented
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    export HOME="$TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+    # Deliberately NO API key: resync is a pure local primitive and must
+    # never require registry authentication.
+
+    create_git_local_source "resync-a" >/dev/null
+
+    # resync-a installed but stale (payload.txt missing); resync-b has no local source
+    mkdir -p "$LOA_CONSTRUCTS_DIR/packs/resync-a"
+    echo 'name: resync-a' > "$LOA_CONSTRUCTS_DIR/packs/resync-a/construct.yaml"
+    mkdir -p "$LOA_CONSTRUCTS_DIR/packs/resync-b"
+    echo 'name: resync-b' > "$LOA_CONSTRUCTS_DIR/packs/resync-b/construct.yaml"
+
+    run bash "$INSTALL_SCRIPT" resync --all
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Downloading from"* ]]
+    [ -f "$LOA_CONSTRUCTS_DIR/packs/resync-a/payload.txt" ]
+    [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/resync-a/payload.txt")" = "main-content" ]
+    [[ "$output" == *"resync-b"*"no local source"* ]]
+    [[ "$output" == *"1 synced"* ]]
+    [[ "$output" == *"1 skipped"* ]]
+}
+
+@test "fetch failure tolerated: install still mirrors existing origin/main ref" {
+    skip_if_not_implemented
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    export HOME="$TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+    export LOA_CONSTRUCTS_API_KEY="test-key"
+    export LOA_REGISTRY_URL="https://127.0.0.1:1"
+
+    local src
+    src=$(create_git_local_source "offtol")
+    # Break the origin remote: fetch will fail, but refs/remotes/origin/main persists
+    git -C "$src" remote set-url origin "$TEST_TMPDIR/nonexistent-origin.git"
+
+    source "$INSTALL_SCRIPT"
+    run do_install_pack "offtol"
+
+    [ "$status" -eq 0 ]
+    [ -f "$LOA_CONSTRUCTS_DIR/packs/offtol/payload.txt" ]
+    [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/offtol/payload.txt")" = "main-content" ]
+}

--- a/tests/unit/test_constructs_install.bats
+++ b/tests/unit/test_constructs_install.bats
@@ -760,3 +760,56 @@ create_git_local_source() {
     [ -f "$LOA_CONSTRUCTS_DIR/packs/offtol/payload.txt" ]
     [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/offtol/payload.txt")" = "main-content" ]
 }
+
+@test "resync prunes files deleted from origin/main after a prior install (DISS-001)" {
+    skip_if_not_implemented
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    export HOME="$TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+
+    local src
+    src=$(create_git_local_source "pruner")
+
+    # First install from local SoT — pack gains payload.txt
+    run bash "$INSTALL_SCRIPT" pack pruner
+    [ "$status" -eq 0 ]
+    [ -f "$LOA_CONSTRUCTS_DIR/packs/pruner/payload.txt" ]
+
+    # Upstream deletes payload.txt on main
+    git -C "$src" checkout -q main
+    git -C "$src" rm -q payload.txt
+    git -C "$src" commit -qm "remove payload"
+    git -C "$src" push -q origin main
+    git -C "$src" checkout -q wip
+
+    run bash "$INSTALL_SCRIPT" resync pruner
+
+    [ "$status" -eq 0 ]
+    # Mirror semantics: the deleted file must be pruned, kept files remain
+    [ ! -f "$LOA_CONSTRUCTS_DIR/packs/pruner/payload.txt" ]
+    [ -f "$LOA_CONSTRUCTS_DIR/packs/pruner/construct.yaml" ]
+}
+
+@test "license file from a prior install survives a local re-sync (DISS-001 guard)" {
+    skip_if_not_implemented
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    export HOME="$TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+
+    create_git_local_source "licensed" >/dev/null
+
+    run bash "$INSTALL_SCRIPT" pack licensed
+    [ "$status" -eq 0 ]
+
+    # Simulate registry-era runtime state not tracked in the source repo
+    echo '{"token":"keep-me"}' > "$LOA_CONSTRUCTS_DIR/packs/licensed/.license.json"
+
+    run bash "$INSTALL_SCRIPT" resync licensed
+
+    [ "$status" -eq 0 ]
+    [ -f "$LOA_CONSTRUCTS_DIR/packs/licensed/.license.json" ]
+    [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/licensed/.license.json")" = '{"token":"keep-me"}' ]
+    [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/licensed/payload.txt")" = "main-content" ]
+}

--- a/tests/unit/test_constructs_install.bats
+++ b/tests/unit/test_constructs_install.bats
@@ -813,3 +813,69 @@ create_git_local_source() {
     [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/licensed/.license.json")" = '{"token":"keep-me"}' ]
     [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/licensed/payload.txt")" = "main-content" ]
 }
+
+# =============================================================================
+# Configured-path slug matching (sprint-bug-207, bd-mjd)
+# =============================================================================
+# constructs.local_source_paths entries were checked only for existence +
+# manifest presence, never matched against the requested slug — any slug
+# resolved to the first existing configured dir. Post-#1021 (local-SoT-first
+# with atomic replace), that mis-resolution would mirror the WRONG pack's
+# content over an installed pack.
+
+@test "bd-mjd: configured path for a different pack does not satisfy an unrelated slug" {
+    skip_if_not_implemented
+
+    mkdir -p "$TEST_TMPDIR/sources/construct-gecko"
+    echo 'name: gecko' > "$TEST_TMPDIR/sources/construct-gecko/construct.yaml"
+    cat > "$TEST_TMPDIR/.loa.config.yaml" << EOF
+constructs:
+  local_source_paths:
+    - $TEST_TMPDIR/sources/construct-gecko
+EOF
+
+    source "$PROJECT_ROOT/.claude/scripts/constructs-lib.sh"
+    run find_local_source "kranz"
+
+    # Slug-blind behavior returned the gecko path with rc=0; a non-matching
+    # configured path must be skipped → no source found → return 1.
+    [ "$status" -eq 1 ]
+}
+
+@test "bd-mjd: configured path satisfies its own slug via basename match" {
+    skip_if_not_implemented
+
+    mkdir -p "$TEST_TMPDIR/sources/construct-gecko"
+    echo 'name: gecko' > "$TEST_TMPDIR/sources/construct-gecko/construct.yaml"
+    cat > "$TEST_TMPDIR/.loa.config.yaml" << EOF
+constructs:
+  local_source_paths:
+    - $TEST_TMPDIR/sources/construct-gecko
+EOF
+
+    source "$PROJECT_ROOT/.claude/scripts/constructs-lib.sh"
+    run find_local_source "gecko"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"construct-gecko"* ]]
+}
+
+@test "bd-mjd: configured path with non-slug basename matches via manifest name (case-insensitive)" {
+    skip_if_not_implemented
+
+    # Checkout dir name carries no slug; construct.yaml declares the name in
+    # uppercase (the real construct-fagan manifest declares name: "FAGAN").
+    mkdir -p "$TEST_TMPDIR/sources/my-pack-checkout"
+    echo 'name: "KRANZ"' > "$TEST_TMPDIR/sources/my-pack-checkout/construct.yaml"
+    cat > "$TEST_TMPDIR/.loa.config.yaml" << EOF
+constructs:
+  local_source_paths:
+    - $TEST_TMPDIR/sources/my-pack-checkout
+EOF
+
+    source "$PROJECT_ROOT/.claude/scripts/constructs-lib.sh"
+    run find_local_source "kranz"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"my-pack-checkout"* ]]
+}


### PR DESCRIPTION
Fixes bd-mjd (discovered during sprint-bug-205, `discovered-during:br-h2r`). **Stacked on #1021** (base = `fix/constructs-install-local-sot`): merge #1021 first; this diff is the slug-match commit only.

## What

`find_local_source()` treated every `constructs.local_source_paths` entry as a valid source for ANY slug: the candidate loop checked dir existence + manifest presence but never the requested slug, so any slug resolved to the first existing configured dir.

Post-#1021 this stops being a freshness nuisance and becomes a wrong-pack overwrite vector: local-SoT-first install with atomic replace would mirror the WRONG pack's content over an installed pack. Verified live during triage: `find_local_source "kranz"` with only a `construct-gecko` configured path returned the gecko path, rc=0.

## Fix

A candidate dir matches only if:
- basename is `construct-<slug>` or `<slug>` (case-insensitive), OR
- its `construct.yaml` `.name` / `manifest.json` `.slug // .name` equals the slug case-insensitively (covers real manifests like construct-fagan's `name: "FAGAN"`).

Non-matching paths are skipped; no match anywhere returns 1 (registry fall-through preserved, guard test at `:559` green). Default paths embed the slug and pass the basename check by construction: zero behavior change for non-config lookups.

## Evidence

Test-first: rejection case red pre-fix, green post-fix; 2 acceptance pins guard against over-rejection. Suites: 36/36 install (all six #1021 tests intact), 34/34 lib, shellcheck clean. Full AC walk in the sprint report (`grimoires/loa/a2a/bug-20260612-ca7070/reviewer.md`, a2a gitignored).

Known limitation flagged for review: multi-word manifest names (`The Arcade`) don't normalize to slugs (`the-arcade`); such dirs match via basename only. No estate case observed; predicate kept minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
