### PR TITLE
fix(constructs): find_local_source slug-matches candidate dirs (bd-mjd, supersedes #1023)

### DIFF
--- a/.claude/scripts/constructs-lib.sh
+++ b/.claude/scripts/constructs-lib.sh
@@ -588,12 +588,47 @@ find_local_source() {
 
     for path in "${search_paths[@]}"; do
         if [[ -d "$path" && ( -f "$path/construct.yaml" || -f "$path/manifest.json" ) ]]; then
-            echo "$path"
-            return 0
+            # bd-mjd: a candidate dir must MATCH the requested slug — without
+            # this, every configured local_source_paths entry satisfied every
+            # slug, and the first existing dir won (post-#1021 that mirrors
+            # the WRONG pack's content over an installed pack). Default paths
+            # embed the slug, so they pass the basename check unchanged.
+            if _local_source_matches_slug "$path" "$slug"; then
+                echo "$path"
+                return 0
+            fi
         fi
     done
 
     return 1
+}
+
+# Does a candidate local-source dir belong to the requested slug? (bd-mjd)
+# Accepts: basename `construct-<slug>` or `<slug>` (case-insensitive), OR a
+# declared name/slug in the dir's construct.yaml (.name) / manifest.json
+# (.slug, falling back to .name) equal to the slug case-insensitively.
+# Args: $1 = candidate dir, $2 = requested slug
+_local_source_matches_slug() {
+    local path="$1"
+    local slug="$2"
+
+    local slug_lc base_lc
+    slug_lc=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
+    base_lc=$(basename "$path" | tr '[:upper:]' '[:lower:]')
+    if [[ "$base_lc" == "construct-$slug_lc" || "$base_lc" == "$slug_lc" ]]; then
+        return 0
+    fi
+
+    local declared=""
+    if [[ -f "$path/construct.yaml" ]]; then
+        declared=$(yq eval '.name // ""' "$path/construct.yaml" 2>/dev/null) || declared=""
+    fi
+    if [[ -z "$declared" && -f "$path/manifest.json" ]]; then
+        declared=$(jq -r '.slug // .name // ""' "$path/manifest.json" 2>/dev/null) || declared=""
+    fi
+    declared=$(printf '%s' "$declared" | tr '[:upper:]' '[:lower:]')
+
+    [[ -n "$declared" && "$declared" == "$slug_lc" ]]
 }
 
 # Update registry meta file

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1728,9 +1728,23 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260612-75116b/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260612-75116b/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260612-ca7070",
+      "label": "Bug Fix — find_local_source is slug-blind for configured paths",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": null,
+      "beads": "bd-mjd",
+      "created_at": "2026-06-12T21:17:01Z",
+      "sprints": [
+        "sprint-bug-207"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260612-ca7070/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260612-ca7070/sprint.md"
     }
   ],
-  "global_sprint_counter": 205,
+  "global_sprint_counter": 207,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/test_constructs_install.bats
+++ b/tests/unit/test_constructs_install.bats
@@ -813,3 +813,69 @@ create_git_local_source() {
     [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/licensed/.license.json")" = '{"token":"keep-me"}' ]
     [ "$(cat "$LOA_CONSTRUCTS_DIR/packs/licensed/payload.txt")" = "main-content" ]
 }
+
+# =============================================================================
+# Configured-path slug matching (sprint-bug-207, bd-mjd)
+# =============================================================================
+# constructs.local_source_paths entries were checked only for existence +
+# manifest presence, never matched against the requested slug — any slug
+# resolved to the first existing configured dir. Post-#1021 (local-SoT-first
+# with atomic replace), that mis-resolution would mirror the WRONG pack's
+# content over an installed pack.
+
+@test "bd-mjd: configured path for a different pack does not satisfy an unrelated slug" {
+    skip_if_not_implemented
+
+    mkdir -p "$TEST_TMPDIR/sources/construct-gecko"
+    echo 'name: gecko' > "$TEST_TMPDIR/sources/construct-gecko/construct.yaml"
+    cat > "$TEST_TMPDIR/.loa.config.yaml" << EOF
+constructs:
+  local_source_paths:
+    - $TEST_TMPDIR/sources/construct-gecko
+EOF
+
+    source "$PROJECT_ROOT/.claude/scripts/constructs-lib.sh"
+    run find_local_source "kranz"
+
+    # Slug-blind behavior returned the gecko path with rc=0; a non-matching
+    # configured path must be skipped → no source found → return 1.
+    [ "$status" -eq 1 ]
+}
+
+@test "bd-mjd: configured path satisfies its own slug via basename match" {
+    skip_if_not_implemented
+
+    mkdir -p "$TEST_TMPDIR/sources/construct-gecko"
+    echo 'name: gecko' > "$TEST_TMPDIR/sources/construct-gecko/construct.yaml"
+    cat > "$TEST_TMPDIR/.loa.config.yaml" << EOF
+constructs:
+  local_source_paths:
+    - $TEST_TMPDIR/sources/construct-gecko
+EOF
+
+    source "$PROJECT_ROOT/.claude/scripts/constructs-lib.sh"
+    run find_local_source "gecko"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"construct-gecko"* ]]
+}
+
+@test "bd-mjd: configured path with non-slug basename matches via manifest name (case-insensitive)" {
+    skip_if_not_implemented
+
+    # Checkout dir name carries no slug; construct.yaml declares the name in
+    # uppercase (the real construct-fagan manifest declares name: "FAGAN").
+    mkdir -p "$TEST_TMPDIR/sources/my-pack-checkout"
+    echo 'name: "KRANZ"' > "$TEST_TMPDIR/sources/my-pack-checkout/construct.yaml"
+    cat > "$TEST_TMPDIR/.loa.config.yaml" << EOF
+constructs:
+  local_source_paths:
+    - $TEST_TMPDIR/sources/my-pack-checkout
+EOF
+
+    source "$PROJECT_ROOT/.claude/scripts/constructs-lib.sh"
+    run find_local_source "kranz"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"my-pack-checkout"* ]]
+}


### PR DESCRIPTION
Supersedes #1023 (auto-closed by GitHub when its stack base #1021 merged with branch deletion; branch since rebased onto main, identical diff). Fixes bd-mjd. Full review trail on #1023: reviewer verdict "All good (with noted concerns)", cross-model dissent 0 findings, and the same defect independently flagged by Codex as P1 on #1021.

## What

`find_local_source()` treated every `constructs.local_source_paths` entry as a valid source for ANY slug. Post-#1021 local-SoT-first install, that mis-resolution mirrors the WRONG pack's content over an installed pack via the atomic-replace path. Verified live during triage: `find_local_source "kranz"` with only a `construct-gecko` configured path returned the gecko path, rc=0.

## Fix

A candidate dir matches only if its basename is `construct-<slug>` or `<slug>` (case-insensitive), or its `construct.yaml` `.name` / `manifest.json` `.slug // .name` equals the slug case-insensitively. Non-matching paths are skipped; no match returns 1 (registry fall-through guard at `:559` green). Default paths embed the slug and pass by construction: zero behavior change for non-config lookups. Glob-safe: quoted RHS in `[[ ]]` makes comparisons literal.

## Evidence

Test-first: rejection case red pre-fix, green post-fix, plus 2 acceptance pins. Suites re-run post-rebase on this exact head: bd-mjd 3/3, install 36/36, lib 34/34, shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
