### PR TITLE
fix(gates): #1025 sweep leg 2 — swallowed-jq + input-validation hardening in post-pr-triage & red-team-retention (sprint-bug-210)

### DIFF
--- a/.claude/scripts/post-pr-triage.sh
+++ b/.claude/scripts/post-pr-triage.sh
@@ -399,7 +399,23 @@ process_findings_file() {
   done
 }
 
+# DISS-001 (review iter-3): hard-require jq + the soft-sourced compat-lib
+# helper before processing. A missing helper must surface as a clear config
+# error (exit 2), not as a misleading per-file DEGRADED (which would conflate
+# "environment broken" with "all findings artifacts corrupt").
+_require_deps() {
+  local missing=()
+  command -v jq >/dev/null 2>&1 || missing+=("jq")
+  declare -F jq_strict >/dev/null 2>&1 || missing+=("jq_strict (compat-lib.sh)")
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    log "FATAL: required dependencies unavailable: ${missing[*]} — config error (#1025 / DISS-001)"
+    return 2
+  fi
+}
+
 main() {
+  _require_deps || exit $?
+
   if [[ ! -d "$REVIEW_DIR" ]]; then
     log "Review directory not found: $REVIEW_DIR"
     log "No findings to triage (bridge-orchestrator may not have run yet)"

--- a/.claude/scripts/post-pr-triage.sh
+++ b/.claude/scripts/post-pr-triage.sh
@@ -17,12 +17,26 @@
 #
 # Exit codes:
 #   0 - Triage complete (findings processed or none present — both success)
-#   1 - Input validation error
+#   1 - Input validation error (incl. corrupt .run/bridge-state.json)
 #   2 - Configuration error
+#   3 - Triage DEGRADED: one or more findings artifacts failed to parse
+#       (sprint-bug-210 / #1025; convergence record carries state=DEGRADED +
+#       parse_failures — that record, not this exit code, is the load-bearing
+#       channel for the orchestrator)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# sprint-bug-210 (#1025): jq_strict (fail-loud jq) from compat-lib. Defensive
+# source pattern per adversarial-review.sh:43-51 — absolute SCRIPT_DIR path,
+# soft-fail so eval-based test sourcing can pre-source.
+# shellcheck source=compat-lib.sh
+source "$SCRIPT_DIR/compat-lib.sh" 2>/dev/null || true
+
+# Accumulate-then-fail: parse failures are counted, every remaining artifact
+# is still processed, and main exits 3 with a DEGRADED convergence record.
+PARSE_FAILURES=0
 
 # Default paths resolve relative to cwd (not script location) to stay consistent
 # with how post-pr-orchestrator.sh passes paths and with how bridge-orchestrator.sh
@@ -302,7 +316,14 @@ process_findings_file() {
   iteration=$(basename "$findings_file" | grep -oE 'iter[0-9]+' | grep -oE '[0-9]+' || echo "1")
 
   local total_findings
-  total_findings=$(jq '.findings | length // 0' "$findings_file" 2>/dev/null || echo "0")  # check-no-swallowed-jq: ok (pending #1025 sweep)
+  # sprint-bug-210 (#1025) / KF-004 guard: a corrupt findings artifact must
+  # never read as zero-findings-clean — that silently drops CRITICAL/BLOCKER
+  # findings from the bug queue and lets the run emit FLATLINE.
+  if ! total_findings=$(JQ_STRICT_CTX="post-pr-triage:total-findings" jq_strict '.findings | length // 0' "$findings_file"); then
+    log "ERROR: findings file unparseable: $findings_file — triage will exit DEGRADED, not clean (KF-004 guard, #1025)"
+    PARSE_FAILURES=$((PARSE_FAILURES + 1))
+    return 0
+  fi
 
   if [[ "$total_findings" -eq 0 ]]; then
     log "No findings in $findings_file"
@@ -334,7 +355,11 @@ process_findings_file() {
   local idx=0
   while [[ $idx -lt $total_findings ]]; do
     local finding_json
-    finding_json=$(jq -c ".findings[$idx]" "$findings_file" 2>/dev/null || echo "null")  # check-no-swallowed-jq: ok (pending #1025 sweep)
+    if ! finding_json=$(JQ_STRICT_CTX="post-pr-triage:finding-extract" jq_strict -c ".findings[$idx]" "$findings_file"); then
+      log "ERROR: finding[$idx] extraction failed in $findings_file (KF-004 guard, #1025)"
+      PARSE_FAILURES=$((PARSE_FAILURES + 1))
+      finding_json="null"
+    fi
 
     if [[ "$finding_json" == "null" ]]; then
       idx=$((idx + 1))
@@ -389,7 +414,14 @@ main() {
   local bridge_state_file="$CWD_AT_INVOKE/.run/bridge-state.json"
   local bridge_id=""
   if [[ -f "$bridge_state_file" ]]; then
-    bridge_id=$(jq -r '.bridge_id // empty' "$bridge_state_file" 2>/dev/null || echo "")  # check-no-swallowed-jq: ok (pending #1025 sweep)
+    # sprint-bug-210 (#1025): a CORRUPT state file must not fall through to
+    # the glob-all legacy path — that resurrects #676 Defect B (stale findings
+    # re-tagged to the current PR). Absent file / absent bridge_id (valid
+    # JSON) keep the documented legacy behavior.
+    if ! bridge_id=$(JQ_STRICT_CTX="post-pr-triage:bridge-id" jq_strict -r '.bridge_id // empty' "$bridge_state_file"); then
+      log "ERROR: corrupt bridge-state.json: $bridge_state_file — refusing glob fall-through (#676 Defect B guard, #1025)"
+      return 1
+    fi
   fi
 
   local findings_files=()
@@ -460,7 +492,12 @@ main() {
   fi
 
   local convergence_state
-  if [[ "$actionable_high" -eq 0 && "$blocker_count" -eq 0 ]]; then
+  # sprint-bug-210 (#1025): parse failures force DEGRADED — never FLATLINE.
+  # The convergence record is the orchestrator's load-bearing channel
+  # (post-pr-orchestrator.sh treats the triage exit code as non-fatal).
+  if [[ "$PARSE_FAILURES" -gt 0 ]]; then
+    convergence_state="DEGRADED"
+  elif [[ "$actionable_high" -eq 0 && "$blocker_count" -eq 0 ]]; then
     convergence_state="FLATLINE"
   else
     convergence_state="KEEP_ITERATING"
@@ -479,7 +516,8 @@ main() {
       --argjson blocker "$blocker_count" \
       --argjson disputed "$disputed_count" \
       --arg state "$convergence_state" \
-      '{timestamp: $ts, pr_number: $pr, state: $state, actionable_high: $high, blocker_count: $blocker, disputed_count: $disputed}' \
+      --argjson pf "$PARSE_FAILURES" \
+      '{timestamp: $ts, pr_number: $pr, state: $state, actionable_high: $high, blocker_count: $blocker, disputed_count: $disputed, parse_failures: $pf}' \
       > "$convergence_file"
   fi
 
@@ -492,6 +530,10 @@ main() {
     fi
   fi
 
+  if [[ "$PARSE_FAILURES" -gt 0 ]]; then
+    log "Triage DEGRADED: $PARSE_FAILURES parse failure(s) — exit 3 (convergence record carries state=DEGRADED)"
+    return 3
+  fi
   return 0
 }
 

--- a/.claude/scripts/post-pr-triage.sh
+++ b/.claude/scripts/post-pr-triage.sh
@@ -366,6 +366,18 @@ process_findings_file() {
       continue
     fi
 
+    # AUDIT-1 (#1025): a schema-valid but non-object element (e.g.
+    # {"findings": ["str"]}) survives the jq_strict guards above, but the
+    # per-field `.id // "unknown"` extraction below errors on a non-object and
+    # aborts under set -e BEFORE the convergence write — a stale-clean hole.
+    # Route shape-invalid elements to DEGRADED instead.
+    if ! echo "$finding_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+      log "ERROR: finding[$idx] is not a JSON object (shape-invalid) in $findings_file — DEGRADED, not silent abort (#1025)"
+      PARSE_FAILURES=$((PARSE_FAILURES + 1))
+      idx=$((idx + 1))
+      continue
+    fi
+
     local fid severity title
     fid=$(echo "$finding_json" | jq -r '.id // "unknown"')
     severity=$(echo "$finding_json" | jq -r '.severity // "UNKNOWN"')

--- a/.claude/scripts/post-pr-triage.sh
+++ b/.claude/scripts/post-pr-triage.sh
@@ -420,6 +420,18 @@ main() {
     # JSON) keep the documented legacy behavior.
     if ! bridge_id=$(JQ_STRICT_CTX="post-pr-triage:bridge-id" jq_strict -r '.bridge_id // empty' "$bridge_state_file"); then
       log "ERROR: corrupt bridge-state.json: $bridge_state_file — refusing glob fall-through (#676 Defect B guard, #1025)"
+      # DISS-001 (review iter-1): overwrite any stale convergence record so a
+      # prior iteration's FLATLINE can't survive this refusal — the
+      # orchestrator reads .state from this file, not the exit code.
+      if [[ "$DRY_RUN" != "true" ]]; then
+        local conv="$CWD_AT_INVOKE/.run/bridge-triage-convergence.json"
+        mkdir -p "$(dirname "$conv")"
+        jq -nc \
+          --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+          --argjson pr "$PR_NUMBER" \
+          '{timestamp: $ts, pr_number: $pr, state: "DEGRADED", actionable_high: 0, blocker_count: 0, disputed_count: 0, parse_failures: 1, reason: "corrupt bridge-state.json"}' \
+          > "$conv"
+      fi
       return 1
     fi
   fi

--- a/.claude/scripts/post-pr-triage.sh
+++ b/.claude/scripts/post-pr-triage.sh
@@ -315,12 +315,25 @@ process_findings_file() {
   local iteration
   iteration=$(basename "$findings_file" | grep -oE 'iter[0-9]+' | grep -oE '[0-9]+' || echo "1")
 
-  local total_findings
+  local total_findings ftype
   # sprint-bug-210 (#1025) / KF-004 guard: a corrupt findings artifact must
   # never read as zero-findings-clean — that silently drops CRITICAL/BLOCKER
   # findings from the bug queue and lets the run emit FLATLINE.
-  if ! total_findings=$(JQ_STRICT_CTX="post-pr-triage:total-findings" jq_strict '.findings | length // 0' "$findings_file"); then
+  if ! ftype=$(JQ_STRICT_CTX="post-pr-triage:findings-type" jq_strict -r '.findings | type' "$findings_file"); then
     log "ERROR: findings file unparseable: $findings_file — triage will exit DEGRADED, not clean (KF-004 guard, #1025)"
+    PARSE_FAILURES=$((PARSE_FAILURES + 1))
+    return 0
+  fi
+  # DISS-001 (#1025): a non-array .findings (object/string/absent) is a shape
+  # failure, not zero clean findings. `{"findings":{}}` / `""` would otherwise
+  # `length` to 0 and read as clean.
+  if [[ "$ftype" != "array" ]]; then
+    log "ERROR: .findings is '$ftype' (not an array) in $findings_file — DEGRADED, not zero-clean (#1025)"
+    PARSE_FAILURES=$((PARSE_FAILURES + 1))
+    return 0
+  fi
+  if ! total_findings=$(JQ_STRICT_CTX="post-pr-triage:total-findings" jq_strict '.findings | length' "$findings_file"); then
+    log "ERROR: findings count failed: $findings_file — DEGRADED (#1025)"
     PARSE_FAILURES=$((PARSE_FAILURES + 1))
     return 0
   fi
@@ -361,18 +374,15 @@ process_findings_file() {
       finding_json="null"
     fi
 
-    if [[ "$finding_json" == "null" ]]; then
-      idx=$((idx + 1))
-      continue
-    fi
-
-    # AUDIT-1 (#1025): a schema-valid but non-object element (e.g.
-    # {"findings": ["str"]}) survives the jq_strict guards above, but the
-    # per-field `.id // "unknown"` extraction below errors on a non-object and
-    # aborts under set -e BEFORE the convergence write — a stale-clean hole.
-    # Route shape-invalid elements to DEGRADED instead.
+    # AUDIT-1 + DISS-001 (#1025): every element must be a JSON object. A
+    # non-object element (literal null, string, number, nested array) survives
+    # the jq_strict array extraction, but the per-field `.id // "unknown"`
+    # below errors on a non-object and aborts under set -e BEFORE the
+    # convergence write — a stale-clean hole. Route shape-invalid elements to
+    # DEGRADED. (Replaces the old literal-"null" skip, which silently dropped
+    # null elements instead of flagging them.)
     if ! echo "$finding_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
-      log "ERROR: finding[$idx] is not a JSON object (shape-invalid) in $findings_file — DEGRADED, not silent abort (#1025)"
+      log "ERROR: finding[$idx] is not a JSON object (shape-invalid) in $findings_file — DEGRADED, not silent skip/abort (#1025)"
       PARSE_FAILURES=$((PARSE_FAILURES + 1))
       idx=$((idx + 1))
       continue

--- a/.claude/scripts/post-pr-triage.sh
+++ b/.claude/scripts/post-pr-triage.sh
@@ -414,7 +414,16 @@ _require_deps() {
 }
 
 main() {
-  _require_deps || exit $?
+  if ! _require_deps; then
+    # DISS-002 iter-4: the dep-guard exits before the normal convergence write,
+    # so a stale (possibly FLATLINE) record from a prior run must be invalidated
+    # — else the orchestrator reads it as clean. rm (not a DEGRADED jq-write)
+    # because jq itself may be the missing dependency.
+    if [[ "$DRY_RUN" != "true" ]]; then
+      rm -f "$CWD_AT_INVOKE/.run/bridge-triage-convergence.json"
+    fi
+    exit 2
+  fi
 
   if [[ ! -d "$REVIEW_DIR" ]]; then
     log "Review directory not found: $REVIEW_DIR"

--- a/.claude/scripts/red-team-retention.sh
+++ b/.claude/scripts/red-team-retention.sh
@@ -178,6 +178,14 @@ purge_expired() {
                 classification="RESTRICTED"
                 audit "CONSERVATIVE: $result_file unparseable timestamp '$timestamp' — RESTRICTED policy, mtime age (#1025)"
                 created=$(_file_mtime_epoch "$result_file")
+            elif (( created > now + 86400 )); then
+                # AUDIT-2 (#1025): a beyond-clock-skew FUTURE timestamp makes
+                # age negative → indefinite retention. Treat as suspicious:
+                # conservative RESTRICTED, age by mtime (not the future value).
+                conservative=true
+                classification="RESTRICTED"
+                audit "CONSERVATIVE: $result_file has a future timestamp '$timestamp' — RESTRICTED policy, mtime age (#1025)"
+                created=$(_file_mtime_epoch "$result_file")
             fi
         fi
 

--- a/.claude/scripts/red-team-retention.sh
+++ b/.claude/scripts/red-team-retention.sh
@@ -90,19 +90,24 @@ get_retention_days() {
     local default_restricted=30
     local default_internal=90
 
+    # AUDIT-secrets (#1025): unknown/mislabeled classification defaults to the
+    # MOST-restrictive policy (RESTRICTED, shorter retention), not INTERNAL.
+    # Previously a RESTRICTED report mislabeled PUBLIC / lowercase / trailing-
+    # space won the longer 90d window — keeping sensitive material past its
+    # policy. Only an explicit INTERNAL gets the 90d window now.
     if [[ -f "$CONFIG_FILE" ]] && command -v yq &>/dev/null; then
         case "$classification" in
-            RESTRICTED)
-                yq ".red_team.safety.retention_days_restricted // $default_restricted" "$CONFIG_FILE" 2>/dev/null || echo "$default_restricted"
+            INTERNAL)
+                yq ".red_team.safety.retention_days_internal // $default_internal" "$CONFIG_FILE" 2>/dev/null || echo "$default_internal"
                 ;;
             *)
-                yq ".red_team.safety.retention_days_internal // $default_internal" "$CONFIG_FILE" 2>/dev/null || echo "$default_internal"
+                yq ".red_team.safety.retention_days_restricted // $default_restricted" "$CONFIG_FILE" 2>/dev/null || echo "$default_restricted"
                 ;;
         esac
     else
         case "$classification" in
-            RESTRICTED) echo "$default_restricted" ;;
-            *)          echo "$default_internal" ;;
+            INTERNAL) echo "$default_internal" ;;
+            *)        echo "$default_restricted" ;;
         esac
     fi
 }

--- a/.claude/scripts/red-team-retention.sh
+++ b/.claude/scripts/red-team-retention.sh
@@ -204,6 +204,15 @@ purge_expired() {
         fi
 
         max_age_days=$(get_retention_days "$classification")
+        # AUDIT-config (#1025): retention_days comes from .loa.config.yaml via
+        # yq; an invalid value (0, negative, empty, non-numeric) would make
+        # max_age_seconds <= 0 → mass-purge of every report through the rm -f
+        # sink. Refuse a non-positive-integer and fall back to the
+        # most-restrictive hardcoded default (30d) — loud, never silent-destructive.
+        if ! [[ "$max_age_days" =~ ^[1-9][0-9]*$ ]]; then
+            log "ERROR: invalid retention_days ('$max_age_days') for classification=$classification — refusing destructive mass-purge; using safe 30d default (#1025)"
+            max_age_days=30
+        fi
         max_age_seconds=$((max_age_days * 86400))
 
         # AUDIT-2b (#1025): a future `created` (from a future .timestamp OR a

--- a/.claude/scripts/red-team-retention.sh
+++ b/.claude/scripts/red-team-retention.sh
@@ -14,6 +14,12 @@
 # Exit codes:
 #   0 - Success (or nothing to purge)
 #   1 - Configuration error
+#   3 - Completed with conservative dispositions (sprint-bug-210 / #1025):
+#       one or more result files were unparseable or lacked a usable
+#       timestamp; they were aged by file mtime under the most-restrictive
+#       (RESTRICTED) policy — purged when expired, retained with a loud
+#       WARN when young. Quarantine was rejected (it just relocates the
+#       indefinite retention this fixes).
 # =============================================================================
 
 set -euo pipefail
@@ -23,6 +29,19 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CONFIG_FILE="$PROJECT_ROOT/.loa.config.yaml"
 RED_TEAM_DIR="$PROJECT_ROOT/.run/red-team"
 AUDIT_LOG="$PROJECT_ROOT/.run/red-team-audit.log"
+
+# sprint-bug-210 (#1025): jq_strict (fail-loud jq) from compat-lib.
+# shellcheck source=compat-lib.sh
+source "$SCRIPT_DIR/compat-lib.sh" 2>/dev/null || true
+
+# Conservative dispositions applied this run (parse failures + missing/
+# unparseable timestamps). Non-zero → main exits 3.
+CONSERVATIVE_COUNT=0
+
+# Portable file mtime (GNU stat -c, BSD stat -f).
+_file_mtime_epoch() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
 
 # =============================================================================
 # Logging
@@ -87,21 +106,56 @@ purge_expired() {
         [[ -f "$result_file" ]] || continue
 
         local timestamp classification max_age_days max_age_seconds created run_id
+        local parse_ok=true conservative=false
 
-        run_id=$(jq -r '.run_id // "unknown"' "$result_file" 2>/dev/null || echo "unknown")  # check-no-swallowed-jq: ok (pending #1025 sweep)
-        timestamp=$(jq -r '.timestamp // ""' "$result_file" 2>/dev/null || echo "")  # check-no-swallowed-jq: ok (pending #1025 sweep)
-        classification=$(jq -r '.classification // "INTERNAL"' "$result_file" 2>/dev/null || echo "INTERNAL")  # check-no-swallowed-jq: ok (pending #1025 sweep)
-
-        if [[ -z "$timestamp" ]]; then
-            [[ "$verbose" == "true" ]] && log "Skipping $result_file (no timestamp)"
-            continue
+        # sprint-bug-210 (#1025) / KF-004 guard: a corrupt result JSON must
+        # never be silently SKIPPED — pre-fix, the jq swallow yielded an
+        # empty timestamp and expired RESTRICTED reports were retained
+        # indefinitely. Parse failure → most-restrictive disposition.
+        if ! run_id=$(JQ_STRICT_CTX="red-team-retention:run_id" jq_strict -r '.run_id // "unknown"' "$result_file"); then
+            parse_ok=false
+            run_id="unknown"
+            timestamp=""
+            classification="RESTRICTED"
+        else
+            if ! timestamp=$(JQ_STRICT_CTX="red-team-retention:timestamp" jq_strict -r '.timestamp // ""' "$result_file"); then
+                parse_ok=false
+                timestamp=""
+            fi
+            if ! classification=$(JQ_STRICT_CTX="red-team-retention:classification" jq_strict -r '.classification // "INTERNAL"' "$result_file"); then
+                parse_ok=false
+                classification="RESTRICTED"
+            fi
         fi
 
-        # Parse timestamp to epoch
-        created=$(date -d "$timestamp" +%s 2>/dev/null || echo "0")
-        if [[ "$created" == "0" ]]; then
-            [[ "$verbose" == "true" ]] && log "Skipping $result_file (unparseable timestamp: $timestamp)"
-            continue
+        if [[ "$parse_ok" == "false" ]]; then
+            conservative=true
+            classification="RESTRICTED"
+            audit "PARSE-FAILURE: $result_file unparseable — conservative disposition: RESTRICTED policy, mtime age (#1025)"
+        fi
+
+        # Conservative timestamp handling: missing or unparseable timestamp
+        # (even in VALID JSON) falls back to file mtime under the
+        # most-restrictive classification, instead of skipping forever.
+        if [[ -z "$timestamp" ]]; then
+            if [[ "$conservative" != "true" ]]; then
+                conservative=true
+                classification="RESTRICTED"
+                audit "CONSERVATIVE: $result_file has no usable timestamp — RESTRICTED policy, mtime age (#1025)"
+            fi
+            created=$(_file_mtime_epoch "$result_file")
+        else
+            created=$(date -d "$timestamp" +%s 2>/dev/null || echo "0")
+            if [[ "$created" == "0" ]]; then
+                conservative=true
+                classification="RESTRICTED"
+                audit "CONSERVATIVE: $result_file unparseable timestamp '$timestamp' — RESTRICTED policy, mtime age (#1025)"
+                created=$(_file_mtime_epoch "$result_file")
+            fi
+        fi
+
+        if [[ "$conservative" == "true" ]]; then
+            CONSERVATIVE_COUNT=$((CONSERVATIVE_COUNT + 1))
         fi
 
         max_age_days=$(get_retention_days "$classification")
@@ -124,7 +178,11 @@ purge_expired() {
                 purged=$((purged + 1))
             fi
         else
-            [[ "$verbose" == "true" ]] && log "RETAIN: $run_id ($classification, ${age_days}d/${max_age_days}d)"
+            if [[ "$conservative" == "true" ]]; then
+                log "WARN: RETAIN (conservative): $result_file unparseable/un-timestamped, mtime age ${age_days}d under RESTRICTED ${max_age_days}d — will purge when expired (#1025)"
+            else
+                [[ "$verbose" == "true" ]] && log "RETAIN: $run_id ($classification, ${age_days}d/${max_age_days}d)"
+            fi
         fi
     done
 
@@ -161,6 +219,10 @@ main() {
 
     mkdir -p "$(dirname "$AUDIT_LOG")"
     purge_expired "$dry_run" "$verbose"
+    if [[ "$CONSERVATIVE_COUNT" -gt 0 ]]; then
+        log "Retention DEGRADED: $CONSERVATIVE_COUNT conservative disposition(s) applied — exit 3 (#1025)"
+        exit 3
+    fi
 }
 
 main "$@"

--- a/.claude/scripts/red-team-retention.sh
+++ b/.claude/scripts/red-team-retention.sh
@@ -13,7 +13,10 @@
 #
 # Exit codes:
 #   0 - Success (or nothing to purge)
-#   1 - Configuration error
+#   1 - Configuration error (bad argument)
+#   2 - Dependency/config error: required jq / compat-lib helpers
+#       (jq_strict, _date_to_epoch) unavailable — aborts BEFORE any deletion
+#       decision so a missing helper can't mass-purge valid reports (#1025)
 #   3 - Completed with conservative dispositions (sprint-bug-210 / #1025):
 #       one or more result files were unparseable or lacked a usable
 #       timestamp; they were aged by file mtime under the most-restrictive

--- a/.claude/scripts/red-team-retention.sh
+++ b/.claude/scripts/red-team-retention.sh
@@ -145,8 +145,13 @@ purge_expired() {
             fi
             created=$(_file_mtime_epoch "$result_file")
         else
-            created=$(date -d "$timestamp" +%s 2>/dev/null || echo "0")
-            if [[ "$created" == "0" ]]; then
+            # DISS-002 (review iter-1): portable parse via compat-lib
+            # _date_to_epoch (GNU/BSD/perl tiers). Raw `date -d` is GNU-only —
+            # on macOS it failed for EVERY valid ISO timestamp, which post-fix
+            # would have mass-purged valid reports as conservative RESTRICTED.
+            # Only a genuine unparseable timestamp now triggers conservative.
+            created=$(_date_to_epoch "$timestamp" 2>/dev/null || echo "")
+            if [[ -z "$created" || "$created" == "0" ]]; then
                 conservative=true
                 classification="RESTRICTED"
                 audit "CONSERVATIVE: $result_file unparseable timestamp '$timestamp' — RESTRICTED policy, mtime age (#1025)"

--- a/.claude/scripts/red-team-retention.sh
+++ b/.claude/scripts/red-team-retention.sh
@@ -43,6 +43,25 @@ _file_mtime_epoch() {
     stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
 }
 
+# DISS-001 (review iter-3): a MISSING dependency must abort loudly, never be
+# treated like a corrupt data file. compat-lib is soft-sourced (|| true); if
+# it failed, jq_strict/_date_to_epoch are undefined and every result file
+# would hit the conservative path → mass-purge of valid reports. Hard-require
+# the deletion-path dependencies before any purge decision (the sha256_portable
+# exit-127 principle: missing tool = loud abort, not destructive degrade).
+_require_deps() {
+    local missing=()
+    command -v jq >/dev/null 2>&1 || missing+=("jq")
+    declare -F jq_strict >/dev/null 2>&1 || missing+=("jq_strict (compat-lib.sh)")
+    declare -F _date_to_epoch >/dev/null 2>&1 || missing+=("_date_to_epoch (compat-lib.sh)")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log "FATAL: required dependencies unavailable: ${missing[*]}"
+        log "Refusing to make deletion decisions without them — a missing helper must not"
+        log "mass-purge valid reports as conservative (#1025 / DISS-001)."
+        exit 2
+    fi
+}
+
 # =============================================================================
 # Logging
 # =============================================================================
@@ -222,6 +241,7 @@ main() {
         esac
     done
 
+    _require_deps
     mkdir -p "$(dirname "$AUDIT_LOG")"
     purge_expired "$dry_run" "$verbose"
     if [[ "$CONSERVATIVE_COUNT" -gt 0 ]]; then

--- a/.claude/scripts/red-team-retention.sh
+++ b/.claude/scripts/red-team-retention.sh
@@ -149,7 +149,12 @@ purge_expired() {
                 parse_ok=false
                 timestamp=""
             fi
-            if ! classification=$(JQ_STRICT_CTX="red-team-retention:classification" jq_strict -r '.classification // "INTERNAL"' "$result_file"); then
+            # AUDIT-secrets-b (#1025): default a MISSING classification to a
+            # non-INTERNAL sentinel so get_retention_days applies the
+            # most-restrictive (RESTRICTED 30d) policy — defaulting to
+            # "INTERNAL" here would grant the longer 90d window to unlabeled
+            # (potentially sensitive) reports.
+            if ! classification=$(JQ_STRICT_CTX="red-team-retention:classification" jq_strict -r '.classification // "UNKNOWN"' "$result_file"); then
                 parse_ok=false
                 classification="RESTRICTED"
             fi
@@ -201,6 +206,14 @@ purge_expired() {
         max_age_days=$(get_retention_days "$classification")
         max_age_seconds=$((max_age_days * 86400))
 
+        # AUDIT-2b (#1025): a future `created` (from a future .timestamp OR a
+        # future file mtime fallback) makes age negative → retained forever.
+        # Clamp to now so age is never negative; a future-dated file is then
+        # young (retained) but LOUDLY flagged via the conservative WARN + exit 3
+        # rather than silently bypassing retention via negative arithmetic.
+        if (( created > now )); then
+            created=$now
+        fi
         local age=$((now - created))
         local age_days=$((age / 86400))
 

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1768,9 +1768,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260613-i966-01593f/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260613-i966-01593f/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260613-i1025-004d22",
+      "label": "Bug Fix — #1025 sweep leg 2: swallowed-jq sites in post-pr-triage.sh + red-team-retention.sh",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/1025",
+      "created_at": "2026-06-13T01:51:48Z",
+      "sprints": [
+        "sprint-bug-210"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260613-i1025-004d22/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260613-i1025-004d22/sprint.md"
     }
   ],
-  "global_sprint_counter": 209,
+  "global_sprint_counter": 210,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/post-pr-bridgebuilder.bats
+++ b/tests/unit/post-pr-bridgebuilder.bats
@@ -440,6 +440,21 @@ EOF
     [[ "$output" == *"dependencies unavailable"* || "$output" == *"FATAL"* ]]
 }
 
+@test "dep-guard: dependency failure invalidates a stale FLATLINE convergence record (T-A7, DISS-002 iter-4)" {
+    # The dep-guard exit must not leave a prior run's FLATLINE record for the
+    # orchestrator to read as clean (same stale-convergence class as T-A5).
+    mkdir -p "$TEST_TMPDIR/.run"
+    cat > "$TEST_TMPDIR/.run/bridge-triage-convergence.json" <<'JSON'
+{"timestamp":"2020-01-01T00:00:00Z","pr_number":100,"state":"FLATLINE","actionable_high":0,"blocker_count":0,"disputed_count":0}
+JSON
+    rm -f "$TEST_TMPDIR/.claude/scripts/compat-lib.sh"
+    create_findings_file "bridge-x-iter1-findings.json" "CRITICAL" "c1" "Real finding"
+    run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100 --auto-triage true
+    [ "$status" -eq 2 ]
+    # Stale FLATLINE must be gone (absent → orchestrator defaults KEEP_ITERATING, not clean)
+    [ ! -f "$TEST_TMPDIR/.run/bridge-triage-convergence.json" ]
+}
+
 @test "KF-004 guard: corrupt bridge-state.json overwrites stale FLATLINE convergence → DEGRADED (T-A5)" {
     # DISS-001: the corrupt-state early-return must not let a prior iteration's
     # clean convergence record survive — the orchestrator reads .state from it.

--- a/tests/unit/post-pr-bridgebuilder.bats
+++ b/tests/unit/post-pr-bridgebuilder.bats
@@ -25,6 +25,10 @@ setup() {
     cp "$PROJECT_ROOT/.claude/scripts/post-pr-triage.sh" "$TEST_TMPDIR/.claude/scripts/"
     chmod +x "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh"
 
+    # sprint-bug-210 (#1025): the triage script soft-sources compat-lib.sh
+    # (jq_strict) from its own SCRIPT_DIR — copy it alongside.
+    cp "$PROJECT_ROOT/.claude/scripts/compat-lib.sh" "$TEST_TMPDIR/.claude/scripts/"
+
     cd "$TEST_TMPDIR"
 }
 
@@ -216,11 +220,14 @@ EOF
     [[ "$output" == *crit-xyz* ]]
 }
 
-@test "triage: malformed findings file is handled gracefully" {
+@test "triage: malformed findings file fails loud (DEGRADED, not silent skip)" {
+    # sprint-bug-210 (#1025): this test previously asserted exit 0 ("just skip
+    # malformed files") — that silent skip WAS the KF-004 bug. The corrected
+    # contract: a corrupt findings artifact exits 3 with a DEGRADED convergence
+    # record, never a clean FLATLINE. (See T-A1 for the convergence assertions.)
     echo "not valid json" > "$TEST_TMPDIR/.run/bridge-reviews/bridge-broken-iter1-findings.json"
     run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100
-    # Should not crash — just skip malformed files
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 3 ]
 }
 
 # ============================================================================
@@ -374,6 +381,9 @@ EOF
     local alt_script_dir="$TEST_TMPDIR/alt-install"
     mkdir -p "$alt_script_dir"
     cp "$PROJECT_ROOT/.claude/scripts/post-pr-triage.sh" "$alt_script_dir/"
+    # sprint-bug-210 (#1025): compat-lib.sh (jq_strict) is a co-located sibling
+    # in every real .claude/scripts/ install and travels via the copy-set.
+    cp "$PROJECT_ROOT/.claude/scripts/compat-lib.sh" "$alt_script_dir/"
 
     # Run from $TEST_TMPDIR — default paths should resolve relative to cwd
     create_findings_file "bridge-test-iter1-findings.json" "HIGH" "h1" "Test H4"
@@ -384,4 +394,48 @@ EOF
     local traj_count
     traj_count=$(ls "$TEST_TMPDIR/grimoires/loa/a2a/trajectory/"bridge-triage-*.jsonl 2>/dev/null | wc -l)
     [ "$traj_count" -ge 1 ]
+}
+
+
+# =============================================================================
+# sprint-bug-210 / #1025 sweep leg 2 — KF-004 guards (post-pr-triage.sh)
+# A corrupt Bridgebuilder findings artifact must never produce a clean
+# FLATLINE / exit-0 triage; a corrupt bridge-state.json must never fall
+# through to the glob-all legacy path (#676 Defect B resurrection).
+# =============================================================================
+
+@test "KF-004 guard: corrupt findings file → exit 3 + DEGRADED convergence, never FLATLINE (T-A1)" {
+    echo 'this is not json' > "$TEST_TMPDIR/.run/bridge-reviews/bridge-x-iter1-findings.json"
+    run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100 --auto-triage true
+    [ "$status" -eq 3 ]
+    local conv="$TEST_TMPDIR/.run/bridge-triage-convergence.json"
+    [ -f "$conv" ]
+    [ "$(jq -r '.state' "$conv")" == "DEGRADED" ]
+    [ "$(jq -r '.parse_failures' "$conv")" -ge 1 ]
+}
+
+@test "KF-004 guard: valid+corrupt mix → CRITICAL still queued, run degraded (T-A2)" {
+    create_findings_file "bridge-x-iter1-findings.json" "CRITICAL" "crit-1" "Real blocker"
+    echo '{broken' > "$TEST_TMPDIR/.run/bridge-reviews/bridge-x-iter2-findings.json"
+    run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100 --auto-triage true
+    [ "$status" -eq 3 ]
+    [ -f "$TEST_TMPDIR/.run/bridge-pending-bugs.jsonl" ]
+    [ "$(jq -r '.finding.severity' "$TEST_TMPDIR/.run/bridge-pending-bugs.jsonl")" == "CRITICAL" ]
+    [ "$(jq -r '.state' "$TEST_TMPDIR/.run/bridge-triage-convergence.json")" == "DEGRADED" ]
+}
+
+@test "KF-004 guard: corrupt bridge-state.json → exit 1, no glob fall-through (T-A3)" {
+    echo 'garbage{' > "$TEST_TMPDIR/.run/bridge-state.json"
+    create_findings_file "stale-bridge-iter1-findings.json" "CRITICAL" "stale-1" "Stale finding"
+    run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100 --auto-triage true
+    [ "$status" -eq 1 ]
+    [ ! -f "$TEST_TMPDIR/.run/bridge-pending-bugs.jsonl" ]
+}
+
+@test "regression pin: bridge-state.json without bridge_id → legacy glob unchanged (T-A4)" {
+    echo '{}' > "$TEST_TMPDIR/.run/bridge-state.json"
+    create_findings_file "any-iter1-findings.json" "PRAISE" "p-1" "Nice work"
+    run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100 --auto-triage true
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_TMPDIR/.run/bridge-lore-candidates.jsonl" ]
 }

--- a/tests/unit/post-pr-bridgebuilder.bats
+++ b/tests/unit/post-pr-bridgebuilder.bats
@@ -432,6 +432,20 @@ EOF
     [ ! -f "$TEST_TMPDIR/.run/bridge-pending-bugs.jsonl" ]
 }
 
+@test "KF-004 guard: corrupt bridge-state.json overwrites stale FLATLINE convergence → DEGRADED (T-A5)" {
+    # DISS-001: the corrupt-state early-return must not let a prior iteration's
+    # clean convergence record survive — the orchestrator reads .state from it.
+    mkdir -p "$TEST_TMPDIR/.run"
+    cat > "$TEST_TMPDIR/.run/bridge-triage-convergence.json" <<'JSON'
+{"timestamp":"2020-01-01T00:00:00Z","pr_number":100,"state":"FLATLINE","actionable_high":0,"blocker_count":0,"disputed_count":0}
+JSON
+    echo 'garbage{' > "$TEST_TMPDIR/.run/bridge-state.json"
+    run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100 --auto-triage true
+    [ "$status" -eq 1 ]
+    # Stale FLATLINE must have been overwritten with DEGRADED
+    [ "$(jq -r '.state' "$TEST_TMPDIR/.run/bridge-triage-convergence.json")" == "DEGRADED" ]
+}
+
 @test "regression pin: bridge-state.json without bridge_id → legacy glob unchanged (T-A4)" {
     echo '{}' > "$TEST_TMPDIR/.run/bridge-state.json"
     create_findings_file "any-iter1-findings.json" "PRAISE" "p-1" "Nice work"

--- a/tests/unit/post-pr-bridgebuilder.bats
+++ b/tests/unit/post-pr-bridgebuilder.bats
@@ -432,6 +432,14 @@ EOF
     [ ! -f "$TEST_TMPDIR/.run/bridge-pending-bugs.jsonl" ]
 }
 
+@test "dep-guard: missing compat-lib (jq_strict undefined) → config-error exit 2, not misleading DEGRADED (T-A6, DISS-001 iter-3)" {
+    rm -f "$TEST_TMPDIR/.claude/scripts/compat-lib.sh"
+    create_findings_file "bridge-x-iter1-findings.json" "CRITICAL" "c1" "Real finding"
+    run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100 --auto-triage true
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"dependencies unavailable"* || "$output" == *"FATAL"* ]]
+}
+
 @test "KF-004 guard: corrupt bridge-state.json overwrites stale FLATLINE convergence → DEGRADED (T-A5)" {
     # DISS-001: the corrupt-state early-return must not let a prior iteration's
     # clean convergence record survive — the orchestrator reads .state from it.

--- a/tests/unit/post-pr-bridgebuilder.bats
+++ b/tests/unit/post-pr-bridgebuilder.bats
@@ -455,6 +455,18 @@ JSON
     [ ! -f "$TEST_TMPDIR/.run/bridge-triage-convergence.json" ]
 }
 
+@test "KF-004 guard: non-array .findings (object/string/null-element) → DEGRADED, not zero-clean (T-A9, DISS-001)" {
+    mkdir -p "$TEST_TMPDIR/.run"
+    for shape in '{"findings":{}}' '{"findings":""}' '{"findings":[null]}'; do
+        rm -f "$TEST_TMPDIR/.run/bridge-triage-convergence.json"
+        rm -f "$TEST_TMPDIR/.run/bridge-reviews/"*-findings.json
+        echo "$shape" > "$TEST_TMPDIR/.run/bridge-reviews/bridge-s-iter1-findings.json"
+        run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100 --auto-triage true
+        [ "$status" -eq 3 ]
+        [ "$(jq -r '.state' "$TEST_TMPDIR/.run/bridge-triage-convergence.json")" == "DEGRADED" ]
+    done
+}
+
 @test "KF-004 guard: schema-valid non-object finding → DEGRADED, no set-e abort (T-A8, AUDIT-1)" {
     # {"findings": ["not-an-object"]} parses fine and survives the jq_strict
     # guards, but per-field extraction on a string element aborts under set -e

--- a/tests/unit/post-pr-bridgebuilder.bats
+++ b/tests/unit/post-pr-bridgebuilder.bats
@@ -455,6 +455,22 @@ JSON
     [ ! -f "$TEST_TMPDIR/.run/bridge-triage-convergence.json" ]
 }
 
+@test "KF-004 guard: schema-valid non-object finding → DEGRADED, no set-e abort (T-A8, AUDIT-1)" {
+    # {"findings": ["not-an-object"]} parses fine and survives the jq_strict
+    # guards, but per-field extraction on a string element aborts under set -e
+    # BEFORE the convergence write — leaving a stale clean record. Must route
+    # to DEGRADED instead.
+    mkdir -p "$TEST_TMPDIR/.run"
+    cat > "$TEST_TMPDIR/.run/bridge-triage-convergence.json" <<'JSON'
+{"timestamp":"2020-01-01T00:00:00Z","pr_number":100,"state":"FLATLINE","actionable_high":0,"blocker_count":0,"disputed_count":0}
+JSON
+    echo '{"findings": ["not-an-object"]}' > "$TEST_TMPDIR/.run/bridge-reviews/bridge-z-iter1-findings.json"
+    run "$TEST_TMPDIR/.claude/scripts/post-pr-triage.sh" --pr 100 --auto-triage true
+    [ "$status" -eq 3 ]
+    [ "$(jq -r '.state' "$TEST_TMPDIR/.run/bridge-triage-convergence.json")" == "DEGRADED" ]
+    [ "$(jq -r '.parse_failures' "$TEST_TMPDIR/.run/bridge-triage-convergence.json")" -ge 1 ]
+}
+
 @test "KF-004 guard: corrupt bridge-state.json overwrites stale FLATLINE convergence → DEGRADED (T-A5)" {
     # DISS-001: the corrupt-state early-return must not let a prior iteration's
     # clean convergence record survive — the orchestrator reads .state from it.

--- a/tests/unit/red-team-retention.bats
+++ b/tests/unit/red-team-retention.bats
@@ -115,3 +115,18 @@ EOF
         ! grep -qiE "CONSERVATIVE|PARSE-FAILURE" "$AUDIT"
     fi
 }
+
+@test "dep-guard: missing compat-lib (jq_strict undefined) → abort exit 2, no purge (T-B7, DISS-001 iter-3)" {
+    # A MISSING dependency must not be treated like a corrupt data file —
+    # otherwise every report hits the conservative path and valid material is
+    # mass-purged. Remove the co-located helper to simulate the broken env.
+    rm -f "$TEST_TMPDIR/.claude/scripts/compat-lib.sh"
+    cat > "$RT/rt-ggg-result.json" <<EOF
+{"run_id": "rt-ggg", "timestamp": "$(_old_date)", "classification": "RESTRICTED"}
+EOF
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    # The aged-but-VALID report must survive a dependency failure
+    [ -f "$RT/rt-ggg-result.json" ]
+    [[ "$output" == *"dependencies unavailable"* || "$output" == *"FATAL"* ]]
+}

--- a/tests/unit/red-team-retention.bats
+++ b/tests/unit/red-team-retention.bats
@@ -146,3 +146,27 @@ EOF
     # A future-dated report aged by a recent mtime is young → retained, but no
     # longer via the silent negative-age path.
 }
+
+@test "AUDIT-secrets: unknown/mislabeled classification → conservative RESTRICTED (30d), not INTERNAL (90d) (T-B9)" {
+    # A RESTRICTED report mislabeled PUBLIC/lowercase/trailing-space must NOT
+    # win the longer 90d window. Default unknown classification → most-restrictive.
+    # 45-day-old report: purged under 30d RESTRICTED, retained under 90d INTERNAL.
+    local ts; ts=$(date -u -d "45 days ago" +%Y-%m-%dT%H:%M:%SZ)
+    cat > "$RT/rt-mislabel-result.json" <<EOF
+{"run_id": "rt-mislabel", "timestamp": "$ts", "classification": "PUBLIC"}
+EOF
+    run "$SCRIPT"
+    # Purged → unknown classification was treated as RESTRICTED (30d), not INTERNAL (90d)
+    [ ! -f "$RT/rt-mislabel-result.json" ]
+    grep -q "PURGED: rt-mislabel" "$AUDIT"
+}
+
+@test "regression pin: explicit INTERNAL still gets 90d (not over-purged) (T-B10)" {
+    local ts; ts=$(date -u -d "45 days ago" +%Y-%m-%dT%H:%M:%SZ)
+    cat > "$RT/rt-internal-result.json" <<EOF
+{"run_id": "rt-internal", "timestamp": "$ts", "classification": "INTERNAL"}
+EOF
+    run "$SCRIPT"
+    # 45d < 90d INTERNAL → retained
+    [ -f "$RT/rt-internal-result.json" ]
+}

--- a/tests/unit/red-team-retention.bats
+++ b/tests/unit/red-team-retention.bats
@@ -130,3 +130,19 @@ EOF
     [ -f "$RT/rt-ggg-result.json" ]
     [[ "$output" == *"dependencies unavailable"* || "$output" == *"FATAL"* ]]
 }
+
+@test "AUDIT-2: future timestamp → conservative RESTRICTED, not indefinite retention (T-B8)" {
+    # A far-future .timestamp makes age negative → retained forever. Must be
+    # treated as suspicious (conservative RESTRICTED + mtime age), exit 3.
+    local future
+    future=$(date -u -d "+5 years" +%Y-%m-%dT%H:%M:%SZ)
+    cat > "$RT/rt-future-result.json" <<EOF
+{"run_id": "rt-future", "timestamp": "$future", "classification": "RESTRICTED"}
+EOF
+    # mtime now → young → retained with WARN (not purged), but flagged conservative + exit 3
+    run "$SCRIPT"
+    [ "$status" -eq 3 ]
+    grep -qiE "future|CONSERVATIVE" "$AUDIT"
+    # A future-dated report aged by a recent mtime is young → retained, but no
+    # longer via the silent negative-age path.
+}

--- a/tests/unit/red-team-retention.bats
+++ b/tests/unit/red-team-retention.bats
@@ -170,3 +170,29 @@ EOF
     # 45d < 90d INTERNAL → retained
     [ -f "$RT/rt-internal-result.json" ]
 }
+
+@test "AUDIT-2b: future FILE MTIME on conservative file → age clamped >=0, not retained-forever (T-B11)" {
+    # A corrupt file whose mtime is in the future → mtime fallback gives a
+    # future `created` → negative age → retained forever. age must clamp >=0.
+    printf 'not json' > "$RT/rt-futuremtime-result.json"
+    touch -d "+5 years" "$RT/rt-futuremtime-result.json"
+    run "$SCRIPT" --verbose
+    [ "$status" -eq 3 ]
+    # The clamp makes age >= 0. Pre-fix the log showed a NEGATIVE age
+    # (e.g. "-1826d"), the negative-age-retains-forever bypass. Post-fix: no
+    # negative age anywhere in the output.
+    ! echo "$output" | grep -qE -- '-[0-9]+d'
+}
+
+@test "AUDIT-secrets-b: MISSING classification → conservative RESTRICTED (30d), not INTERNAL (90d) (T-B12)" {
+    # Valid JSON with NO classification field. The extraction default must not
+    # be the less-restrictive INTERNAL.
+    local ts; ts=$(date -u -d "45 days ago" +%Y-%m-%dT%H:%M:%SZ)
+    cat > "$RT/rt-noclass-result.json" <<EOF
+{"run_id": "rt-noclass", "timestamp": "$ts"}
+EOF
+    run "$SCRIPT"
+    # 45d old: purged under 30d RESTRICTED default; would survive under 90d INTERNAL
+    [ ! -f "$RT/rt-noclass-result.json" ]
+    grep -q "PURGED: rt-noclass" "$AUDIT"
+}

--- a/tests/unit/red-team-retention.bats
+++ b/tests/unit/red-team-retention.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# =============================================================================
+# tests/unit/red-team-retention.bats — sprint-bug-210 / #1025 sweep leg 2
+#
+# red-team-retention.sh previously had ZERO tests. The KF-004-class defect
+# pinned here: a corrupt rt-*-result.json yielded empty timestamp via the
+# `jq … || echo` swallow, the purge loop silently SKIPPED the file, and
+# expired RESTRICTED red-team material was retained indefinitely past policy.
+#
+# Post-fix contract (most-restrictive disposition, per the sprint-bug-208
+# audit recommendation; quarantine rejected — see triage.md):
+#   - unparseable result JSON → treat as RESTRICTED, age by file mtime
+#   - expired → purged with siblings + audit PARSE-FAILURE/PURGED entries
+#   - young   → retained with loud WARN (still counts as degraded run)
+#   - any conservative disposition → exit 3 (documented)
+#   - --dry-run never deletes; reports WOULD-disposition
+# =============================================================================
+
+setup() {
+    BATS_TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIR/../.." && pwd)"
+    export TEST_TMPDIR="${BATS_TMPDIR:-/tmp}/red-team-retention-test-$$"
+    mkdir -p "$TEST_TMPDIR/.claude/scripts" "$TEST_TMPDIR/.run/red-team"
+    cp "$PROJECT_ROOT/.claude/scripts/red-team-retention.sh" "$TEST_TMPDIR/.claude/scripts/"
+    cp "$PROJECT_ROOT/.claude/scripts/compat-lib.sh" "$TEST_TMPDIR/.claude/scripts/"
+    chmod +x "$TEST_TMPDIR/.claude/scripts/red-team-retention.sh"
+    RT="$TEST_TMPDIR/.run/red-team"
+    AUDIT="$TEST_TMPDIR/.run/red-team-audit.log"
+    SCRIPT="$TEST_TMPDIR/.claude/scripts/red-team-retention.sh"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+_old_date() { date -u -d "60 days ago" +%Y-%m-%dT%H:%M:%SZ; }
+
+@test "KF-004 guard: corrupt result + aged mtime → purged, audited, exit 3 (T-B1)" {
+    printf 'not json at all' > "$RT/rt-aaa-result.json"
+    printf 'sibling report' > "$RT/rt-aaa-report.md"
+    touch -d "60 days ago" "$RT/rt-aaa-result.json"
+    run "$SCRIPT"
+    [ "$status" -eq 3 ]
+    [ ! -f "$RT/rt-aaa-result.json" ]
+    [ ! -f "$RT/rt-aaa-report.md" ]
+    grep -qi "PARSE-FAILURE" "$AUDIT"
+    grep -qi "PURGED" "$AUDIT"
+}
+
+@test "KF-004 guard: corrupt result + young mtime → retained with loud WARN, exit 3 (T-B2)" {
+    printf '{broken' > "$RT/rt-bbb-result.json"
+    run "$SCRIPT"
+    [ "$status" -eq 3 ]
+    [ -f "$RT/rt-bbb-result.json" ]
+    grep -qi "PARSE-FAILURE" "$AUDIT"
+}
+
+@test "regression pin: valid RESTRICTED expired → purged, exit 0 (T-B3)" {
+    cat > "$RT/rt-ccc-result.json" <<EOF
+{"run_id": "rt-ccc", "timestamp": "$(_old_date)", "classification": "RESTRICTED"}
+EOF
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ ! -f "$RT/rt-ccc-result.json" ]
+    grep -q "PURGED: rt-ccc" "$AUDIT"
+}
+
+@test "KF-004 guard: valid JSON missing timestamp → conservative disposition, loud, exit 3 (T-B4)" {
+    # Pre-fix: silently skipped forever (indefinite retention). Post-fix:
+    # mtime-age fallback under the most-restrictive classification.
+    printf '{"run_id": "rt-ddd", "classification": "INTERNAL"}' > "$RT/rt-ddd-result.json"
+    touch -d "60 days ago" "$RT/rt-ddd-result.json"
+    run "$SCRIPT"
+    [ "$status" -eq 3 ]
+    # 60d > 30d RESTRICTED limit (conservative) → purged despite INTERNAL claim
+    [ ! -f "$RT/rt-ddd-result.json" ]
+    grep -qiE "conservative|no usable timestamp|PARSE-FAILURE" "$AUDIT"
+}
+
+@test "KF-004 guard: --dry-run with corrupt file → no deletion, WOULD-disposition reported (T-B5)" {
+    printf 'garbage' > "$RT/rt-eee-result.json"
+    touch -d "60 days ago" "$RT/rt-eee-result.json"
+    run "$SCRIPT" --dry-run
+    [ "$status" -eq 3 ]
+    [ -f "$RT/rt-eee-result.json" ]
+    [[ "$output" == *"WOULD PURGE"* ]]
+}

--- a/tests/unit/red-team-retention.bats
+++ b/tests/unit/red-team-retention.bats
@@ -27,6 +27,7 @@ setup() {
     RT="$TEST_TMPDIR/.run/red-team"
     AUDIT="$TEST_TMPDIR/.run/red-team-audit.log"
     SCRIPT="$TEST_TMPDIR/.claude/scripts/red-team-retention.sh"
+    REAL_DATE="$(command -v date)"
 }
 
 teardown() {
@@ -84,4 +85,33 @@ EOF
     [ "$status" -eq 3 ]
     [ -f "$RT/rt-eee-result.json" ]
     [[ "$output" == *"WOULD PURGE"* ]]
+}
+
+@test "portability: valid timestamp parses without GNU date -d → not conservative (T-B6, DISS-002)" {
+    # DISS-002: a -d-rejecting `date` (simulating macOS/BSD) must NOT push a
+    # valid-timestamp report onto the conservative RESTRICTED-by-mtime path.
+    # Pins that timestamp parsing routes through compat-lib _date_to_epoch
+    # (GNU/BSD/perl tiers), not raw `date -d`.
+    local shim="$TEST_TMPDIR/shim"
+    mkdir -p "$shim"
+    cat > "$shim/date" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do [[ "\$a" == "-d" ]] && exit 1; done
+exec "$REAL_DATE" "\$@"
+EOF
+    chmod +x "$shim/date"
+    # Valid INTERNAL report, well within 90d retention → must RETAIN, exit 0,
+    # and NOT be marked conservative (no PARSE-FAILURE/CONSERVATIVE audit).
+    cat > "$RT/rt-fff-result.json" <<EOF
+{"run_id": "rt-fff", "timestamp": "$("$REAL_DATE" -u -d "5 days ago" +%Y-%m-%dT%H:%M:%SZ)", "classification": "INTERNAL"}
+EOF
+    PATH="$shim:$PATH" run "$SCRIPT" --verbose
+    [ "$status" -eq 0 ]
+    [ -f "$RT/rt-fff-result.json" ]
+    # A correctly-parsed valid timestamp triggers no conservative disposition
+    # and no purge → audit() is never called → the audit log may not exist at
+    # all. Either way, there must be zero CONSERVATIVE/PARSE-FAILURE entries.
+    if [[ -f "$AUDIT" ]]; then
+        ! grep -qiE "CONSERVATIVE|PARSE-FAILURE" "$AUDIT"
+    fi
 }

--- a/tests/unit/red-team-retention.bats
+++ b/tests/unit/red-team-retention.bats
@@ -196,3 +196,23 @@ EOF
     [ ! -f "$RT/rt-noclass-result.json" ]
     grep -q "PURGED: rt-noclass" "$AUDIT"
 }
+
+@test "AUDIT-config: zero/invalid retention_days must not mass-purge (safe default) (T-B13)" {
+    command -v yq >/dev/null 2>&1 || skip "yq required for config-path test"
+    # A config typo (retention_days_restricted: 0) would make max_age_seconds=0
+    # → every report purged. Guard must reject it and use the safe 30d default.
+    cat > "$TEST_TMPDIR/.loa.config.yaml" <<'YML'
+red_team:
+  safety:
+    retention_days_restricted: 0
+    retention_days_internal: 90
+YML
+    local ts; ts=$(date -u -d "10 days ago" +%Y-%m-%dT%H:%M:%SZ)
+    cat > "$RT/rt-cfg-result.json" <<EOF
+{"run_id": "rt-cfg", "timestamp": "$ts", "classification": "RESTRICTED"}
+EOF
+    run "$SCRIPT"
+    # 10d old < 30d safe default → RETAINED (bug would purge at 0d)
+    [ -f "$RT/rt-cfg-result.json" ]
+    echo "$output" | grep -qiE "invalid|retention_days"
+}


### PR DESCRIPTION
Follow-up sweep of #1025 (output-swallowing jq class), consequence-ranked targets #1 + #2 from sprint-bug-208's convergent cross-model review + independent audit.

## What
Migrated the 6 marker-suppressed swallowed-jq sites in **post-pr-triage.sh** (:305/:337/:392) and **red-team-retention.sh** (:91-93) to `jq_strict`, removed the suppression markers (live scanner now enforces both files), and hardened the surrounding input-validation. Two silent-failure classes closed:
- **post-pr-triage**: a corrupt Bridgebuilder findings artifact no longer reads as zero-findings-clean / FLATLINE (drops CRITICAL/BLOCKER from the bug queue). Parse/shape failure → `state: DEGRADED` + exit 3; the convergence *record* (not the exit code) is the load-bearing channel the orchestrator reads.
- **red-team-retention**: a corrupt/un-timestamped/mislabeled result JSON no longer causes silent indefinite retention of RESTRICTED material → most-restrictive conservative disposition (mtime age, RESTRICTED policy, loud + exit 3).

## Hardening surfaced by the gates (all test-pinned, failing-first)
corrupt-state stale-convergence overwrite · portable `_date_to_epoch` (GNU/BSD/perl) · `_require_deps` hard-abort before any deletion (missing-helper ≠ mass-purge) · dep-guard convergence invalidation · non-object/non-array findings → DEGRADED (no set-e abort) · future timestamp **and** future mtime age-clamp · unknown/missing classification → conservative RESTRICTED · invalid `retention_days` config → safe-default (no mass-purge).

## Gate trail
`/bug → /implement → /review-sprint → /audit-sprint`, full cross-model gates. The KF-004 sidecar drill ran every round (canonical-clean vs sidecar-real recurred and was honored each time) — it recovered ~half the fixes. ~12 in-scope findings fixed test-first across the iterations; 4 out-of-scope/pre-existing items declined-with-rationale and **filed**: #1036 (orchestrator DEGRADED-handling), #1037 (compat-lib BSD tz), #1038 (bridge_id glob), #1039 (audit-log injection). Audit converged (final round = single already-filed #1038).

Tests: post-pr-bridgebuilder 35/35 · red-team-retention 13/13 (was 0 before) · check-no-swallowed-jq 13/13 · adjacent (676/state/e2e/cycle-109-consumers) green · scanner green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
