### PR TITLE
fix(settings): encode State-Zone write-freedom in permission allow-list (#1043, sprint-bug-212)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -385,7 +385,15 @@
       "Bash(.:*)",
       "Bash(bash:*)",
       "Bash(sh:*)",
-      "Bash(zsh:*)"
+      "Bash(zsh:*)",
+      "Write(grimoires/**)",
+      "Edit(grimoires/**)",
+      "Write(.beads/**)",
+      "Edit(.beads/**)",
+      "Write(.run/**)",
+      "Edit(.run/**)",
+      "Write(.ck/**)",
+      "Edit(.ck/**)"
     ],
     "deny": [
       "Bash(sudo:*)",

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1796,7 +1796,7 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260613-i937-ddbd73/sprint.md"
     }
   ],
-  "global_sprint_counter": 211,
+  "global_sprint_counter": 212,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -2015,6 +2015,19 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260610-i942-0f917b/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260610-i942-0f917b/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260613-i1043-2ee50c",
+      "label": "Bug Fix — default permission allow-list doesn't encode the Three-Zone Model's State-Zone write-freedom (#1043)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/1043",
+      "created_at": "2026-06-13T04:35:40Z",
+      "sprints": [
+        "sprint-bug-212"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260613-i1043-2ee50c/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260613-i1043-2ee50c/sprint.md"
     }
   ],
   "bugfixes": [
@@ -2032,5 +2045,5 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260428-i640-1cc190/sprint.md"
     }
   ],
-  "next_sprint_number": 212
+  "next_sprint_number": 213
 }

--- a/tests/unit/settings-permissions.bats
+++ b/tests/unit/settings-permissions.bats
@@ -393,9 +393,11 @@ setup() {
 # Pattern Format Tests
 # =============================================================================
 
-@test "all allow patterns use Bash() format" {
+@test "all allow patterns use Bash()/Write()/Edit() format" {
+    # sprint-bug-212 (#1043): State-Zone Write()/Edit() allow-rules joined the
+    # previously Bash-only allow-list. Widen the format predicate accordingly.
     local bad_patterns
-    bad_patterns=$(jq -r '.permissions.allow[] | select(startswith("Bash(") | not)' "$SETTINGS_FILE" | wc -l)
+    bad_patterns=$(jq -r '.permissions.allow[] | select((startswith("Bash(") or startswith("Write(") or startswith("Edit(")) | not)' "$SETTINGS_FILE" | wc -l)
     [ "$bad_patterns" -eq 0 ]
 }
 
@@ -423,4 +425,41 @@ setup() {
     run jq -e '[.hooks.SessionStart[].hooks[].command] | any(test("check-updates"))' "$SETTINGS_FILE"
     [ "$status" -eq 0 ]
     [ "$output" = "true" ]
+}
+
+# =============================================================================
+# State-Zone Write/Edit Permission Tests (sprint-bug-212 / #1043)
+# Encode the Three-Zone Model's State-Zone (grimoires/, .beads/, .run/, .ck/)
+# write-freedom in the permission allow-list so gate-skill artifact writes
+# (reviewer.md, engineer-feedback.md, auditor-sprint-feedback.md, COMPLETED,
+# ledger.json, NOTES.md, beads JSONL) never stall on a declined Write prompt.
+# =============================================================================
+
+@test "SZ1: State-Zone Write() rules present (grimoires/.beads/.run/.ck)" {
+    for p in 'Write(grimoires/**)' 'Write(.beads/**)' 'Write(.run/**)' 'Write(.ck/**)'; do
+        run jq -e --arg p "$p" '.permissions.allow | index($p)' "$SETTINGS_FILE"
+        [ "$status" -eq 0 ] || { echo "MISSING allow rule: $p" >&2; return 1; }
+    done
+}
+
+@test "SZ2: State-Zone Edit() rules present (grimoires/.beads/.run/.ck)" {
+    for p in 'Edit(grimoires/**)' 'Edit(.beads/**)' 'Edit(.run/**)' 'Edit(.ck/**)'; do
+        run jq -e --arg p "$p" '.permissions.allow | index($p)' "$SETTINGS_FILE"
+        [ "$status" -eq 0 ] || { echo "MISSING allow rule: $p" >&2; return 1; }
+    done
+}
+
+@test "SZ3: NO over-grant — System Zone (.claude/**) and wildcard writes are NOT allowed" {
+    # The fix must NOT grant Write/Edit to the System Zone or globally.
+    for forbidden in 'Write(.claude/**)' 'Edit(.claude/**)' 'Write(**)' 'Edit(**)' 'Write(*)' 'Edit(*)'; do
+        run jq -e --arg p "$forbidden" '.permissions.allow | index($p)' "$SETTINGS_FILE"
+        [ "$status" -ne 0 ] || { echo "OVER-GRANT present: $forbidden" >&2; return 1; }
+    done
+}
+
+@test "SZ4: NO App-Zone write grant (src/lib/app stay confirm-on-write)" {
+    for forbidden in 'Write(src/**)' 'Edit(src/**)' 'Write(lib/**)' 'Write(app/**)'; do
+        run jq -e --arg p "$forbidden" '.permissions.allow | index($p)' "$SETTINGS_FILE"
+        [ "$status" -ne 0 ] || { echo "App-Zone grant present: $forbidden" >&2; return 1; }
+    done
 }


### PR DESCRIPTION
Closes #1043. **This is the core-process fix** the operator flagged — every gate skill's State-Zone artifact write was at risk of stalling on a declined Write prompt.

## What
`.claude/settings.json` `permissions.allow` had 374 rules, **zero** `Write()`/`Edit()` — so the documented Three-Zone Model's State-Zone write-freedom (`grimoires/`, `.beads/`, `.run/`, `.ck/` = Read/Write per zone-state.md) was **documented but not encoded**, falling through to session permission mode. Adds the 8 State-Zone rules to the shipped settings.json (which is in the #842 copy-set → propagates to all mounted consumers). System Zone (`.claude/**`) stays protected; App Zone stays confirm-on-write.

Observed live: the Write tool was denied on `grimoires/loa/a2a/` repeatedly across this session's gate runs (sprint-bug-210/211 reviewer.md, and #1043's own triage + report), forcing Bash-heredoc fallbacks — the exact stall the issue describes.

## Tests (failing-first)
`tests/unit/settings-permissions.bats`: widened the Bash()-only format test to accept `Write()`/`Edit()` (would otherwise go RED); added **SZ1/SZ2** (State-Zone rules present) + **SZ3/SZ4** (negative pins: no `.claude/**`/wildcard over-grant, no App-Zone grant). 63/63.

## Gate trail
`/bug → /implement → /review-sprint → /audit-sprint`. **Review**: cross-model gate hit an all-voice KF-002 degradation (recorded as `adversarial-review.json` api_failure) → single-model + mechanical-pin assessment per the failure-mode clause. **Audit**: cross-model recovered (gpt-5.5-pro); 2 KF-004-sidecar findings (HIGH `.run` executable surface, MED skills lifecycle) — both **declined-with-rationale, not regressions**: the shipped Bash allow-list (`cp`/`tee`/`cat`/`echo`/`python3`/`bash`/`sh`) **already** permits these writes frictionlessly, so the grant adds zero new capability; the genuine underlying surface is filed as **#1044** (HIGH, comprehensive Write+Bash hardening). SZ3/SZ4 mechanically pin no-over-grant.

## Note
settings.json is read at session start → the grant takes effect next session (this session still hit the denial, confirming the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
