### PR TITLE
fix(tests): add required auth_type/dispatch_group to v3-codegen byte-equality fixtures (#1056, sprint-bug-217)

### DIFF
--- a/tests/unit/v3-codegen-byte-equality.bats
+++ b/tests/unit/v3-codegen-byte-equality.bats
@@ -70,6 +70,8 @@ providers:
     models:
       claude-opus-4-7:
         capabilities: [chat, tools]
+        auth_type: http_api
+        dispatch_group: anthropic-claude
         context_window: 200000
         token_param: max_tokens
         max_output_tokens: 32000
@@ -85,6 +87,8 @@ providers:
     models:
       gpt-5.5-pro:
         capabilities: [chat, tools, function_calling]
+        auth_type: http_api
+        dispatch_group: openai-gpt
         context_window: 128000
         token_param: max_completion_tokens
         endpoint_family: chat
@@ -115,6 +119,8 @@ providers:
     models:
       claude-opus-4-7:
         capabilities: [chat, tools]
+        auth_type: http_api
+        dispatch_group: anthropic-claude
         context_window: 200000
         token_param: max_tokens
         max_output_tokens: 32000
@@ -141,6 +147,8 @@ providers:
     models:
       gpt-5.5-pro:
         capabilities: [chat, tools, function_calling]
+        auth_type: http_api
+        dispatch_group: openai-gpt
         context_window: 128000
         token_param: max_completion_tokens
         endpoint_family: chat
@@ -390,6 +398,8 @@ providers:
     models:
       claude-opus-4-7:
         capabilities: [chat]
+        auth_type: http_api
+        dispatch_group: anthropic-claude
         context_window: 200000
         token_param: max_tokens
         max_output_tokens: 32000


### PR DESCRIPTION
## Summary

`tests/unit/v3-codegen-byte-equality.bats` was **red on `main`** — Z1, Z2, and Z6 failed with **status 5** — producing a false-negative **"Shell Tests"** check on *every* open PR. This is pre-existing **fixture rot**: three inline YAML fixtures predate the cycle-110 (`c35f9256`, 2026-05-15) requirement that every model entry carry both `auth_type` **and** `dispatch_group`. `gen-adapter-maps.sh` aborts (`jq` exit 5, `[CODEGEN-INVALID] … missing required auth_type`) under `set -euo pipefail` before emitting any map, so the byte-equality / drift assertions never run.

Fixes the false-negative CI that unblocks contributors' open PRs (#1055, #1057, #1058, and anything touching `.claude/scripts | .claude/defaults | .claude/adapters/**/*.py | tests/unit`).

Closes #1056.

## Root cause (verified)

- `gen-adapter-maps.sh:184-193` requires `auth_type`; `:201-210` **independently** requires `dispatch_group`. Both run before codegen under `set -euo pipefail` (`:31`), so a missing field aborts with exit 5.
- The test landed `04e6b4df` (2026-05-14); the field requirement landed `c35f9256` (2026-05-15) without updating these fixtures. Both are ancestors of HEAD → chronic red on `main`.
- **Correction to the issue text:** #1056 proposed adding only `auth_type`. That is **insufficient** — an `auth_type`-only patch still aborts on `dispatch_group` (reproduced). Both fields are required.

## Change

Test-fixture only, **+10 lines**. Adds `auth_type: http_api` + `dispatch_group` (`anthropic-claude` / `openai-gpt`) at the model-entry level to the 5 affected entries:

| Fixture | Model | dispatch_group |
|---------|-------|----------------|
| `_v2_fixture` | claude-opus-4-7 / gpt-5.5-pro | anthropic-claude / openai-gpt |
| `_v2_plus_v3_fixture` | claude-opus-4-7 / gpt-5.5-pro | anthropic-claude / openai-gpt |
| Z6 `pre.yaml` | claude-opus-4-7 | anthropic-claude |

Values per the schema enums (`.claude/data/schemas/model-config-v3.schema.json:127-135`). `http_api` is correct — these are HTTP-API models (no `kind: cli`). No production code touched.

## Why byte-equality is preserved

Both sides of each comparison pair receive **identical** field values, so the generated maps stay byte-identical and the suite's drift assertion is intact — not bypassed.

## Verification

Reproduced against the real `gen-adapter-maps.sh` (bats not on PATH locally):
- **Z1** — both fixtures gen exit 0; maps byte-identical, sha256 `81371f28…`
- **Z2** — `--check` idempotent regen exit 0
- **Z6** — migrator preserves both fields; pre/post codegen byte-identical, sha256 `713df78b…`
- **Z3/Z4/Z5** — untouched, remain green
- **Negative control** — removing the two fields reproduces `jq` exit 5 (`missing required auth_type`), proving the fields are load-bearing and the test still exercises the requirement

## Loa quality gates

Shipped through the full gated pipeline (sprint-bug-217, bead `bd-dwn7`):
- `/implement` — verified test-first (harness above)
- `/review-sprint` — **All good**; cross-model adversarial review clean/APPROVED (gpt-5.5-pro), KF-004 sidecar checked (none)
- `/audit-sprint` — **APPROVED**; cross-model adversarial audit clean/APPROVED, KF-004 sidecar checked (none); COMPLETED marker written

## Note for the maintainer

This removes Z1/Z2/Z6 from the failing set, so the name-wise Shell-Tests baseline drops by **3 names** — a good delta, but the next merge's byte-identical-to-baseline comparison should expect the reduced baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
