### PR TITLE
feat(karpathy): integrate ponytail YAGNI principles into loa core (sprint-ponytail-yagni)

### DIFF
--- a/.claude/data/constraints.json
+++ b/.claude/data/constraints.json
@@ -1356,6 +1356,28 @@
       ],
       "severity": "critical",
       "source_incident": "#506"
+    },
+    {
+      "id": "C-PROC-011",
+      "name": "yagni_ladder",
+      "category": "process",
+      "rule_type": "ALWAYS",
+      "text": "walk the YAGNI ladder before writing code — stop at the first rung that holds (need it? → stdlib → native → installed dependency → one line → minimum code)",
+      "text_variants": {
+        "skill-md": "DO walk the YAGNI ladder before writing code — stop at the first rung that holds (need it? → stdlib → native → installed dependency → one line → minimum code); reinventing stdlib/native features is a dominant over-engineering class"
+      },
+      "why": "Speculative code and reinvented stdlib/native features are dominant over-engineering classes; the ladder is the reflex that prevents them (adapted from ponytail, MIT)",
+      "severity": "medium",
+      "order": 13,
+      "layers": [
+        {
+          "target": "skill-md",
+          "skills": [
+            "implementing-tasks"
+          ],
+          "render_as": "constraint_rule"
+        }
+      ]
     }
   ]
 }

--- a/.claude/loa/CLAUDE.loa.md
+++ b/.claude/loa/CLAUDE.loa.md
@@ -1,4 +1,4 @@
-<!-- @loa-managed: true | version: 1.173.6 | hash: 3824353f16dfd31c7a7552fdbf7ae154797685ca95a203ff433aeb797ffde6d4 -->
+<!-- @loa-managed: true | version: 1.173.6 | hash: 22b1c12d01593178b467221dc6d3d190ffe49b2027cf994b39f67cd56db69997 -->
 <!-- WARNING: This file is managed by the Loa Framework. Do not edit directly. -->
 
 # Loa Framework Instructions
@@ -114,6 +114,23 @@ Write minimum code that solves the request — nothing speculative.
 
 The test: would a senior engineer call this overcomplicated?
 
+Before writing code, walk the ladder — stop at the first rung that holds:
+1. Does this need to be built at all? (YAGNI — speculative need: say so and skip)
+2. Does the standard library already do it? Use it.
+3. Does a native platform feature cover it? Use it.
+4. Does an already-installed dependency solve it? Use it. (Never add one for a few lines.)
+5. Can it be one line? Make it one line.
+6. Only then: write the minimum code that works.
+
+The ladder is a reflex, not a research project — the first lazy solution that
+works is the right one.
+
+Never simplify away: input validation at trust boundaries, error handling that
+prevents data loss, security, accessibility, real-hardware calibration, and
+anything explicitly requested. Lazy means efficient, not careless (the audit
+gate enforces this floor). When the user asks for the full version, build it —
+don't re-argue.
+
 ### 3. Surgical Changes
 
 Touch only what the request requires. When editing existing code:
@@ -126,6 +143,12 @@ Touch only what the request requires. When editing existing code:
 Every changed line should trace directly to the user's request. No
 "while I'm here" changes — note them in the PR description instead.
 
+Mark deliberate simplifications in-code so they read as intent, not ignorance:
+`// loa:shortcut: <what>`. When the shortcut has a known ceiling, name both the
+ceiling and the upgrade trigger — `# loa:shortcut: global lock; per-account
+locks if throughput matters`. A marker that names a ceiling with no upgrade
+trigger rots silently — don't leave one.
+
 ### 4. Goal-Driven Execution
 
 Transform tasks into verifiable goals before starting:
@@ -137,6 +160,11 @@ For multi-step tasks, state the plan + per-step verification before
 implementing. Vague success criteria ("make it robust", "improve quality")
 get replaced with concrete checks ("returns 401 on invalid creds", "test
 file X passes").
+
+Non-trivial logic (a branch, loop, parser, money or security path) MUST leave at
+least one runnable check that fails if the logic breaks — satisfied by the
+sprint's acceptance-criteria tests. Trivial one-liners need no test (YAGNI
+applies to tests too) — but never skip the check on logic that can break.
 
 ## Process Compliance
 

--- a/.claude/protocols/karpathy-principles.md
+++ b/.claude/protocols/karpathy-principles.md
@@ -73,7 +73,22 @@ SIMPLICITY CHECK:
 IF code is longer than necessary:
   → Rewrite simpler
   → Delete speculative additions
+
+YAGNI LADDER (walk before writing code, stop at the first rung that holds):
+  1. Need it at all?            → no: skip (YAGNI)
+  2. Stdlib does it?            → use it
+  3. Native platform feature?   → use it
+  4. Installed dependency?      → use it (never add one for a few lines)
+  5. One line?                  → one line
+  6. Only then: minimum that works
+The ladder is a reflex, not a research project.
+
+NEVER simplify away: trust-boundary validation, data-loss handling, security,
+accessibility, real-hardware calibration, or anything explicitly requested.
 ```
+
+> Attribution: the YAGNI ladder and the `loa:shortcut:` marker are adapted
+> from [ponytail](https://github.com/DietrichGebert/ponytail) (Dietrich Gebert), MIT.
 
 **Metrics**:
 | Smell | Action |
@@ -82,6 +97,7 @@ IF code is longer than necessary:
 | Unused parameters | Remove them |
 | "Extensibility" hooks | Delete unless requested |
 | Generic interfaces for specific use | Simplify to concrete |
+| Reinventing stdlib / native feature | Use the platform |
 
 ---
 
@@ -111,6 +127,12 @@ DIFF REVIEW:
 - Every changed line should relate to the request
 - No "while I'm here" changes
 - If you see issues elsewhere, note them separately
+
+INTENTIONAL SHORTCUTS:
+- Mark deliberate simplifications in-code: `// loa:shortcut: <what>`
+- If the shortcut has a known ceiling, name the ceiling AND the upgrade trigger
+  (`# loa:shortcut: global lock; per-account locks if throughput matters`)
+- A marker naming a ceiling with no upgrade trigger rots — don't leave one
 ```
 
 **Verification**:

--- a/.claude/skills/implementing-tasks/SKILL.md
+++ b/.claude/skills/implementing-tasks/SKILL.md
@@ -346,7 +346,7 @@ Implement sprint tasks from `grimoires/loa/sprint.md` with production-grade code
 - **Desired state**: Working, tested implementation + comprehensive report
 
 ## Constraints (E - Explicit)
-<!-- @constraint-generated: start implementing_tasks_constraints | hash:14f0ec969f05599d -->
+<!-- @constraint-generated: start implementing_tasks_constraints | hash:5b15ea042277c84d -->
 <!-- DO NOT EDIT — generated from .claude/data/constraints.json -->
 1. DO NOT start new work without checking for audit feedback FIRST (highest priority)
 2. DO NOT start new work without checking for engineer feedback SECOND
@@ -358,6 +358,7 @@ Implement sprint tasks from `grimoires/loa/sprint.md` with production-grade code
 8. DO update relevant documentation if specified in integration context
 9. DO format commits per org standards if defined
 10. DO follow SemVer for version updates
+11. DO walk the YAGNI ladder before writing code — stop at the first rung that holds (need it? → stdlib → native → installed dependency → one line → minimum code); reinventing stdlib/native features is a dominant over-engineering class
 <!-- @constraint-generated: end implementing_tasks_constraints -->
 
 ## Verification (E - Easy to Verify)

--- a/.claude/skills/reviewing-code/SKILL.md
+++ b/.claude/skills/reviewing-code/SKILL.md
@@ -806,6 +806,22 @@ During Phase 2 (Code Review), add complexity checks:
 - Functions 40-50 lines (borderline)
 - 2-3 duplicate patterns
 - Minor naming inconsistencies
+
+### YAGNI over-engineering taxonomy (#1012-adjacent)
+
+Tag each over-engineering finding so the engineer gets a crisp delete-list
+(reuse the existing `SIMPLICITY:` feedback template):
+
+| Tag | Meaning | Example finding |
+|-----|---------|-----------------|
+| `delete` | Needn't exist (YAGNI) | `SIMPLICITY[delete]: unused config layer — remove` |
+| `stdlib` | Reinvents the standard library | `SIMPLICITY[stdlib]: hand-rolled debounce — use stdlib` |
+| `native` | Reinvents a native platform feature | `SIMPLICITY[native]: custom date widget — native input` |
+| `yagni` | Speculative flexibility/abstraction | `SIMPLICITY[yagni]: generic iface for one caller — inline` |
+| `shrink` | Correct but larger than needed | `SIMPLICITY[shrink]: 40 lines that fit in 5` |
+
+A `loa:shortcut:` marker that names a ceiling with **no upgrade trigger** is a
+`SIMPLICITY[shrink]` finding — the deferred work rots without a trigger.
 </complexity_review>
 
 <beads_workflow>

--- a/.claude/skills/riding-codebase/resources/references/deep-analysis-guide.md
+++ b/.claude/skills/riding-codebase/resources/references/deep-analysis-guide.md
@@ -140,10 +140,10 @@ grep -roh 'process\.env\.\w\+\|os\.environ\[.\+\]\|os\.Getenv\(.\+\)\|env\.\w\+\
 
 ```bash
 .claude/scripts/search-orchestrator.sh regex \
-  "TODO|FIXME|HACK|XXX|BUG|@deprecated|eslint-disable|@ts-ignore|type:\\s*any" \
+  "TODO|FIXME|HACK|XXX|BUG|@deprecated|eslint-disable|@ts-ignore|type:\\s*any|loa:shortcut" \
   "${TARGET_REPO}/src" 100 0.0 \
   > grimoires/loa/reality/tech-debt.txt 2>/dev/null || \
-grep -rn "TODO\|FIXME\|HACK\|XXX\|BUG\|@deprecated\|eslint-disable\|@ts-ignore\|type: any" \
+grep -rn "TODO\|FIXME\|HACK\|XXX\|BUG\|@deprecated\|eslint-disable\|@ts-ignore\|type: any\|loa:shortcut" \
   --include="*.ts" --include="*.js" --include="*.py" --include="*.go" "${TARGET_REPO}" 2>/dev/null \
   > grimoires/loa/reality/tech-debt.txt
 ```


### PR DESCRIPTION
## Summary

Integrate the genuinely-new principles from **[ponytail](https://github.com/DietrichGebert/ponytail)** (Dietrich Gebert, MIT — *"the best code is the code you never wrote"*) into loa's existing **Karpathy core**.

A design pass found loa already owns **~70%** of ponytail under the Karpathy banner — Simplicity First, Surgical Changes, the blocking Complexity Review in `/review-sprint`, debt tracking (beads `discovered-during:` + NOTES), and `⏸ [ACCEPTED-DEFERRED]`. Only **three mechanics were genuinely new**, so this is a *sharpening* of loa's core, not a foreign graft. **Smallest faithful footprint: 6 files, all additive, no new skills / hooks / commands.**

## What changed

- **YAGNI escalation ladder** — `need-it? → stdlib → native → installed-dep → one-line → minimum`, stop at the first rung; *"a reflex, not a research project."* Folded into Karpathy **Simplicity First** (`CLAUDE.loa.md` + `karpathy-principles.md` + a Metrics row). loa had the spirit ("write minimum code") but not the decision procedure.
- **`loa:shortcut:` in-code marker** — the only mechanic with zero loa equivalent. `// loa:shortcut: <what>`; when the shortcut has a ceiling, name the **ceiling AND the upgrade trigger** (a ceiling with no trigger rots). Harvested through loa's *existing* surfaces — added to the `/ride` tech-debt scan + a `reviewing-code` `SIMPLICITY[shrink]` finding. **No parallel `PONYTAIL-DEBT.md`.**
- **"One runnable check for non-trivial logic"** — `Goal-Driven Execution`; trivial one-liners need none (*YAGNI applies to tests too*). Defers to loa's stronger AC/test gates — adds permission to skip per-function suites for trivial code, not a parallel mechanism.
- **"Not lazy about" safety floor** — trust-boundary validation, data-loss handling, security, accessibility, hardware calibration, anything explicitly requested — placed next to the simplicity rule, cross-referencing the audit gate. Fences *lazy* from *careless*.
- **Constraint `C-PROC-011` (`yagni_ladder`)** added to `constraints.json` + regenerated into the `implementing-tasks` constraint table — makes simplicity a **first-class registry constraint** (it was hand-authored prose, absent from the registry). Rendered skill-md-only (the `ALWAYS` table is gate-bypass-framed; every-turn presence is the prose ladder).
- **5-tag over-engineering taxonomy** (`delete/stdlib/native/yagni/shrink`) into the `reviewing-code` Complexity Review for a crisper reviewer delete-list.

## Declined (each fails the ladder's own rung 1)

Vendoring the 5-skill/2-hook plugin, intensity levels (`lite/ultra`), a SessionStart hook (loa already loads every turn via `CLAUDE.loa.md`), new `/ponytail-*` commands (duplicate `/review-sprint`/`/ride`). **Operator decisions:** `loa:shortcut:` token (not `ponytail:`), `full` posture (not `ultra`), instructions-only, native-weave.

## Verification

- `generate-constraints.sh` → exit 0, **idempotent** on re-run; `implementing-tasks/SKILL.md` renders "11. DO walk the YAGNI ladder…" with a valid `@constraint-generated` hash; CLAUDE.loa.md generated tables untouched; no unrelated drift.
- `validate-skill-capabilities.sh` → **35/35 pass**.
- Prose coherent across `CLAUDE.loa.md` ↔ `karpathy-principles.md`; `/ride` ERE+BRE patterns valid; attribution present (MIT).

## Loa quality gates

sprint-ponytail-yagni, bead `bd-t3xh`: `/implement` → `/review-sprint` (**All good**, cross-model clean) → `/audit-sprint` (**APPROVED**, cross-model clean, KF-004 checked).

## Notes

- `C-PROC-011` is rendered into the implementing-tasks constraint table only (not a CLAUDE.loa.md generated table) — a deliberate refinement from the design's `process_compliance_always` suggestion, since that table is framed "rules that prevent bypassing quality gates" and a coding-discipline rule is a category mismatch there. Every-turn presence is the prose ladder.
- Possible follow-up (out of scope per operator): make the K-1 surgical hook count net-of-deletions to reward deletion-over-addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
