### PR TITLE
fix(scripts): next-bug-sprint-id scans the sprint-bug-N/ dir layout (#1064, sprint-bug-222)

### DIFF
--- a/.claude/scripts/next-bug-sprint-id.sh
+++ b/.claude/scripts/next-bug-sprint-id.sh
@@ -84,6 +84,22 @@ for f in "$PROJECT_ROOT"/grimoires/loa/a2a/bug-*/sprint.md; do
 done
 shopt -u nullglob
 
+# 2b. Max sprint-bug-N from the sprint-bug-N/ directory layout (#1064). The
+#     bug-*/sprint.md scan above misses these dirs (used by #1053/#1056/#1059+).
+#     Extraction is EXACT-anchored (^sprint-bug-([0-9]+)$) so the malformed live
+#     dir `sprint-bug-622-623` is rejected, not mis-parsed as 623.
+shopt -s nullglob
+for d in "$PROJECT_ROOT"/grimoires/loa/a2a/sprint-bug-*/; do
+    base="$(basename "$d")"
+    if [[ "$base" =~ ^sprint-bug-([0-9]+)$ ]]; then
+        n="${BASH_REMATCH[1]}"
+        if [[ "$n" -gt "$disk_max" ]]; then
+            disk_max="$n"
+        fi
+    fi
+done
+shopt -u nullglob
+
 # 3. origin/main's global_sprint_counter + cycle claims (best-effort, no fetch)
 origin_counter=0
 origin_claims=0

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1861,7 +1861,7 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260613-i1038-7bc405/sprint.md"
     }
   ],
-  "global_sprint_counter": 221,
+  "global_sprint_counter": 222,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -2171,6 +2171,19 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260614-i1012-e52467/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260614-i1012-e52467/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260615-i1064-2e8933",
+      "label": "Bug Fix \u2014 next-bug-sprint-id.sh disk-scan misses sprint-bug-N/ layout (#1064)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/1064",
+      "created_at": "2026-06-15T03:41:37Z",
+      "sprints": [
+        "sprint-bug-222"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260615-i1064-2e8933/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260615-i1064-2e8933/sprint.md"
     }
   ],
   "bugfixes": [

--- a/tests/unit/next-bug-sprint-id.bats
+++ b/tests/unit/next-bug-sprint-id.bats
@@ -265,3 +265,31 @@ EOF
     [[ "$status" -eq 0 ]]
     [[ "$output" == "sprint-bug-311" ]]
 }
+
+# =============================================================================
+# Issue #1064 — the bug-*/sprint.md disk-scan missed the sprint-bug-N/ directory
+# layout (used by #1053/#1056/#1059+). When the counter lagged a claimed id, the
+# helper re-emitted an already-used sprint-bug-N (observed: sprint-bug-217 this
+# session). Extraction must be exact-anchored so the malformed live dir
+# sprint-bug-622-623 is rejected, not mis-parsed as 623.
+# =============================================================================
+
+@test "issue#1064: sprint-bug-N/ directory layout is consulted when counter lags" {
+    _write_ledger 200
+    mkdir -p "$PROJECT_ROOT/grimoires/loa/a2a/sprint-bug-230"
+    cd "$PROJECT_ROOT" && git init --quiet
+    run bash "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "sprint-bug-231" ]]
+}
+
+@test "issue#1064: malformed sprint-bug-622-623 dir is not mis-parsed (anchored)" {
+    _write_ledger 200
+    mkdir -p "$PROJECT_ROOT/grimoires/loa/a2a/sprint-bug-230"
+    mkdir -p "$PROJECT_ROOT/grimoires/loa/a2a/sprint-bug-622-623"
+    cd "$PROJECT_ROOT" && git init --quiet
+    run bash "$SCRIPT"
+    [[ "$status" -eq 0 ]]
+    # 622-623 rejected (else would parse 623 -> 624); max real id is 230 -> 231
+    [[ "$output" == "sprint-bug-231" ]]
+}


### PR DESCRIPTION
## Summary

`next-bug-sprint-id.sh`'s disk-scan globbed only `grimoires/loa/a2a/bug-*/sprint.md` and never scanned the **`sprint-bug-N/` directory layout** used by #1053/#1056/#1059+. When the ledger `global_sprint_counter` lagged a claimed id (#942 class), no source reported N → the helper re-emitted an **already-used** `sprint-bug-N`.

**Observed this session:** during the `/bug` for #1013, `next-bug-sprint-id.sh` returned `sprint-bug-217` (the already-merged #1056) and had to be hand-overridden. This is the root-cause fix.

Closes #1064.

## Fix

A second disk scan over `sprint-bug-*/` directory names, folded into the existing `disk_max` (the final `max()` already consumes it — no picking-logic change):

```sh
for d in "$PROJECT_ROOT"/grimoires/loa/a2a/sprint-bug-*/; do
    base="$(basename "$d")"
    if [[ "$base" =~ ^sprint-bug-([0-9]+)$ ]]; then ... fold into disk_max ...
done
```

Extraction is **exact-anchored** `^sprint-bug-([0-9]+)$` — so the malformed live dir `sprint-bug-622-623` is **rejected**, not mis-parsed as `623` (which would poison the id to 624). Mirrors the existing `_CLAIMS_JQ` anchoring discipline.

## Verification (end-to-end)

- Lagging counter (200) + `sprint-bug-230/` → **`sprint-bug-231`**; negative control: `origin/main` script → `201` (misses the dir).
- Malformed `sprint-bug-622-623/` present → **still `231`** (rejected, not 624).
- `bug-*/sprint.md` scan preserved → `241`.
- +2 bats regression cases (fail on `origin/main`, pass here); 15 `@test` total; `bash -n` clean.

## ⚠️ Gate status — KF-002 (do not admin-merge yet)

The cross-model review + audit gates hit **KF-002** (substrate `api_failure` on all voices except one clean `gemini-3.1-pro` audit voice this run). Per the multi-model contract, a degraded chain cannot yield a clean multi-voice APPROVED:
- **Review:** single-model (substrate down both invocations) = **All good** (per the failure-mode clause).
- **Audit:** 1/3 voices clean / 0 findings, `verdict_quality=FAILED` → **DEGRADED**, no COMPLETED marker.

The fix's quality rests on the exhaustive end-to-end verification above (substrate-independent). **Recommend:** re-run `/audit-sprint sprint-bug-222` when the substrate recovers for a clean APPROVED, then merge — or merge at operator discretion on the strength of the verification + the single clean audit voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
