### PR TITLE
fix(config): refresh advisor/BB/red-team anthropic pins to claude-opus-4-8 (#1058 Half A)

### DIFF
--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -33,7 +33,7 @@ advisor_strategy:
     implementation: advisor
   tier_aliases:
     advisor:
-      anthropic: claude-opus-4-7
+      anthropic: claude-opus-4-8
       openai: gpt-5.5-pro
       google: gemini-3.1-pro-preview
     executor:
@@ -225,7 +225,7 @@ run_bridge:
       # #789b deferred to cycle-101 follow-up: invoke-time probe gate for preview-tier models.
       models:
         - provider: anthropic
-          model_id: claude-opus-4-7
+          model_id: claude-opus-4-8
           role: primary
         - provider: openai
           model_id: gpt-5.5-pro
@@ -379,7 +379,7 @@ red_team:
     # + google), so red team now invokes all 3 like Bridgebuilder + Flatline.
     # See grimoires/loa/known-failures.md (post KF-001 resolution context).
     evaluator_multi_model: true
-    evaluator_primary: claude-opus-4-7   # anthropic
+    evaluator_primary: claude-opus-4-8   # anthropic
     evaluator_secondary: gpt-5.5-pro     # openai
     evaluator_tertiary: gemini-3.1-pro   # google
   defaults:


### PR DESCRIPTION
## Summary

**Half A of @zkSoju's #1058**, split out per the merged #1066 honest-routing plan. The three `.loa.config.yaml` anthropic version-pins — advisor tier alias (`:36`), run_bridge primary (`:228`), red_team `evaluator_primary` (`:382`) — refresh `claude-opus-4-7 → claude-opus-4-8` (the newest registered Opus, `model-config.yaml:372`).

This is the orthogonal, correct half of #1058. The headless `cli_model` override (#1058 **Half B**) overlaps #1006's `cli_model_map` and is folded into #1006 instead — not landed here (avoids the "two overlapping mechanisms" #1066 warns against).

## Verification
- Exactly 3 pins changed (only opus-4-7 occurrences in the file); YAML valid; `claude-opus-4-8` is a registered model.
- Cross-model gate not run (substrate KF-017-degraded); this is a 3-line version-pin to an already-registered model — offline-validated.

Credit @zkSoju (diagnosis correct — this is a redirect of #1058, not a rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
