### PR TITLE
feat(karpathy): close ponytail v4.7.0 parity gaps (intensity, output discipline, /ride --with-simplicity)

### DIFF
--- a/.claude/loa/CLAUDE.loa.md
+++ b/.claude/loa/CLAUDE.loa.md
@@ -125,11 +125,27 @@ Before writing code, walk the ladder — stop at the first rung that holds:
 The ladder is a reflex, not a research project — the first lazy solution that
 works is the right one.
 
+Two stdlib options the same size? Take the edge-case-correct one — lazy means
+less code, not the flimsier algorithm. Deletion over addition, boring over
+clever, fewest files, shortest working diff.
+
 Never simplify away: input validation at trust boundaries, error handling that
 prevents data loss, security, accessibility, real-hardware calibration, and
 anything explicitly requested. Lazy means efficient, not careless (the audit
 gate enforces this floor). When the user asks for the full version, build it —
 don't re-argue.
+
+**Output discipline**: code first, then at most three lines — what you skipped
+and when to add it (`[code] → skipped: X, add when Y`). An explanation longer
+than the code is complexity smuggled back as prose; cut it. Reports,
+walkthroughs, or per-phase notes the user explicitly asked for are exempt —
+give those in full.
+
+**Intensity** (`simplicity_intensity`, default `full`): `full` enforces the
+ladder — stdlib and native first, shortest diff. `ultra` is deletion-first —
+challenge whether the requirement should shrink before building; ship the
+one-liner and question the rest of the requirement in the same response. There
+is no advise-only level — the floor above is never softened.
 
 ### 3. Surgical Changes
 

--- a/.claude/protocols/karpathy-principles.md
+++ b/.claude/protocols/karpathy-principles.md
@@ -82,6 +82,9 @@ YAGNI LADDER (walk before writing code, stop at the first rung that holds):
   5. One line?                  → one line
   6. Only then: minimum that works
 The ladder is a reflex, not a research project.
+Tie-break: two same-size stdlib options -> the edge-case-correct one (lazy is
+less code, not a flimsier algorithm). Deletion over addition, fewest files,
+shortest working diff.
 
 NEVER simplify away: trust-boundary validation, data-loss handling, security,
 accessibility, real-hardware calibration, or anything explicitly requested.
@@ -89,6 +92,15 @@ accessibility, real-hardware calibration, or anything explicitly requested.
 
 > Attribution: the YAGNI ladder and the `loa:shortcut:` marker are adapted
 > from [ponytail](https://github.com/DietrichGebert/ponytail) (Dietrich Gebert), MIT.
+
+**Output discipline**: code first, then at most three lines (what was skipped,
+when to add it: `[code] → skipped: X, add when Y`). An explanation longer than
+the code is complexity as prose — cut it. Reports / walkthroughs the user
+explicitly asked for are exempt.
+
+**Intensity** (`simplicity_intensity`, default `full`): `full` enforces the
+ladder; `ultra` is deletion-first and challenges the requirement before
+building. No advise-only level — the floor is never softened.
 
 **Metrics**:
 | Smell | Action |

--- a/.claude/skills/reviewing-code/SKILL.md
+++ b/.claude/skills/reviewing-code/SKILL.md
@@ -822,6 +822,11 @@ Tag each over-engineering finding so the engineer gets a crisp delete-list
 
 A `loa:shortcut:` marker that names a ceiling with **no upgrade trigger** is a
 `SIMPLICITY[shrink]` finding — the deferred work rots without a trigger.
+
+End an over-engineering pass with the only metric that matters:
+`net: -<N> lines possible`. If nothing should be cut, say `Lean already. Ship.`
+and stop. Never flag the one required acceptance-check behind non-trivial logic
+(the smallest runnable check) for deletion — that is the YAGNI minimum, not bloat.
 </complexity_review>
 
 <beads_workflow>

--- a/.claude/skills/riding-codebase/SKILL.md
+++ b/.claude/skills/riding-codebase/SKILL.md
@@ -108,11 +108,12 @@ Scan the user's invocation for these flags:
 | `--with-gaps` | `ENRICH_GAPS` | `false` | Enable Phase 12: Gap Tracker |
 | `--with-decisions` | `ENRICH_DECISIONS` | `false` | Enable Phase 13: Decision Archaeology |
 | `--with-terms` | `ENRICH_TERMS` | `false` | Enable Phase 14: Terminology Extraction |
-| `--enriched` | Sets all three above | `false` | Enable all enrichment phases |
+| `--with-simplicity` | `ENRICH_SIMPLICITY` | `false` | Enable Phase 15: Over-Engineering Audit + shortcut ledger |
+| `--enriched` | Sets all four above | `false` | Enable all enrichment phases |
 
 ### Parsing Rules
 
-1. If `--enriched` is present, set `ENRICH_GAPS=true`, `ENRICH_DECISIONS=true`, `ENRICH_TERMS=true`
+1. If `--enriched` is present, set `ENRICH_GAPS=true`, `ENRICH_DECISIONS=true`, `ENRICH_TERMS=true`, `ENRICH_SIMPLICITY=true`
 2. Individual flags can be combined: `--with-gaps --with-decisions`
 3. If NO enrichment flags are present, all variables remain `false` — standard ride proceeds unchanged
 4. Log parsed flags to trajectory:
@@ -974,6 +975,55 @@ After writing, verify with `Glob` pattern `grimoires/loa/reality/terminology.md`
 Log phase completion:
 ```json
 {"phase": 14, "action": "terminology_extraction", "status": "complete", "details": {"terms_extracted": N, "domains": N, "output": "grimoires/loa/reality/terminology.md"}}
+```
+
+---
+
+## Phase 15: Over-Engineering Audit + Shortcut Ledger (`ENRICH_SIMPLICITY` only)
+
+**Skip condition**: If `ENRICH_SIMPLICITY == false`, skip this phase. Log skip to trajectory:
+```json
+{"phase": 15, "action": "simplicity_audit", "status": "skipped", "details": {"reason": "ENRICH_SIMPLICITY not set"}}
+```
+
+The complexity-only counterpart to a security audit: a ranked, whole-repo
+over-engineering pass plus a dedicated `loa:shortcut:` debt ledger. Reports
+only, applies no fixes.
+
+### 15.1 Over-engineering scan (ranked, biggest cut first)
+
+Apply the reviewing-code over-engineering taxonomy (`delete` / `stdlib` /
+`native` / `yagni` / `shrink`) tree-wide instead of to a diff. Hunt:
+dependencies the stdlib or platform already ships, single-implementation
+interfaces, factories with one product, wrappers that only delegate, dead
+flags/config, hand-rolled stdlib. One line per finding, ranked biggest-cut
+first: `<tag>: <what to cut>. <replacement>. [path:line]`. End with
+`net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. Ship.`
+
+### 15.2 `loa:shortcut:` debt ledger
+
+Harvest deliberate-simplification markers (distinct from the generic
+TODO/FIXME tech-debt scan in the standard ride):
+
+```bash
+grep -rnE '(#|//|--) ?loa:shortcut:' . \
+  --exclude-dir={.git,node_modules,dist,build} \
+  > grimoires/loa/reality/shortcut-ledger.raw 2>/dev/null || true
+```
+
+One row per marker, grouped by file, parsing the `loa:shortcut: <ceiling>,
+<upgrade>` convention:
+`<file>:<line> - <what was simplified>. ceiling: <limit>. upgrade: <trigger>.`
+Any marker naming a ceiling with NO upgrade trigger gets a `no-trigger` tag,
+those rot silently. End with `<N> markers, <M> no-trigger.` None found:
+`No loa:shortcut: debt. Clean ledger.`
+
+### 15.3 Write the report
+
+Write both sections to `grimoires/loa/reality/over-engineering.md` (ranked
+findings, then ledger). Log completion:
+```json
+{"phase": 15, "action": "simplicity_audit", "status": "complete", "details": {"findings": N, "net_lines": -N, "markers": N, "no_trigger": N, "output": "grimoires/loa/reality/over-engineering.md"}}
 ```
 
 ---

--- a/.loa.config.yaml.example
+++ b/.loa.config.yaml.example
@@ -2664,6 +2664,12 @@ karpathy_principles:
   # consumer in v1; reserved for v2 when surface-assumption analysis lands.
   surface_assumptions: true
 
+  # Simplicity enforcement intensity: full (default, enforced — the YAGNI ladder,
+  # stdlib/native first, shortest diff) or ultra (deletion-first, challenges the
+  # requirement before building). There is NO advise-only 'lite' level: the
+  # "never simplify away" floor (C-PROC-011) stays enforced at every level.
+  simplicity_intensity: full
+
   # G-1 — master switch for the PostToolUse:Write|Edit surgical-diff hook
   # at .claude/hooks/quality/karpathy-surgical-diff-check.sh. When false,
   # the hook fast-paths to exit 0 in <10ms.

--- a/grimoires/loa/proposals/ponytail-parity-audit-2026-06-16.md
+++ b/grimoires/loa/proposals/ponytail-parity-audit-2026-06-16.md
@@ -1,0 +1,28 @@
+# Ponytail v4.7.0 ↔ Loa parity audit (2026-06-16)
+
+Source: 21-agent ultracode workflow (10 capabilities × map+verify → synthesis),
+grounded in /tmp/ponytail (v4.7.0) vs origin/main @ 2a88594e.
+
+**Capability parity before this sprint: ~72%.** Loa already embodies ponytail's
+load-bearing "full"-mode doctrine (PR #1067): the full 6-rung YAGNI ladder, the
+reflex framing, the safety floor, the one-runnable-check, the `loa:shortcut:`
+marker (= ponytail's `ponytail:`), the 5-tag taxonomy in reviewing-code, and
+C-PROC-011 + MIT attribution.
+
+## Operator decisions (AskUserQuestion, 2026-06-16)
+- Approach: **(A) capability-map** — close gaps inside loa's architecture, no literal /ponytail* port (avoids duplicating reviewing-code / auditing-security / ride / loa-help).
+- Intensity: **full + ultra only** — NO advise-only `lite` (it would soften the enforced YAGNI constraint, conflicting with loa's gated philosophy).
+
+## Gaps closed by sprint-ponytail-parity
+| # | Sev | Gap | Home |
+|---|-----|-----|------|
+| G1 | high | No `full`/`ultra` intensity dial | CLAUDE.loa.md + .loa.config.yaml.example + C-PROC-011 |
+| G2 | high | No per-response output discipline (code-first, ≤3 lines, `[code] → skipped: X, add when Y`) | CLAUDE.loa.md + karpathy-principles.md |
+| G3 | med | reviewing-code lacks `net: -N lines` metric + "Lean already. Ship." + never-flag-the-required-check | reviewing-code/SKILL.md |
+| G4 | med | No whole-repo over-engineering (complexity-only) ranked scan | riding-codebase (`--with-simplicity`) |
+| G5 | med | loa:shortcut harvest lumps with TODO/FIXME; no ceiling/upgrade/no-trigger ledger | riding-codebase debt ledger |
+| G6 | low | Two ponytail Rules clauses absent (edge-case tie-break; deletion/fewest-files/shortest-diff) | CLAUDE.loa.md + karpathy-principles.md |
+| G7 | low | No command surface for the new modes | folded into `/ride` flags (YAGNI: no new commands) |
+| G8 | low | No explicit persona on/off + intensity toggle | subsumed by G1 (loa already applies Karpathy every turn) |
+
+Host adapters (Cursor/Windsurf/Copilot rules, statusline hooks) = N/A: loa is its own host.


### PR DESCRIPTION
## Summary

Closes the **8 ponytail v4.7.0 ↔ loa parity gaps** found by a 21-agent grounded parity audit (`grimoires/loa/proposals/ponytail-parity-audit-2026-06-16.md`). loa already had ponytail's load-bearing doctrine (≈72%, via #1067); this brings it to behavioral 1:1.

**Operator decisions** (AskUserQuestion): **(A) capability-map** — extend loa's existing skills/constraints, no literal `/ponytail*` port (which would duplicate `reviewing-code`/`auditing-security`/`/ride`); **full + ultra only** — NO advise-only `lite` (the YAGNI floor stays enforced).

### Gaps closed
| | Gap | Where |
|---|-----|-------|
| G1 | `simplicity_intensity` = `full` (default, enforced) \| `ultra` (deletion-first); no `lite` | `CLAUDE.loa.md` + `.loa.config.yaml.example` |
| G2 | Output discipline: code-first, ≤3 lines, `[code] → skipped: X, add when Y`, requested-reports carve-out | `CLAUDE.loa.md` + `karpathy-principles.md` |
| G3 | `net: -N lines possible` metric + `Lean already. Ship.` + never-flag-the-required-check | `reviewing-code/SKILL.md` |
| G4+G5 | `/ride --with-simplicity` (Phase 15): whole-repo over-engineering audit (5-tag, ranked, net-lines) + dedicated `loa:shortcut:` ledger w/ `no-trigger` flagging | `riding-codebase/SKILL.md` |
| G6 | Edge-case tie-break + deletion/fewest-files/shortest-diff ladder clauses | `CLAUDE.loa.md` + `karpathy-principles.md` |

Host adapters (Cursor/Windsurf/Copilot rules, statusline hooks) intentionally **not** ported — loa is its own host, not a guest. C-PROC-011 text unchanged (YAGNI: intensity is documented; no constraint-block regen churn). G7/G8 subsumed (no new commands; loa already applies Karpathy every turn).

### Verification
- Additive/opt-in only — zero runtime behavior change unless `ultra` is set or `--with-simplicity` is invoked (default off).
- `validate-skill-capabilities.sh` ✅ 35/35, `validate-constraints.sh` ✅ 0 errors, config YAML valid.
- **Review + audit gates: both `clean`, 0 findings, no KF-004 sidecar** (gpt-5.5-pro, full diff, under `LOA_HEADLESS_MODE=api-only`). `verdict_quality` DEGRADED only from the single-voice fleet (KF-017 billing/auth — environmental, not the change).

System Zone change → requesting operator review (@deep-name). Substrate is single-voice under KF-017; if you want a full multi-voice audit, restore the subscription paths first (`codex login` + Anthropic credits), else this is offline+gpt-5.5-pro verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
