### PR TITLE
fix(butterfreezone): #1069 — 3 residual macOS/BSD defects (table-row extraction + GNU-only \U sed + '---' purpose capture)

### DIFF
--- a/.claude/scripts/butterfreezone-gen.sh
+++ b/.claude/scripts/butterfreezone-gen.sh
@@ -423,7 +423,7 @@ describe_from_name() {
         sed 's/_/ /g' | \
         sed 's/\([a-z]\)\([A-Z]\)/\1 \2/g' | \
         tr '[:upper:]' '[:lower:]' | \
-        sed 's/^./\U&/' | \
+        ucfirst | \
         head -c 80
 }
 
@@ -442,12 +442,18 @@ extract_project_description() {
 
     # Strategy 2: README.md first real paragraph (skip title, badges, quotes, HTML comments)
     if [[ -z "$desc" || "$desc" == "null" ]] && [[ -f "README.md" ]]; then
+        # #1069 bug 3: skip markdown horizontal rules (---, ***, ___ and spaced
+        # variants) so a rule following a badge row is not captured as the
+        # description (observed downstream: "purpose: ---").
         desc=$(awk '
             /^#/{next}
             /^\[!\[/{next}
             /^>/{next}
             /<!--/{skip=1; next} /-->/{skip=0; next}
             skip{next}
+            /^[[:space:]]*-[[:space:]]*-[[:space:]]*-([[:space:]]*-)*[[:space:]]*$/{next}
+            /^[[:space:]]*\*[[:space:]]*\*[[:space:]]*\*([[:space:]]*\*)*[[:space:]]*$/{next}
+            /^[[:space:]]*_[[:space:]]*_[[:space:]]*_([[:space:]]*_)*[[:space:]]*$/{next}
             /^[[:space:]]*$/{if(found) exit; next}
             {found=1; printf "%s ", $0}
         ' README.md 2>/dev/null | sed 's/ *$//' | cut -c1-220 | sed 's/ [^ ]*$//' | \
@@ -583,7 +589,7 @@ infer_module_purpose() {
 
     # Strategy 4: Capitalize directory name as last resort
     if [[ -z "$purpose" ]]; then
-        purpose=$(echo "$dname" | sed 's/[-_]/ /g' | sed 's/^./\U&/')
+        purpose=$(echo "$dname" | sed 's/[-_]/ /g' | ucfirst)
     fi
 
     echo "$purpose"
@@ -981,8 +987,26 @@ extract_capabilities() {
         local grimoire_dir
         grimoire_dir=$(get_config_value "paths.grimoire" "grimoires/loa")
         if [[ -f "${grimoire_dir}/reality/api-surface.md" ]]; then
+            # #1069 bug 1: reality/api-surface.md is frequently authored as
+            # markdown TABLES (rows start with '|'). The old grep kept only
+            # bullet/header lines, dropping every table row -> empty
+            # capabilities -> sparse output that failed min_words. Include table
+            # rows and lift each into a bullet, skipping the |---|---| separator.
             caps=$(head -50 "${grimoire_dir}/reality/api-surface.md" 2>/dev/null | \
-                grep -E '^[-*]|^#+' | head -20 | sed -E 's/^(#+) /##\1 /') || true
+                grep -E '^[-*]|^#+|^\|' | \
+                sed -E 's/^(#+) /##\1 /' | \
+                awk '
+                    /^[[:space:]|:-]+$/ { next }
+                    /^\|/ {
+                        line = $0
+                        sub(/^\|[[:space:]]*/, "", line)
+                        sub(/[[:space:]]*\|[[:space:]]*$/, "", line)
+                        gsub(/[[:space:]]*\|[[:space:]]*/, " — ", line)
+                        print "- " line
+                        next
+                    }
+                    { print }
+                ' | head -20) || true
         fi
     fi
 
@@ -1407,7 +1431,7 @@ extract_interfaces() {
 
                 # Strategy 3: Synthesize from directory name
                 if [[ -z "$skill_desc" ]]; then
-                    skill_desc=$(echo "$sname" | sed 's/-/ /g' | sed 's/^./\U&/')
+                    skill_desc=$(echo "$sname" | sed 's/-/ /g' | ucfirst)
                 fi
 
                 local provenance_class
@@ -1802,7 +1826,7 @@ extract_persona_agents() {
 
         # Extract heading
         agent_name=$(grep -m1 '^# ' "$pf" 2>/dev/null | sed 's/^# //') || true
-        [[ -z "$agent_name" ]] && agent_name=$(basename "$pf" | sed 's/-persona\.md//' | sed 's/-/ /g;s/^./\U&/')
+        [[ -z "$agent_name" ]] && agent_name=$(basename "$pf" | sed 's/-persona\.md//' | sed 's/-/ /g' | ucfirst)
 
         # Extract Identity first sentence (sentence boundary, then char safety limit)
         identity=$(awk '/^## Identity/{f=1;next} f && /^##/{exit} f && /^[[:space:]]*$/{next} f{print;exit}' \

--- a/.claude/scripts/compat-lib.sh
+++ b/.claude/scripts/compat-lib.sh
@@ -522,6 +522,21 @@ sha256_portable() {
 }
 
 # =============================================================================
+# ucfirst - Portable upper-case of the first character (issue #1069)
+# =============================================================================
+#
+# GNU sed's `s/^./\U&/` uppercase escape is NOT portable: BSD/macOS sed takes
+# `\U` literally and emits a stray `U` prefix (e.g. "Ucompositions"). This
+# stdin filter upper-cases the first character of each line via awk's toupper(),
+# which is POSIX (gawk / mawk / BSD awk). Same portability family as
+# sha256_portable (#911) and _date_to_epoch (#1034).
+#
+# Usage (stdin filter):  printf '%s' "$name" | ucfirst
+ucfirst() {
+  awk '{ print toupper(substr($0, 1, 1)) substr($0, 2) }'
+}
+
+# =============================================================================
 # jq_strict - Fail-loud jq wrapper (sprint-bug-208 / issue #1025)
 # =============================================================================
 #

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1872,9 +1872,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260617-i1076-f214d0/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260617-i1076-f214d0/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260617-i1069-8b7a4c",
+      "label": "Bug Fix \u2014 butterfreezone-gen 3 residual macOS/BSD defects (#1069)",
+      "type": "bugfix",
+      "status": "active",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/1069",
+      "created_at": "2026-06-17T00:47:51Z",
+      "sprints": [
+        "sprint-bug-224"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260617-i1069-8b7a4c/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260617-i1069-8b7a4c/sprint.md"
     }
   ],
-  "global_sprint_counter": 223,
+  "global_sprint_counter": 224,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -2214,5 +2227,5 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260428-i640-1cc190/sprint.md"
     }
   ],
-  "next_sprint_number": 223
+  "next_sprint_number": 224
 }

--- a/tests/unit/butterfreezone-gen-1069.bats
+++ b/tests/unit/butterfreezone-gen-1069.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# =============================================================================
+# #1069 — butterfreezone-gen: 3 residual macOS/BSD defects
+# =============================================================================
+# 1. Tier-1 capability extraction dropped markdown TABLE rows (grep '^[-*]|^#+')
+#    -> empty capabilities -> sparse output failing min_words.
+# 2. `sed 's/^./\U&/'` is GNU-only; BSD/macOS sed emits a literal 'U' prefix
+#    (Ucompositions, Udata, ...). Replaced by the portable `ucfirst` filter.
+# 3. extract_project_description captured a `---` horizontal rule as the README
+#    first paragraph -> "purpose: ---".
+# =============================================================================
+
+setup() {
+    BATS_TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIR/../.." && pwd)"
+    SCRIPT="$PROJECT_ROOT/.claude/scripts/butterfreezone-gen.sh"
+    COMPAT="$PROJECT_ROOT/.claude/scripts/compat-lib.sh"
+    [[ -f "$SCRIPT" ]] || skip "butterfreezone-gen.sh not found"
+
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    export TEST_TMPDIR="$BATS_TMPDIR/bfz-1069-$$"
+    mkdir -p "$TEST_TMPDIR"
+    export MOCK_REPO="$TEST_TMPDIR/repo"
+    mkdir -p "$MOCK_REPO"
+    cd "$MOCK_REPO"
+    git init -q
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    mkdir -p src
+    echo 'console.log("hi")' > src/index.js
+    git add -A && git commit -q -m "init"
+}
+
+teardown() {
+    cd /
+    [[ -n "${TEST_TMPDIR:-}" && -d "$TEST_TMPDIR" ]] && rm -rf "$TEST_TMPDIR"
+}
+
+# -----------------------------------------------------------------------------
+# Bug 1 — table-row capability extraction
+# -----------------------------------------------------------------------------
+@test "#1069 bug1: Tier-1 capabilities are extracted from markdown TABLE rows" {
+    mkdir -p grimoires/loa/reality
+    cat > grimoires/loa/reality/api-surface.md <<'EOF'
+# API Surface
+
+This API surface documentation has more than ten words of content to trigger Tier 1 detection here.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `deployWidget` | Ships the build to production safely |
+| `rollbackWidget` | Reverts to the previous release on demand |
+EOF
+    git add -A && git commit -q -m "table api-surface"
+
+    run "$SCRIPT" --tier 1
+    [ "$status" -eq 0 ]
+
+    # Pre-fix: table rows were dropped (grep '^[-*]|^#+'), so these cells never
+    # reached the doc. Post-fix: table rows are lifted into capability bullets.
+    run grep -E 'deployWidget|Ships the build to production' BUTTERFREEZONE.md
+    [ "$status" -eq 0 ]
+}
+
+# -----------------------------------------------------------------------------
+# Bug 2 — portable first-char upper-casing (no GNU-only \U)
+# -----------------------------------------------------------------------------
+@test "#1069 bug2: no GNU-only 'sed s/^./\\U&/' remains in butterfreezone-gen.sh" {
+    run grep -nE "sed 's/\\^\\./\\\\U" "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "#1069 bug2: ucfirst helper upper-cases only the first char (portable)" {
+    # shellcheck disable=SC1090
+    source "$COMPAT"
+    [ "$(printf '%s' 'compositions' | ucfirst)" = "Compositions" ]
+    [ "$(printf '%s' 'data'         | ucfirst)" = "Data" ]
+    [ "$(printf '%s' 'multi word x' | ucfirst)" = "Multi word x" ]
+    [ "$(printf '%s' ''             | ucfirst)" = "" ]
+}
+
+@test "#1069 bug2: generated module/agent names are not U-prefixed" {
+    # Exercise the describe_from_name / module-map paths; assert no 'U'-prefixed
+    # artifacts like 'Ucompositions' / 'Udata' leak into the output.
+    mkdir -p compositions data modules
+    echo x > compositions/a.txt; echo y > data/b.txt; echo z > modules/c.txt
+    git add -A && git commit -q -m "dirs"
+    run "$SCRIPT" --dry-run
+    [ "$status" -eq 0 ]
+    run grep -E '\bU(compositions|data|modules|templates|observatory)\b' <<<"$output"
+    [ "$status" -ne 0 ]
+}
+
+# -----------------------------------------------------------------------------
+# Bug 3 — '---' horizontal rule must not become the project description
+# -----------------------------------------------------------------------------
+@test "#1069 bug3: README horizontal rule is not captured as purpose" {
+    cat > README.md <<'EOF'
+# My Project
+
+[![ci](https://img.shields.io/badge/ci-pass-green.svg)](https://example.com)
+
+---
+
+My Project does a specific and useful thing for developers and their teams.
+EOF
+    git add -A && git commit -q -m "readme with hr"
+
+    run "$SCRIPT" --dry-run
+    [ "$status" -eq 0 ]
+
+    # The AGENT-CONTEXT purpose must be the real paragraph, never the rule.
+    purpose_line=$(printf '%s\n' "$output" | grep -iE 'purpose:' | head -1)
+    [[ "$purpose_line" != *"---"* ]]
+    [[ "$purpose_line" == *"specific and useful thing"* ]]
+}


### PR DESCRIPTION
## What

Fixes the 3 residual macOS/BSD defects in `butterfreezone-gen.sh` reported in #1069 — a downstream macOS run (v1.178.2) where `/butterfreezone-gen` regressed a healthy 934-word `BUTTERFREEZONE.md` into a sparse 397-word artifact that FAILED `min_words`.

Sprint: `sprint-bug-224` · Beads: `bd-ojf3`

## Defects & fixes

| # | Defect | Fix |
|---|--------|-----|
| 1 | Tier-1 capability extraction dropped markdown **table rows** (`grep '^[-*]\|^#+'` at :984) → empty capabilities → `min_words` FAIL. Follow-up to #1035 (the census *face* was fixed there; the root cause was untouched). | Include `^\|` rows and lift each into a bullet via portable awk; skip the `\|---\|` separator row. |
| 2 | `sed 's/^./\U&/'` is **GNU-only** → BSD/macOS sed emits a literal `U` prefix (`Ucompositions`, `Udata`, …) at 4 sites (426/586/1410/1805). | Added a portable `ucfirst` filter to `compat-lib.sh` (awk `toupper`, POSIX) — same portability family as `sha256_portable` (#911) / `_date_to_epoch` (#1034) — and routed all 4 sites through it. |
| 3 | `extract_project_description` captured a `---` horizontal rule as the README first paragraph → `purpose: ---`. | The README paragraph scan now skips markdown horizontal rules (`---` / `***` / `___` and spaced variants). |

## Tests — 5 new, full suite green

`tests/unit/butterfreezone-gen-1069.bats`: table-row extraction, no-GNU-`\U` static guard, `ucfirst` portability, no-`U`-prefix-in-output, HR-not-captured-as-purpose. Bugs 1 / 2-static / 3 are confirmed to **fail against pre-fix code**; the bug-2 `U`-prefix manifestation is BSD-only by nature, so its output guard can't fail on Linux's GNU sed (the static guard is the fail-pre-fix proof). The existing butterfreezone suites (`gen` 29, `validate` 14, `construct-gen` 18, `sha256-portability` 6) all pass — **72 bats total**.

## Review / audit

- Implemented test-first.
- Adversarial self-audit (the cross-model substrate hit a session limit this run): **APPROVED**. Verified awk POSIX-portability (no GNU-awk-only constructs; no `{n,}` intervals — the HR rules use explicit 3-char + `*`), `ucfirst` ↔ `sed \U` equivalence across all 4 pipelines (incl. the 1805 split and the `head -c 80` site), and that the HR regexes neither over-match (real text lines have letters) nor under-match (`---`/`***`/`___`/spaced).
- Known minor limitations (fail safe, no regression): an escaped `\|` inside a table cell and an all-dash data cell parse imperfectly; setext-heading underlines are no longer appended to the description (a strict improvement).

## Completeness sweep

Swept the entire `.claude/` tree for other GNU-only `\U`/`\L`/`\E` sed escapes — the 4 sites in `butterfreezone-gen.sh` are the only ones (the reporter's enumeration was complete).

Closes #1069
