### PR TITLE
docs(readme): sync version badge to CHANGELOG (1.173.6 → 1.180.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Power user interface: 48 slash commands (truenames).
 Architecture: Three-zone model (System: .claude/, State: grimoires/ + .beads/, App: src/).
 Configuration: .loa.config.yaml (user-owned, never modified by framework).
 Health check: /loa doctor
-Version: 1.173.6
+Version: 1.180.0
 -->
 
-[![Version](https://img.shields.io/badge/version-1.173.6-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.180.0-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE.md)
 [![Release](https://img.shields.io/badge/release-v1.173.0%20Opus%204.8-purple.svg)](CHANGELOG.md#11730---2026-06-01)
 


### PR DESCRIPTION
## What

The README version (header line + shields badge) had drifted to **1.173.6** while `CHANGELOG.md`'s top entry advanced to **[1.180.0]**. `ci.yml`'s "Validate Framework Files" job compares the CHANGELOG top version against the README `version-` badge and **failed on every PR** as a result (seen on #1077 and #1078).

## Fix

Sync both README version references (`Version:` header comment + `version-` badge) to the current named release `1.180.0`. Two-line change; no other content touched.

Verified against the exact `ci.yml` check logic locally — `CHANGELOG=1.180.0 README=1.180.0` → passes.

_Note: the separate `release-v1.173.0 Opus 4.8` name badge is intentionally left as-is (it's the named-release label, not part of the version-consistency check)._