### PR TITLE
fix(version): catch up stale framework markers to 1.180.0 (completes #1079)

### DIFF
--- a/.claude/loa/CLAUDE.loa.md
+++ b/.claude/loa/CLAUDE.loa.md
@@ -1,4 +1,4 @@
-<!-- @loa-managed: true | version: 1.173.6 | hash: 22b1c12d01593178b467221dc6d3d190ffe49b2027cf994b39f67cd56db69997 -->
+<!-- @loa-managed: true | version: 1.180.0 | hash: b15c8bfa9c4804c12808e4c99800526425777eb130f36ae659929a65ac3433c3 -->
 <!-- WARNING: This file is managed by the Loa Framework. Do not edit directly. -->
 
 # Loa Framework Instructions

--- a/.loa-version.json
+++ b/.loa-version.json
@@ -1,7 +1,7 @@
 {
-  "framework_version": "1.173.6",
+  "framework_version": "1.180.0",
   "schema_version": 2,
-  "last_sync": "2026-06-10T13:26:47Z",
+  "last_sync": "2026-06-17T01:10:06Z",
   "zones": {
     "system": ".claude",
     "state": [


### PR DESCRIPTION
## Why

My #1079 README sync revealed a deeper drift: the framework **version markers were stale at 1.173.6** (`.loa-version.json` last_sync 2026-06-10, pre-dating the v1.179/v1.180 named releases) while CHANGELOG top is `[1.180.0]` and tags reach v1.180.3.

Two CI checks anchor the README version to **different sources**, so they disagreed:
- `ci.yml` **Validate Framework Files** → README badge must equal CHANGELOG top (1.180.0)
- `readme-version-sync.yml` → README must equal `.loa-version.json::framework_version` (1.173.6)

#1079 moved README to 1.180.0 — fixing the first, breaking the second. This completes the reconciliation.

## What

Bump the **canonical source** to 1.180.0 via the canonical `update-loa-bump-version.sh`:
- `.loa-version.json::framework_version` (+ `last_sync`)
- `.claude/loa/CLAUDE.loa.md:1` managed header (integrity **hash recomputed**)

Now README == `.loa-version.json` == CHANGELOG top == **1.180.0**, and BOTH version checks pass.

## Verified
- `sync-readme-version.sh --check` → OK (in sync at v1.180.0)
- CHANGELOG==README==1.180.0 (ci.yml logic)
- `lint-invariants.sh` → `CLAUDE.loa.md header integrity hash verifies (VALID)`

_Target is 1.180.0 (the named release / CHANGELOG top), not the latest patch tag v1.180.3 — the patch tags are unnamed bugfix bumps with no CHANGELOG entries, and ci.yml anchors to CHANGELOG top._