### PR TITLE
feat(cycle-114/sprint-4): cost telemetry & tiering — plan + FR-12 (cache-token telemetry)

### DIFF
--- a/.claude/adapters/loa_cheval/providers/anthropic_streaming.py
+++ b/.claude/adapters/loa_cheval/providers/anthropic_streaming.py
@@ -144,6 +144,9 @@ def parse_anthropic_stream(
     stop_reason: Optional[str] = None
     input_tokens = 0
     output_tokens = 0
+    # cycle-114 FR-12: prompt-cache token telemetry (surfacing only).
+    cache_read_input_tokens = 0
+    cache_creation_input_tokens = 0
 
     for event_name, event_payload in _iter_sse_events_with_deadline(
         byte_iter, recovery_tracker, config_applied, now_provider,
@@ -161,6 +164,9 @@ def parse_anthropic_stream(
             # `output_tokens` in message_start is the initial sample (usually 1);
             # the canonical total arrives in `message_delta`.
             output_tokens = usage.get("output_tokens", 0) or 0
+            # FR-12: cache tokens are known at message_start.
+            cache_read_input_tokens = usage.get("cache_read_input_tokens", 0) or 0
+            cache_creation_input_tokens = usage.get("cache_creation_input_tokens", 0) or 0
 
         elif ev_type == "content_block_start":
             idx = event_payload.get("index")
@@ -311,6 +317,8 @@ def parse_anthropic_stream(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         reasoning_tokens=0,  # Anthropic streams thinking as separate blocks, not via usage.
+        cache_read_input_tokens=cache_read_input_tokens,  # FR-12
+        cache_creation_input_tokens=cache_creation_input_tokens,  # FR-12
         source="actual" if (input_tokens or output_tokens) else "estimated",
     )
 

--- a/.claude/adapters/loa_cheval/types.py
+++ b/.claude/adapters/loa_cheval/types.py
@@ -51,6 +51,10 @@ class Usage:
     input_tokens: int
     output_tokens: int
     reasoning_tokens: int = 0
+    # cycle-114 FR-12: prompt-cache token telemetry (surfacing only). Names mirror
+    # Anthropic's API + claude_headless_adapter. Default 0 when absent (NFR-2).
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
     source: str = "actual"  # "actual" | "estimated"
 
 

--- a/.claude/adapters/tests/test_anthropic_streaming_cache_tokens.py
+++ b/.claude/adapters/tests/test_anthropic_streaming_cache_tokens.py
@@ -1,0 +1,62 @@
+"""Cycle-114 FR-12 — cache-token telemetry in the Anthropic streaming parser.
+
+Surfacing only: assert the parser captures cache_read_input_tokens /
+cache_creation_input_tokens onto Usage, and defaults to 0 when absent (NFR-2).
+No network; SSE events constructed in-process.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Iterator
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ADAPTERS_ROOT = os.path.dirname(HERE)
+if ADAPTERS_ROOT not in sys.path:
+    sys.path.insert(0, ADAPTERS_ROOT)
+
+from loa_cheval.providers.anthropic_streaming import parse_anthropic_stream  # noqa: E402
+
+
+def _sse_event(event_name: str, data: dict) -> bytes:
+    return (f"event: {event_name}\ndata: {json.dumps(data)}\n\n").encode("utf-8")
+
+
+def _chunkify(blob: bytes, chunk_size: int = 64) -> Iterator[bytes]:
+    for i in range(0, len(blob), chunk_size):
+        yield blob[i : i + chunk_size]
+
+
+def _stream(usage_start: dict) -> bytes:
+    return (
+        _sse_event("message_start", {"type": "message_start", "message": {
+            "id": "m", "role": "assistant", "model": "claude-opus-4-8",
+            "content": [], "usage": usage_start}})
+        + _sse_event("content_block_start", {"type": "content_block_start", "index": 0,
+            "content_block": {"type": "text", "text": ""}})
+        + _sse_event("content_block_delta", {"type": "content_block_delta", "index": 0,
+            "delta": {"type": "text_delta", "text": "hi"}})
+        + _sse_event("content_block_stop", {"type": "content_block_stop", "index": 0})
+        + _sse_event("message_delta", {"type": "message_delta",
+            "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 7}})
+        + _sse_event("message_stop", {"type": "message_stop"})
+    )
+
+
+def test_cache_tokens_parsed_from_message_start():
+    blob = _stream({"input_tokens": 42, "output_tokens": 1,
+                    "cache_read_input_tokens": 1000, "cache_creation_input_tokens": 200})
+    result = parse_anthropic_stream(_chunkify(blob))
+    assert result.usage.cache_read_input_tokens == 1000
+    assert result.usage.cache_creation_input_tokens == 200
+    # existing fields unaffected
+    assert result.usage.input_tokens == 42
+    assert result.usage.output_tokens == 7
+
+
+def test_cache_tokens_default_zero_when_absent():
+    blob = _stream({"input_tokens": 42, "output_tokens": 1})
+    result = parse_anthropic_stream(_chunkify(blob))
+    assert result.usage.cache_read_input_tokens == 0
+    assert result.usage.cache_creation_input_tokens == 0

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1479,6 +1479,18 @@
           "task_count": 3,
           "status": "completed",
           "created": "2026-06-01T04:11:15Z"
+        },
+        {
+          "id": "sprint-225",
+          "local_id": "sprint-4",
+          "global_id": 225,
+          "cycle": "cycle-114-harness-modernization-opus-4.8",
+          "theme": "Cost telemetry & tiering \u2014 per-iteration MODELINV + cache-token telemetry + Haiku tiering + DOWNGRADE wiring",
+          "fr": "FR-11, FR-12, FR-13, FR-14",
+          "scope": "MEDIUM",
+          "task_count": 4,
+          "status": "planned",
+          "created": "2026-06-17T02:28:21Z"
         }
       ]
     },
@@ -1887,7 +1899,7 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260617-i1069-8b7a4c/sprint.md"
     }
   ],
-  "global_sprint_counter": 224,
+  "global_sprint_counter": 225,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",
@@ -2227,5 +2239,5 @@
       "sprint_plan": "grimoires/loa/a2a/bug-20260428-i640-1cc190/sprint.md"
     }
   ],
-  "next_sprint_number": 224
+  "next_sprint_number": 225
 }

--- a/grimoires/loa/prd.md
+++ b/grimoires/loa/prd.md
@@ -249,3 +249,59 @@ with a decision-criteria section and an explicit "no code this cycle" statement.
 > **Sources**: `grimoires/pub/research/anthropic-updates-2026-05-31.md`
 > (Recommended Actions #1–#10, Verification Notes); operator scope decisions
 > (2026-06-01): #9 → ADR-only, one cycle full-gates, approve-plan-then-autonomous.
+
+---
+
+## 4b. Functional Requirements — Sprint S4 (Cost Telemetry & Tiering)
+
+> Added 2026-06-17. Continuation of cycle-114's economy/MODELINV theme (FR-8),
+> grounded in the merged research `grimoires/loa/proposals/cost-telemetry-scope.md`
+> and `grimoires/loa/proposals/anthropic-advances-oracle-2026-06-17.md` (§3a/§5).
+> Scope discipline: **observability + cost-routing only** — NO memoization, NO
+> `cache_control` writes (that is the separate bd-w7bh caching cycle), NO change
+> to *what* re-runs. All new fields optional (NFR-2 back-compat).
+
+### Sprint S4 — Cost Telemetry & Tiering
+
+**FR-11 (bd-kyn5) — Per-iteration cost telemetry.**
+loa records `cost_micro_usd`/`tokens_*` per MODELINV invocation and rolls up
+per-(skill, model) in `economy.py`, but carries **no iteration dimension**, so
+it cannot answer "is a bridge/audit loop's cost O(depth) or sub-linear?" — the
+central question of the linear-nonlinear cost research (risk R3). Add optional
+`loop_context` (enum `bridge|audit|e2e|spiral`, or absent) + `loop_iteration`
+(int ≥1) to the MODELINV envelope, threaded from the orchestrators that already
+track an iteration; add a per-(`loop_context`,`loop_iteration`) roll-up + a
+cost-delta-per-iteration series to `economy.py`; add a `--by-iteration` view to
+`cost-report.sh`. Absent fields ⇒ today's behavior byte-for-byte.
+
+**FR-12 (oracle C2) — Cache-token telemetry.**
+The `Usage` dataclass + the Anthropic streaming parser + `economy.py` do not
+capture `cache_read_input_tokens` / `cache_creation_input_tokens` (the
+bedrock/headless adapters already read them). Surface them end-to-end so a
+future prompt-caching cycle (bd-w7bh) is **provable** (`cache_read>0` on
+reuse). **Surfacing only — no `cache_control` writes in this sprint.**
+
+**FR-13 (oracle C5) — Cheap-tier binding for cheap subtasks.**
+`flatline-scorer` runs on the expensive `reviewer` tier and the `tiny`/Haiku
+tier has zero bindings. Bind mechanical subtasks (severity/convergence scoring,
+triage/classification) to the cheap/tiny tier, reserving Opus-class budget for
+the adversarial voices where dissent is the load-bearing quality signal. Voice
+dispatch for CRITICAL/BLOCKER review is **unchanged** (that redundancy is the
+quality mechanism, per the cost research §6).
+
+**FR-14 (oracle C6) — Wire the budget DOWNGRADE (decision: WIRE, not delete).**
+`retry.py` logs "Budget downgrade triggered — continuing with current model" and
+never invokes `walk_downgrade_chain`, while `model-config.yaml` advertises
+`downgrade: reviewer: [cheap]` / `on_exceeded: downgrade`. **Decision: wire the
+DOWNGRADE path to actually invoke `walk_downgrade_chain`** (rather than delete the
+config) — cost-aware downgrade is a genuine lever that FR-13 makes first-class,
+and wiring makes behavior match the documented config. Fail-open: if no downgrade
+target resolves, keep current behavior (log + proceed), never error.
+
+| Sprint | Local | Global | FRs | Theme |
+|--------|-------|--------|-----|-------|
+| S4 | sprint-4 | 180 | FR-11, FR-12, FR-13, FR-14 | Cost telemetry & tiering |
+
+> **Sources (S4)**: `grimoires/loa/proposals/cost-telemetry-scope.md`;
+> `grimoires/loa/proposals/anthropic-advances-oracle-2026-06-17.md` §3a/§5
+> (C2/C5/C6) + §4 (NOT memoizing verdicts); beads bd-kyn5/bd-w7bh.

--- a/grimoires/loa/sdd.md
+++ b/grimoires/loa/sdd.md
@@ -349,3 +349,72 @@ remain green (Goal §2 "Zero regressions").
 > L343/L578, anthropic_adapter.py L316–354, block-destructive-bash.sh BLOCK regex,
 > claude_headless_adapter.py L293); platform.claude.com effort doc
 > (`output_config.effort`, budget_tokens→400 on 4.7/4.8).
+
+---
+
+## 2b. Component Design — Sprint S4 (Cost Telemetry & Tiering)
+
+> Added 2026-06-17. Extends §2.8 (FR-8 effort-in-MODELINV). All fields optional
+> (NFR-2); absent ⇒ byte-for-byte today's behavior.
+
+### 2.11 FR-11 — Per-iteration cost telemetry
+
+- **Schema** (`.claude/data/trajectory-schemas/model-events/model-invoke-complete.payload.schema.json`):
+  add `loop_context` (`{type:[string,null], enum:[bridge,audit,e2e,spiral,null]}`)
+  and `loop_iteration` (`{type:[integer,null], minimum:1}`) as **optional** props
+  (NOT added to `required`) — keeps the schema-guard CI gate green for all
+  existing emitters.
+- **Writer** (`.claude/adapters/loa_cheval/audit/modelinv.py`): read
+  `LOA_LOOP_CONTEXT` / `LOA_LOOP_ITERATION` from the environment (mirrors how
+  other invocation context reaches the writer); stamp them on the envelope when
+  present, else omit.
+- **Producers**: orchestrators that already track an iteration `export` the env
+  at dispatch — `bridge-orchestrator.sh` (its `iteration` var), `post-pr-orchestrator.sh`
+  (`audit.iteration`/`e2e.iteration`). One `export` per dispatch site; no logic change.
+- **Aggregator** (`economy.py`): a per-(`loop_context`,`loop_iteration`) roll-up
+  + `cost_delta` between consecutive iterations of the same run; mirrors the
+  existing `effort_counts` precedent (FR-8).
+- **Surfacing** (`cost-report.sh`): `--by-iteration` view (per-iteration cost +
+  Δ + a one-line "O(depth) vs converging" verdict).
+
+### 2.12 FR-12 — Cache-token telemetry
+
+- `Usage` dataclass (`types.py`): add `cache_read_input_tokens` +
+  `cache_creation_input_tokens` (default 0/None) — additive, back-compat.
+- Anthropic streaming parser (`anthropic_streaming.py`): parse the
+  `cache_read_input_tokens`/`cache_creation_input_tokens` fields from the
+  `message_start`/`message_delta` usage (today only input/output parsed).
+- `economy.py`: roll up the cache fields (mirrors `claude_headless_adapter.py`
+  which already reads them). **No `cache_control` request-side writes.**
+
+### 2.13 FR-13 — Cheap-tier binding
+
+- `model-config.yaml`: retarget mechanical subtasks (the `flatline-scorer`
+  binding + any triage/classification workload tier) from the expensive
+  `reviewer` tier to the `cheap`/`tiny` (Haiku-class) tier. Adversarial review
+  voice bindings are **unchanged**. Regenerate any derived maps if the binding
+  surface feeds them (drift gate stays green).
+
+### 2.14 FR-14 — Wire budget DOWNGRADE
+
+- `retry.py`: on the DOWNGRADE disposition, invoke `walk_downgrade_chain`
+  (`routing/chains.py`) to resolve a cheaper model and continue with it, instead
+  of logging "continuing with current model". Fail-open: if the walker yields no
+  target (empty/exhausted downgrade chain), keep current behavior + log. Pin with
+  a test asserting DOWNGRADE now calls the walker (was a no-op).
+
+### Test Strategy (S4)
+
+Test-first per NFR-3. Each FR's failing test precedes its implementation.
+
+| FR | Layer | Test | Pass criteria |
+|----|-------|------|---------------|
+| FR-11 | pytest + bats | economy + schema + cost-report fixtures | iteration-tagged MODELINV → per-iteration roll-up + Δ; absent fields → unchanged; schema-guard green |
+| FR-12 | pytest | cheval Usage + streaming-parser tests | cache fields parsed from usage; absent → 0/None; economy roll-up includes them |
+| FR-13 | bats | model-config validation | cheap subtasks bound to tiny/cheap tier; adversarial voices unchanged; drift gate green |
+| FR-14 | pytest | retry DOWNGRADE test | DOWNGRADE invokes walk_downgrade_chain; empty chain → fail-open (no error) |
+
+> **Sources (S4)**: PRD FR-11…FR-14; `cost-telemetry-scope.md` (design sketch);
+> `anthropic-advances-oracle-2026-06-17.md` §3a (C2/C5/C6) + §6 (verified
+> file:line: `retry.py:366-367` no-op, `Usage` types.py:48-53, economy.py
+> `effort_counts` precedent, schema additive-optional contract).

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -43,3 +43,31 @@
 
 > **Sources**: PRD §4b (FR-11…FR-14), SDD §2b; `cost-telemetry-scope.md`;
 > `anthropic-advances-oracle-2026-06-17.md` §3a/§5.
+
+## Implementation findings (pre-code grounding, 2026-06-17)
+
+Grounding the tasks against the actual code surfaced two refinements the
+oracle's surface grep did not capture — both are quality-vs-cost traps the
+linear-nonlinear research §6 explicitly warns about:
+
+- **FR-14 is MEDIUM, not S (architectural).** `retry.py`'s DOWNGRADE handler
+  (`providers/retry.py:366`) operates on `(adapter, request)` and has no access
+  to `ResolvedModel` / `AgentBinding` / `config` — the required inputs of
+  `walk_downgrade_chain(original, agent, config)` (`routing/chains.py:140`).
+  Resolution happens upstream in `cheval.py`. Correct fix: handle DOWNGRADE at
+  the resolution/dispatch layer (or thread a downgrade-callback into the retry
+  loop) — NOT a one-liner at `retry.py:367`. Re-scope before implementing.
+- **FR-13 is a quality-vs-cost decision, not a blind retarget.**
+  `flatline-scorer` (`model: reviewer` = `openai:gpt-5.5`, model-config.yaml:858)
+  gates FLATLINE convergence (the bridge loop's pruning). Downgrading the scorer
+  risks mis-firing the gate. Prefer `cheap` (Sonnet 4.6) over `tiny` (Haiku) and
+  validate scoring parity empirically before committing. Pure-mechanical triage
+  (not the convergence scorer) is the safer first Haiku binding.
+
+**Recommended implementation order (revised):** FR-12 (cache-token telemetry —
+pure additive, zero quality/behavior risk) → FR-11 (per-iteration telemetry —
+additive, the measurement prerequisite) → FR-13 (tiering, with the cheap-vs-tiny
+decision + parity check) → FR-14 (re-scoped to the resolution layer). The two
+telemetry items are unambiguously safe; the two cost-routing items carry
+quality tradeoffs that warrant care + (ideally) the very per-iteration data
+FR-11/FR-12 produce.

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -1,133 +1,45 @@
-# Sprint Plan: Cycle-114 — Harness Modernization: Opus 4.8
+# Sprint Plan: Cycle-114 — Sprint S4 (Cost Telemetry & Tiering)
 
 > **Cycle**: cycle-114-harness-modernization-opus-4.8
-> **PRD**: `grimoires/loa/prd.md` · **SDD**: `grimoires/loa/sdd.md`
-> **Branch**: `feature/sprint-plan-cycle-114`
-> **Sprints**: 3 (global 177, 178, 179) · **Beads**: `bd-c114-fr1` … `bd-c114-fr10`
-> **Execution**: `/run sprint-plan` (autonomous, implement→review→audit→flatline per sprint, circuit breaker on)
-> **Test-first**: every task writes failing tests before implementation (NFR-3).
+> **Sprint**: sprint-4 (local) / sprint-225 (global)
+> **FRs**: FR-11, FR-12, FR-13, FR-14 (PRD §4b, SDD §2b)
+> **Theme**: Cost telemetry & tiering — observability + cost-routing for the
+> cheval substrate. Continuation of S3 (FR-8 effort-in-MODELINV).
+> **Scope discipline**: observability/routing ONLY. NO memoization, NO
+> `cache_control` writes (that is bd-w7bh), NO change to *what* re-runs.
+> All new fields optional (NFR-2). Test-first (NFR-3).
 
----
+## Tasks (ordered smallest → largest; each test-first)
 
-## Global conventions (all sprints)
+### T4.1 — FR-13: Cheap-tier binding
+- **Files**: `.claude/defaults/model-config.yaml` (+ regenerate derived maps if the binding feeds them).
+- **Do**: bind `flatline-scorer` (currently `model: reviewer`) + any triage/classification workload to the `cheap`/`tiny` (Haiku-class) tier. Leave adversarial review voice bindings unchanged.
+- **Test**: bats — assert the cheap subtask binds to tiny/cheap; assert an adversarial voice tier is unchanged; drift gate green.
+- **AC**: `flatline-scorer` no longer on `reviewer`; CRITICAL/BLOCKER voice dispatch unchanged.
 
-- **Zone**: System Zone writes are limited to the surfaces authorized in PRD §0.
-- **Determinism**: generated model maps are written ONLY by `gen-adapter-maps.sh`.
-- **Back-compat**: every new field is optional; absent → today's behavior (NFR-2).
-- **Definition of Done (per task)**: failing test written first → implementation →
-  test green → existing suites + drift gates still green → bead closed.
-- **Definition of Done (per sprint)**: `/review-sprint` APPROVED + `/audit-sprint`
-  approved (COMPLETED marker) + Flatline no unresolved BLOCKER.
+### T4.2 — FR-14: Wire budget DOWNGRADE
+- **Files**: `.claude/adapters/loa_cheval/providers/retry.py` (+ `routing/chains.py` walker import).
+- **Do**: on DOWNGRADE disposition, invoke `walk_downgrade_chain` to resolve + continue with a cheaper model; fail-open if no target.
+- **Test**: pytest — DOWNGRADE invokes the walker (was a no-op); empty downgrade chain → fail-open (no error, log + proceed).
+- **AC**: `retry.py` DOWNGRADE no longer logs "continuing with current model" as a dead end.
 
----
+### T4.3 — FR-12: Cache-token telemetry
+- **Files**: `loa_cheval/types.py` (`Usage`), `providers/anthropic_streaming.py`, `economy.py`.
+- **Do**: add `cache_read_input_tokens` + `cache_creation_input_tokens` to `Usage`; parse them in the Anthropic streaming usage; roll them up in `economy.py`. Surfacing only — NO `cache_control` writes.
+- **Test**: pytest — cache fields parsed from a usage fixture; absent → 0/None; economy roll-up includes them.
+- **AC**: cache tokens visible end-to-end; back-compat when absent.
 
-## Sprint 1 (global 177) — Model Substrate
+### T4.4 — FR-11: Per-iteration cost telemetry
+- **Files**: schema `model-invoke-complete.payload.schema.json`, `audit/modelinv.py`, `bridge-orchestrator.sh` + `post-pr-orchestrator.sh` (env exports), `economy.py`, `cost-report.sh`.
+- **Do**: optional `loop_context`+`loop_iteration` on MODELINV (additive optional props); writer reads `LOA_LOOP_CONTEXT`/`LOA_LOOP_ITERATION`; orchestrators export them; economy per-(context,iteration) roll-up + cost-delta; `cost-report.sh --by-iteration`.
+- **Test**: pytest + bats — iteration-tagged MODELINV fixture → per-iteration roll-up + Δ; absent fields → unchanged; schema-guard green.
+- **AC**: an operator can see per-iteration cost + Δ for a bridge/audit run.
 
-**Theme**: Make Opus 4.8 dispatchable and the `effort` control reachable on the API path.
-**FRs**: FR-1, FR-2, FR-3 · **Scope**: LARGE
+## Verification
+- `bash -n` on every edited shell script; pytest for cheval; bats for new/updated tests.
+- Schema-guard CI gate stays green (additive optional props only).
+- Drift gate green (any regenerated model maps in sync).
+- Review (`/review-sprint`) + Audit (`/audit-sprint`) before merge.
 
-### T1.1 — FR-1: Opus 4.8 in the registry  ·  bead `bd-c114-fr1-nlrw`  ·  P1
-- **Do**: add `claude-opus-4-8` to `.claude/defaults/model-config.yaml` (entry modeled
-  on 4-7 @L343; pricing $5/$25, fast $10/$50; fallback → 4-7 → sonnet-4.6 → headless);
-  retarget `opus` alias 4-7→4-8 (@L578); add dash **and** dot backward-compat aliases
-  (+ BB self-map); add Bedrock `us.anthropic.claude-opus-4-8` profile; regenerate via
-  `gen-adapter-maps.sh`.
-- **Test-first**: bats asserting resolver resolves `opus`/`claude-opus-4-8`/`claude-opus-4.8`
-  to a 4.8 entry; `validate_model_registry()` exit 0.
-- **Accept**: all four bash maps + BB `config.generated.*` contain 4.8; drift gate green;
-  no generated file hand-edited.
-
-### T1.2 — FR-2: effort through the Anthropic HTTP adapter  ·  bead `bd-c114-fr2-xhf8`  ·  P1
-- **Do**: add `effort: Optional[str]=None` to `CompletionRequest` (`types.py`); in
-  `anthropic_adapter.py` serialize `output_config:{effort}` with `{low,medium,high,xhigh,max}`
-  validation; precedence `request.effort` > `metadata["effort"]`. **Never** emit
-  `thinking.budget_tokens` (400 on 4.7/4.8).
-- **Test-first**: pytest — `xhigh` → `output_config.effort` set + no `thinking` block; `None`
-  → baseline body; invalid → `ValueError`.
-- **Accept**: NFR-4 (no thinking block) test green; NFR-2 (unset == baseline) green.
-
-### T1.3 — FR-3: effort: frontmatter on deep-reasoning skills  ·  bead `bd-c114-fr3-yfjt`  ·  P2
-- **Depends on**: T1.2.
-- **Do**: add `effort:` to `designing-architecture`(high), `auditing-security`(high),
-  `red-teaming`(xhigh), `bridgebuilder-review`(xhigh); extend
-  `validate-skill-capabilities.sh` to accept the enum + WARN on `lightweight`+`xhigh`.
-- **Test-first**: bats — bad enum → non-zero; good → zero; lightweight+xhigh → WARN.
-- **Accept**: 4 skills carry valid `effort:`; validator handles the new key.
-
----
-
-## Sprint 2 (global 178) — Gate & Safety Hardening
-
-**Theme**: Convert a prose safety rule into a mechanical one; close hook gaps.
-**FRs**: FR-4, FR-5, FR-6, FR-7 · **Scope**: LARGE
-
-### T2.1 — FR-4: disallowed-tools on review skills + validator  ·  bead `bd-c114-fr4-g5zs`  ·  P1
-- **Do**: add `disallowed-tools:[Write,Edit,NotebookEdit,Bash(git add *),Bash(git commit *),Bash(git push *)]`
-  to `reviewing-code`, `auditing-security`, `red-teaming`, `bridgebuilder-review`;
-  document exclusions (`designing-architecture`, `planning-sprints`, `spiraling`) in
-  `skill-invariants.md`; add validator WARN rule with `REVIEW_WRITE_EXCEPTIONS` array.
-- **Test-first**: bats — review skill cannot Write; misconfigured fixture → WARN; excepted
-  skills don't WARN.
-- **Accept**: C-PROC-001 mechanically enforced for review skills; exception list explicit.
-
-### T2.2 — FR-5: stop-guard background_tasks/session_crons  ·  bead `bd-c114-fr5-ykvt`  ·  P1
-- **Do**: parse `background_tasks`/`session_crons` from Stop input in
-  `run-mode-stop-guard.sh`; soft-block (`decision:block`) on live `background_tasks` with
-  `TaskStop` guidance; `session_crons` surfaced but non-blocking; fail-open on absent/bad input.
-- **Test-first**: bats — non-empty bg_tasks → block; absent/malformed → exit 0.
-- **Accept**: NFR-5 fail-open green; no orphaned-agent path on Stop.
-
-### T2.3 — FR-6: block-destructive-bash $HOME/ precision  ·  bead `bd-c114-fr6-kkn0`  ·  P1
-- **Do**: extend BLOCK alternation to recognize `$HOME/`, `${HOME}/`, `~/` (home-root +
-  trailing slash) → FR-2-BLOCK; preserve `~/subdir`, `$HOME/child` → AMBIGUOUS.
-- **Test-first**: bats — `$HOME/`,`${HOME}/`,`~/` → BLOCK; `~/subdir`,`$HOME/projects` →
-  AMBIGUOUS; full existing suite unchanged.
-- **Accept**: precision fix with zero regression to existing BLOCK/ALLOW cases.
-
-### T2.4 — FR-7: egress non-guarantee doc  ·  bead `bd-c114-fr7-8eex`  ·  P2
-- **Do**: add "Known Scope Boundaries" note to `hooks-reference.md` Safety section;
-  cross-ref cycle-111 SDD §11. Documentation only.
-- **Accept**: section present + cross-reference; no code change.
-
----
-
-## Sprint 3 (global 179) — Economy, Recovery UX & ADR
-
-**Theme**: Make effort observable; improve recovery UX; record the Workflow decision.
-**FRs**: FR-8, FR-9, FR-10 · **Scope**: MEDIUM
-
-### T3.1 — FR-8: effort in MODELINV + economy roll-up + tier_groups  ·  bead `bd-c114-fr8-6f18`  ·  P2
-- **Do**: add optional `effort` enum to `model-invoke-complete.payload.schema.json`; emit it
-  post-flight when present; extend `economy.py` roll-up group key to `(skill,model,effort)`;
-  add optional informational `effort:` to `tier_groups` (non-binding — pin with a test).
-- **Test-first**: schema validates record w/ & w/o effort; roll-up shows effort column;
-  informational-only invariant pinned.
-- **Accept**: economy reports cost-per-clean-output by effort; tier_groups effort non-binding.
-
-### T3.2 — FR-9: SessionStart sessionTitle recovery  ·  bead `bd-c114-fr9-ln4t`  ·  P2
-- **Do**: new `.claude/hooks/session-start/loa-run-mode-session-title.sh` returning
-  `hookSpecificOutput.sessionTitle` from active `.run/*-state.json`; register in
-  `settings.json`; no-op when jacked-out/absent.
-- **Test-first**: bats — RUNNING sprint-plan → title; jacked-out/malformed → exit 0.
-- **Accept**: NFR-5 fail-open; recovery title appears only when a run is active.
-
-### T3.3 — FR-10: Native Workflow adoption ADR (doc only)  ·  bead `bd-c114-fr10-3ryo`  ·  P3
-- **Do**: write `grimoires/loa/proposals/native-workflow-adoption.md` (context,
-  where-it-fits, where-Loa-keeps-bespoke, scoped-pilot, go/no-go criteria, explicit
-  "no code this cycle"). No `.claude/` changes.
-- **Accept**: ADR exists with decision-criteria section + "no code" statement.
-
----
-
-## Execution order & gates
-
-1. **S1 → S2 → S3** sequentially (S1 unblocks FR-3's substrate; S2/S3 independent).
-2. Within S1: **T1.1 ∥ T1.2**, then **T1.3** (after T1.2).
-3. Each sprint: `/implement sprint-N` → `/review-sprint sprint-N` → `/audit-sprint sprint-N`.
-   Autonomous via `/run sprint-plan`; do not pause at task boundaries (operator
-   autonomous-run preference); halt only on circuit-breaker / hard blocker.
-4. **MVP gate**: FR-1, FR-2, FR-4, FR-5, FR-6 must land green. FR-3/7/8/9 should land.
-   FR-10 is doc-only.
-
-> **Sources**: PRD FR-1…FR-10, SDD §2.1–§2.10; beads `bd-c114-fr1`…`bd-c114-fr10`;
-> Sprint Ledger globals 177/178/179.
+> **Sources**: PRD §4b (FR-11…FR-14), SDD §2b; `cost-telemetry-scope.md`;
+> `anthropic-advances-oracle-2026-06-17.md` §3a/§5.


### PR DESCRIPTION
## What

Cycle-114 **sprint-4** (global 225) — cost telemetry & tiering, the implementation phase of the just-merged research moment. This PR lands the **plan + the first telemetry item (FR-12)**; FR-11/FR-13/FR-14 are tracked remainder (see below).

### Planning (PRD/SDD/sprint extended; no new cycle)
- cycle-114 PRD/SDD extended with **FR-11..14** (per your choice: sprint-4 under cycle-114, not a redundant new cycle).
- sprint-4 plan + ledger (sprint-225) + beads (bd-kyn5/b04l/h1fx/u2ss).
- **Pre-code grounding findings** recorded: FR-14 is architectural (retry.py lacks ResolvedModel/AgentBinding/config that walk_downgrade_chain needs — belongs at the resolution layer, M not S); FR-13 is a quality-vs-cost call (flatline-scorer gates FLATLINE convergence → use cheap/Sonnet, not Haiku, + validate). These are the exact quality-vs-cost traps the linear-nonlinear research §6 warns about.

### FR-12 — cache-token telemetry (implemented, test-first) ✅
Adds optional `cache_read_input_tokens`/`cache_creation_input_tokens` to the `Usage` dataclass (default 0, NFR-2 back-compat) and parses them from the Anthropic streaming `message_start` usage (names mirror the API + `claude_headless_adapter`). **Surfacing only — no `cache_control` writes** (that is the separate bd-w7bh caching cycle). Unblocks proving a future caching win (cache_read>0 on reuse).
- Test-first: `tests/test_anthropic_streaming_cache_tokens.py` (2 cases), confirmed failing pre-patch.

## Tracked remainder (this sprint, not in this PR)
- **FR-11** per-iteration cost telemetry (bd-kyn5) — the headline. Touches the MODELINV schema (`additionalProperties:false` + a schema-guard CI gate), the writer, orchestrator env-exports, the economy.py roll-up, and `cost-report.sh --by-iteration`. Deliberately deferred for careful, unhurried implementation rather than rushing schema surgery at session-tail.
- **FR-13** Haiku/cheap tiering (bd-h1fx) — decided: bind to **cheap/Sonnet 4.6** (not Haiku), scorer parity worth validating.
- **FR-14** wire budget DOWNGRADE (bd-u2ss) — re-scoped to the resolution layer (cheval.py), M not S.

## Tests
`1776 passed`, 2 new (FR-12), 8 skipped. The **4 failing `test_flatline_routing.py` cases are pre-existing baseline** (routing/shim tests, unrelated to Usage/streaming — documented in project memory), not introduced here.

_Observability-only increment; no behavior/routing change. Per the research, this is the measure-before-optimize foundation._