### PR TITLE
fix: latest-issue triage batch — #1085 post-merge guard + #1086 verify-gate + #1089 KF-018

### DIFF
--- a/.claude/skills/implementing-tasks/SKILL.md
+++ b/.claude/skills/implementing-tasks/SKILL.md
@@ -199,7 +199,7 @@ Agents SHOULD proactively run CLI tools from the approved allowlist without aski
 |------|-----------------|-------|
 | `git` | `status`, `log`, `diff`, `branch`, `show` | Local only, no network |
 | `gh` | `issue list`, `issue view`, `pr list`, `pr view`, `pr checks` | Use `--json` + field filtering to avoid leaking secrets from PR bodies |
-| `npm`/`bun` | `test`, `run lint`, `run typecheck` | Build/check commands |
+| `npm`/`bun` | `test`, `run lint`, `run typecheck`, `run format` | Build/check + format-check commands (#1086) |
 | `cargo` | `check`, `test`, `clippy` | Build/check commands |
 
 ### Require Confirmation
@@ -408,6 +408,23 @@ See `resources/templates/implementation-report.md` for the structured
 - Document specific file paths and line numbers: NOT "updated auth" → "src/auth/middleware.ts:42-67"
 - Include exact commands to reproduce: NOT "run tests" → "npm test -- --coverage --watch=false"
 - Reference specific commits or branches when relevant
+
+## Pre-Handoff Verification Gate — match CI's fast gate (#1086)
+
+Before marking a task done, run the SAME fast checks CI will run — not just a
+linter + tests. When the project configures them (detect from `pyproject.toml`,
+`package.json` scripts, `.golangci.yml`, `Cargo.toml`, or the `.github/workflows`
+files), ALSO run, in addition to the linter and tests:
+
+- the **formatter in check mode** — `ruff format --check`, `prettier --check`,
+  `gofmt -l`, `cargo fmt --check`, … (a formatter that would *rewrite* files is
+  a red CI waiting to happen), and
+- the **type checker** — `mypy`, `tsc --noEmit`, `pyright`, `go vet`, ….
+
+Treat a format-check or type-check failure exactly like a lint/test failure: fix
+it before handoff. Goal: **the agent's self-check == CI's fast gate**, so work
+marked done doesn't bounce on formatting/types after it's otherwise approved.
+Tool-agnostic — the above are examples; run whatever the project configures.
 </kernel_framework>
 
 <uncertainty_protocol>

--- a/.claude/skills/reviewing-code/SKILL.md
+++ b/.claude/skills/reviewing-code/SKILL.md
@@ -416,6 +416,22 @@ Read ALL context documents in order:
 6. Perform security audit (see `resources/REFERENCE.md` §Security)
 7. Check performance and resource management
 8. **Karpathy Principles Check** (see below)
+9. **Fast-Gate Parity Check** (see below) — confirm format-check + typecheck were run
+
+### Fast-Gate Parity — match CI (#1086)
+
+The implementer's self-check must equal CI's fast gate, not just lint + tests.
+When the project configures them, verify the implementer ran (and re-run if in
+doubt):
+
+- the **formatter in check mode** (`ruff format --check`, `prettier --check`,
+  `gofmt -l`, …), and
+- the **type checker** (`mypy`, `tsc --noEmit`, `pyright`, …).
+
+Flag an unrun or failing check as feedback with the same weight as a lint/test
+failure, e.g. "FAST-GATE: `mypy` not run — a type error in src/x.py:N would fail
+CI" or "FAST-GATE: `ruff format --check` flags 3 just-written files". Tool-agnostic
+— detect from `pyproject.toml` / `package.json` / the CI workflows.
 
 ### Karpathy Principles Verification
 

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -89,6 +89,12 @@ jobs:
           # readability only — do NOT re-parse $GITHUB_OUTPUT (it's a
           # producer-write, runner-read contract; reading it back inverts
           # GitHub's intent and breaks if the wrapper ever uses heredoc syntax).
+          # #1085 preflight: fail LOUD (not a buried chmod error that cascades
+          # into silently skipping tag/CHANGELOG/release) when a Loa script is
+          # unresolved — the submodule-symlink-not-checked-out edge case.
+          for _s in .claude/scripts/classify-merge-pr.sh; do
+            test -f "$_s" || { echo "::error::Loa script '$_s' unresolved — submodule symlink not checked out? Ensure 'submodules: recursive' resolves .claude/scripts (#1085)."; exit 1; }
+          done
           chmod +x .claude/scripts/classify-merge-pr.sh
           RESULT=$(.claude/scripts/classify-merge-pr.sh --merge-sha "$MERGE_SHA")
           echo "Classifier output:"
@@ -136,6 +142,10 @@ jobs:
       - name: Compute semver
         id: semver
         run: |
+          # #1085 preflight: fail loud on unresolved Loa scripts (submodule symlink).
+          for _s in .claude/scripts/semver-bump.sh .claude/scripts/bootstrap.sh; do
+            test -f "$_s" || { echo "::error::Loa script '$_s' unresolved — submodule symlink not checked out? Ensure 'submodules: recursive' resolves .claude/scripts (#1085)."; exit 1; }
+          done
           chmod +x .claude/scripts/semver-bump.sh .claude/scripts/bootstrap.sh
           RESULT=$(.claude/scripts/semver-bump.sh 2>/dev/null || echo '{}')
           NEXT=$(echo "$RESULT" | jq -r '.next // empty')
@@ -236,6 +246,10 @@ jobs:
           PM_MERGE_SHA: ${{ github.sha }}
         run: |
           echo "Running shell-only pipeline (no ANTHROPIC_API_KEY)"
+          # #1085 preflight: fail loud on unresolved Loa scripts (submodule symlink).
+          for _s in .claude/scripts/post-merge-orchestrator.sh .claude/scripts/semver-bump.sh .claude/scripts/release-notes-gen.sh .claude/scripts/bootstrap.sh; do
+            test -f "$_s" || { echo "::error::Loa script '$_s' unresolved — submodule symlink not checked out? Ensure 'submodules: recursive' resolves .claude/scripts (#1085)."; exit 1; }
+          done
           chmod +x .claude/scripts/post-merge-orchestrator.sh .claude/scripts/semver-bump.sh .claude/scripts/release-notes-gen.sh .claude/scripts/bootstrap.sh
           .claude/scripts/post-merge-orchestrator.sh \
             --pr "$PM_PR_NUMBER" \

--- a/grimoires/loa/known-failures.md
+++ b/grimoires/loa/known-failures.md
@@ -1065,3 +1065,28 @@ If a flatline / adversarial-review / bridgebuilder run on a **Bedrock-only** ope
 
 ### Reading guide
 If cross-model voices all return `api_failure` / the gates degrade: do NOT assume KF-002 (empty-content) — check `.run/model-invoke.jsonl` `message_redacted` for the actual per-leg error. The 2026-06-15 cause was billing (Anthropic $0 credits) + an invalidated codex subscription token, with openai+google HTTP keys still valid. Fastest unblock: `LOA_HEADLESS_MODE=api-only` (uses the valid HTTP keys). A `codex login status` of "logged in" is NOT authoritative — the token can be server-side-invalidated while the local auth.json looks fine.
+
+---
+
+## KF-018: gemini-headless CLI auth-tier deprecated (Gemini Code Assist for individuals retired) — Gemini voice silently drops from multi-model review
+
+**Status**: OPEN — MITIGATED-BY-WORKAROUND (upstream migration BLOCKED on Antigravity CLI availability)
+**Feature**: cheval `gemini-headless` adapter (`.claude/adapters/loa_cheval/providers/gemini_headless_adapter.py`) → Flatline / Bridgebuilder / any `google:*` multi-model consumer
+**Symptom**: every `gemini-headless` dispatch fails auth with `IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals … migrate to … antigravity.google`. cheval's circuit breaker `google/headless` trips HALF_OPEN→OPEN and the Gemini voice is silently removed from the consensus (degrades to fewer voices, no visible error to the operator).
+**First observed**: 2026-06-18 (issue #1089, live Flatline run on loa-laplas)
+**Recurrence count**: 1
+**Current workaround**: `LOA_HEADLESS_MODE=api-only` routes google through the HTTP API (valid `GOOGLE_API_KEY` against `generativelanguage.googleapis.com/v1beta`, already `providers.google.endpoint`) instead of the dead CLI; OR operators drop the tertiary Gemini voice (`flatline_protocol.models.tertiary`) / re-point it at another provider so reviews run on the remaining voices instead of silently degrading. (Sibling to the Fable-5 headless retirement — re-pin `extra.cli_model: fable → opus` via the `hounfour:` override; see bd-01o1.)
+**Upstream issue**: [#1089](https://github.com/0xHoneyJar/loa/issues/1089)
+
+### Attempts
+
+| Date | What we tried | Outcome | Evidence |
+|------|---------------|---------|----------|
+| 2026-06-18 | Continue using the `@google/gemini-cli` headless path | DID NOT WORK — Google retired the "Code Assist for individuals" tier the CLI auths against; `IneligibleTierError` on every dispatch | issue #1089 cheval log |
+| 2026-06-19 | Assess the issue's proposed `flatline-readiness.sh` headless-CLI probe | WORKAROUND-AT-LIMIT — the existing `health_check()` probes `gemini --version` (binary presence), which still SUCCEEDS while the auth TIER is dead (the error fires only on real inference). A presence probe does NOT catch tier-deprecation; a real-auth probe (`gemini -p ping`) would but is slow/costly and trips the breaker. Readiness CLI-tier probe DEFERRED (bd-yohy). | this entry |
+| not started | Migrate `gemini-headless` to the Antigravity CLI | BLOCKED — Google's replacement is not publicly available; cannot implement against an unreleased CLI | antigravity.google |
+| not started | Add a `gemini-api` terminal (GOOGLE_API_KEY → v1beta REST) as a key-based alternative | DEFERRED — needs model-config schema + fallback-chain wiring + tests; design separately | issue #1089 fix (2) |
+
+### Reading guide
+
+If the Gemini voice vanishes from Flatline/BB (`google/headless` circuit OPEN, `IneligibleTierError`): the gemini CLI tier is dead, not a transient outage — do NOT wait for recovery. Apply `LOA_HEADLESS_MODE=api-only` (uses the valid `GOOGLE_API_KEY` HTTP path) or drop/re-point the tertiary voice. `flatline-readiness.sh` reports providers by API-KEY presence and a `gemini --version` probe passes, so neither currently flags this — treat a silent voice-drop in consensus as the signal. The structural fix (Antigravity migration / gemini-api terminal) is upstream-blocked / deferred.

--- a/tests/unit/post-merge-preflight-guard.bats
+++ b/tests/unit/post-merge-preflight-guard.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# =============================================================================
+# #1085 — post-merge.yml must preflight-guard submodule-symlinked Loa scripts
+# =============================================================================
+# When loa is submodule-mounted, .claude/scripts is a symlink that can fail to
+# resolve on a CI runner. The pre-fix `chmod +x .claude/scripts/X.sh` then failed
+# with a buried chmod error under `bash -e`, cascading (needs: classify) into a
+# SILENT skip of the whole release pipeline (tag/CHANGELOG/release). The fix adds
+# a loud `::error::` preflight before each chmod so the cause is audible. The
+# downstream skip is intentional (don't release on a broken checkout) — the guard
+# only makes WHY visible.
+# =============================================================================
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    WF="$REPO_ROOT/.github/workflows/post-merge.yml"
+    [[ -f "$WF" ]] || skip "post-merge.yml not found"
+}
+
+@test "#1085: every 'chmod +x .claude/scripts' is preceded by a preflight guard" {
+    local chmods guards
+    chmods=$(grep -c 'chmod +x .claude/scripts' "$WF")
+    guards=$(grep -c '#1085 preflight' "$WF")
+    [ "$chmods" -ge 3 ]
+    [ "$chmods" -eq "$guards" ]
+}
+
+@test "#1085: the guard fails loud with an actionable ::error:: (not a buried chmod)" {
+    grep -qE '::error::Loa script .* unresolved' "$WF"
+    grep -q "submodules: recursive" "$WF"
+}
+
+@test "#1085: the guard logic exits 1 + emits ::error:: when a script is missing" {
+    # Functional sim of the embedded guard against a non-existent path.
+    run bash -c '
+      set -e
+      for _s in /nonexistent/loa-script.sh; do
+        test -f "$_s" || { echo "::error::Loa script '"'"'$_s'"'"' unresolved (#1085)"; exit 1; }
+      done
+      echo "SHOULD-NOT-REACH"
+    '
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::"* ]]
+    [[ "$output" != *"SHOULD-NOT-REACH"* ]]
+}


### PR DESCRIPTION
## What

Reviewed the 4 latest issues (#1085/#1086/#1088/#1089) via an ultracode grounded-triage workflow and shipped the deliverable fixes. Adversarial review: **APPROVED, no findings**.

### #1085 — post-merge pipeline fails closed on unresolved submodule-symlinked script [bug] ✅
A buried `chmod` error on an unresolved `.claude/scripts` symlink cascaded (needs: classify) into **silently skipping the entire release pipeline** (tag/CHANGELOG/release). Added a loud `::error::` preflight before each of the 3 `chmod +x .claude/scripts` sites in `post-merge.yml` (classify / simple-release / full-pipeline). The job still exits non-zero on a genuinely broken checkout (don't release on a broken tree) — but the cause is now audible + actionable. Test: `post-merge-preflight-guard.bats` (3). **Closes #1085.**

### #1086 — verification gate: format-check + typecheck, not only lint+tests [enhancement] ✅
`implementing-tasks` + `reviewing-code` prescribed lint+tests, so code passing the skill self-check still bounced on CI formatting/types. Added a "Pre-Handoff Verification Gate" / "Fast-Gate Parity" block (run the formatter in check mode + the type checker WHEN configured; tool-agnostic) so **agent self-check == CI fast gate**. Prose-only; `validate-skill-capabilities.sh` 35/35. **Closes #1086.**

### #1089 — gemini-headless CLI auth-tier deprecated [bug/migration] — visibility + workaround ✅ (migration deferred)
Google retired "Gemini Code Assist for individuals" → `IneligibleTierError` → circuit breaker `google/headless` OPEN → Gemini voice silently dropped. Shipped **KF-018** documenting the deprecation + the `LOA_HEADLESS_MODE=api-only` workaround + a key nuance: a `gemini --version` readiness probe does NOT catch tier-deprecation (the error fires only on real inference), so the proposed readiness CLI-probe is **deferred** (bd-yohy). The structural fixes are tracked/blocked: **Antigravity CLI migration BLOCKED** (CLI unreleased), **gemini-api terminal deferred**. Addresses #1089 (does not fully close it).

### #1088 — intermittent Edit/Write denial [feedback-harness] — NOT loa-code-fixable
Grounded review of all 4 Write/Edit `PreToolUse` hooks (`zone-write-guard`, `team-role-guard-write`, `spiral-dispatch-guard`, `adversarial-review-gate`): each is a pure function of `file_path` + env → **a deterministic hook cannot produce denied→denied→allowed for identical input**. The flip originates in the Claude Code permission layer, not loa code. No code change; routed as harness feedback (commented on the issue).

## Tests
`post-merge-preflight-guard.bats` (3) + post-merge classifier/scaffold regression (39) green; `skill-capabilities.bats` green; `validate-skill-capabilities.sh` 35/35.

Beads: bd-cib3 (#1085), bd-rmb3 (#1086), bd-yohy (#1089 readiness, deferred).