### PR TITLE
fix(schema): add 'xai-grok' to dispatch_group enum (v2+v3) — bd-3m0a

### DIFF
--- a/.claude/data/schemas/model-config-v2.schema.json
+++ b/.claude/data/schemas/model-config-v2.schema.json
@@ -122,7 +122,7 @@
         },
         "dispatch_group": {
           "type": "string",
-          "enum": ["anthropic-claude", "bedrock-anthropic", "google-gemini", "openai-gpt"],
+          "enum": ["anthropic-claude", "bedrock-anthropic", "google-gemini", "openai-gpt", "xai-grok"],
           "description": "cycle-110 sprint-2a T2.3 (SDD §3.2): logical model family for dispatch routing. Independent of provider — Bedrock-Anthropic models share this with native Anthropic API for capability-equivalence. KF-006-symmetric third occurrence: paired with auth_type, also landed in PR #904 commit 073842c0 without v2 schema admission. /bug #888 closure."
         },
         "api_format": {

--- a/.claude/data/schemas/model-config-v3.schema.json
+++ b/.claude/data/schemas/model-config-v3.schema.json
@@ -131,7 +131,7 @@
         },
         "dispatch_group": {
           "type": "string",
-          "enum": ["anthropic-claude", "bedrock-anthropic", "google-gemini", "openai-gpt"],
+          "enum": ["anthropic-claude", "bedrock-anthropic", "google-gemini", "openai-gpt", "xai-grok"],
           "description": "cycle-110 sprint-2a T2.3 (SDD §3.2): logical model family for dispatch routing. Independent of provider — Bedrock-Anthropic models share this with native Anthropic API for capability-equivalence. KF-006-symmetric third occurrence: paired with auth_type, also landed in PR #904 commit 073842c0. /bug #888 closure."
         },
         "api_format": {

--- a/tests/integration/migrate-model-config.bats
+++ b/tests/integration/migrate-model-config.bats
@@ -817,3 +817,49 @@ assert m["dispatch_group"] == "openai-gpt", m
 assert "dispatch_group" not in (m.get("_archived_v1_fields") or {})
 EOF
 }
+
+@test "M19.6 bd-3m0a: xai-grok dispatch_group passes v2/v3 validation" {
+    # cycle-114: the xAI/grok provider (#1057) ships dispatch_group: xai-grok
+    # as its own company family, but the value was missing from the v2/v3
+    # dispatch_group enum — every model-config migration tripped exit 78.
+    # Pin the enum value directly, independent of whether grok stays in the
+    # production config (which M19.3 guards transitively).
+    local v1="$WORK_DIR/v1-with-xai-grok.yaml"
+    cat > "$v1" <<'EOF'
+providers:
+  xai:
+    type: grok-headless
+    endpoint: "ignored"
+    models:
+      grok-build:
+        capabilities: [chat]
+        context_window: 256000
+        dispatch_group: xai-grok
+EOF
+    # v2 path (default)
+    run "$PYTHON_BIN" "$CLI" "$v1" -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"MIGRATION-PRODUCED-INVALID-V2"* ]]
+    _python_assert <<'EOF'
+import os
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open(os.environ["OUT"]) as f:
+    data = y.load(f)
+m = data["providers"]["xai"]["models"]["grok-build"]
+assert m["dispatch_group"] == "xai-grok", m
+assert "dispatch_group" not in (m.get("_archived_v1_fields") or {})
+EOF
+    # v3 path (--to-v3 validates against model-config-v3.schema.json)
+    run "$PYTHON_BIN" "$CLI" "$v1" --to-v3 -o "$OUT"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"INVALID"* ]]
+    _python_assert <<'EOF'
+import os
+from ruamel.yaml import YAML
+y = YAML(typ='safe')
+with open(os.environ["OUT"]) as f:
+    data = y.load(f)
+assert data["providers"]["xai"]["models"]["grok-build"]["dispatch_group"] == "xai-grok"
+EOF
+}


### PR DESCRIPTION
## Summary

Adds `"xai-grok"` to the `dispatch_group` enum in both the v2 and v3 model-config schemas. This is the latent root cause behind the recurring `migrate-config` M19.3 failure that has tripped on `origin/main` for every model-config-touching PR since the grok adapter (#1057) landed.

**bd-3m0a.** Closes the gate for every future model-config PR.

## Why

The xAI/grok provider (#1057) ships in `.claude/defaults/model-config.yaml`:

```yaml
providers:
  xai:
    type: grok-headless
    models:
      grok-build:           { dispatch_group: xai-grok, ... }
      grok-composer-2.5-fast: { dispatch_group: xai-grok, ... }
```

grok is its own company family — `type: grok-headless`, OIDC subscription auth, no HTTP sibling — so it correctly needs a distinct `dispatch_group` (the per-`(dispatch_group, auth_type)` telemetry bucket key in `dispatch_filter.py`, and the never-cross-companies chain invariant). But `xai-grok` was never admitted to the enum, so `loa-migrate-model-config.py` rejected the production config with `MIGRATION-PRODUCED-INVALID-V2` (exit 78).

The failure was **latent**: `migrate-config` CI only runs on model-config changes, so it surfaced intermittently as a "pre-existing" red on unrelated PRs. `origin/main` fails `M19.3` identically without this change.

## Changes

| File | Change |
|------|--------|
| `model-config-v2.schema.json` | append `"xai-grok"` to `dispatch_group` enum (1 line) |
| `model-config-v3.schema.json` | append `"xai-grok"` to `dispatch_group` enum (1 line) |
| `tests/integration/migrate-model-config.bats` | new `M19.6` — pins `xai-grok` through both the v2 (default) and `--to-v3` migration paths |

## Verification

- **`M19.6`** (new) green; exercises both v2 and `--to-v3` so both patched enums are covered.
- **`M19.3`** (production config smoke-migrate) was RED before, GREEN after — proven by reverting the enum (→ exit 78) and restoring it.
- Full `migrate-model-config.bats`: **43/43** (was 42 + new M19.6).
- Both schemas remain valid JSON; diff is exactly one enum token per file.

## Adversarial review

Confirmed the JSON schema is the **only** enum-style gate on `dispatch_group`:
- the python loader validates with a regex (`^[a-z][a-z0-9-]{1,63}$`) that `xai-grok` already matches — never the gate;
- `_HEADLESS_TYPE_INFERENCE` and `generated-model-maps.sh` already carry `grok → xai-grok`;
- Bridgebuilder TS has no `dispatch_group` enum/union;
- every `dispatch_group:` value in the production config is now in the enum (no third uncovered value).

No codegen drift: nothing references these schemas in a checksum/manifest, and the schema-guard workflow only watches `advisor-strategy.schema.json`.

## Follow-up (out of scope)

**bd-fy8e** — the same review surfaced a latent same-class gap: `loader.py:454` stamps `cursor-headless → cursor-composer`, but `cursor-composer` is absent from both enums. **Not currently triggered** (no cursor provider ships), so it's deferred rather than bundled — pre-committing the schema to a cursor dispatch_group with no shipping config would be speculative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
