### PR TITLE
fix(cheval): walk past a revoked CLI leg to a valid HTTP leg (KF-017 / #1071)

### DIFF
--- a/.claude/adapters/cheval.py
+++ b/.claude/adapters/cheval.py
@@ -31,6 +31,7 @@ from loa_cheval.types import (
     ChevalError,
     CompletionRequest,
     ConfigError,
+    AuthRevokedError,
     ContextTooLargeError,
     InvalidInputError,
     NativeRuntimeRequired,
@@ -95,6 +96,7 @@ EXIT_CODES = {
     "PROVIDER_UNAVAILABLE": 1,
     "RETRIES_EXHAUSTED": 1,
     "CONNECTION_LOST": 1,  # Issue #774: typed transient transport failure
+    "AUTH_REVOKED": 1,  # KF-017/#1071: runtime token revocation — walk-eligible
     "INVALID_INPUT": 2,
     "INVALID_CONFIG": 2,
     "NATIVE_RUNTIME_REQUIRED": 2,
@@ -1863,6 +1865,28 @@ def cmd_invoke(args: argparse.Namespace) -> int:
                     print(
                         f"[cheval] fallback {_entry_target} -> next "
                         f"({_re_class.lower()})",
+                        file=sys.stderr,
+                    )
+                continue
+            except AuthRevokedError as _e:
+                # KF-017/#1071: a leg's credential was server-side revoked (was
+                # valid, now invalidated). The leg is unusable NOW, but the
+                # operator's other legs (e.g. a valid HTTP key) may still work,
+                # so walk to the next chain entry instead of hard-aborting.
+                # STATIC misconfig (ConfigError/INVALID_CONFIG) still falls
+                # through to the hard-abort arm below — operator config errors
+                # are NEVER silently masked (#1095 safety constraint).
+                _modelinv_state["models_failed"].append({
+                    "model": _entry_target,
+                    "provider": _entry.provider,
+                    "error_class": "AUTH_REVOKED",
+                    "message_redacted": str(_e),
+                })
+                _last_walk_exit_code = EXIT_CODES["AUTH_REVOKED"]
+                _last_walk_exception = _e
+                if _verbose:
+                    print(
+                        f"[cheval] fallback {_entry_target} -> next (auth_revoked)",
                         file=sys.stderr,
                     )
                 continue

--- a/.claude/adapters/loa_cheval/providers/claude_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/claude_headless_adapter.py
@@ -63,6 +63,7 @@ from loa_cheval.providers.base import (
 from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
+    AuthRevokedError,
     ConfigError,
     ProviderUnavailableError,
     RateLimitError,
@@ -558,6 +559,25 @@ class ClaudeHeadlessAdapter(ProviderAdapter):
         ):
             raise RateLimitError(self.provider)
 
+        # Runtime auth revocation → WALKABLE (KF-017/#1071). Ambiguous
+        # "unauthorized"/"401" walkable only when no static-misconfig marker.
+        _static_auth = (
+            "not logged in" in diag_lower
+            or "/login" in diag_lower
+        )
+        if (
+            "invalidated" in diag_lower
+            or "session expired" in diag_lower
+            or "token expired" in diag_lower
+            or (("unauthorized" in diag_lower or "401" in full_diag) and not _static_auth)
+        ):
+            raise AuthRevokedError(
+                self.provider,
+                f"claude token revoked/expired — re-auth with {_CLAUDE_LOGIN_HINT}. "
+                f"(diagnostic: {full_diag[:300]})",
+            )
+
+        # Static misconfig (never authenticated / no key) → hard-abort.
         # Auth failure — Claude Code's most common first-run failure
         if (
             "not logged in" in diag_lower

--- a/.claude/adapters/loa_cheval/providers/codex_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/codex_headless_adapter.py
@@ -63,6 +63,7 @@ from loa_cheval.redaction import sanitize_provider_error_message
 from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
+    AuthRevokedError,
     ConfigError,
     ProviderUnavailableError,
     RateLimitError,
@@ -584,6 +585,28 @@ class CodexHeadlessAdapter(ProviderAdapter):
         # classification above still keys off the raw stderr.
         safe_stderr = sanitize_provider_error_message(stderr.strip())
 
+        # Runtime auth revocation (was valid, server-invalidated) → WALKABLE
+        # (KF-017/#1071). The ambiguous "unauthorized"/"401" is walkable only
+        # when no static-misconfig marker is present, so a never-authenticated
+        # error still hard-aborts below (#1095 safety constraint).
+        _static_auth = (
+            "not authenticated" in stderr_lower
+            or "auth.json" in stderr_lower
+            or "codex login" in stderr_lower
+        )
+        if (
+            "invalidated" in stderr_lower
+            or "session expired" in stderr_lower
+            or "token expired" in stderr_lower
+            or (("unauthorized" in stderr_lower or "401" in stderr) and not _static_auth)
+        ):
+            raise AuthRevokedError(
+                self.provider,
+                f"codex token revoked/expired — re-auth with `codex login`. "
+                f"(stderr: {safe_stderr[:300]})",
+            )
+
+        # Static misconfig (never authenticated / no key) → hard-abort.
         # Auth failure — most actionable for operators new to subscription mode
         if (
             "not authenticated" in stderr_lower

--- a/.claude/adapters/loa_cheval/providers/cursor_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/cursor_headless_adapter.py
@@ -58,6 +58,7 @@ from loa_cheval.providers.base import (
 from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
+    AuthRevokedError,
     ConfigError,
     ProviderUnavailableError,
     RateLimitError,
@@ -492,6 +493,26 @@ class CursorHeadlessAdapter(ProviderAdapter):
         ):
             raise RateLimitError(self.provider)
 
+        # Runtime auth revocation → WALKABLE (KF-017/#1071). Ambiguous
+        # "unauthorized"/"401" walkable only when no static-misconfig marker.
+        _static_auth = (
+            "not logged in" in combined
+            or "press any key to sign in" in combined
+            or "please log in" in combined
+        )
+        if (
+            "invalidated" in combined
+            or "session expired" in combined
+            or "token expired" in combined
+            or (("unauthorized" in combined or "401" in combined) and not _static_auth)
+        ):
+            raise AuthRevokedError(
+                self.provider,
+                f"cursor token revoked/expired — re-auth with `cursor-agent login`. "
+                f"diagnostic: {probe.strip()[:300]}",
+            )
+
+        # Static misconfig (never authenticated / no key) → hard-abort.
         # Auth failure — most actionable for operators new to Cursor headless.
         if (
             "not logged in" in combined

--- a/.claude/adapters/loa_cheval/providers/gemini_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/gemini_headless_adapter.py
@@ -54,6 +54,7 @@ from loa_cheval.providers.base import (
 from loa_cheval.types import (
     CompletionRequest,
     CompletionResult,
+    AuthRevokedError,
     ConfigError,
     ProviderUnavailableError,
     RateLimitError,
@@ -471,6 +472,29 @@ class GeminiHeadlessAdapter(ProviderAdapter):
         ):
             raise RateLimitError(self.provider)
 
+        # Runtime auth revocation → WALKABLE (KF-017/#1071). Ambiguous
+        # "unauthorized"/"401" walkable only when no static-misconfig marker.
+        _static_auth = (
+            "auth method" in diag_lower
+            or "set an auth" in diag_lower
+            or "settings.json" in diag_lower
+            or "gemini_api_key" in diag_lower
+            or "google_genai_use" in diag_lower
+        )
+        if (
+            "invalidated" in diag_lower
+            or "session expired" in diag_lower
+            or "token expired" in diag_lower
+            or "permission_denied" in diag_lower
+            or (("unauthorized" in diag_lower or "401" in full_diag) and not _static_auth)
+        ):
+            raise AuthRevokedError(
+                self.provider,
+                f"gemini token revoked/expired — re-auth by running `gemini` "
+                f"interactively. (diagnostic: {full_diag[:300]})",
+            )
+
+        # Static misconfig (never authenticated / no key) → hard-abort.
         # Auth failure — gemini-cli's most common first-run failure
         if (
             "auth method" in diag_lower

--- a/.claude/adapters/loa_cheval/providers/gemini_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/gemini_headless_adapter.py
@@ -485,7 +485,6 @@ class GeminiHeadlessAdapter(ProviderAdapter):
             "invalidated" in diag_lower
             or "session expired" in diag_lower
             or "token expired" in diag_lower
-            or "permission_denied" in diag_lower
             or (("unauthorized" in diag_lower or "401" in full_diag) and not _static_auth)
         ):
             raise AuthRevokedError(

--- a/.claude/adapters/loa_cheval/types.py
+++ b/.claude/adapters/loa_cheval/types.py
@@ -314,6 +314,30 @@ class ConfigError(ChevalError):
         super().__init__("INVALID_CONFIG", message, retryable=False)
 
 
+class AuthRevokedError(ChevalError):
+    """Runtime auth-credential revocation on a CLI/subscription leg (KF-017/#1071).
+
+    Distinct from ConfigError (INVALID_CONFIG / static misconfig). A token that
+    WAS valid and is now server-side-invalidated ("401 Unauthorized: token
+    invalidated", expired session) makes THIS leg unusable but says nothing
+    about the operator's other legs. retryable=True, code AUTH_REVOKED so the
+    cheval chain-walk loop walks to the next entry (e.g. a valid HTTP leg)
+    rather than hard-aborting. NOT a ProviderUnavailableError subclass: it must
+    reach cheval.py via retry.py's `except ChevalError: raise`, like
+    EmptyContentError. STATIC misconfig still raises ConfigError (hard-abort) so
+    operator config errors are never silently masked.
+    """
+
+    def __init__(self, provider: str, message: str):
+        super().__init__(
+            "AUTH_REVOKED",
+            f"auth credential revoked for {provider}: {message}",
+            retryable=True,
+            context={"provider": provider},
+        )
+        self.provider = provider
+
+
 class InvalidInputError(ChevalError):
     """Invalid input to model-invoke."""
 

--- a/.claude/adapters/tests/test_chain_walk_audit_envelope.py
+++ b/.claude/adapters/tests/test_chain_walk_audit_envelope.py
@@ -39,6 +39,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from loa_cheval.types import (
+    AuthRevokedError,
     BudgetExceededError,
     CompletionRequest,
     CompletionResult,
@@ -389,3 +390,81 @@ def test_capability_miss_records_missing_and_walks(capsys, monkeypatch):
     for item in captured["models_failed"]:
         assert item["error_class"] == "CAPABILITY_MISS"
         assert item["missing_capabilities"] == ["tools"]
+
+
+# ----------------------------------------------------------------------------
+# KF-017 / #1071: a leg whose credential was server-side REVOKED must WALK to
+# the next chain entry (e.g. a valid HTTP leg), not hard-abort the dispatch.
+# ----------------------------------------------------------------------------
+def test_auth_revoked_leg_walks_to_http_fallback(capsys):
+    cfg = _multi_entry_config()
+    fake_binding = MagicMock(temperature=0.7, capability_class=None)
+    fake_resolved = MagicMock(provider="openai", model_id="gpt-5.5-pro")
+    fake_provider_cfg = MagicMock()
+    primary_adapter = MagicMock()
+    fallback_adapter = MagicMock()
+    fallback_result = _build_completion_result("codex-headless", "openai")
+    calls = {"n": 0}
+
+    def _retry_side(_adapter, _req, _cfg, budget_hook=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # KF-017 trigger: the codex CLI leg's token was server-invalidated.
+            raise AuthRevokedError(
+                "openai",
+                "401 Unauthorized: your authentication token has been invalidated",
+            )
+        return fallback_result
+
+    captured, fake_emit = _capture_modelinv()
+    with patch.object(cheval, "load_config", return_value=(cfg, {})), \
+         patch.object(cheval, "resolve_execution", return_value=(fake_binding, fake_resolved)), \
+         patch.object(cheval, "_build_provider_config", return_value=fake_provider_cfg), \
+         patch.object(cheval, "get_adapter", side_effect=[primary_adapter, fallback_adapter]), \
+         patch("loa_cheval.providers.retry.invoke_with_retry", side_effect=_retry_side), \
+         patch("loa_cheval.audit_envelope.audit_emit", fake_emit), \
+         patch("loa_cheval.audit.modelinv.redact_payload_strings", side_effect=lambda x: x), \
+         patch("loa_cheval.audit.modelinv.assert_no_secret_shapes_remain"):
+        exit_code = cheval.cmd_invoke(_make_args())
+
+    out = capsys.readouterr()
+    assert exit_code == cheval.EXIT_CODES["SUCCESS"], out.err
+    assert calls["n"] == 2, f"Expected walk to fallback, got {calls['n']} dispatch(es)"
+    assert len(captured["models_failed"]) == 1
+    assert captured["models_failed"][0]["error_class"] == "AUTH_REVOKED"
+    assert captured["final_model_id"] == "openai:codex-headless"
+
+
+# ----------------------------------------------------------------------------
+# KF-017 SAFETY (#1095 constraint): a genuine STATIC misconfig (ConfigError /
+# INVALID_CONFIG) must STILL hard-abort — it is never silently walked/masked.
+# ----------------------------------------------------------------------------
+def test_static_misconfig_still_hard_aborts(capsys):
+    from loa_cheval.types import ConfigError
+    cfg = _multi_entry_config()
+    fake_binding = MagicMock(temperature=0.7, capability_class=None)
+    fake_resolved = MagicMock(provider="openai", model_id="gpt-5.5-pro")
+    fake_provider_cfg = MagicMock()
+    primary_adapter = MagicMock()
+    fallback_adapter = MagicMock()
+    calls = {"n": 0}
+
+    def _retry_side(_adapter, _req, _cfg, budget_hook=None):
+        calls["n"] += 1
+        raise ConfigError("codex CLI not authenticated. Run: codex login.")
+
+    captured, fake_emit = _capture_modelinv()
+    with patch.object(cheval, "load_config", return_value=(cfg, {})), \
+         patch.object(cheval, "resolve_execution", return_value=(fake_binding, fake_resolved)), \
+         patch.object(cheval, "_build_provider_config", return_value=fake_provider_cfg), \
+         patch.object(cheval, "get_adapter", side_effect=[primary_adapter, fallback_adapter]), \
+         patch("loa_cheval.providers.retry.invoke_with_retry", side_effect=_retry_side), \
+         patch("loa_cheval.audit_envelope.audit_emit", fake_emit), \
+         patch("loa_cheval.audit.modelinv.redact_payload_strings", side_effect=lambda x: x), \
+         patch("loa_cheval.audit.modelinv.assert_no_secret_shapes_remain"):
+        exit_code = cheval.cmd_invoke(_make_args())
+
+    out = capsys.readouterr()
+    # Hard-abort on the FIRST leg — must NOT walk to the fallback.
+    assert exit_code == cheval.EXIT_CODES["INVALID_CONFIG"], out.err
+    assert calls["n"] == 1, f"Static misconfig must hard-abort, not walk (got {calls['n']})"

--- a/.claude/adapters/tests/test_claude_headless_adapter.py
+++ b/.claude/adapters/tests/test_claude_headless_adapter.py
@@ -34,6 +34,7 @@ from loa_cheval.providers.claude_headless_adapter import (
 )
 from loa_cheval.types import (
     CompletionRequest,
+    AuthRevokedError,
     ConfigError,
     ModelConfig,
     ProviderConfig,
@@ -397,6 +398,35 @@ class TestErrorClassification:
             with pytest.raises(ConfigError) as exc_info:
                 adapter.complete(_make_request())
             assert "claude /login" in str(exc_info.value)
+
+    def test_runtime_token_revocation_raises_auth_revoked(self):
+        # KF-017/#1071: server-invalidated token → WALKABLE (AuthRevokedError).
+        adapter = ClaudeHeadlessAdapter(_make_config())
+        revoked_json = json.dumps({
+            "type": "result", "subtype": "success", "is_error": True,
+            "api_error_status": 401,
+            "result": "401 Unauthorized: your authentication token has been invalidated",
+            "session_id": "x", "usage": {"input_tokens": 0, "output_tokens": 0},
+        })
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
+            mock_run.return_value = _ok_proc(revoked_json)
+            with pytest.raises(AuthRevokedError) as exc_info:
+                adapter.complete(_make_request())
+            assert exc_info.value.code == "AUTH_REVOKED"
+
+    def test_ambiguous_unauthorized_with_static_marker_still_config_error(self):
+        # #1095 safety: "unauthorized" + a never-logged-in marker → ConfigError.
+        adapter = ClaudeHeadlessAdapter(_make_config())
+        static_json = json.dumps({
+            "type": "result", "subtype": "success", "is_error": True,
+            "api_error_status": None,
+            "result": "unauthorized — not logged in. Please run /login",
+            "session_id": "x", "usage": {"input_tokens": 0, "output_tokens": 0},
+        })
+        with patch("loa_cheval.providers.claude_headless_adapter.run_subprocess_pgkill") as mock_run:
+            mock_run.return_value = _ok_proc(static_json)
+            with pytest.raises(ConfigError):
+                adapter.complete(_make_request())
 
     def test_overloaded_raises_rate_limit(self):
         adapter = ClaudeHeadlessAdapter(_make_config())

--- a/.claude/adapters/tests/test_codex_headless_adapter.py
+++ b/.claude/adapters/tests/test_codex_headless_adapter.py
@@ -32,6 +32,7 @@ from loa_cheval.providers.codex_headless_adapter import (
 )
 from loa_cheval.types import (
     CompletionRequest,
+    AuthRevokedError,
     ConfigError,
     ModelConfig,
     ProviderConfig,
@@ -366,6 +367,31 @@ class TestErrorClassification:
         adapter = CodexHeadlessAdapter(_make_config())
         with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
             mock_run.return_value = _fail_proc(1, "Error: not authenticated. Run codex login.")
+            with pytest.raises(ConfigError) as exc_info:
+                adapter.complete(_make_request())
+            assert "codex login" in str(exc_info.value)
+
+    def test_runtime_token_revocation_raises_auth_revoked(self):
+        # KF-017/#1071: a previously-valid token, server-invalidated, must be
+        # classified WALKABLE (AuthRevokedError), not a hard-abort ConfigError.
+        adapter = CodexHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
+            mock_run.return_value = _fail_proc(
+                1, "401 Unauthorized: your authentication token has been invalidated"
+            )
+            with pytest.raises(AuthRevokedError) as exc_info:
+                adapter.complete(_make_request())
+            assert exc_info.value.code == "AUTH_REVOKED"
+            assert exc_info.value.retryable is True
+
+    def test_ambiguous_unauthorized_with_static_marker_still_config_error(self):
+        # #1095 safety: "unauthorized" co-occurring with a never-authenticated
+        # marker must STILL hard-abort (ConfigError), not be silently walked.
+        adapter = CodexHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.codex_headless_adapter.run_subprocess_pgkill") as mock_run:
+            mock_run.return_value = _fail_proc(
+                1, "Error: unauthorized — not authenticated. Run: codex login."
+            )
             with pytest.raises(ConfigError) as exc_info:
                 adapter.complete(_make_request())
             assert "codex login" in str(exc_info.value)

--- a/.claude/adapters/tests/test_cursor_headless_adapter.py
+++ b/.claude/adapters/tests/test_cursor_headless_adapter.py
@@ -34,6 +34,7 @@ from loa_cheval.providers import get_adapter
 from loa_cheval.providers.cursor_headless_adapter import CursorHeadlessAdapter
 from loa_cheval.types import (
     CompletionRequest,
+    AuthRevokedError,
     ConfigError,
     ModelConfig,
     ProviderConfig,
@@ -286,6 +287,19 @@ class TestErrorClassification:
 
     def test_not_logged_in_is_configerror(self):
         with patch(_PGKILL, return_value=_completed("", stderr="Not logged in", returncode=1)):
+            with pytest.raises(ConfigError):
+                _adapter().complete(_req())
+
+    def test_runtime_token_revocation_raises_auth_revoked(self):
+        # KF-017/#1071: server-invalidated token → WALKABLE (AuthRevokedError).
+        with patch(_PGKILL, return_value=_completed("", stderr="401 Unauthorized: session expired", returncode=1)):
+            with pytest.raises(AuthRevokedError) as exc_info:
+                _adapter().complete(_req())
+            assert exc_info.value.code == "AUTH_REVOKED"
+
+    def test_ambiguous_unauthorized_with_static_marker_still_config_error(self):
+        # #1095 safety: "unauthorized" + a not-logged-in marker → ConfigError.
+        with patch(_PGKILL, return_value=_completed("", stderr="unauthorized — please log in", returncode=1)):
             with pytest.raises(ConfigError):
                 _adapter().complete(_req())
 

--- a/.claude/adapters/tests/test_gemini_headless_adapter.py
+++ b/.claude/adapters/tests/test_gemini_headless_adapter.py
@@ -380,6 +380,18 @@ class TestErrorClassification:
             with pytest.raises(ConfigError):
                 adapter.complete(_make_request())
 
+    def test_permission_denied_is_static_config_error_not_walkable(self):
+        # gRPC PERMISSION_DENIED (status 7) is a static authorization misconfig
+        # (API not enabled / bad key / missing scope), NOT runtime revocation —
+        # must hard-abort (ConfigError), never be walked. (#1095 / PR #1101 review)
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
+            mock_run.return_value = _fail_proc(
+                1, stderr="PERMISSION_DENIED: set an auth method in settings.json (code=7)"
+            )
+            with pytest.raises(ConfigError):
+                adapter.complete(_make_request())
+
     def test_quota_error_raises_rate_limit(self):
         adapter = GeminiHeadlessAdapter(_make_config())
         with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:

--- a/.claude/adapters/tests/test_gemini_headless_adapter.py
+++ b/.claude/adapters/tests/test_gemini_headless_adapter.py
@@ -30,6 +30,7 @@ from loa_cheval.providers import get_adapter
 from loa_cheval.providers.gemini_headless_adapter import GeminiHeadlessAdapter
 from loa_cheval.types import (
     CompletionRequest,
+    AuthRevokedError,
     ConfigError,
     ModelConfig,
     ProviderConfig,
@@ -356,6 +357,28 @@ class TestErrorClassification:
             with pytest.raises(ConfigError) as exc_info:
                 adapter.complete(_make_request())
             assert "settings.json" in str(exc_info.value) or "Auth method" in str(exc_info.value)
+
+    def test_runtime_token_revocation_raises_auth_revoked(self):
+        # KF-017/#1071: server-invalidated token → WALKABLE (AuthRevokedError).
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
+            mock_run.return_value = _fail_proc(
+                1, stderr="401 Unauthorized: your token has been invalidated"
+            )
+            with pytest.raises(AuthRevokedError) as exc_info:
+                adapter.complete(_make_request())
+            assert exc_info.value.code == "AUTH_REVOKED"
+
+    def test_ambiguous_unauthorized_with_static_marker_still_config_error(self):
+        # #1095 safety: "unauthorized" co-occurring with a static-misconfig
+        # marker must STILL hard-abort (ConfigError), not be walked.
+        adapter = GeminiHeadlessAdapter(_make_config())
+        with patch("loa_cheval.providers.gemini_headless_adapter.run_subprocess_pgkill") as mock_run:
+            mock_run.return_value = _fail_proc(
+                1, stderr="unauthorized: set an auth method in settings.json"
+            )
+            with pytest.raises(ConfigError):
+                adapter.complete(_make_request())
 
     def test_quota_error_raises_rate_limit(self):
         adapter = GeminiHeadlessAdapter(_make_config())


### PR DESCRIPTION
## Summary
Closes **#1071** (KF-017). The prefer-api fallback chain hard-aborted when a leading CLI leg raised `INVALID_CONFIG`, because the headless adapters conflated **runtime auth-revocation** (a previously-valid token the server invalidated — e.g. codex `401 Unauthorized: token has been invalidated`) with **static misconfig** (never logged in). A revoked CLI leg therefore killed the whole dispatch before a valid HTTP leg was tried.

## Fix — typed-taxonomy split
- New **`AuthRevokedError(ChevalError)`** (`code=AUTH_REVOKED`, retryable, exit 1) — a *direct* `ChevalError` subclass (not `ProviderUnavailableError`), so it threads through `retry.py`'s `except ChevalError: raise` unchanged, exactly like `EmptyContentError`.
- `cheval.py` chain-walk loop gains `except AuthRevokedError: … continue` **above** the `except ChevalError: return` catch-all → a revoked leg walks to the next entry; a genuine `ConfigError` **still hard-aborts**.
- All 4 headless adapters split the auth branch: runtime-revocation phrases → `AuthRevokedError`; the **ambiguous `unauthorized`/`401` is walkable only when no static-misconfig marker is present** (the #1095 safety constraint — operator config errors are never silently masked). Static → `ConfigError`.

## Tests (+10, additive only)
- **Integration** (chain-walk): revoked leg → walks to HTTP fallback → `SUCCESS`; static misconfig → `INVALID_CONFIG`, **no walk**.
- **Per-adapter classification** (codex/gemini/claude/cursor): runtime→`AuthRevoked`; ambiguous+static→`ConfigError`.
- Affected suite **181 passed**, broader cheval suite **438 passed**, **0 regressions**.

## Process
Design adversarially verified → **SAFE-TO-IMPLEMENT after the all-4-adapters guard revision** (applied + tested here). `retry.py` / `chain_resolver.py` unchanged. Design doc: `grimoires/loa/proposals/kf017-kf018-billing-designs-2026-06-22.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)