### PR TITLE
fix(cheval): walk past Anthropic refusal + drop arbiter rationale (#1102)

### DIFF
--- a/.claude/adapters/loa_cheval/providers/anthropic_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/anthropic_adapter.py
@@ -35,6 +35,7 @@ from loa_cheval.types import (
     Usage,
     dispatch_provider_stream_error,
 )
+from loa_cheval.routing import EmptyContentError
 
 logger = logging.getLogger("loa_cheval.providers.anthropic")
 
@@ -81,6 +82,17 @@ def _is_billing_class_error(message: str) -> bool:
         return False
     haystack = message.lower()
     return any(token in haystack for token in _BILLING_CLASS_TOKENS)
+
+
+def _is_refusal(metadata: Optional[Dict[str, Any]]) -> bool:
+    """issue #1102: True when the provider returned stop_reason == "refusal".
+
+    A Fable/Anthropic refusal arrives as HTTP 200 + non-empty prose +
+    stop_reason "refusal". Treating it as empty-content (retryable) lets the
+    within-company chain walk instead of the flatline arbiter silently
+    passing a zero-decision gate.
+    """
+    return bool(metadata) and metadata.get("stop_reason") == "refusal"
 
 
 class AnthropicAdapter(ProviderAdapter):
@@ -276,6 +288,16 @@ class AnthropicAdapter(ProviderAdapter):
         # cycle-103 T3.2 / AC-3.2: set observed-transport flag for audit.
         _meta = dict(result.metadata or {})
         _meta["streaming"] = True
+        # issue #1102: a refusal (HTTP 200 + prose + stop_reason:"refusal") must
+        # raise a retryable EmptyContentError so the within-company chain walks
+        # (caught at cheval.py `except _EmptyContentError`) instead of the
+        # flatline arbiter silently applying zero decisions.
+        if _is_refusal(_meta):
+            raise EmptyContentError(
+                provider=self.provider,
+                model_id=body["model"],
+                reason="stop_reason:refusal",
+            )
         return CompletionResult(
             content=result.content,
             tool_calls=result.tool_calls,
@@ -369,6 +391,18 @@ class AnthropicAdapter(ProviderAdapter):
         )
 
         # cycle-103 T3.2 / AC-3.2: non-streaming path → metadata['streaming']=False.
+        # issue #1102: thread stop_reason for parity with the streaming path
+        # and raise a retryable EmptyContentError on refusal so the chain walks.
+        _meta: Dict[str, Any] = {"streaming": False}
+        stop_reason = resp.get("stop_reason")
+        if stop_reason:
+            _meta["stop_reason"] = stop_reason
+        if _is_refusal(_meta):
+            raise EmptyContentError(
+                provider=self.provider,
+                model_id=resp.get("model", "unknown"),
+                reason="stop_reason:refusal",
+            )
         return CompletionResult(
             content=content,
             tool_calls=tool_calls if tool_calls else None,
@@ -377,7 +411,7 @@ class AnthropicAdapter(ProviderAdapter):
             model=resp.get("model", "unknown"),
             latency_ms=latency_ms,
             provider=self.provider,
-            metadata={"streaming": False},
+            metadata=_meta,
         )
 
     def validate_config(self) -> List[str]:

--- a/.claude/adapters/tests/test_anthropic_refusal_fallback.py
+++ b/.claude/adapters/tests/test_anthropic_refusal_fallback.py
@@ -1,0 +1,250 @@
+"""issue #1102 — Fable/Anthropic refusal must walk the chain, not silently pass.
+
+A Claude Fable refusal returns HTTP 200 with non-empty prose content and
+``stop_reason: "refusal"``. Before this fix nothing raised on that, so the
+within-company chain-walk arm (``cheval.py`` ``except _EmptyContentError``)
+was never reached and the flatline arbiter applied zero decisions while
+reporting success.
+
+These tests pin: (1) the ``_is_refusal`` helper, (2) both adapter paths
+(streaming default + non-streaming kill-switch) raising a retryable
+``EmptyContentError`` on refusal, (3) a regression guard that non-refusal
+stop_reasons do NOT raise, and (4) the chain-walk contract the fix relies on
+(the existing ``cheval.py`` arm catches the SAME class and ``continue``s).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loa_cheval.providers.anthropic_adapter import AnthropicAdapter  # noqa: E402
+from loa_cheval.routing import EmptyContentError  # noqa: E402
+from loa_cheval.types import (  # noqa: E402
+    CompletionRequest,
+    ModelConfig,
+    ProviderConfig,
+)
+
+MODEL = "claude-fable-5"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> ProviderConfig:
+    return ProviderConfig(
+        name="anthropic",
+        type="anthropic",
+        endpoint="https://api.anthropic.com/v1",
+        auth="sk-ant-test",
+        connect_timeout=10.0,
+        read_timeout=30.0,
+        models={MODEL: ModelConfig(capabilities=["chat"], context_window=200000)},
+    )
+
+
+def _make_request() -> CompletionRequest:
+    return CompletionRequest(
+        messages=[{"role": "user", "content": "arbiter prompt"}],
+        model=MODEL,
+        temperature=0.0,
+        max_tokens=1024,
+    )
+
+
+def _nonstreaming_response(stop_reason) -> dict:
+    """Anthropic non-streaming body: HTTP 200 + prose + stop_reason."""
+    return {
+        "id": "msg_refusal",
+        "model": MODEL,
+        "role": "assistant",
+        "content": [{"type": "text", "text": "I can't help with that."}],
+        "stop_reason": stop_reason,
+        "usage": {"input_tokens": 50, "output_tokens": 8},
+    }
+
+
+def _sse_blob(stop_reason: str) -> bytes:
+    """A complete Anthropic SSE sequence carrying prose + the given stop_reason."""
+
+    def ev(name: str, data: dict) -> bytes:
+        return (f"event: {name}\ndata: {json.dumps(data)}\n\n").encode("utf-8")
+
+    return (
+        ev(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_r",
+                    "role": "assistant",
+                    "model": MODEL,
+                    "content": [],
+                    "usage": {"input_tokens": 50, "output_tokens": 1},
+                },
+            },
+        )
+        + ev(
+            "content_block_start",
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        )
+        + ev(
+            "content_block_delta",
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "I can't help with that."}},
+        )
+        + ev("content_block_stop", {"type": "content_block_stop", "index": 0})
+        + ev(
+            "message_delta",
+            {"type": "message_delta", "delta": {"stop_reason": stop_reason}, "usage": {"output_tokens": 8}},
+        )
+        + ev("message_stop", {"type": "message_stop"})
+    )
+
+
+def _mock_stream(blob: bytes):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.http_version = "HTTP/2"
+    resp.iter_bytes = MagicMock(return_value=iter([blob]))
+
+    @contextmanager
+    def fake_http_post_stream(*args, **kwargs):
+        yield resp
+
+    return fake_http_post_stream
+
+
+# ---------------------------------------------------------------------------
+# _is_refusal pure helper
+# ---------------------------------------------------------------------------
+
+
+def test_is_refusal_true_only_for_refusal():
+    from loa_cheval.providers.anthropic_adapter import _is_refusal
+
+    assert _is_refusal({"stop_reason": "refusal"}) is True
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [{"stop_reason": "end_turn"}, {"stop_reason": "max_tokens"}, {"stop_reason": "tool_use"}, {"stop_reason": None}, {}, None],
+)
+def test_is_refusal_false_otherwise(meta):
+    from loa_cheval.providers.anthropic_adapter import _is_refusal
+
+    assert _is_refusal(meta) is False
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming path (LOA_CHEVAL_DISABLE_STREAMING=1 kill switch)
+# ---------------------------------------------------------------------------
+
+
+def test_nonstreaming_refusal_raises_empty_content_error(monkeypatch):
+    monkeypatch.setenv("LOA_CHEVAL_DISABLE_STREAMING", "1")
+    adapter = AnthropicAdapter(_make_config())
+    with patch(
+        "loa_cheval.providers.anthropic_adapter.http_post",
+        return_value=(200, _nonstreaming_response("refusal")),
+    ):
+        with pytest.raises(EmptyContentError) as exc_info:
+            adapter.complete(_make_request())
+    err = exc_info.value
+    assert err.retryable is True
+    assert err.code == "EMPTY_CONTENT"
+    assert "stop_reason:refusal" in str(err)
+    assert err.context["model_id"] == MODEL
+
+
+@pytest.mark.parametrize("stop_reason", ["end_turn", "max_tokens", "tool_use", None])
+def test_nonstreaming_non_refusal_does_not_raise(monkeypatch, stop_reason):
+    monkeypatch.setenv("LOA_CHEVAL_DISABLE_STREAMING", "1")
+    adapter = AnthropicAdapter(_make_config())
+    with patch(
+        "loa_cheval.providers.anthropic_adapter.http_post",
+        return_value=(200, _nonstreaming_response(stop_reason)),
+    ):
+        result = adapter.complete(_make_request())
+    assert result.content == "I can't help with that."
+    assert result.metadata["streaming"] is False
+    if stop_reason is not None:
+        assert result.metadata["stop_reason"] == stop_reason
+
+
+# ---------------------------------------------------------------------------
+# Streaming path (default)
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_refusal_raises_empty_content_error(monkeypatch):
+    monkeypatch.delenv("LOA_CHEVAL_DISABLE_STREAMING", raising=False)
+    adapter = AnthropicAdapter(_make_config())
+    with patch(
+        "loa_cheval.providers.anthropic_adapter.http_post_stream",
+        _mock_stream(_sse_blob("refusal")),
+    ):
+        with pytest.raises(EmptyContentError) as exc_info:
+            adapter.complete(_make_request())
+    err = exc_info.value
+    assert err.retryable is True
+    assert err.code == "EMPTY_CONTENT"
+    assert "stop_reason:refusal" in str(err)
+    assert err.context["model_id"] == MODEL
+
+
+def test_streaming_non_refusal_does_not_raise(monkeypatch):
+    monkeypatch.delenv("LOA_CHEVAL_DISABLE_STREAMING", raising=False)
+    adapter = AnthropicAdapter(_make_config())
+    with patch(
+        "loa_cheval.providers.anthropic_adapter.http_post_stream",
+        _mock_stream(_sse_blob("end_turn")),
+    ):
+        result = adapter.complete(_make_request())
+    assert result.metadata["streaming"] is True
+    assert result.metadata["stop_reason"] == "end_turn"
+    assert result.content == "I can't help with that."
+
+
+# ---------------------------------------------------------------------------
+# Chain-walk contract — the fix reuses the EXISTING arm, no new wiring
+# ---------------------------------------------------------------------------
+
+
+def test_refusal_error_is_retryable():
+    err = EmptyContentError(provider="anthropic", model_id=MODEL, reason="stop_reason:refusal")
+    assert err.retryable is True
+
+
+def test_cheval_wrapper_catches_empty_content_and_continues():
+    """Pin the contract the fix depends on: cheval imports the SAME class the
+    adapter raises and ``continue``s the chain on it. A refactor that drops the
+    arm or changes it to re-raise would silently re-open the silent-pass hole."""
+    cheval_src = (ROOT / "cheval.py").read_text(encoding="utf-8")
+    assert "EmptyContentError as _EmptyContentError" in cheval_src
+    idx = cheval_src.index("except _EmptyContentError")
+    # Scan the arm body up to the NEXT except-clause and assert it walks
+    # (continues) rather than re-raising/aborting.
+    next_except = cheval_src.index("except ", idx + len("except _EmptyContentError"))
+    assert "continue" in cheval_src[idx:next_except]
+
+
+def test_adapter_references_refusal_raise_in_source():
+    """Source guard: the refusal trap exists in the adapter (both paths share
+    the ``_is_refusal`` helper + the ``stop_reason:refusal`` reason)."""
+    import inspect
+    from loa_cheval.providers import anthropic_adapter
+
+    src = inspect.getsource(anthropic_adapter)
+    assert "_is_refusal" in src
+    assert 'reason="stop_reason:refusal"' in src

--- a/.claude/scripts/flatline-orchestrator.sh
+++ b/.claude/scripts/flatline-orchestrator.sh
@@ -2341,7 +2341,7 @@ main() {
                 --arg doc_excerpt "$doc_excerpt" \
                 --arg phase "$phase" \
                 --argjson findings "$findings_to_arbitrate" \
-                '"You are the arbiter for this Flatline review. For each finding below, decide: accept (integrate the suggestion) or reject (with rationale). Your decision is final.\n\nDocument (" + $phase + ") excerpt:\n" + $doc_excerpt[0:2048] + "\n\nFindings requiring your decision:\n" + ($findings | tojson) + "\n\nRespond with a JSON array:\n[{\"finding_id\": \"...\", \"decision\": \"accept\"|\"reject\", \"rationale\": \"...\"}]"' \
+                '"You are the arbiter for this Flatline review. For each finding below, decide: accept (integrate the suggestion) or reject. Your decision is final.\n\nDocument (" + $phase + ") excerpt:\n" + $doc_excerpt[0:2048] + "\n\nFindings requiring your decision:\n" + ($findings | tojson) + "\n\nRespond with a JSON array:\n[{\"finding_id\": \"...\", \"decision\": \"accept\"|\"reject\"}]"' \
                 | jq -r '.' > "$arbiter_prompt_file"
 
             # Invoke with provider cascade (SKP-006)

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1897,9 +1897,22 @@
       ],
       "triage": "grimoires/loa/a2a/bug-20260617-i1069-8b7a4c/triage.md",
       "sprint_plan": "grimoires/loa/a2a/bug-20260617-i1069-8b7a4c/sprint.md"
+    },
+    {
+      "id": "cycle-bug-20260623-i1102-f309a6",
+      "label": "Bug Fix \u2014 Fable readiness: arbiter rationale field + missing stop_reason:refusal fallback (#1102)",
+      "type": "bugfix",
+      "status": "completed",
+      "source_issue": "https://github.com/0xHoneyJar/loa/issues/1102",
+      "created_at": "2026-06-23T00:21:08Z",
+      "sprints": [
+        "sprint-bug-226"
+      ],
+      "triage": "grimoires/loa/a2a/bug-20260623-i1102-f309a6/triage.md",
+      "sprint_plan": "grimoires/loa/a2a/bug-20260623-i1102-f309a6/sprint.md"
     }
   ],
-  "global_sprint_counter": 225,
+  "global_sprint_counter": 226,
   "bugfix_cycles": [
     {
       "id": "cycle-bug-20260418-i554-00a529",

--- a/tests/unit/flatline-arbiter.bats
+++ b/tests/unit/flatline-arbiter.bats
@@ -273,3 +273,22 @@ teardown() {
     echo "$log_entry" | jq -e '.decision == "accept"'
     echo "$log_entry" | jq -e '.cascade_attempts == 1'
 }
+
+# =============================================================================
+# Arbiter Prompt Schema — Fable readiness (issue #1102)
+# =============================================================================
+
+@test "arbiter: prompt schema drops free-text rationale (Fable refusal trigger #1102)" {
+    local orch="$PROJECT_ROOT/.claude/scripts/flatline-orchestrator.sh"
+    [ -f "$orch" ]
+    # The arbiter response-schema line must NOT request a free-text rationale
+    # field: per the Fable 5 prompting guide, instructions that make the model
+    # reproduce its reasoning as output can trip the reasoning_extraction
+    # refusal. It must still carry the two fields the orchestrator consumes.
+    local schema_line
+    schema_line=$(grep 'Respond with a JSON array' "$orch")
+    [ -n "$schema_line" ]
+    [[ "$schema_line" != *rationale* ]]
+    [[ "$schema_line" == *finding_id* ]]
+    [[ "$schema_line" == *decision* ]]
+}


### PR DESCRIPTION
## Summary

Fixes #1102 — a Claude **Fable refusal** (`stop_reason: "refusal"`) returns HTTP 200 with non-empty prose, so nothing in the anthropic adapter raised. The within-company chain-walk arm (`cheval.py:1789 except _EmptyContentError: … continue`) was never reached, and the flatline arbiter saw exit-0 prose, set `arbiter_success=true`, found no JSON array via `grep -oE '\[.*\]'`, defaulted `decisions="[]"`, and **applied zero decisions while reporting success** — a silent gate bypass.

## The fix (minimal, two parts, test-first)

**PART A — `anthropic_adapter.py`** (load-bearing): raise a retryable `EmptyContentError` on `stop_reason == "refusal"` on **both** the streaming (`_complete_streaming`) and non-streaming (`_parse_response`) paths.
- Imports `EmptyContentError` from `loa_cheval.routing` — the exact class `cheval.py:1162` catches (`loa_cheval.types` has none), so a refusal walks `fable → opus-4-8 → sonnet-4-6 → claude-headless` reusing the existing chain with **zero new wiring** in `retry.py` or the cheval wrapper.
- Narrow trap: only `== "refusal"` (`_is_refusal` helper); every other stop_reason is untouched (regression-guarded). Non-streaming path also threads `stop_reason` into metadata for parity with streaming.

**PART B — `flatline-orchestrator.sh:2344`**: drop the free-text `rationale` field from the arbiter response schema — per the Fable 5 prompting guide, instructions to reproduce reasoning as output can trip the `reasoning_extraction` refusal. Downstream consumes only `.decision`/`.finding_id` (`:2387-2388`), so this is behavior-preserving.

## Why this is safe / a net improvement

Converts a **silent** zero-decision gate pass into a **fail-loud** within-company chain walk (and typed exhaustion if every Claude leg refuses). The chain is within-company (all Claude, same Anthropic safety stack; cheval forbids cross-company substitution), so there is no weaker-safety fallback — see the audit's evaluation of the refusal-bypass concern (non-blocking; follow-up #1105 tracks the genuine-vs-spurious distinction should cheval ever serve a user-facing path).

## Testing

- **+17 pytest** `test_anthropic_refusal_fallback.py` (both paths raise on refusal w/ `retryable`/`code`/`model_id`/message asserts; regression guard for `end_turn`/`max_tokens`/`tool_use`/`None`; chain-walk contract; `_is_refusal` unit).
- **+1 bats** `flatline-arbiter.bats` (prompt schema drops `rationale`, keeps `finding_id`+`decision`).
- **Failing-first verified** on both layers.
- Full adapter suite: **1825 passed / 4 pre-existing `test_flatline_routing` baseline fails** (unrelated `--validate-bindings` CLI contract).

## Quality gates

- `/review-sprint`: **APPROVED** (adversarial analysis, non-blocking concerns documented).
- `/audit-sprint`: **APPROVED** — no CRITICAL/HIGH; net gate-integrity improvement.
- Cross-model **review + audit** (gpt-5.5-pro→gpt-5.5): both clean / consensus / `confidence_floor: high`.

## Out of scope (tracked)

- `reasoning_class: true` for `claude-fable-5` (arms a different guard + forces model-config artifact regen).
- #1105 — genuine vs spurious refusal distinction (moot for today's internal within-company architecture).

`sprint-bug-226` · `bd-2q3f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
