### PR TITLE
feat(audit): local pre-push enforcement for verify-for-merge (CI wiring would be theater)

### DIFF
--- a/.claude/scripts/audit-verify-for-merge.sh
+++ b/.claude/scripts/audit-verify-for-merge.sh
@@ -58,8 +58,13 @@ if [[ $rc -ne 0 ]]; then
   exit $rc
 fi
 if [[ $checked -eq 0 ]]; then
-  # Don't pass silently when there was nothing to check — surface it loudly so an
-  # absent/renamed MODELINV log can't read as a green gate.
+  # Absent log: WARN + pass by default (legit first-push before any MODELINV exists),
+  # but FAIL CLOSED when the operator opts into LOA_AUDIT_REQUIRE_LOG=1 (a deleted/renamed
+  # chain must not read as a green gate — closes the rm-the-log soft spot).
+  if [[ "${LOA_AUDIT_REQUIRE_LOG:-0}" == "1" ]]; then
+    echo "[audit-gate] FAIL-CLOSED: no target audit chain found and LOA_AUDIT_REQUIRE_LOG=1 — a missing/deleted log is not acceptable" >&2
+    exit 1
+  fi
   echo "[audit-gate] WARNING: no target audit chain found to verify (nothing checked) — confirm LOA_AUDIT_MERGE_LOGS / .run/model-invoke.jsonl is present" >&2
   exit 0
 fi

--- a/.claude/scripts/git-hooks/pre-push-audit
+++ b/.claude/scripts/git-hooks/pre-push-audit
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# loa:pre-push-audit:v1
+# pre-push-audit — opt-in LOCAL audit-chain attestation before `git push`.
+#
+# Installed by .claude/scripts/install-audit-prepush.sh into .git/hooks/pre-push
+# (per-clone; git hooks are not committed). This is the ONLY wiring point where the
+# strict verify-for-merge gate is meaningful: the operator's box has the real
+# .run/model-invoke.jsonl AND can block transmission. CI/post-merge would be a no-op.
+#
+# DEFAULT OFF: audit-verify-for-merge.sh is itself opt-in — unset LOA_AUDIT_VERIFY_FOR_MERGE
+# prints "DISABLED" and exits 0, so this hook passes through. Set it to 1 to ENFORCE: a
+# broken/tampered/unsigned-post-cutoff chain then exits non-zero and BLOCKS the push.
+# (`git push --no-verify` bypasses ALL hooks — this is operator self-attestation, not a
+#  hard security boundary.)
+set -euo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+GATE="$REPO_ROOT/.claude/scripts/audit-verify-for-merge.sh"
+[[ -f "$GATE" ]] || exit 0                      # gate absent (older checkout) → never block
+exec env PROJECT_ROOT="$REPO_ROOT" bash "$GATE" # pin the root (ignore any stale inherited PROJECT_ROOT)

--- a/.claude/scripts/install-audit-prepush.sh
+++ b/.claude/scripts/install-audit-prepush.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# install-audit-prepush.sh — install the opt-in audit pre-push hook into this clone.
+#
+# Copies .claude/scripts/git-hooks/pre-push-audit → <hooks>/pre-push (respecting
+# core.hooksPath). DEFAULT-OFF (enforces only when LOA_AUDIT_VERIFY_FOR_MERGE=1), so
+# installing it is inert until you opt in. A pre-existing NON-loa pre-push hook is
+# BACKED UP to <hooks>/pre-push.pre-loa-bak (never silently destroyed).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="${SCRIPT_DIR}/git-hooks/pre-push-audit"
+SENTINEL='# loa:pre-push-audit:v1'
+[[ -f "$SRC" ]] || { echo "install-audit-prepush: template missing: $SRC" >&2; exit 1; }
+HOOKS_DIR="$(git rev-parse --git-path hooks 2>/dev/null)" || { echo "not a git repo" >&2; exit 1; }
+mkdir -p "$HOOKS_DIR"; DEST="${HOOKS_DIR}/pre-push"
+if [[ -f "$DEST" ]] && ! grep -qF "$SENTINEL" "$DEST" 2>/dev/null; then
+  bak="${DEST}.pre-loa-bak"
+  cp -p "$DEST" "$bak"
+  echo "install-audit-prepush: backed up existing non-loa pre-push hook → $bak"
+fi
+cp "$SRC" "$DEST"; chmod +x "$DEST"
+echo "installed pre-push-audit → $DEST"
+echo "  inert until you opt in: export LOA_AUDIT_VERIFY_FOR_MERGE=1 to enforce on push."

--- a/grimoires/loa/runbooks/audit-verify-for-merge-activation.md
+++ b/grimoires/loa/runbooks/audit-verify-for-merge-activation.md
@@ -63,11 +63,23 @@ Only now: set `LOA_AUDIT_VERIFY_FOR_MERGE=1` and wire the gate into the release 
 LOA_AUDIT_VERIFY_FOR_MERGE=1 bash .claude/scripts/audit-verify-for-merge.sh
 ```
 
-and treats a non-zero exit as a blocking failure. (To add it as a `post-merge-orchestrator.sh` phase, register it in the phase matrix + ordered list after the existing phases; keep it gated on the env flag so it stays inert until activated.)
+and treat a non-zero exit as a blocking failure.
 
-## Verifying the handoff locally (no root key needed)
-- `bash .claude/scripts/audit-envelope.sh verify-chain --verify-for-merge .run/model-invoke.jsonl` → today this **fails closed** with `[TRUST-STORE-BOOTSTRAP-PENDING] … (ATK-3)`. That failure **is** the correct pre-ceremony behavior.
-- `bash .claude/scripts/audit-verify-for-merge.sh` → prints `DISABLED` and exits 0 (opt-in off).
+**Where to wire it — local pre-push, NOT CI.** `.run/model-invoke.jsonl` is gitignored/local: it exists only on the operator's box, never in a stateless CI checkout. So wiring the gate into `post-merge-orchestrator.sh` or any GitHub-Actions job would be a **no-op (integrity theater)** — the log is absent there, the gate finds nothing and exits 0, manufacturing false assurance. The one surface with both the real log AND the power to block transmission is a **local `pre-push` hook**:
+
+```bash
+bash .claude/scripts/install-audit-prepush.sh   # installs .git/hooks/pre-push (opt-in, default-off)
+export LOA_AUDIT_VERIFY_FOR_MERGE=1             # flip on to enforce; a broken/unsigned chain then blocks push
+```
+
+The hook is inert until `LOA_AUDIT_VERIFY_FOR_MERGE=1`; it delegates to `audit-verify-for-merge.sh` and refuses to clobber a pre-existing non-loa pre-push hook. (Confirmed by the gate-wiring investigation: CI emits no real MODELINV, so no CI signing secret is needed; the gate belongs local.)
+
+## Verifying locally (post-ceremony state)
+The ceremony is DONE (commit `bf68a4e2`): the trust-store is **VERIFIED** (root_signature populated; writer `deep-name` in `keys[]`; `trust_cutoff` advanced to `2026-06-29` grandfathering the legacy entries). So:
+- `LOA_AUDIT_VERIFY_FOR_MERGE=1 bash .claude/scripts/audit-verify-for-merge.sh` → `OK … entries`, exit 0 — the strict gate now **PASSES** over the local log.
+- `bash .claude/scripts/audit-verify-for-merge.sh` (no env) → prints `DISABLED`, exits 0 (opt-in off).
+- `LOA_AUDIT_REQUIRE_LOG=1` makes a missing/deleted log fail closed (defends the rm-the-log soft spot).
+- *Pre-ceremony* it failed closed with `[TRUST-STORE-BOOTSTRAP-PENDING]/ATK-3` — that was the correct behavior **before** signing.
 
 ## Tracking
 - Agent-doable half: OKF cycle Sprint 9 (this commit).

--- a/tests/integration/audit-prepush-hook.bats
+++ b/tests/integration/audit-prepush-hook.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# audit pre-push hook + installer — the MEANINGFUL local enforcement surface for the
+# verify-for-merge gate (CI/post-merge would be a no-op over gitignored .run/).
+
+setup() {
+  BATS_TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  REPO="$(cd "$BATS_TEST_DIR/../.." && pwd)"
+  HOOK_SRC="$REPO/.claude/scripts/git-hooks/pre-push-audit"
+  INSTALLER="$REPO/.claude/scripts/install-audit-prepush.sh"
+  [[ -f "$HOOK_SRC" && -f "$INSTALLER" ]] || skip "hook/installer not present"
+  T="$(mktemp -d)"; ( cd "$T" && git init -q )
+  mkdir -p "$T/.claude/scripts"
+}
+teardown() { [[ -n "${T:-}" ]] && find "$T" -mindepth 0 -delete 2>/dev/null || true; }
+
+_stub_gate() { # rc — install a stub gate at the temp repo that exits with rc
+  cat > "$T/.claude/scripts/audit-verify-for-merge.sh" <<EOF
+#!/usr/bin/env bash
+echo "[stub-gate] PROJECT_ROOT=\${PROJECT_ROOT:-unset}"
+exit $1
+EOF
+  chmod +x "$T/.claude/scripts/audit-verify-for-merge.sh"
+}
+
+@test "installer: installs pre-push-audit into .git/hooks/pre-push (with the v1 sentinel)" {
+  ( cd "$T" && bash "$INSTALLER" )
+  [ -x "$T/.git/hooks/pre-push" ]
+  grep -qF '# loa:pre-push-audit:v1' "$T/.git/hooks/pre-push"
+}
+
+@test "installer: BACKS UP a pre-existing non-loa pre-push hook (never clobbers)" {
+  printf '#!/bin/sh\necho someone-elses-hook\n' > "$T/.git/hooks/pre-push"; chmod +x "$T/.git/hooks/pre-push"
+  run bash -c "cd '$T' && bash '$INSTALLER'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"backed up"* ]]
+  grep -q 'someone-elses-hook' "$T/.git/hooks/pre-push.pre-loa-bak"   # original preserved
+  grep -qF '# loa:pre-push-audit:v1' "$T/.git/hooks/pre-push"          # ours installed
+}
+
+@test "installer: a foreign hook merely MENTIONING the string is still backed up, not clobbered" {
+  printf '#!/bin/sh\n# see also pre-push-audit docs\necho IMPORTANT-USER-HOOK\n' > "$T/.git/hooks/pre-push"; chmod +x "$T/.git/hooks/pre-push"
+  ( cd "$T" && bash "$INSTALLER" )
+  grep -q 'IMPORTANT-USER-HOOK' "$T/.git/hooks/pre-push.pre-loa-bak"   # not lost
+}
+
+@test "installer: re-installing its own hook is idempotent (sentinel match → no spurious backup)" {
+  ( cd "$T" && bash "$INSTALLER" && bash "$INSTALLER" )
+  grep -qF '# loa:pre-push-audit:v1' "$T/.git/hooks/pre-push"
+  [ ! -f "$T/.git/hooks/pre-push.pre-loa-bak" ]   # our own hook is never backed up over itself
+}
+
+@test "installer: respects core.hooksPath (lands in the configured dir)" {
+  ( cd "$T" && git config core.hooksPath .githooks && bash "$INSTALLER" )
+  [ -x "$T/.githooks/pre-push" ]
+  grep -qF '# loa:pre-push-audit:v1' "$T/.githooks/pre-push"
+}
+
+@test "hook: gate present + returns 0 → hook exits 0 (push allowed)" {
+  _stub_gate 0
+  run bash -c "cd '$T' && bash '$HOOK_SRC' </dev/null"
+  [ "$status" -eq 0 ]
+}
+
+@test "hook: gate present + returns non-zero → hook exits non-zero (push blocked)" {
+  _stub_gate 7
+  run bash -c "cd '$T' && bash '$HOOK_SRC' </dev/null"
+  [ "$status" -eq 7 ]
+}
+
+@test "hook: handles git's real pre-push contract (argv = remote name+url, ref lines on stdin)" {
+  _stub_gate 0
+  run bash -c "cd '$T' && printf 'refs/heads/x aaa refs/heads/x bbb\n' | bash '$HOOK_SRC' origin https://example.invalid/repo.git"
+  [ "$status" -eq 0 ]
+}
+
+@test "hook: pins PROJECT_ROOT to the git root (ignores a stale inherited PROJECT_ROOT)" {
+  _stub_gate 0
+  run bash -c "cd '$T' && PROJECT_ROOT=/some/other/repo bash '$HOOK_SRC' </dev/null"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROJECT_ROOT=$T"* ]]   # gate saw the git root, not the stale value
+}
+
+@test "hook: gate ABSENT → hook exits 0 (never blocks a push on an older checkout)" {
+  run bash -c "cd '$T' && bash '$HOOK_SRC' </dev/null"
+  [ "$status" -eq 0 ]
+}
+
+@test "hook: against the REAL gate in DEFAULT-OFF state → exits 0 (installing is genuinely inert)" {
+  run bash -c "cd '$REPO' && env -u LOA_AUDIT_VERIFY_FOR_MERGE bash '$HOOK_SRC' </dev/null"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DISABLED"* ]]
+}

--- a/tests/integration/audit-verify-for-merge.bats
+++ b/tests/integration/audit-verify-for-merge.bats
@@ -83,6 +83,13 @@ teardown() { [[ -n "${TEST_DIR:-}" ]] && find "$TEST_DIR" -mindepth 0 -delete 2>
   [ "$status" -eq 0 ]
 }
 
+@test "gate: LOA_AUDIT_REQUIRE_LOG=1 makes an absent/deleted log FAIL CLOSED (closes the rm-the-log soft spot)" {
+  run env LOA_AUDIT_VERIFY_FOR_MERGE=1 LOA_AUDIT_REQUIRE_LOG=1 LOA_TRUST_STORE_FILE="$BOOT_TS" \
+      LOA_AUDIT_MERGE_LOGS="$TEST_DIR/absent.jsonl" PROJECT_ROOT="$TEST_DIR" bash "$GATE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL-CLOSED"* ]]
+}
+
 # Build a VERIFIED (root-signed) trust-store with a writer in keys[] + the writer
 # keypair on disk. Echoes the writer_id. Skips if crypto deps are unavailable.
 _build_verified_store() {


### PR DESCRIPTION
## Local pre-push enforcement for the verify-for-merge audit gate

The operator asked to "enforce the gate." A 3-agent investigation (grounded in `file:line`) established that wiring the gate into **CI/post-merge would be integrity theater**: `.run/model-invoke.jsonl` is gitignored/local, so on a stateless runner the gate finds no log and exits 0 — false assurance. CI also emits **no real MODELINV** (no CI signing secret needed). The one surface with both the real log **and** the power to block transmission is a **local `pre-push` hook**. So this ships the *meaningful* enforcement, not the theater version.

### What's added (opt-in, DEFAULT-OFF)
- **`.claude/scripts/git-hooks/pre-push-audit`** — delegates to `audit-verify-for-merge.sh` (itself default-off via `LOA_AUDIT_VERIFY_FOR_MERGE`). Sentinel `# loa:pre-push-audit:v1`; pins `PROJECT_ROOT` to the git root; fails **open** when the gate is absent (older checkout) so it never blocks a push it can't reason about. (`git push --no-verify` bypasses all hooks — this is operator self-attestation, not a hard boundary.)
- **`.claude/scripts/install-audit-prepush.sh`** — installs into `<hooks>/pre-push` (respects `core.hooksPath`); **backs up** any pre-existing non-loa hook to `.pre-loa-bak` (never clobbers); idempotent.
- **`audit-verify-for-merge.sh`** — new `LOA_AUDIT_REQUIRE_LOG=1` (fail-closed on a missing/deleted log — closes the `rm`-the-log soft spot) while keeping absent==pass by default.
- **Tests**: 11 pre-push bats + a `LOA_AUDIT_REQUIRE_LOG` gate test.
- **Runbook**: corrected Step 7 (local pre-push, not CI) + refreshed the post-ceremony "Verifying locally" section.

### Review
2-persona adversarial review (correctness + security/bypass): **APPROVE_WITH_NITS, no blockers** — enforcement verified real end-to-end (default-off inert, exit-code propagation, blocks on failure, respects `core.hooksPath`). Every actioned nit applied: substring-clobber → backup; absent-log fail-open → opt-in `LOA_AUDIT_REQUIRE_LOG`; `PROJECT_ROOT` pin; stale runbook; coverage gaps.

### Enablement (operator)
```bash
bash .claude/scripts/install-audit-prepush.sh   # already installed locally; commits the source-of-truth
export LOA_AUDIT_VERIFY_FOR_MERGE=1             # flip on to enforce on push
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
