### PR TITLE
docs(readme): correct stale badges + skill count after v1.196.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Version: 1.196.0
 
 [![Version](https://img.shields.io/badge/version-1.196.0-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE.md)
-[![Release](https://img.shields.io/badge/release-v1.173.0%20Opus%204.8-purple.svg)](CHANGELOG.md#11730---2026-06-01)
+[![Release](https://img.shields.io/badge/release-v1.196.0%20Mechanical%20Floor-purple.svg)](https://github.com/0xHoneyJar/loa/releases/tag/v1.196.0)
 
 > *"The Loa are pragmatic entities... They're not worshipped for salvation—they're worked with for practical results."*
 
 ## What Is This?
 
-Loa is an agent-driven development framework for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (Anthropic's official CLI). It adds 18 specialized AI agents, quality gates, persistent memory, and structured workflows on top of Claude Code — including a self-improving [spiral orchestrator](#spiral-autopoietic-orchestrator) that can autonomously plan, build, review, and learn across multiple development cycles. Works on macOS and Linux. Created by [@janitooor](https://github.com/deep-name) at [The Honey Jar](https://0xhoneyjar.xyz).
+Loa is an agent-driven development framework for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (Anthropic's official CLI). It adds 40 specialized skills, quality gates, persistent memory, and structured workflows on top of Claude Code — including a self-improving [spiral orchestrator](#spiral-autopoietic-orchestrator) that can autonomously plan, build, review, and learn across multiple development cycles. Works on macOS and Linux. Created by [@janitooor](https://github.com/deep-name) at [The Honey Jar](https://0xhoneyjar.xyz).
 
 ### Why "Loa"?
 
@@ -32,7 +32,7 @@ In William Gibson's Sprawl trilogy (*Neuromancer*, *Count Zero*), Loa are AI ent
 curl -fsSL https://raw.githubusercontent.com/0xHoneyJar/loa/main/.claude/scripts/mount-loa.sh | bash
 
 # Or pin to a specific version
-curl -fsSL https://raw.githubusercontent.com/0xHoneyJar/loa/main/.claude/scripts/mount-loa.sh | bash -s -- --tag v1.109.4
+curl -fsSL https://raw.githubusercontent.com/0xHoneyJar/loa/main/.claude/scripts/mount-loa.sh | bash -s -- --tag v1.196.0
 
 # Start Claude Code
 claude
@@ -61,7 +61,7 @@ New project? See **[INSTALLATION.md](INSTALLATION.md#method-2-clone-template)** 
 **The solution**: Loa adds structure without ceremony. Each phase produces a traceable artifact (PRD, SDD, Sprint Plan, Code, Review, Audit) using specialized AI agents. Your code gets reviewed by a Tech Lead agent *and* a Security Auditor agent before it ships.
 
 **Key differentiators**:
-- **Multi-agent orchestration**: 18 specialized skills, not one general-purpose prompt
+- **Multi-agent orchestration**: 40 specialized skills, not one general-purpose prompt
 - **Quality gates**: Two-phase review (code + security) prevents unreviewed code from shipping
 - **Session persistence**: Beads task graph + persistent memory survive context clears
 - **Adversarial review**: Flatline Protocol uses cross-model dissent (Opus + GPT) for planning QA
@@ -109,7 +109,7 @@ For fine-grained control, use the underlying commands directly:
 
 ## The Agents
 
-Eighteen specialized skills that ride alongside you:
+A selection of the specialized skills that ride alongside you:
 
 | Skill | Role |
 |-------|------|


### PR DESCRIPTION
Post-release accuracy pass on the README (operator-requested — "ensure accuracy").

## Fixed
| Line | Was | Now | Why |
|------|-----|-----|-----|
| Release badge | `v1.173.0 Opus 4.8` | `v1.196.0 Mechanical Floor` → release page | Named-release badge was 23 tags stale |
| Intro | "18 specialized AI agents" | "40 specialized skills" | BUTTERFREEZONE.md (agent-grounded SoT) = 40 skills; only 1 agent *persona* exists |
| Key differentiators | "18 specialized skills" | "40 specialized skills" | same |
| "The Agents" header | "Eighteen specialized skills" | "A selection of the specialized skills" | table is a 19-row curated showcase, not the full 40 |
| Version-pin example | `--tag v1.109.4` | `--tag v1.196.0` | currency |

## Deliberately unchanged
`**48 total commands.**` — `agents-md-gen.sh --check` computes 48 (53 command files − 5 golden-path routers) and requires both README claims to equal it. Verified the check passes with this diff.

## Verification
- `agents-md-gen.sh --check` → consistent (48 commands)
- `sync-readme-version.sh` → version badge already 1.196.0 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)